### PR TITLE
3.next - Add deprecations for core package.

### DIFF
--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -93,6 +93,7 @@ class PhpConfig implements ConfigEngineInterface
         if (!isset($config)) {
             throw new Exception(sprintf('Config file "%s" did not return an array', $key . '.php'));
         }
+        deprecationWarning('PHP configuration files should not set `$config. Instead return an array.');
 
         return $config;
     }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -176,7 +176,7 @@ trait InstanceConfigTrait
     public function config($key = null, $value = null, $merge = true)
     {
         deprecationWarning(
-            'InstanceConfigTrait::config() is deprecated. ' .
+            get_called_class() . '::config() is deprecated. ' .
             'Use setConfig()/getConfig() instead.'
         );
 

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -175,6 +175,11 @@ trait InstanceConfigTrait
      */
     public function config($key = null, $value = null, $merge = true)
     {
+        deprecationWarning(
+            'InstanceConfigTrait::config() is deprecated. ' .
+            'Use setConfig()/getConfig() instead.'
+        );
+
         if (is_array($key) || func_num_args() >= 2) {
             return $this->setConfig($key, $value, $merge);
         }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -163,6 +163,11 @@ trait StaticConfigTrait
      */
     public static function config($key, $config = null)
     {
+        deprecationWarning(
+            'StaticConfigTrait::config() is deprecated. ' .
+            'Use setConfig()/getConfig() instead.'
+        );
+
         if ($config !== null || is_array($key)) {
             static::setConfig($key, $config);
 
@@ -362,6 +367,11 @@ REGEXP;
      */
     public static function dsnClassMap(array $map = null)
     {
+        deprecationWarning(
+            'StaticConfigTrait::setDsnClassMap() is deprecated. ' .
+            'Use setDsnClassMap()/getDsnClassMap() instead.'
+        );
+
         if ($map !== null) {
             static::setDsnClassMap($map);
         }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -368,7 +368,7 @@ REGEXP;
     public static function dsnClassMap(array $map = null)
     {
         deprecationWarning(
-            'StaticConfigTrait::setDsnClassMap() is deprecated. ' .
+            get_called_class() . '::setDsnClassMap() is deprecated. ' .
             'Use setDsnClassMap()/getDsnClassMap() instead.'
         );
 

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -164,7 +164,7 @@ trait StaticConfigTrait
     public static function config($key, $config = null)
     {
         deprecationWarning(
-            'StaticConfigTrait::config() is deprecated. ' .
+            get_called_class() . '::config() is deprecated. ' .
             'Use setConfig()/getConfig() instead.'
         );
 

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -68,8 +68,8 @@ class BasicAuthenticateTest extends TestCase
             'userModel' => 'AuthUser',
             'fields' => ['username' => 'user', 'password' => 'password']
         ]);
-        $this->assertEquals('AuthUser', $object->config('userModel'));
-        $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->config('fields'));
+        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->getConfig('fields'));
     }
 
     /**
@@ -220,7 +220,7 @@ class BasicAuthenticateTest extends TestCase
      */
     public function testAuthenticateFailReChallenge()
     {
-        $this->auth->config('scope.username', 'nate');
+        $this->auth->setConfig('scope.username', 'nate');
         $request = new ServerRequest([
             'url' => 'posts/index',
             'environment' => [

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -83,10 +83,10 @@ class DigestAuthenticateTest extends TestCase
             'fields' => ['username' => 'user', 'password' => 'pass'],
             'nonce' => 123456
         ]);
-        $this->assertEquals('AuthUser', $object->config('userModel'));
-        $this->assertEquals(['username' => 'user', 'password' => 'pass'], $object->config('fields'));
-        $this->assertEquals(123456, $object->config('nonce'));
-        $this->assertEquals(env('SERVER_NAME'), $object->config('realm'));
+        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertEquals(['username' => 'user', 'password' => 'pass'], $object->getConfig('fields'));
+        $this->assertEquals(123456, $object->getConfig('nonce'));
+        $this->assertEquals(env('SERVER_NAME'), $object->getConfig('realm'));
     }
 
     /**
@@ -357,7 +357,7 @@ class DigestAuthenticateTest extends TestCase
      */
     public function testAuthenticateFailReChallenge()
     {
-        $this->auth->config('scope.username', 'nate');
+        $this->auth->setConfig('scope.username', 'nate');
         $request = new ServerRequest([
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -75,8 +75,8 @@ class FormAuthenticateTest extends TestCase
             'userModel' => 'AuthUsers',
             'fields' => ['username' => 'user', 'password' => 'password']
         ]);
-        $this->assertEquals('AuthUsers', $object->config('userModel'));
-        $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->config('fields'));
+        $this->assertEquals('AuthUsers', $object->getConfig('userModel'));
+        $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->getConfig('fields'));
     }
 
     /**
@@ -259,7 +259,7 @@ class FormAuthenticateTest extends TestCase
         $user['password'] = password_hash(Security::getSalt() . 'cake', PASSWORD_BCRYPT);
         $PluginModel->save(new Entity($user));
 
-        $this->auth->config('userModel', 'TestPlugin.AuthUsers');
+        $this->auth->setConfig('userModel', 'TestPlugin.AuthUsers');
 
         $request = new ServerRequest('posts/index');
         $request->data = [
@@ -291,7 +291,7 @@ class FormAuthenticateTest extends TestCase
             'password' => 'password'
         ];
 
-        $this->auth->config([
+        $this->auth->setConfig([
             'userModel' => 'AuthUsers',
             'finder' => 'auth'
         ]);
@@ -303,7 +303,7 @@ class FormAuthenticateTest extends TestCase
         ];
         $this->assertEquals($expected, $result, 'Result should not contain "created" and "modified" fields');
 
-        $this->auth->config([
+        $this->auth->setConfig([
             'finder' => ['auth' => ['return_created' => true]]
         ]);
 
@@ -329,7 +329,7 @@ class FormAuthenticateTest extends TestCase
             'password' => 'password'
         ];
 
-        $this->auth->config([
+        $this->auth->setConfig([
             'userModel' => 'AuthUsers',
             'finder' => 'username'
         ]);
@@ -341,7 +341,7 @@ class FormAuthenticateTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
-        $this->auth->config([
+        $this->auth->setConfig([
             'finder' => ['username' => ['username' => 'nate']]
         ]);
 
@@ -360,13 +360,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testPasswordHasherSettings()
     {
-        $this->auth->config('passwordHasher', [
+        $this->auth->setConfig('passwordHasher', [
             'className' => 'Default',
             'hashType' => PASSWORD_BCRYPT
         ]);
 
         $passwordHasher = $this->auth->passwordHasher();
-        $result = $passwordHasher->config();
+        $result = $passwordHasher->getConfig();
         $this->assertEquals(PASSWORD_BCRYPT, $result['hashType']);
 
         $hash = password_hash('mypass', PASSWORD_BCRYPT);
@@ -395,7 +395,7 @@ class FormAuthenticateTest extends TestCase
             'fields' => ['username' => 'username', 'password' => 'password'],
             'userModel' => 'Users'
         ]);
-        $this->auth->config('passwordHasher', [
+        $this->auth->setConfig('passwordHasher', [
             'className' => 'Default'
         ]);
         $this->assertEquals($expected, $this->auth->authenticate($request, $this->response));

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -39,7 +39,7 @@ class PasswordHasherFactoryTest extends TestCase
             'hashOptions' => ['foo' => 'bar']
         ]);
         $this->assertInstanceof('Cake\Auth\DefaultPasswordHasher', $hasher);
-        $this->assertEquals(['foo' => 'bar'], $hasher->config('hashOptions'));
+        $this->assertEquals(['foo' => 'bar'], $hasher->getConfig('hashOptions'));
 
         Plugin::load('TestPlugin');
         $hasher = PasswordHasherFactory::build('TestPlugin.Legacy');

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -58,12 +58,12 @@ class WeakPasswordHasherTest extends TestCase
     public function testHashAndCheck()
     {
         $hasher = new WeakPasswordHasher();
-        $hasher->config('hashType', 'md5');
+        $hasher->setConfig('hashType', 'md5');
         $password = $hasher->hash('foo');
         $this->assertTrue($hasher->check('foo', $password));
         $this->assertFalse($hasher->check('bar', $password));
 
-        $hasher->config('hashType', 'sha1');
+        $hasher->setConfig('hashType', 'sha1');
         $this->assertFalse($hasher->check('foo', $password));
     }
 }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -411,6 +411,28 @@ class CacheTest extends TestCase
     /**
      * Test reading configuration.
      *
+     * @group deprecated
+     * @return void
+     */
+    public function testConfigReadCompat()
+    {
+        $this->deprecated(function () {
+            $config = [
+                'engine' => 'File',
+                'path' => TMP,
+                'prefix' => 'cake_'
+            ];
+            Cache::config('tests', $config);
+            $expected = $config;
+            $expected['className'] = $config['engine'];
+            unset($expected['engine']);
+            $this->assertEquals($expected, Cache::config('tests'));
+        });
+    }
+
+    /**
+     * Test reading configuration.
+     *
      * @return void
      */
     public function testConfigRead()
@@ -424,7 +446,7 @@ class CacheTest extends TestCase
         $expected = $config;
         $expected['className'] = $config['engine'];
         unset($expected['engine']);
-        $this->assertEquals($expected, Cache::config('tests'));
+        $this->assertEquals($expected, Cache::getConfig('tests'));
     }
 
     /**
@@ -453,7 +475,7 @@ class CacheTest extends TestCase
     public function testGroupConfigs()
     {
         Cache::drop('test');
-        Cache::config('latest', [
+        Cache::setConfig('latest', [
             'duration' => 300,
             'engine' => 'File',
             'groups' => ['posts', 'comments'],
@@ -470,7 +492,7 @@ class CacheTest extends TestCase
         $result = Cache::groupConfigs('posts');
         $this->assertEquals(['posts' => ['latest']], $result);
 
-        Cache::config('page', [
+        Cache::setConfig('page', [
             'duration' => 86400,
             'engine' => 'File',
             'groups' => ['posts', 'archive'],
@@ -706,7 +728,7 @@ class CacheTest extends TestCase
         Cache::clear(false, 'test_cache_disable_1');
 
         Cache::disable();
-        Cache::config('test_cache_disable_2', [
+        Cache::setConfig('test_cache_disable_2', [
             'engine' => 'File',
             'path' => TMP . 'tests'
         ]);
@@ -734,11 +756,11 @@ class CacheTest extends TestCase
      */
     public function testClearAll()
     {
-        Cache::config('configTest', [
+        Cache::setConfig('configTest', [
             'engine' => 'File',
             'path' => TMP . 'tests'
         ]);
-        Cache::config('anotherConfigTest', [
+        Cache::setConfig('anotherConfigTest', [
             'engine' => 'File',
             'path' => TMP . 'tests'
         ]);

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -69,7 +69,7 @@ class ApcuEngineTest extends TestCase
             'warnOnWriteFailures' => true,
         ];
         Cache::drop('apcu');
-        Cache::config('apcu', array_merge($defaults, $config));
+        Cache::setConfig('apcu', array_merge($defaults, $config));
     }
 
     /**
@@ -104,7 +104,7 @@ class ApcuEngineTest extends TestCase
     public function testReadWriteDurationZero()
     {
         Cache::drop('apcu');
-        Cache::config('apcu', ['engine' => 'Apcu', 'duration' => 0, 'prefix' => 'cake_']);
+        Cache::setConfig('apcu', ['engine' => 'Apcu', 'duration' => 0, 'prefix' => 'cake_']);
         Cache::write('zero', 'Should save', 'apcu');
         sleep(1);
 
@@ -220,7 +220,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testGroupsReadWrite()
     {
-        Cache::config('apcu_groups', [
+        Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -248,7 +248,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('apcu_groups', [
+        Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -269,7 +269,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('apcu_groups', [
+        Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -65,7 +65,7 @@ class FileEngineTest extends TestCase
             'path' => TMP . 'tests',
         ];
         Cache::drop('file_test');
-        Cache::config('file_test', array_merge($defaults, $config));
+        Cache::setConfig('file_test', array_merge($defaults, $config));
     }
 
     /**
@@ -331,7 +331,7 @@ class FileEngineTest extends TestCase
      */
     public function testRemoveWindowsSlashesFromCache()
     {
-        Cache::config('windows_test', [
+        Cache::setConfig('windows_test', [
             'engine' => 'File',
             'isWindows' => true,
             'prefix' => null,
@@ -388,7 +388,7 @@ class FileEngineTest extends TestCase
         $this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
 
         Cache::drop('file_test');
-        Cache::config('file_test', [
+        Cache::setConfig('file_test', [
             'className' => 'File',
             'isWindows' => true,
             'path' => TMP . 'tests'
@@ -412,7 +412,7 @@ class FileEngineTest extends TestCase
         $dir = TMP . 'tests/autocreate-' . microtime(true);
 
         Cache::drop('file_test');
-        Cache::config('file_test', [
+        Cache::setConfig('file_test', [
             'engine' => 'File',
             'path' => $dir
         ]);
@@ -435,7 +435,7 @@ class FileEngineTest extends TestCase
         $dir = TMP . 'tests/autocreate-' . microtime(true);
 
         Cache::drop('file_test');
-        Cache::config('file_test', [
+        Cache::setConfig('file_test', [
             'engine' => 'File',
             'path' => $dir
         ]);
@@ -457,7 +457,7 @@ class FileEngineTest extends TestCase
         if (DS === '\\') {
             $this->markTestSkipped('File permission testing does not work on Windows.');
         }
-        Cache::config('mask_test', ['engine' => 'File', 'path' => TMP . 'tests']);
+        Cache::setConfig('mask_test', ['engine' => 'File', 'path' => TMP . 'tests']);
         $data = 'This is some test content';
         $write = Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
@@ -466,7 +466,7 @@ class FileEngineTest extends TestCase
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
-        Cache::config('mask_test', ['engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests']);
+        Cache::setConfig('mask_test', ['engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests']);
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0666';
@@ -474,7 +474,7 @@ class FileEngineTest extends TestCase
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
-        Cache::config('mask_test', ['engine' => 'File', 'mask' => 0644, 'path' => TMP . 'tests']);
+        Cache::setConfig('mask_test', ['engine' => 'File', 'mask' => 0644, 'path' => TMP . 'tests']);
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0644';
@@ -482,7 +482,7 @@ class FileEngineTest extends TestCase
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
-        Cache::config('mask_test', ['engine' => 'File', 'mask' => 0640, 'path' => TMP . 'tests']);
+        Cache::setConfig('mask_test', ['engine' => 'File', 'mask' => 0640, 'path' => TMP . 'tests']);
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0640';
@@ -498,7 +498,7 @@ class FileEngineTest extends TestCase
      */
     public function testGroupsReadWrite()
     {
-        Cache::config('file_groups', [
+        Cache::setConfig('file_groups', [
             'engine' => 'File',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']
@@ -517,7 +517,7 @@ class FileEngineTest extends TestCase
      */
     public function testClearingWithRepeatWrites()
     {
-        Cache::config('repeat', [
+        Cache::setConfig('repeat', [
             'engine' => 'File',
             'groups' => ['users']
         ]);
@@ -547,7 +547,7 @@ class FileEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('file_groups', [
+        Cache::setConfig('file_groups', [
             'engine' => 'File',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']
@@ -566,17 +566,17 @@ class FileEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('file_groups', [
+        Cache::setConfig('file_groups', [
             'engine' => 'File',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']
         ]);
-        Cache::config('file_groups2', [
+        Cache::setConfig('file_groups2', [
             'engine' => 'File',
             'duration' => 3600,
             'groups' => ['group_b']
         ]);
-        Cache::config('file_groups3', [
+        Cache::setConfig('file_groups3', [
             'engine' => 'File',
             'duration' => 3600,
             'groups' => ['group_b'],
@@ -609,7 +609,7 @@ class FileEngineTest extends TestCase
      */
     public function testGroupClearNoPrefix()
     {
-        Cache::config('file_groups', [
+        Cache::setConfig('file_groups', [
             'className' => 'File',
             'duration' => 3600,
             'prefix' => '',

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -58,7 +58,7 @@ class MemcachedEngineTest extends TestCase
             'duration' => 3600
         ];
         Cache::drop('memcached');
-        Cache::config('memcached', array_merge($defaults, $config));
+        Cache::setConfig('memcached', array_merge($defaults, $config));
     }
 
     /**
@@ -85,7 +85,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testConfig()
     {
-        $config = Cache::engine('memcached')->config();
+        $config = Cache::engine('memcached')->getConfig();
         unset($config['path']);
         $expecting = [
             'prefix' => 'cake_',
@@ -386,7 +386,7 @@ class MemcachedEngineTest extends TestCase
         $Memcached = new MemcachedEngine();
         $Memcached->init(['engine' => 'Memcached', 'servers' => $servers]);
 
-        $config = $Memcached->config();
+        $config = $Memcached->getConfig();
         $this->assertEquals($config['servers'], $servers);
         Cache::drop('dual_server');
     }
@@ -648,7 +648,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testDecrementCompressedKeys()
     {
-        Cache::config('compressed_memcached', [
+        Cache::setConfig('compressed_memcached', [
             'engine' => 'Memcached',
             'duration' => '+2 seconds',
             'servers' => ['127.0.0.1:11211'],
@@ -725,7 +725,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testIncrementCompressedKeys()
     {
-        Cache::config('compressed_memcached', [
+        Cache::setConfig('compressed_memcached', [
             'engine' => 'Memcached',
             'duration' => '+2 seconds',
             'servers' => ['127.0.0.1:11211'],
@@ -757,12 +757,12 @@ class MemcachedEngineTest extends TestCase
      */
     public function testConfigurationConflict()
     {
-        Cache::config('long_memcached', [
+        Cache::setConfig('long_memcached', [
             'engine' => 'Memcached',
             'duration' => '+3 seconds',
             'servers' => ['127.0.0.1:11211'],
         ]);
-        Cache::config('short_memcached', [
+        Cache::setConfig('short_memcached', [
             'engine' => 'Memcached',
             'duration' => '+2 seconds',
             'servers' => ['127.0.0.1:11211'],
@@ -792,7 +792,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testClear()
     {
-        Cache::config('memcached2', [
+        Cache::setConfig('memcached2', [
             'engine' => 'Memcached',
             'prefix' => 'cake2_',
             'duration' => 3600
@@ -836,13 +836,13 @@ class MemcachedEngineTest extends TestCase
      */
     public function testGroupReadWrite()
     {
-        Cache::config('memcached_groups', [
+        Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b'],
             'prefix' => 'test_'
         ]);
-        Cache::config('memcached_helper', [
+        Cache::setConfig('memcached_helper', [
             'engine' => 'Memcached',
             'duration' => 3600,
             'prefix' => 'test_'
@@ -868,7 +868,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('memcached_groups', [
+        Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']
@@ -887,7 +887,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('memcached_groups', [
+        Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -72,7 +72,7 @@ class RedisEngineTest extends TestCase
             'duration' => 3600
         ];
         Cache::drop('redis');
-        Cache::config('redis', array_merge($defaults, $config));
+        Cache::setConfig('redis', array_merge($defaults, $config));
     }
 
     /**
@@ -82,7 +82,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConfig()
     {
-        $config = Cache::engine('redis')->config();
+        $config = Cache::engine('redis')->getConfig();
         $expecting = [
             'prefix' => 'cake_',
             'duration' => 3600,
@@ -107,11 +107,11 @@ class RedisEngineTest extends TestCase
      */
     public function testConfigDsn()
     {
-        Cache::config('redis_dsn', [
+        Cache::setConfig('redis_dsn', [
             'url' => 'redis://localhost:6379?database=1&prefix=redis_'
         ]);
 
-        $config = Cache::engine('redis_dsn')->config();
+        $config = Cache::engine('redis_dsn')->getConfig();
         $expecting = [
             'prefix' => 'redis_',
             'duration' => 3600,
@@ -140,7 +140,7 @@ class RedisEngineTest extends TestCase
     public function testConnect()
     {
         $Redis = new RedisEngine();
-        $this->assertTrue($Redis->init(Cache::engine('redis')->config()));
+        $this->assertTrue($Redis->init(Cache::engine('redis')->getConfig()));
     }
 
     /**
@@ -150,14 +150,14 @@ class RedisEngineTest extends TestCase
      */
     public function testMultiDatabaseOperations()
     {
-        Cache::config('redisdb0', [
+        Cache::setConfig('redisdb0', [
             'engine' => 'Redis',
             'prefix' => 'cake2_',
             'duration' => 3600,
             'persistent' => false,
         ]);
 
-        Cache::config('redisdb1', [
+        Cache::setConfig('redisdb1', [
             'engine' => 'Redis',
             'database' => 1,
             'prefix' => 'cake2_',
@@ -388,7 +388,7 @@ class RedisEngineTest extends TestCase
      */
     public function testClear()
     {
-        Cache::config('redis2', [
+        Cache::setConfig('redis2', [
             'engine' => 'Redis',
             'prefix' => 'cake2_',
             'duration' => 3600
@@ -432,13 +432,13 @@ class RedisEngineTest extends TestCase
      */
     public function testGroupReadWrite()
     {
-        Cache::config('redis_groups', [
+        Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b'],
             'prefix' => 'test_'
         ]);
-        Cache::config('redis_helper', [
+        Cache::setConfig('redis_helper', [
             'engine' => 'Redis',
             'duration' => 3600,
             'prefix' => 'test_'
@@ -464,7 +464,7 @@ class RedisEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('redis_groups', [
+        Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']
@@ -483,7 +483,7 @@ class RedisEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('redis_groups', [
+        Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
             'duration' => 3600,
             'groups' => ['group_a', 'group_b']

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -62,7 +62,7 @@ class WincacheEngineTest extends TestCase
             'prefix' => 'cake_'
         ];
         Cache::drop('wincache');
-        Cache::config('wincache', array_merge($defaults, $config));
+        Cache::setConfig('wincache', array_merge($defaults, $config));
     }
 
     /**
@@ -214,7 +214,7 @@ class WincacheEngineTest extends TestCase
      */
     public function testGroupsReadWrite()
     {
-        Cache::config('wincache_groups', [
+        Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -241,7 +241,7 @@ class WincacheEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('wincache_groups', [
+        Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -261,7 +261,7 @@ class WincacheEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('wincache_groups', [
+        Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -75,7 +75,7 @@ class XcacheEngineTest extends TestCase
      */
     public function testConfig()
     {
-        $config = Cache::engine('xcache')->config();
+        $config = Cache::engine('xcache')->getConfig();
         $expecting = [
             'prefix' => 'cake_',
             'duration' => 3600,

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -37,7 +37,7 @@ class XcacheEngineTest extends TestCase
             $this->markTestSkipped('Xcache is not installed or configured properly');
         }
         Cache::enable();
-        Cache::config('xcache', ['engine' => 'Xcache', 'prefix' => 'cake_']);
+        Cache::setConfig('xcache', ['engine' => 'Xcache', 'prefix' => 'cake_']);
     }
 
     /**
@@ -53,7 +53,7 @@ class XcacheEngineTest extends TestCase
             'prefix' => 'cake_',
         ];
         Cache::drop('xcache');
-        Cache::config('xcache', array_merge($defaults, $config));
+        Cache::setConfig('xcache', array_merge($defaults, $config));
     }
 
     /**
@@ -250,7 +250,7 @@ class XcacheEngineTest extends TestCase
      */
     public function testGroupsReadWrite()
     {
-        Cache::config('xcache_groups', [
+        Cache::setConfig('xcache_groups', [
             'engine' => 'Xcache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -277,7 +277,7 @@ class XcacheEngineTest extends TestCase
      */
     public function testGroupDelete()
     {
-        Cache::config('xcache_groups', [
+        Cache::setConfig('xcache_groups', [
             'engine' => 'Xcache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],
@@ -297,7 +297,7 @@ class XcacheEngineTest extends TestCase
      */
     public function testGroupClear()
     {
-        Cache::config('xcache_groups', [
+        Cache::setConfig('xcache_groups', [
             'engine' => 'Xcache',
             'duration' => 0,
             'groups' => ['group_a', 'group_b'],

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -482,7 +482,7 @@ class ConsoleIoTest extends TestCase
 
         $this->assertNotEmpty(Log::engine('stderr'));
         $engine = Log::engine('stdout');
-        $this->assertEquals(['notice', 'info', 'debug'], $engine->config('levels'));
+        $this->assertEquals(['notice', 'info', 'debug'], $engine->getConfig('levels'));
     }
 
     /**

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -73,7 +73,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadWithConfig()
     {
         $result = $this->helpers->load('Simple', ['key' => 'value']);
-        $this->assertEquals('value', $result->config('key'));
+        $this->assertEquals('value', $result->getConfig('key'));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -215,8 +215,8 @@ class AuthComponentTest extends TestCase
         $Users = TableRegistry::get('Users');
         $user = $Users->find('all')->hydrate(false)->first();
         $this->Controller->Auth->storage()->write($user);
-        $this->Controller->Auth->config('userModel', 'Users');
-        $this->Controller->Auth->config('authorize', false);
+        $this->Controller->Auth->setConfig('userModel', 'Users');
+        $this->Controller->Auth->setConfig('authorize', false);
         $this->Controller->request->addParams(['controller' => 'AuthTest', 'action' => 'add']);
         $result = $this->Controller->Auth->startup($event);
         $this->assertNull($result);
@@ -240,7 +240,7 @@ class AuthComponentTest extends TestCase
      */
     public function testIsAuthorizedMissingFile()
     {
-        $this->Controller->Auth->config('authorize', 'Missing');
+        $this->Controller->Auth->setConfig('authorize', 'Missing');
         $this->Controller->Auth->isAuthorized(['User' => ['id' => 1]]);
     }
 
@@ -323,7 +323,7 @@ class AuthComponentTest extends TestCase
             ->setMethods(['authorize'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->Auth->config('authorize', ['AuthMockFour']);
+        $this->Auth->setConfig('authorize', ['AuthMockFour']);
         $this->Auth->setAuthorizeObject(0, $AuthMockFourAuthorize);
 
         $user = ['user' => 'mark'];
@@ -345,7 +345,7 @@ class AuthComponentTest extends TestCase
      */
     public function testLoadAuthorizeResets()
     {
-        $this->Controller->Auth->config('authorize', ['Controller']);
+        $this->Controller->Auth->setConfig('authorize', ['Controller']);
         $result = $this->Controller->Auth->constructAuthorize();
         $this->assertCount(1, $result);
 
@@ -361,7 +361,7 @@ class AuthComponentTest extends TestCase
      */
     public function testLoadAuthenticateNoFile()
     {
-        $this->Controller->Auth->config('authenticate', 'Missing');
+        $this->Controller->Auth->setConfig('authenticate', 'Missing');
         $this->Controller->Auth->identify($this->Controller->request, $this->Controller->response);
     }
 
@@ -372,13 +372,13 @@ class AuthComponentTest extends TestCase
      */
     public function testAllConfigWithAuthorize()
     {
-        $this->Controller->Auth->config('authorize', [
+        $this->Controller->Auth->setConfig('authorize', [
             AuthComponent::ALL => ['actionPath' => 'controllers/'],
             'Controller',
         ]);
         $objects = array_values($this->Controller->Auth->constructAuthorize());
         $result = $objects[0];
-        $this->assertEquals('controllers/', $result->config('actionPath'));
+        $this->assertEquals('controllers/', $result->getConfig('actionPath'));
     }
 
     /**
@@ -388,7 +388,7 @@ class AuthComponentTest extends TestCase
      */
     public function testLoadAuthenticateResets()
     {
-        $this->Controller->Auth->config('authenticate', ['Form']);
+        $this->Controller->Auth->setConfig('authenticate', ['Form']);
         $result = $this->Controller->Auth->constructAuthenticate();
         $this->assertCount(1, $result);
 
@@ -403,13 +403,13 @@ class AuthComponentTest extends TestCase
      */
     public function testAllConfigWithAuthenticate()
     {
-        $this->Controller->Auth->config('authenticate', [
+        $this->Controller->Auth->setConfig('authenticate', [
             AuthComponent::ALL => ['userModel' => 'AuthUsers'],
             'Form'
         ]);
         $objects = array_values($this->Controller->Auth->constructAuthenticate());
         $result = $objects[0];
-        $this->assertEquals('AuthUsers', $result->config('userModel'));
+        $this->assertEquals('AuthUsers', $result->getConfig('userModel'));
     }
 
     /**
@@ -419,7 +419,7 @@ class AuthComponentTest extends TestCase
      */
     public function testSameAuthenticateWithDifferentHashers()
     {
-        $this->Controller->Auth->config('authenticate', [
+        $this->Controller->Auth->setConfig('authenticate', [
             'FormSimple' => ['className' => 'Form', 'passwordHasher' => 'Default'],
             'FormBlowfish' => ['className' => 'Form', 'passwordHasher' => 'Fallback'],
         ]);
@@ -590,14 +590,14 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->url = 'users/login';
         $this->Auth->request->env('HTTP_REFERER', false);
 
-        $this->Auth->config('loginRedirect', [
+        $this->Auth->setConfig('loginRedirect', [
             'controller' => 'pages',
             'action' => 'display',
             'welcome'
         ]);
         $event = new Event('Controller.startup', $this->Controller);
         $this->Auth->startup($event);
-        $expected = Router::normalize($this->Auth->config('loginRedirect'));
+        $expected = Router::normalize($this->Auth->getConfig('loginRedirect'));
         $this->assertEquals($expected, $this->Auth->redirectUrl());
 
         $this->Auth->session->delete('Auth');
@@ -611,9 +611,9 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->addParams(['controller' => 'Posts', 'action' => 'view', 'pass' => [1]]);
         $this->Auth->request->here = $url;
 
-        $this->Auth->config('authorize', 'controller');
+        $this->Auth->setConfig('authorize', 'controller');
 
-        $this->Auth->config('loginAction', [
+        $this->Auth->setConfig('loginAction', [
             'controller' => 'AuthTest', 'action' => 'login'
         ]);
         $event = new Event('Controller.startup', $this->Controller);
@@ -629,7 +629,7 @@ class AuthComponentTest extends TestCase
         $url = '/posts/view/1';
         $this->Auth->request->addParams(['controller' => 'Posts', 'action' => 'view', 'pass' => [1]]);
         $this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-        $this->Auth->config('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -653,7 +653,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->env('HTTP_REFERER', Router::url('/foo/bar', true));
         $this->Auth->request->env('REQUEST_METHOD', 'POST');
         $this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-        $this->Auth->config('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -676,7 +676,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->addParams(['controller' => 'Posts', 'action' => 'view', 'pass' => [1]]);
         $this->Auth->request->env('REQUEST_METHOD', 'POST');
         $this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-        $this->Auth->config('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -701,7 +701,7 @@ class AuthComponentTest extends TestCase
             'refer' => 'menu'
         ];
 
-        $this->Auth->config('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -725,7 +725,7 @@ class AuthComponentTest extends TestCase
         ];
 
         $this->Auth->session->delete('Auth');
-        $this->Auth->config('loginAction', '/auth_test/login/passed-param?a=b');
+        $this->Auth->setConfig('loginAction', '/auth_test/login/passed-param?a=b');
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -756,7 +756,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->addParams(['controller' => 'Posts', 'action' => 'add']);
         $this->Auth->request->url = Router::normalize($url);
 
-        $this->Auth->config('loginAction', ['controller' => 'Users', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'Users', 'action' => 'login']);
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
 
@@ -782,14 +782,14 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->url = 'auth_test/login';
 
         $this->Auth->session->write('Auth.User.id', '1');
-        $this->Auth->config('authenticate', ['Form']);
+        $this->Auth->setConfig('authenticate', ['Form']);
         $this->getMockBuilder(BaseAuthorize::class)
             ->setMethods(['authorize'])
             ->disableOriginalConstructor()
             ->setMockClassName('NoLoginRedirectMockAuthorize')
             ->getMock();
-        $this->Auth->config('authorize', ['NoLoginRedirectMockAuthorize']);
-        $this->Auth->config('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
+        $this->Auth->setConfig('authorize', ['NoLoginRedirectMockAuthorize']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
 
         $event = new Event('Controller.startup', $this->Controller);
         $return = $this->Auth->startup($event);
@@ -815,9 +815,9 @@ class AuthComponentTest extends TestCase
         ]);
         Router::pushRequest($request);
 
-        $this->Auth->config('authorize', ['Controller']);
+        $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'mariano', 'password' => 'cake']);
-        $this->Auth->config('loginRedirect', [
+        $this->Auth->setConfig('loginRedirect', [
             'controller' => 'something',
             'action' => 'else'
         ]);
@@ -855,11 +855,11 @@ class AuthComponentTest extends TestCase
             'session' => $this->Auth->session
         ]);
         $this->Auth->request->addParams(['controller' => 'Party', 'action' => 'on']);
-        $this->Auth->config('authorize', ['Controller']);
+        $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'admad', 'password' => 'cake']);
 
         $expected = ['controller' => 'no_can_do', 'action' => 'jack'];
-        $this->Auth->config('unauthorizedRedirect', $expected);
+        $this->Auth->setConfig('unauthorizedRedirect', $expected);
 
         $response = new Response();
         $Controller = $this->getMockBuilder('Cake\Controller\Controller')
@@ -896,11 +896,11 @@ class AuthComponentTest extends TestCase
             'session' => $this->Auth->session
         ]);
         $this->Auth->request->addParams(['controller' => 'Party', 'action' => 'on']);
-        $this->Auth->config('authorize', ['Controller']);
+        $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'admad', 'password' => 'cake']);
 
-        $this->Auth->config('unauthorizedRedirect', true);
-        $this->Auth->config('loginAction', '/users/login');
+        $this->Auth->setConfig('unauthorizedRedirect', true);
+        $this->Auth->setConfig('loginAction', '/users/login');
 
         $response = new Response();
         $Controller = $this->getMockBuilder('Cake\Controller\Controller')
@@ -931,11 +931,11 @@ class AuthComponentTest extends TestCase
             ->getMock();
         $this->Auth->request = $Request = new ServerRequest($url);
         $this->Auth->request->addParams(['controller' => 'Party', 'action' => 'on']);
-        $this->Auth->config('authorize', ['Controller']);
+        $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'admad', 'password' => 'cake']);
         $expected = ['controller' => 'no_can_do', 'action' => 'jack'];
-        $this->Auth->config('unauthorizedRedirect', $expected);
-        $this->Auth->config('authError', false);
+        $this->Auth->setConfig('unauthorizedRedirect', $expected);
+        $this->Auth->setConfig('authError', false);
 
         $Response = new Response();
         $Controller = $this->getMockBuilder('Cake\Controller\Controller')
@@ -966,7 +966,7 @@ class AuthComponentTest extends TestCase
         $url = '/party/on';
         $this->Auth->request = $request = new ServerRequest($url);
         $this->Auth->request->addParams(['controller' => 'Party', 'action' => 'on']);
-        $this->Auth->config([
+        $this->Auth->setConfig([
             'authorize' => ['Controller'],
             'unauthorizedRedirect' => false
         ]);
@@ -999,7 +999,7 @@ class AuthComponentTest extends TestCase
         $url = '/AuthTest/login';
         $this->Auth->request = $controller->request = new ServerRequest($url);
         $this->Auth->request->addParams(['controller' => 'AuthTest', 'action' => 'login']);
-        $this->Auth->config([
+        $this->Auth->setConfig([
             'loginAction', ['controller' => 'AuthTest', 'action' => 'login'],
             'authorize', ['Controller']
         ]);
@@ -1050,7 +1050,7 @@ class AuthComponentTest extends TestCase
 
         Router::setRequestInfo($this->Auth->request);
 
-        $this->Auth->config('loginAction', [
+        $this->Auth->setConfig('loginAction', [
             'prefix' => 'admin',
             'controller' => 'auth_test',
             'action' => 'login'
@@ -1082,7 +1082,7 @@ class AuthComponentTest extends TestCase
         $this->Controller->request->params['action'] = 'add';
 
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Auth->config('ajaxLogin', 'test_element');
+        $this->Auth->setConfig('ajaxLogin', 'test_element');
         $this->Auth->RequestHandler->ajaxLayout = 'ajax2';
 
         $response = $this->Auth->startup($event);
@@ -1150,7 +1150,7 @@ class AuthComponentTest extends TestCase
         $request->url = ltrim($url, '/');
         Router::setRequestInfo($request);
 
-        $this->Auth->config('loginAction', [
+        $this->Auth->setConfig('loginAction', [
             'prefix' => 'admin',
             'controller' => 'auth_test',
             'action' => 'login'
@@ -1175,10 +1175,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->env('PHP_AUTH_USER', 'mariano');
         $this->Auth->request->env('PHP_AUTH_PW', 'cake');
 
-        $this->Auth->config('authenticate', [
+        $this->Auth->setConfig('authenticate', [
             'Basic' => ['userModel' => 'AuthUsers']
         ]);
-        $this->Auth->config('storage', 'Memory');
+        $this->Auth->setConfig('storage', 'Memory');
         $this->Auth->startup($event);
 
         $result = $this->Auth->user();
@@ -1201,7 +1201,7 @@ class AuthComponentTest extends TestCase
      */
     public function testComponentSettings()
     {
-        $this->Auth->config([
+        $this->Auth->setConfig([
             'loginAction' => ['controller' => 'people', 'action' => 'login'],
             'logoutRedirect' => ['controller' => 'people', 'action' => 'login'],
         ]);
@@ -1212,11 +1212,11 @@ class AuthComponentTest extends TestCase
         ];
         $this->assertEquals(
             $expected['loginAction'],
-            $this->Auth->config('loginAction')
+            $this->Auth->getConfig('loginAction')
         );
         $this->assertEquals(
             $expected['logoutRedirect'],
-            $this->Auth->config('logoutRedirect')
+            $this->Auth->getConfig('logoutRedirect')
         );
     }
 
@@ -1228,7 +1228,7 @@ class AuthComponentTest extends TestCase
     public function testLogout()
     {
         $this->Auth->session->write('Auth.User.id', '1');
-        $this->Auth->config('logoutRedirect', '/');
+        $this->Auth->setConfig('logoutRedirect', '/');
         $result = $this->Auth->logout();
 
         $this->assertEquals('/', $result);
@@ -1242,7 +1242,7 @@ class AuthComponentTest extends TestCase
      */
     public function testEventTriggering()
     {
-        $this->Auth->config('authenticate', [
+        $this->Auth->setConfig('authenticate', [
             'Test' => ['className' => 'TestApp\Auth\TestAuthenticate']
         ]);
 
@@ -1280,10 +1280,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->request->env('PHP_AUTH_USER', 'mariano');
         $this->Auth->request->env('PHP_AUTH_PW', 'cake');
 
-        $this->Auth->config('authenticate', [
+        $this->Auth->setConfig('authenticate', [
             'Basic' => ['userModel' => 'AuthUsers']
         ]);
-        $this->Auth->config('storage', 'Memory');
+        $this->Auth->setConfig('storage', 'Memory');
 
         EventManager::instance()->on('Auth.afterIdentify', function (Event $event) {
             $user = $event->getData(0);
@@ -1368,12 +1368,12 @@ class AuthComponentTest extends TestCase
             ->method('set')
             ->with('Auth failure', ['key' => 'auth-key', 'element' => 'custom']);
 
-        $this->Auth->config('flash', [
+        $this->Auth->setConfig('flash', [
             'key' => 'auth-key'
         ]);
         $this->Auth->flash('Auth failure');
 
-        $this->Auth->config('flash', [
+        $this->Auth->setConfig('flash', [
             'key' => 'auth-key',
             'element' => 'custom'
         ], false);
@@ -1399,7 +1399,7 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectQueryStringRead()
     {
-        $this->Auth->config('loginAction', ['controller' => 'users', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'users', 'action' => 'login']);
         $this->Auth->request->query = ['redirect' => '/users/custom'];
 
         $result = $this->Auth->redirectUrl();
@@ -1432,7 +1432,7 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectQueryStringReadEqualToLoginAction()
     {
-        $this->Auth->config([
+        $this->Auth->setConfig([
             'loginAction' => ['controller' => 'users', 'action' => 'login'],
             'loginRedirect' => ['controller' => 'users', 'action' => 'home']
         ]);
@@ -1450,7 +1450,7 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectQueryStringInvalid()
     {
-        $this->Auth->config([
+        $this->Auth->setConfig([
             'loginAction' => ['controller' => 'users', 'action' => 'login'],
             'loginRedirect' => ['controller' => 'users', 'action' => 'home']
         ]);
@@ -1488,8 +1488,8 @@ class AuthComponentTest extends TestCase
 
         Router::setRequestInfo($this->Auth->request);
 
-        $this->Auth->config('loginAction', ['controller' => 'users', 'action' => 'login']);
-        $this->Auth->config('loginRedirect', ['controller' => 'users', 'action' => 'home']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'users', 'action' => 'login']);
+        $this->Auth->setConfig('loginRedirect', ['controller' => 'users', 'action' => 'home']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/home', $result);
@@ -1550,7 +1550,7 @@ class AuthComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $_SESSION = [];
 
-        $this->Auth->config('authenticate', ['Basic']);
+        $this->Auth->setConfig('authenticate', ['Basic']);
         $this->Controller->request['action'] = 'add';
 
         $result = $this->Auth->startup($event);
@@ -1591,7 +1591,7 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->sessionKey = 'Auth.Member';
         $this->assertEquals('Auth.Member', $this->Auth->sessionKey);
-        $this->assertEquals('Auth.Member', $this->Auth->storage()->config('key'));
+        $this->assertEquals('Auth.Member', $this->Auth->storage()->getConfig('key'));
 
         $this->Auth->sessionKey = false;
         $this->assertInstanceOf('Cake\Auth\Storage\MemoryStorage', $this->Auth->storage());
@@ -1613,7 +1613,7 @@ class AuthComponentTest extends TestCase
         $this->assertEquals('Controller.startup', $this->Auth->authCheckCalledFrom);
 
         $this->Auth->authCheckCalledFrom = null;
-        $this->Auth->config('checkAuthIn', 'Controller.initialize');
+        $this->Auth->setConfig('checkAuthIn', 'Controller.initialize');
         $this->Controller->startupProcess();
         $this->assertEquals('Controller.initialize', $this->Auth->authCheckCalledFrom);
     }

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -50,7 +50,7 @@ class CookieComponentTest extends TestCase
         $this->Cookie = $controller->Cookie;
         $this->request = $controller->request;
 
-        $this->Cookie->config([
+        $this->Cookie->setConfig([
             'expires' => '+10 seconds',
             'path' => '/',
             'domain' => '',
@@ -112,7 +112,7 @@ class CookieComponentTest extends TestCase
      */
     public function testSettingsCompatibility()
     {
-        $this->Cookie->config([
+        $this->Cookie->setConfig([
             'expires' => '+10 seconds',
             'path' => '/',
             'domain' => '',
@@ -154,8 +154,8 @@ class CookieComponentTest extends TestCase
             'path' => '/'
         ];
         $Cookie = new CookieComponent(new ComponentRegistry(), $settings);
-        $this->assertEquals($Cookie->config('time'), $settings['time']);
-        $this->assertEquals($Cookie->config('path'), $settings['path']);
+        $this->assertEquals($Cookie->getConfig('time'), $settings['time']);
+        $this->assertEquals($Cookie->getConfig('path'), $settings['path']);
     }
 
     /**
@@ -170,7 +170,7 @@ class CookieComponentTest extends TestCase
         $this->request->cookies = [
             'Test' => $this->_encrypt('value'),
         ];
-        $this->Cookie->config('encryption', 'derp');
+        $this->Cookie->setConfig('encryption', 'derp');
         $this->Cookie->read('Test');
     }
 
@@ -250,7 +250,7 @@ class CookieComponentTest extends TestCase
      */
     public function testWriteInvalidCipher()
     {
-        $this->Cookie->config('encryption', 'derp');
+        $this->Cookie->setConfig('encryption', 'derp');
         $this->Cookie->write('Test', 'nope');
     }
 
@@ -275,7 +275,7 @@ class CookieComponentTest extends TestCase
      */
     public function testWriteWithFalseyValue()
     {
-        $this->Cookie->config([
+        $this->Cookie->setConfig([
             'encryption' => 'aes',
             'key' => 'qSI232qs*&sXOw!adre@34SAv!@*(XSL#$%)asGb$@11~_+!@#HKis~#^',
         ]);
@@ -339,7 +339,7 @@ class CookieComponentTest extends TestCase
      */
     public function testWriteHttpOnly()
     {
-        $this->Cookie->config([
+        $this->Cookie->setConfig([
             'httpOnly' => true,
             'secure' => false
         ]);
@@ -431,7 +431,7 @@ class CookieComponentTest extends TestCase
      */
     public function testDeleteHttpOnly()
     {
-        $this->Cookie->config([
+        $this->Cookie->setConfig([
             'httpOnly' => true,
             'secure' => false
         ]);
@@ -808,6 +808,6 @@ class CookieComponentTest extends TestCase
             $value = $this->_implode($value);
         }
 
-        return 'Q2FrZQ==.' . base64_encode(Security::encrypt($value, $this->Cookie->config('key')));
+        return 'Q2FrZQ==.' . base64_encode(Security::encrypt($value, $this->Cookie->getConfig('key')));
     }
 }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -113,7 +113,7 @@ class FlashComponentTest extends TestCase
     {
         $this->assertNull($this->Session->read('Flash.flash'));
 
-        $this->Flash->config('duplicate', false);
+        $this->Flash->setConfig('duplicate', false);
         $this->Flash->set('This test message should appear once only');
         $this->Flash->set('This test message should appear once only');
         $result = $this->Session->read('Flash.flash');

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -1270,7 +1270,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateQueryWithBindValue()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
         $this->loadFixtures('Posts');
         $table = TableRegistry::get('PaginatorPosts');

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -116,7 +116,7 @@ class RequestHandlerComponentTest extends TestCase
             ->getMock();
         $collection = new ComponentRegistry($controller);
         $requestHandler = new RequestHandlerComponent($collection, $config);
-        $this->assertEquals(['json' => 'MyPlugin.MyJson'], $requestHandler->config('viewClassMap'));
+        $this->assertEquals(['json' => 'MyPlugin.MyJson'], $requestHandler->getConfig('viewClassMap'));
     }
 
     /**
@@ -378,7 +378,7 @@ class RequestHandlerComponentTest extends TestCase
                 'json' => 'CustomJson',
                 'xml' => 'Xml',
                 'ajax' => 'Ajax'
-            ];
+    ];
             $this->assertEquals($expected, $result);
 
             $result = $this->RequestHandler->viewClassMap('xls', 'Excel.Excel');
@@ -631,7 +631,7 @@ class RequestHandlerComponentTest extends TestCase
 
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->initialize([]);
-        $this->RequestHandler->config('enableBeforeRedirect', false);
+        $this->RequestHandler->setConfig('enableBeforeRedirect', false);
         $this->RequestHandler->startup($event);
         $this->assertNull($this->RequestHandler->beforeRedirect($event, '/posts/index', $this->Controller->response));
     }
@@ -1274,7 +1274,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testConstructDefaultOptions()
     {
         $requestHandler = new RequestHandlerComponent($this->Controller->components());
-        $viewClass = $requestHandler->config('viewClassMap');
+        $viewClass = $requestHandler->getConfig('viewClassMap');
         $expected = [
             'json' => 'Json',
             'xml' => 'Xml',
@@ -1282,7 +1282,7 @@ class RequestHandlerComponentTest extends TestCase
         ];
         $this->assertEquals($expected, $viewClass);
 
-        $inputs = $requestHandler->config('inputTypeMap');
+        $inputs = $requestHandler->getConfig('inputTypeMap');
         $this->assertArrayHasKey('json', $inputs);
         $this->assertArrayHasKey('xml', $inputs);
     }
@@ -1301,13 +1301,13 @@ class RequestHandlerComponentTest extends TestCase
                 'inputTypeMap' => ['json' => ['json_decode', true]]
             ]
         );
-        $viewClass = $requestHandler->config('viewClassMap');
+        $viewClass = $requestHandler->getConfig('viewClassMap');
         $expected = [
             'json' => 'Json',
         ];
         $this->assertEquals($expected, $viewClass);
 
-        $inputs = $requestHandler->config('inputTypeMap');
+        $inputs = $requestHandler->getConfig('inputTypeMap');
         $this->assertArrayHasKey('json', $inputs);
         $this->assertCount(1, $inputs);
     }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -378,7 +378,7 @@ class RequestHandlerComponentTest extends TestCase
                 'json' => 'CustomJson',
                 'xml' => 'Xml',
                 'ajax' => 'Ajax'
-    ];
+            ];
             $this->assertEquals($expected, $result);
 
             $result = $this->RequestHandler->viewClassMap('xls', 'Excel.Excel');

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -171,7 +171,7 @@ class SecurityComponentTest extends TestCase
 
         $this->Controller = new SecurityTestController($request);
         $this->Controller->Security = $this->Controller->TestSecurity;
-        $this->Controller->Security->config('blackHoleCallback', 'fail');
+        $this->Controller->Security->setConfig('blackHoleCallback', 'fail');
         $this->Security = $this->Controller->Security;
         $this->Security->session = $session;
         Security::setSalt('foo!');
@@ -228,7 +228,7 @@ class SecurityComponentTest extends TestCase
         $Controller = new \TestApp\Controller\SomePagesController($request);
         $event = new Event('Controller.startup', $Controller);
         $Security = new SecurityComponent($Controller->components());
-        $Security->config('blackHoleCallback', '_fail');
+        $Security->setConfig('blackHoleCallback', '_fail');
         $Security->startup($event);
         $Security->blackHole($Controller, 'csrf');
     }
@@ -399,7 +399,7 @@ class SecurityComponentTest extends TestCase
     {
         $this->deprecated(function () {
             $_SERVER['REQUEST_METHOD'] = 'AUTH';
-            $this->Controller->Security->config('validatePost', false);
+            $this->Controller->Security->setConfig('validatePost', false);
 
             $event = new Event('Controller.startup', $this->Controller);
             $this->Controller->request->addParams([
@@ -908,7 +908,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostWithDisabledFields()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Security->config('disabledFields', ['Model.username', 'Model.password']);
+        $this->Security->setConfig('disabledFields', ['Model.username', 'Model.password']);
         $this->Security->startup($event);
         $fields = '0313460e1136e1227044399fe10a6edc0cbca279%3AModel.hidden';
         $unlocked = '';
@@ -1305,7 +1305,7 @@ class SecurityComponentTest extends TestCase
         $this->assertFalse($result);
 
         $this->Security->startup($event);
-        $this->Security->config('disabledFields', ['MyModel.name']);
+        $this->Security->setConfig('disabledFields', ['MyModel.name']);
 
         $this->Controller->request->data = [
             'MyModel' => ['name' => 'some data'],
@@ -1510,7 +1510,7 @@ class SecurityComponentTest extends TestCase
      */
     public function testBlackholeThrowsException()
     {
-        $this->Security->config('blackHoleCallback', '');
+        $this->Security->setConfig('blackHoleCallback', '');
         $this->Security->blackHole($this->Controller, 'auth', new SecurityException('error description'));
     }
 
@@ -1523,7 +1523,7 @@ class SecurityComponentTest extends TestCase
      */
     public function testBlackholeThrowsBadRequest()
     {
-        $this->Security->config('blackHoleCallback', '');
+        $this->Security->setConfig('blackHoleCallback', '');
         $message = '';
 
         Configure::write('debug', false);
@@ -1650,7 +1650,7 @@ class SecurityComponentTest extends TestCase
     public function testAuthRequiredThrowsExceptionTokenNotFoundPost()
     {
         $this->deprecated(function () {
-            $this->Security->config('requireAuth', ['protected']);
+            $this->Security->setConfig('requireAuth', ['protected']);
             $this->Controller->request->params['action'] = 'protected';
             $this->Controller->request->data = 'notEmpty';
             $this->Security->authRequired($this->Controller);
@@ -1671,7 +1671,7 @@ class SecurityComponentTest extends TestCase
     public function testAuthRequiredThrowsExceptionTokenNotFoundSession()
     {
         $this->deprecated(function () {
-            $this->Security->config('requireAuth', ['protected']);
+            $this->Security->setConfig('requireAuth', ['protected']);
             $this->Controller->request->params['action'] = 'protected';
             $this->Controller->request->data = ['_Token' => 'not empty'];
             $this->Security->authRequired($this->Controller);
@@ -1692,7 +1692,7 @@ class SecurityComponentTest extends TestCase
     public function testAuthRequiredThrowsExceptionControllerNotAllowed()
     {
         $this->deprecated(function () {
-            $this->Security->config('requireAuth', ['protected']);
+            $this->Security->setConfig('requireAuth', ['protected']);
             $this->Controller->request->params['controller'] = 'NotAllowed';
             $this->Controller->request->params['action'] = 'protected';
             $this->Controller->request->data = ['_Token' => 'not empty'];
@@ -1716,7 +1716,7 @@ class SecurityComponentTest extends TestCase
     public function testAuthRequiredThrowsExceptionActionNotAllowed()
     {
         $this->deprecated(function () {
-            $this->Security->config('requireAuth', ['protected']);
+            $this->Security->setConfig('requireAuth', ['protected']);
             $this->Controller->request->params['controller'] = 'NotAllowed';
             $this->Controller->request->params['action'] = 'protected';
             $this->Controller->request->data = ['_Token' => 'not empty'];
@@ -1738,7 +1738,7 @@ class SecurityComponentTest extends TestCase
     public function testAuthRequired()
     {
         $this->deprecated(function () {
-            $this->Security->config('requireAuth', ['protected']);
+            $this->Security->setConfig('requireAuth', ['protected']);
             $this->Controller->request->params['controller'] = 'Allowed';
             $this->Controller->request->params['action'] = 'protected';
             $this->Controller->request->data = ['_Token' => 'not empty'];

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -84,7 +84,7 @@ class ComponentRegistryTest extends TestCase
         $result = $this->Components->load('Cookie', ['className' => __NAMESPACE__ . '\CookieAliasComponent', 'somesetting' => true]);
         $this->assertInstanceOf(__NAMESPACE__ . '\CookieAliasComponent', $result);
         $this->assertInstanceOf(__NAMESPACE__ . '\CookieAliasComponent', $this->Components->Cookie);
-        $this->assertTrue($this->Components->Cookie->config('somesetting'));
+        $this->assertTrue($this->Components->Cookie->getConfig('somesetting'));
 
         $result = $this->Components->loaded();
         $this->assertEquals(['Cookie'], $result, 'loaded() results are wrong.');

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -187,7 +187,7 @@ class ComponentTest extends TestCase
     {
         $Component = new ConfiguredComponent(new ComponentRegistry(), ['chicken' => 'soup']);
         $this->assertEquals(['chicken' => 'soup'], $Component->configCopy);
-        $this->assertEquals(['chicken' => 'soup'], $Component->config());
+        $this->assertEquals(['chicken' => 'soup'], $Component->getConfig());
     }
 
     /**
@@ -226,7 +226,7 @@ class ComponentTest extends TestCase
         $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['Configured' => ['foo' => 'bar']]);
         $this->assertInstanceOf(ConfiguredComponent::class, $Component->Configured, 'class is wrong');
         $this->assertNotSame($Component, $Component->Configured, 'Component instance was reused');
-        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->config());
+        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->getConfig());
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -416,7 +416,7 @@ class ConfigureTest extends TestCase
     public function testStoreAndRestore()
     {
         Cache::enable();
-        Cache::config('configure', [
+        Cache::setConfig('configure', [
             'className' => 'File',
             'path' => TMP . 'tests'
         ]);
@@ -442,7 +442,7 @@ class ConfigureTest extends TestCase
     public function testStoreAndRestoreWithData()
     {
         Cache::enable();
-        Cache::config('configure', [
+        Cache::setConfig('configure', [
             'className' => 'File',
             'path' => TMP . 'tests'
         ]);

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -103,7 +103,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDefaultsAreSet()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $this->assertSame(
                 [
                     'some' => 'string',

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -103,17 +103,19 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDefaultsAreSet()
     {
-        $this->assertSame(
-            [
-                'some' => 'string',
-                'a' => [
-                    'nested' => 'value',
-                    'other' => 'value'
-                ]
-            ],
-            $this->object->config(),
-            'runtime config should match the defaults if not overridden'
-        );
+        $this->deprecated(function() {
+            $this->assertSame(
+                [
+                    'some' => 'string',
+                    'a' => [
+                        'nested' => 'value',
+                        'other' => 'value'
+                    ]
+                ],
+                $this->object->getConfig(),
+                'runtime config should match the defaults if not overridden'
+            );
+        });
     }
 
     /**
@@ -125,13 +127,13 @@ class InstanceConfigTraitTest extends TestCase
     {
         $this->assertSame(
             'string',
-            $this->object->config('some'),
+            $this->object->getConfig('some'),
             'should return the key value only'
         );
 
         $this->assertSame(
             ['nested' => 'value', 'other' => 'value'],
-            $this->object->config('a'),
+            $this->object->getConfig('a'),
             'should return the key value only'
         );
     }
@@ -145,7 +147,7 @@ class InstanceConfigTraitTest extends TestCase
     {
         $this->assertSame(
             'value',
-            $this->object->config('a.nested'),
+            $this->object->getConfig('a.nested'),
             'should return the nested value only'
         );
     }
@@ -175,17 +177,17 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetSimple()
     {
-        $this->object->config('foo', 'bar');
+        $this->object->setConfig('foo', 'bar');
         $this->assertSame(
             'bar',
-            $this->object->config('foo'),
+            $this->object->getConfig('foo'),
             'should return the same value just set'
         );
 
-        $return = $this->object->config('some', 'zum');
+        $return = $this->object->setConfig('some', 'zum');
         $this->assertSame(
             'zum',
-            $this->object->config('some'),
+            $this->object->getConfig('some'),
             'should return the overwritten value'
         );
         $this->assertSame(
@@ -200,7 +202,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -212,17 +214,17 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetNested()
     {
-        $this->object->config('new.foo', 'bar');
+        $this->object->setConfig('new.foo', 'bar');
         $this->assertSame(
             'bar',
-            $this->object->config('new.foo'),
+            $this->object->getConfig('new.foo'),
             'should return the same value just set'
         );
 
-        $this->object->config('a.nested', 'zum');
+        $this->object->setConfig('a.nested', 'zum');
         $this->assertSame(
             'zum',
-            $this->object->config('a.nested'),
+            $this->object->getConfig('a.nested'),
             'should return the overwritten value'
         );
 
@@ -232,7 +234,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'zum', 'other' => 'value'],
                 'new' => ['foo' => 'bar']
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -244,10 +246,10 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetArray()
     {
-        $this->object->config(['foo' => 'bar']);
+        $this->object->setConfig(['foo' => 'bar']);
         $this->assertSame(
             'bar',
-            $this->object->config('foo'),
+            $this->object->getConfig('foo'),
             'should return the same value just set'
         );
 
@@ -257,14 +259,14 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'updates should be merged with existing config'
         );
 
-        $this->object->config(['new.foo' => 'bar']);
+        $this->object->setConfig(['new.foo' => 'bar']);
         $this->assertSame(
             'bar',
-            $this->object->config('new.foo'),
+            $this->object->getConfig('new.foo'),
             'should return the same value just set'
         );
 
@@ -275,11 +277,11 @@ class InstanceConfigTraitTest extends TestCase
                 'foo' => 'bar',
                 'new' => ['foo' => 'bar']
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'updates should be merged with existing config'
         );
 
-        $this->object->config(['multiple' => 'different', 'a.values.to' => 'set']);
+        $this->object->setConfig(['multiple' => 'different', 'a.values.to' => 'set']);
 
         $this->assertSame(
             [
@@ -289,7 +291,7 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => ['foo' => 'bar'],
                 'multiple' => 'different'
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -309,7 +311,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['new_nested' => true],
                 'new' => 'bar'
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -323,8 +325,8 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetClobber()
     {
-        $this->object->config(['a.nested.value' => 'not possible'], null, false);
-        $result = $this->object->config();
+        $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
+        $this->object->getConfig();
     }
 
     /**
@@ -334,7 +336,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testMerge()
     {
-        $this->object->config(['a' => ['nother' => 'value']]);
+        $this->object->setConfig(['a' => ['nother' => 'value']]);
 
         $this->assertSame(
             [
@@ -345,7 +347,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'Merging should not delete untouched array values'
         );
     }
@@ -357,7 +359,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testMergeDotKey()
     {
-        $this->object->config('a.nother', 'value');
+        $this->object->setConfig('a.nother', 'value');
 
         $this->assertSame(
             [
@@ -368,11 +370,11 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'Should act the same as having passed the equivalent array to the config function'
         );
 
-        $this->object->config(['a.nextra' => 'value']);
+        $this->object->setConfig(['a.nextra' => 'value']);
 
         $this->assertSame(
             [
@@ -384,7 +386,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nextra' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'Merging should not delete untouched array values'
         );
     }
@@ -396,7 +398,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetDefaultsMerge()
     {
-        $this->object->config(['a' => ['nother' => 'value']]);
+        $this->object->setConfig(['a' => ['nother' => 'value']]);
 
         $this->assertSame(
             [
@@ -407,7 +409,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'First access should act like any subsequent access'
         );
     }
@@ -419,7 +421,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetDefaultsNoMerge()
     {
-        $this->object->config(['a' => ['nother' => 'value']], null, false);
+        $this->object->setConfig(['a' => ['nother' => 'value']], null, false);
 
         $this->assertSame(
             [
@@ -428,7 +430,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'If explicitly no-merge, array values should be overwritten'
         );
     }
@@ -443,7 +445,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetMergeNoClobber()
     {
-        $this->object->config(['a.nested.value' => 'it is possible']);
+        $this->object->setConfig(['a.nested.value' => 'it is possible']);
 
         $this->assertSame(
             [
@@ -455,7 +457,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -476,11 +478,11 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => ['nested' => 'value', 'other' => 'value']
             ],
-            $object->config(),
+            $object->getConfig(),
             'default config should be returned'
         );
 
-        $object->config('throw.me', 'an exception');
+        $object->setConfig('throw.me', 'an exception');
     }
 
     /**
@@ -490,15 +492,15 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteSimple()
     {
-        $this->object->config('foo', null);
+        $this->object->setConfig('foo', null);
         $this->assertNull(
-            $this->object->config('foo'),
+            $this->object->getConfig('foo'),
             'setting a new key to null should have no effect'
         );
 
-        $this->object->config('some', null);
+        $this->object->setConfig('some', null);
         $this->assertNull(
-            $this->object->config('some'),
+            $this->object->getConfig('some'),
             'should delete the existing value'
         );
 
@@ -506,7 +508,7 @@ class InstanceConfigTraitTest extends TestCase
             [
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'deleted keys should not be present'
         );
     }
@@ -518,15 +520,15 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteNested()
     {
-        $this->object->config('new.foo', null);
+        $this->object->setConfig('new.foo', null);
         $this->assertNull(
-            $this->object->config('new.foo'),
+            $this->object->getConfig('new.foo'),
             'setting a new key to null should have no effect'
         );
 
-        $this->object->config('a.nested', null);
+        $this->object->setConfig('a.nested', null);
         $this->assertNull(
-            $this->object->config('a.nested'),
+            $this->object->getConfig('a.nested'),
             'should delete the existing value'
         );
         $this->assertSame(
@@ -536,13 +538,13 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value'
                 ]
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'deleted keys should not be present'
         );
 
-        $this->object->config('a.other', null);
+        $this->object->setConfig('a.other', null);
         $this->assertNull(
-            $this->object->config('a.other'),
+            $this->object->getConfig('a.other'),
             'should delete the existing value'
         );
         $this->assertSame(
@@ -550,23 +552,28 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => []
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'deleted keys should not be present'
         );
     }
 
+    /**
+     * testDeleteArray
+     *
+     * @return void
+     */
     public function testDeleteArray()
     {
-        $this->object->config('a', null);
+        $this->object->setConfig('a', null);
         $this->assertNull(
-            $this->object->config('a'),
+            $this->object->getConfig('a'),
             'should delete the existing value'
         );
         $this->assertSame(
             [
                 'some' => 'string'
             ],
-            $this->object->config(),
+            $this->object->getConfig(),
             'deleted keys should not be present'
         );
     }
@@ -580,6 +587,6 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteClobber()
     {
-        $this->object->config('a.nested.value.whoops', null);
+        $this->object->setConfig('a.nested.value.whoops', null);
     }
 }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -247,30 +247,32 @@ class StaticConfigTraitTest extends TestCase
      */
     public function testCanUpdateClassMap()
     {
-        $expected = [
-            'console' => 'Cake\Log\Engine\ConsoleLog',
-            'file' => 'Cake\Log\Engine\FileLog',
-            'syslog' => 'Cake\Log\Engine\SyslogLog',
-        ];
-        $result = TestLogStaticConfig::dsnClassMap();
-        $this->assertEquals($expected, $result, 'The class map should match the class property');
+        $this->deprecated(function() {
+            $expected = [
+                'console' => 'Cake\Log\Engine\ConsoleLog',
+                'file' => 'Cake\Log\Engine\FileLog',
+                'syslog' => 'Cake\Log\Engine\SyslogLog',
+            ];
+            $result = TestLogStaticConfig::getdsnClassMap();
+            $this->assertEquals($expected, $result, 'The class map should match the class property');
 
-        $expected = [
-            'console' => 'Special\EngineLog',
-            'file' => 'Cake\Log\Engine\FileLog',
-            'syslog' => 'Cake\Log\Engine\SyslogLog',
-        ];
-        $result = TestLogStaticConfig::dsnClassMap(['console' => 'Special\EngineLog']);
-        $this->assertEquals($expected, $result, 'Should be possible to change the map');
+            $expected = [
+                'console' => 'Special\EngineLog',
+                'file' => 'Cake\Log\Engine\FileLog',
+                'syslog' => 'Cake\Log\Engine\SyslogLog',
+            ];
+            $result = TestLogStaticConfig::dsnClassMap(['console' => 'Special\EngineLog']);
+            $this->assertEquals($expected, $result, 'Should be possible to change the map');
 
-        $expected = [
-            'console' => 'Special\EngineLog',
-            'file' => 'Cake\Log\Engine\FileLog',
-            'syslog' => 'Cake\Log\Engine\SyslogLog',
-            'my' => 'Special\OtherLog'
-        ];
-        $result = TestLogStaticConfig::dsnClassMap(['my' => 'Special\OtherLog']);
-        $this->assertEquals($expected, $result, 'Should be possible to add to the map');
+            $expected = [
+                'console' => 'Special\EngineLog',
+                'file' => 'Cake\Log\Engine\FileLog',
+                'syslog' => 'Cake\Log\Engine\SyslogLog',
+                'my' => 'Special\OtherLog'
+            ];
+            $result = TestLogStaticConfig::dsnClassMap(['my' => 'Special\OtherLog']);
+            $this->assertEquals($expected, $result, 'Should be possible to add to the map');
+        });
     }
 
     /**
@@ -281,7 +283,9 @@ class StaticConfigTraitTest extends TestCase
      */
     public function testConfigBC()
     {
-        $result = TestLogStaticConfig::config(404);
-        $this->assertNull($result);
+        $this->deprecated(function() {
+            $result = TestLogStaticConfig::config(404);
+            $this->assertNull($result);
+        });
     }
 }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -247,7 +247,7 @@ class StaticConfigTraitTest extends TestCase
      */
     public function testCanUpdateClassMap()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $expected = [
                 'console' => 'Cake\Log\Engine\ConsoleLog',
                 'file' => 'Cake\Log\Engine\FileLog',
@@ -283,7 +283,7 @@ class StaticConfigTraitTest extends TestCase
      */
     public function testConfigBC()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $result = TestLogStaticConfig::config(404);
             $this->assertNull($result);
         });

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -32,7 +32,7 @@ class MysqlTest extends TestCase
     public function setup()
     {
         parent::setUp();
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
     }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -35,7 +35,7 @@ class MysqlSchemaTest extends TestCase
      */
     protected function _needsConnection()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
     }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -35,7 +35,7 @@ class PostgresSchemaTest extends TestCase
      */
     protected function _needsConnection()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -35,7 +35,7 @@ class SqliteSchemaTest extends TestCase
      */
     protected function _needsConnection()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
     }
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -34,7 +34,7 @@ class SqlserverSchemaTest extends TestCase
      */
     protected function _needsConnection()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
     }
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -99,7 +99,7 @@ class ConnectionManagerTest extends TestCase
     public function testConfigVariants($settings)
     {
         $this->assertNotContains('test_variant', ConnectionManager::configured(), 'test_variant config should not exist.');
-        ConnectionManager::config('test_variant', $settings);
+        ConnectionManager::setConfig('test_variant', $settings);
 
         $ds = ConnectionManager::get('test_variant');
         $this->assertInstanceOf(__NAMESPACE__ . '\FakeConnection', $ds);
@@ -113,7 +113,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testConfigInvalidOptions()
     {
-        ConnectionManager::config('test_variant', [
+        ConnectionManager::setConfig('test_variant', [
             'className' => 'Herp\Derp'
         ]);
         ConnectionManager::get('test_variant');
@@ -132,8 +132,8 @@ class ConnectionManagerTest extends TestCase
             'className' => __NAMESPACE__ . '\FakeConnection',
             'database' => ':memory:',
         ];
-        ConnectionManager::config('test_variant', $settings);
-        ConnectionManager::config('test_variant', $settings);
+        ConnectionManager::setConfig('test_variant', $settings);
+        ConnectionManager::setConfig('test_variant', $settings);
     }
 
     /**
@@ -155,7 +155,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGet()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
 
         $ds = ConnectionManager::get('test');
@@ -173,7 +173,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGetNoAlias()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
 
         ConnectionManager::alias('test', 'other_name');
@@ -187,7 +187,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testConfigured()
     {
-        ConnectionManager::config('test_variant', [
+        ConnectionManager::setConfig('test_variant', [
             'className' => __NAMESPACE__ . '\FakeConnection',
             'database' => ':memory:'
         ]);
@@ -205,7 +205,7 @@ class ConnectionManagerTest extends TestCase
         Plugin::load('TestPlugin');
         $name = 'test_variant';
         $config = ['className' => 'TestPlugin.TestSource', 'foo' => 'bar'];
-        ConnectionManager::config($name, $config);
+        ConnectionManager::setConfig($name, $config);
         $connection = ConnectionManager::get($name);
 
         $this->assertInstanceOf('TestPlugin\Datasource\TestSource', $connection);
@@ -220,7 +220,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testDrop()
     {
-        ConnectionManager::config('test_variant', [
+        ConnectionManager::setConfig('test_variant', [
             'className' => __NAMESPACE__ . '\FakeConnection',
             'database' => ':memory:'
         ]);
@@ -241,7 +241,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testAlias()
     {
-        ConnectionManager::config('test_variant', [
+        ConnectionManager::setConfig('test_variant', [
             'className' => __NAMESPACE__ . '\FakeConnection',
             'database' => ':memory:'
         ]);
@@ -466,7 +466,7 @@ class ConnectionManagerTest extends TestCase
     public function testConfigWithObject()
     {
         $connection = new FakeConnection;
-        ConnectionManager::config('test_variant', $connection);
+        ConnectionManager::setConfig('test_variant', $connection);
         $this->assertSame($connection, ConnectionManager::get('test_variant'));
     }
 
@@ -484,7 +484,7 @@ class ConnectionManagerTest extends TestCase
             return $connection;
         };
 
-        ConnectionManager::config('test_variant', $callable);
+        ConnectionManager::setConfig('test_variant', $callable);
         $this->assertSame($connection, ConnectionManager::get('test_variant'));
     }
 
@@ -496,7 +496,7 @@ class ConnectionManagerTest extends TestCase
     public function testSetConfigName()
     {
         //Set with explicit name
-        ConnectionManager::config('test_variant', [
+        ConnectionManager::setConfig('test_variant', [
             'className' => __NAMESPACE__ . '\FakeConnection',
             'database' => ':memory:'
         ]);
@@ -504,7 +504,7 @@ class ConnectionManagerTest extends TestCase
         $this->assertSame('test_variant', $result->configName());
 
         ConnectionManager::drop('test_variant');
-        ConnectionManager::config([
+        ConnectionManager::setConfig([
             'test_variant' => [
                 'className' => __NAMESPACE__ . '\FakeConnection',
                 'database' => ':memory:'

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -477,7 +477,7 @@ class PaginatorTest extends TestCase
             'limit' => 20,
             'maxLimit' => 100,
         ];
-        $this->Paginator->config('whitelist', ['fields']);
+        $this->Paginator->setConfig('whitelist', ['fields']);
         $defaults = $this->Paginator->getDefaults('Post', $settings);
         $result = $this->Paginator->mergeOptions($params, $defaults);
         $expected = [
@@ -1181,7 +1181,7 @@ class PaginatorTest extends TestCase
      */
     public function testPaginateQueryWithBindValue()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
         $this->loadFixtures('Posts');
         $table = TableRegistry::get('PaginatorPosts');

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -37,7 +37,7 @@ class QueryCacherTest extends TestCase
             ->method('init')
             ->will($this->returnValue(true));
 
-        Cache::config('queryCache', $this->engine);
+        Cache::setConfig('queryCache', $this->engine);
         Cache::enable();
     }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -490,7 +490,7 @@ TEXT;
         $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
             ->setMethods(['log'])
             ->getMock();
-        Log::config('test', ['engine' => $mock]);
+        Log::setConfig('test', ['engine' => $mock]);
 
         $mock->expects($this->at(0))
             ->method('log')
@@ -524,7 +524,7 @@ TEXT;
         $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
             ->setMethods(['log'])
             ->getMock();
-        Log::config('test', ['engine' => $mock]);
+        Log::setConfig('test', ['engine' => $mock]);
 
         $mock->expects($this->at(0))
             ->method('log')

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -95,7 +95,7 @@ class ErrorHandlerTest extends TestCase
         $this->_logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         Log::reset();
-        Log::config('error_test', [
+        Log::setConfig('error_test', [
             'engine' => $this->_logger
         ]);
     }

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -42,7 +42,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
         Log::reset();
-        Log::config('error_test', [
+        Log::setConfig('error_test', [
             'engine' => $this->logger
         ]);
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -38,17 +38,17 @@ class ClientTest extends TestCase
             'host' => 'example.org',
         ];
         $http = new Client($config);
-        $result = $http->config();
+        $result = $http->getConfig();
         foreach ($config as $key => $val) {
             $this->assertEquals($val, $result[$key]);
         }
 
-        $result = $http->config([
+        $result = $http->setConfig([
             'auth' => ['username' => 'mark', 'password' => 'secret']
         ]);
         $this->assertSame($result, $http);
 
-        $result = $http->config();
+        $result = $http->getConfig();
         $expected = [
             'scheme' => 'http',
             'host' => 'example.org',

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -82,7 +82,7 @@ class ConsoleLogTest extends TestCase
         $log = new ConsoleLog([
             'stream' => $output,
         ]);
-        $config = $log->config();
+        $config = $log->getConfig();
         $this->assertEquals($expected, $config['outputAs']);
     }
 }

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -38,7 +38,7 @@ class SyslogLogTest extends TestCase
         $log = $this->getMockBuilder('Cake\Log\Engine\SyslogLog')
             ->setMethods(['_open', '_write'])
             ->getMock();
-        $log->config([
+        $log->setConfig([
             'prefix' => 'thing',
             'flag' => LOG_NDELAY,
             'facility' => LOG_MAIL,

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -46,10 +46,10 @@ class LogTest extends TestCase
         static::setAppNamespace();
         Plugin::load('TestPlugin');
 
-        Log::config('libtest', [
+        Log::setConfig('libtest', [
             'engine' => 'TestApp'
         ]);
-        Log::config('plugintest', [
+        Log::setConfig('plugintest', [
             'engine' => 'TestPlugin.TestPlugin'
         ]);
 
@@ -75,7 +75,7 @@ class LogTest extends TestCase
      */
     public function testImportingLoggerFailure()
     {
-        Log::config('fail', []);
+        Log::setConfig('fail', []);
         Log::engine('fail');
     }
 
@@ -86,7 +86,7 @@ class LogTest extends TestCase
      */
     public function testValidKeyName()
     {
-        Log::config('valid', ['engine' => 'File']);
+        Log::setConfig('valid', ['engine' => 'File']);
         $stream = Log::engine('valid');
         $this->assertInstanceOf('Cake\Log\Engine\FileLog', $stream);
     }
@@ -99,7 +99,7 @@ class LogTest extends TestCase
      */
     public function testNotImplementingInterface()
     {
-        Log::config('fail', ['engine' => '\stdClass']);
+        Log::setConfig('fail', ['engine' => '\stdClass']);
         Log::engine('fail');
     }
 
@@ -110,7 +110,7 @@ class LogTest extends TestCase
      */
     public function testDrop()
     {
-        Log::config('file', [
+        Log::setConfig('file', [
             'engine' => 'File',
             'path' => LOGS
         ]);
@@ -132,7 +132,7 @@ class LogTest extends TestCase
      */
     public function testInvalidLevel()
     {
-        Log::config('myengine', ['engine' => 'File']);
+        Log::setConfig('myengine', ['engine' => 'File']);
         Log::write('invalid', 'This will not be logged');
     }
 
@@ -164,7 +164,7 @@ class LogTest extends TestCase
      */
     public function testConfigVariants($settings)
     {
-        Log::config('test', $settings);
+        Log::setConfig('test', $settings);
         $this->assertContains('test', Log::configured());
         $this->assertInstanceOf('Cake\Log\Engine\FileLog', Log::engine('test'));
         Log::drop('test');
@@ -193,7 +193,7 @@ class LogTest extends TestCase
      */
     public function testConfigInjectErrorOnWrongType()
     {
-        Log::config('test', new \StdClass);
+        Log::setConfig('test', new \StdClass);
         Log::info('testing');
     }
 
@@ -221,12 +221,12 @@ class LogTest extends TestCase
             'engine' => 'File',
             'path' => LOGS
         ];
-        Log::config('tests', $config);
+        Log::setConfig('tests', $config);
 
         $expected = $config;
         $expected['className'] = $config['engine'];
         unset($expected['engine']);
-        $this->assertSame($expected, Log::config('tests'));
+        $this->assertSame($expected, Log::getConfig('tests'));
     }
 
     /**
@@ -237,8 +237,8 @@ class LogTest extends TestCase
      */
     public function testConfigErrorOnReconfigure()
     {
-        Log::config('tests', ['engine' => 'File', 'path' => TMP]);
-        Log::config('tests', ['engine' => 'Apc']);
+        Log::setConfig('tests', ['engine' => 'File', 'path' => TMP]);
+        Log::setConfig('tests', ['engine' => 'Apc']);
     }
 
     /**
@@ -278,13 +278,13 @@ class LogTest extends TestCase
         if (file_exists(LOGS . 'eggs.log')) {
             unlink(LOGS . 'eggs.log');
         }
-        Log::config('spam', [
+        Log::setConfig('spam', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => 'debug',
             'file' => 'spam',
         ]);
-        Log::config('eggs', [
+        Log::setConfig('eggs', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['eggs', 'debug', 'error', 'warning'],
@@ -326,13 +326,13 @@ class LogTest extends TestCase
         if (file_exists(LOGS . 'eggs.log')) {
             unlink(LOGS . 'eggs.log');
         }
-        Log::config('spam', [
+        Log::setConfig('spam', [
             'engine' => 'File',
             'path' => LOGS,
             'types' => 'debug',
             'file' => 'spam',
         ]);
-        Log::config('eggs', [
+        Log::setConfig('eggs', [
             'engine' => 'File',
             'path' => LOGS,
             'types' => ['eggs', 'debug', 'error', 'warning'],
@@ -363,13 +363,13 @@ class LogTest extends TestCase
 
     protected function _resetLogConfig()
     {
-        Log::config('debug', [
+        Log::setConfig('debug', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
         ]);
-        Log::config('error', [
+        Log::setConfig('error', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
@@ -408,7 +408,7 @@ class LogTest extends TestCase
     {
         $this->_deleteLogs();
         $this->_resetLogConfig();
-        Log::config('shops', [
+        Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['info', 'debug', 'warning'],
@@ -449,14 +449,14 @@ class LogTest extends TestCase
     {
         $this->_deleteLogs();
 
-        Log::config('debug', [
+        Log::setConfig('debug', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
             'scopes' => false
         ]);
-        Log::config('shops', [
+        Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['info', 'debug', 'warning'],
@@ -495,7 +495,7 @@ class LogTest extends TestCase
         }
 
         $this->_resetLogConfig();
-        Log::config('shops', [
+        Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['info', 'debug', 'notice', 'warning'],
@@ -536,14 +536,14 @@ class LogTest extends TestCase
     {
         $this->_deleteLogs();
 
-        Log::config('shops', [
+        Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['debug', 'notice', 'warning'],
             'scopes' => ['transactions', 'orders'],
             'file' => 'shops.log',
         ]);
-        Log::config('eggs', [
+        Log::setConfig('eggs', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['debug', 'notice', 'warning'],
@@ -571,7 +571,7 @@ class LogTest extends TestCase
 
         Log::reset();
 
-        Log::config('scope_test', [
+        Log::setConfig('scope_test', [
             'engine' => 'TestApp',
             'path' => LOGS,
             'levels' => ['notice', 'info', 'debug'],
@@ -598,13 +598,13 @@ class LogTest extends TestCase
     {
         $this->_deleteLogs();
 
-        Log::config('debug', [
+        Log::setConfig('debug', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
         ]);
-        Log::config('error', [
+        Log::setConfig('error', [
             'engine' => 'File',
             'path' => LOGS,
             'levels' => ['emergency', 'alert', 'critical', 'error', 'warning'],
@@ -690,7 +690,7 @@ class LogTest extends TestCase
     public function testCreateLoggerWithCallable()
     {
         $instance = new FileLog;
-        Log::config('default', function ($alias) use ($instance) {
+        Log::setConfig('default', function ($alias) use ($instance) {
             $this->assertEquals('default', $alias);
 
             return $instance;

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -44,7 +44,7 @@ class LogTraitTest extends TestCase
             ->method('log')
             ->with('debug', [1, 2]);
 
-        Log::config('trait_test', ['engine' => $mock]);
+        Log::setConfig('trait_test', ['engine' => $mock]);
         $subject = $this->getObjectForTrait('Cake\Log\LogTrait');
 
         $subject->log('Testing');

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1015,8 +1015,8 @@ class EmailTest extends TestCase
             'to' => 'mark@example.com',
             'from' => 'noreply@example.com',
         ];
-        Email::config('test', $settings);
-        $this->assertEquals($settings, Email::config('test'), 'Should be the same.');
+        Email::setConfig('test', $settings);
+        $this->assertEquals($settings, Email::getConfig('test'), 'Should be the same.');
 
         $email = new Email('test');
         $this->assertContains($settings['to'], $email->getTo());
@@ -1034,8 +1034,8 @@ class EmailTest extends TestCase
             'to' => 'mark@example.com',
             'from' => 'noreply@example.com',
         ];
-        Email::config('test', $settings);
-        Email::config('test', $settings);
+        Email::setConfig('test', $settings);
+        Email::setConfig('test', $settings);
     }
 
     /**
@@ -1064,7 +1064,7 @@ class EmailTest extends TestCase
     {
         $config = ['test' => 'ok', 'test2' => true];
         Configure::write('Email.default', $config);
-        Email::config(Configure::consume('Email'));
+        Email::setConfig(Configure::consume('Email'));
         $Email = new Email();
         $this->assertSame($Email->getProfile(), $config);
         Configure::delete('Email');
@@ -1098,7 +1098,7 @@ class EmailTest extends TestCase
             'theme' => 'TestTheme',
             'helpers' => ['Html', 'Form'],
         ];
-        Email::config('test', $config);
+        Email::setConfig('test', $config);
         $this->Email->setProfile('test');
 
         $result = $this->Email->getTo();
@@ -1509,7 +1509,7 @@ class EmailTest extends TestCase
                 )
             );
 
-        Log::config('email', $log);
+        Log::setConfig('email', $log);
 
         $this->Email->setTransport('debug');
         $this->Email->setTo('me@cakephp.org');
@@ -1543,7 +1543,7 @@ class EmailTest extends TestCase
                 )
             );
 
-        Log::config('email', $log);
+        Log::setConfig('email', $log);
 
         $this->Email->setTransport('debug');
         $this->Email->setTo('me@cakephp.org');
@@ -1588,7 +1588,7 @@ class EmailTest extends TestCase
         $this->Email->setFrom('cake@cakephp.org');
         $this->Email->setTo(['you@cakephp.org' => 'You']);
         $this->Email->setSubject('My title');
-        $this->Email->config(['empty']);
+        $this->Email->setConfig(['empty']);
         $this->Email->setTemplate('default');
         $this->Email->setLayout(null);
         $result = $this->Email->send('message body.');
@@ -2223,7 +2223,7 @@ class EmailTest extends TestCase
             'subject' => 'Test mail subject',
             'transport' => 'debug',
         ];
-        Email::config('test', $configs);
+        Email::setConfig('test', $configs);
 
         $this->Email = new Email('test');
 
@@ -2738,7 +2738,7 @@ HTML;
         $mock = $this->getMockBuilder('\Cake\Mailer\AbstractTransport')->getMock();
         $config = ['from' => 'tester@example.org', 'transport' => 'default'];
 
-        Email::config('default', $config);
+        Email::setConfig('default', $config);
         Email::setConfigTransport('default', $mock);
 
         $em = new Email('default');

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -35,7 +35,7 @@ class MailTransportTest extends TestCase
         $this->MailTransport = $this->getMockBuilder('Cake\Mailer\Transport\MailTransport')
             ->setMethods(['_mail'])
             ->getMock();
-        $this->MailTransport->config(['additionalParameters' => '-f']);
+        $this->MailTransport->setConfig(['additionalParameters' => '-f']);
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -81,7 +81,7 @@ class SmtpTransportTest extends TestCase
 
         $this->SmtpTransport = new SmtpTestTransport();
         $this->SmtpTransport->setSocket($this->socket);
-        $this->SmtpTransport->config(['client' => 'localhost']);
+        $this->SmtpTransport->setConfig(['client' => 'localhost']);
     }
 
     /**
@@ -109,7 +109,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testConnectEhloTls()
     {
-        $this->SmtpTransport->config(['tls' => true]);
+        $this->SmtpTransport->setConfig(['tls' => true]);
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->at(1))->method('read')->will($this->returnValue("220 Welcome message\r\n"));
         $this->socket->expects($this->at(2))->method('write')->with("EHLO localhost\r\n");
@@ -129,7 +129,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testConnectEhloTlsOnNonTlsServer()
     {
-        $this->SmtpTransport->config(['tls' => true]);
+        $this->SmtpTransport->setConfig(['tls' => true]);
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->at(1))->method('read')->will($this->returnValue("220 Welcome message\r\n"));
         $this->socket->expects($this->at(2))->method('write')->with("EHLO localhost\r\n");
@@ -159,7 +159,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testConnectEhloNoTlsOnRequiredTlsServer()
     {
-        $this->SmtpTransport->config(['tls' => false, 'username' => 'user', 'password' => 'pass']);
+        $this->SmtpTransport->setConfig(['tls' => false, 'username' => 'user', 'password' => 'pass']);
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->at(1))->method('read')->will($this->returnValue("220 Welcome message\r\n"));
         $this->socket->expects($this->at(2))->method('write')->with("EHLO localhost\r\n");
@@ -225,7 +225,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(3))->method('read')->will($this->returnValue("334 Pass\r\n"));
         $this->socket->expects($this->at(4))->method('write')->with("c3Rvcnk=\r\n");
         $this->socket->expects($this->at(5))->method('read')->will($this->returnValue("235 OK\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
         $this->SmtpTransport->auth();
     }
 
@@ -241,7 +241,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(0))->method('write')->with("AUTH LOGIN\r\n");
         $this->socket->expects($this->at(1))->method('read')
             ->will($this->returnValue("500 5.3.3 Unrecognized command\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
         $this->SmtpTransport->auth();
     }
 
@@ -257,7 +257,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(0))->method('write')->with("AUTH LOGIN\r\n");
         $this->socket->expects($this->at(1))->method('read')
             ->will($this->returnValue("502 5.3.3 Command not implemented\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
         $this->SmtpTransport->auth();
     }
 
@@ -273,7 +273,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(0))->method('write')->with("AUTH LOGIN\r\n");
         $this->socket->expects($this->at(1))
             ->method('read')->will($this->returnValue("503 5.5.1 Already authenticated\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
         $this->SmtpTransport->auth();
     }
 
@@ -289,7 +289,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(2))->method('write')->with("bWFyaw==\r\n");
         $this->socket->expects($this->at(3))->method('read')
             ->will($this->returnValue("535 5.7.8 Authentication failed\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
 
         $e = null;
         try {
@@ -316,7 +316,7 @@ class SmtpTransportTest extends TestCase
         $this->socket->expects($this->at(3))->method('read')->will($this->returnValue("334 Pass\r\n"));
         $this->socket->expects($this->at(4))->method('write')->with("c3Rvcnk=\r\n");
         $this->socket->expects($this->at(5))->method('read')->will($this->returnValue("535 5.7.8 Authentication failed\r\n"));
-        $this->SmtpTransport->config(['username' => 'mark', 'password' => 'story']);
+        $this->SmtpTransport->setConfig(['username' => 'mark', 'password' => 'story']);
 
         $e = null;
         try {
@@ -444,16 +444,16 @@ class SmtpTransportTest extends TestCase
      */
     public function testEmptyConfigArray()
     {
-        $this->SmtpTransport->config([
+        $this->SmtpTransport->setConfig([
             'client' => 'myhost.com',
             'port' => 666
         ]);
-        $expected = $this->SmtpTransport->config();
+        $expected = $this->SmtpTransport->getConfig();
 
         $this->assertEquals(666, $expected['port']);
 
-        $this->SmtpTransport->config([]);
-        $result = $this->SmtpTransport->config();
+        $this->SmtpTransport->setConfig([]);
+        $result = $this->SmtpTransport->getConfig();
         $this->assertEquals($expected, $result);
     }
 
@@ -629,7 +629,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testKeepAlive()
     {
-        $this->SmtpTransport->config(['keepAlive' => true]);
+        $this->SmtpTransport->setConfig(['keepAlive' => true]);
 
         $email = $this->getMockBuilder('Cake\Mailer\Email')
             ->setMethods(['message'])

--- a/tests/TestCase/Network/Session/CacheSessionTest.php
+++ b/tests/TestCase/Network/Session/CacheSessionTest.php
@@ -36,7 +36,7 @@ class CacheSessionTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Cache::config(['session_test' => ['engine' => 'File']]);
+        Cache::setConfig(['session_test' => ['engine' => 'File']]);
         $this->storage = new CacheSession(['config' => 'session_test']);
     }
 

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -54,7 +54,7 @@ class SocketTest extends TestCase
     public function testConstruct()
     {
         $this->Socket = new Socket();
-        $config = $this->Socket->config();
+        $config = $this->Socket->getConfig();
         $this->assertSame($config, [
             'persistent' => false,
             'host' => 'localhost',
@@ -66,16 +66,16 @@ class SocketTest extends TestCase
         $this->Socket->reset();
         $this->Socket->__construct(['host' => 'foo-bar']);
         $config['host'] = 'foo-bar';
-        $this->assertSame($this->Socket->config(), $config);
+        $this->assertSame($this->Socket->getConfig(), $config);
 
         $this->Socket = new Socket(['host' => 'www.cakephp.org', 'port' => 23, 'protocol' => 'udp']);
-        $config = $this->Socket->config();
+        $config = $this->Socket->getConfig();
 
         $config['host'] = 'www.cakephp.org';
         $config['port'] = 23;
         $config['protocol'] = 'udp';
 
-        $this->assertSame($this->Socket->config(), $config);
+        $this->assertSame($this->Socket->getConfig(), $config);
     }
 
     /**
@@ -126,7 +126,7 @@ class SocketTest extends TestCase
      */
     public function testInvalidConnection($data)
     {
-        $this->Socket->config($data);
+        $this->Socket->setConfig($data);
         $this->Socket->connect();
     }
 
@@ -252,7 +252,7 @@ class SocketTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $anotherSocket->config(),
+            $anotherSocket->getConfig(),
             'Reset should cause config to return the defaults defined in _defaultConfig'
         );
     }
@@ -326,8 +326,8 @@ class SocketTest extends TestCase
         $socket = new Socket($configSslTls);
         try {
             $socket->connect();
-            $this->assertEquals('smtp.gmail.com', $socket->config('host'));
-            $this->assertEquals('ssl', $socket->config('protocol'));
+            $this->assertEquals('smtp.gmail.com', $socket->getConfig('host'));
+            $this->assertEquals('ssl', $socket->getConfig('protocol'));
         } catch (SocketException $e) {
             $this->markTestSkipped('Cannot test network, skipping.');
         }
@@ -481,9 +481,9 @@ class SocketTest extends TestCase
         $this->assertFalse($result['ssl']['allow_self_signed']);
         $this->assertEquals(5, $result['ssl']['verify_depth']);
         $this->assertEquals('smtp.gmail.com', $result['ssl']['CN_match']);
-        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
-        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
-        $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
-        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->getConfig());
+        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->getConfig());
+        $this->assertArrayNotHasKey('ssl_verify_host', $socket->getConfig());
+        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->getConfig());
     }
 }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -189,7 +189,7 @@ class BelongsToManyTest extends TestCase
                 ->setMethods(['setDriver'])
                 ->setConstructorArgs(['name' => 'other_source'])
                 ->getMock();
-        ConnectionManager::config('other_source', $mock);
+        ConnectionManager::setConfig('other_source', $mock);
         $this->article->connection(ConnectionManager::get('other_source'));
 
         $assoc = new BelongsToMany('Test', [

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -667,7 +667,7 @@ class TreeBehaviorTest extends TestCase
             ->order('lft')
             ->toArray();
         $table->updateAll(['lft' => null, 'rght' => null, 'depth' => null], []);
-        $table->behaviors()->Tree->config('level', 'depth');
+        $table->behaviors()->Tree->setConfig('level', 'depth');
         $table->recover();
 
         $expected = [
@@ -1223,7 +1223,7 @@ class TreeBehaviorTest extends TestCase
         ];
         $this->assertMpttValues($expected, $table);
 
-        $table->behaviors()->get('Tree')->config('scope', ['menu' => 'categories']);
+        $table->behaviors()->get('Tree')->setConfig('scope', ['menu' => 'categories']);
         $expected = [
             ' 1:10 -  9:electronics',
             '_ 2: 9 - 10:televisions',
@@ -1418,7 +1418,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testSetLevelNewNode()
     {
-        $this->table->behaviors()->Tree->config('level', 'depth');
+        $this->table->behaviors()->Tree->setConfig('level', 'depth');
 
         $entity = new Entity(['parent_id' => null, 'name' => 'Depth 0']);
         $this->table->save($entity);
@@ -1443,7 +1443,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testSetLevelExistingNode()
     {
-        $this->table->behaviors()->Tree->config('level', 'depth');
+        $this->table->behaviors()->Tree->setConfig('level', 'depth');
 
         // Leaf node
         $entity = $this->table->get(4);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -62,7 +62,7 @@ class BehaviorRegistryTest extends TestCase
         $config = ['alias' => 'Sluggable', 'replacement' => '-'];
         $result = $this->Behaviors->load('Sluggable', $config);
         $this->assertInstanceOf('TestApp\Model\Behavior\SluggableBehavior', $result);
-        $this->assertEquals($config, $result->config());
+        $this->assertEquals($config, $result->getConfig());
 
         $result = $this->Behaviors->load('TestPlugin.PersisterOne');
         $this->assertInstanceOf('TestPlugin\Model\Behavior\PersisterOneBehavior', $result);

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -193,7 +193,7 @@ class BehaviorTest extends TestCase
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $config = ['key' => 'value'];
         $behavior = new TestBehavior($table, $config);
-        $this->assertEquals($config, $behavior->config());
+        $this->assertEquals($config, $behavior->getConfig());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2586,7 +2586,7 @@ class TableTest extends TestCase
      */
     public function testAtomicSave()
     {
-        $config = ConnectionManager::config('test');
+        $config = ConnectionManager::getConfig('test');
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
             ->setMethods(['begin', 'commit', 'inTransaction'])
@@ -2623,7 +2623,7 @@ class TableTest extends TestCase
     {
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
             ->setMethods(['begin', 'rollback'])
-            ->setConstructorArgs([ConnectionManager::config('test')])
+            ->setConstructorArgs([ConnectionManager::getConfig('test')])
             ->getMock();
         $connection->setDriver(ConnectionManager::get('test')->getDriver());
         $table = $this->getMockBuilder('\Cake\ORM\Table')
@@ -2663,7 +2663,7 @@ class TableTest extends TestCase
     {
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
             ->setMethods(['begin', 'rollback'])
-            ->setConstructorArgs([ConnectionManager::config('test')])
+            ->setConstructorArgs([ConnectionManager::getConfig('test')])
             ->getMock();
         $connection->setDriver(ConnectionManager::get('test')->getDriver());
         $table = $this->getMockBuilder('\Cake\ORM\Table')

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -82,8 +82,8 @@ class DispatcherFactoryTest extends TestCase
         $config = ['config' => 'value', 'priority' => 999];
         $result = DispatcherFactory::add('Routing', $config);
         $this->assertInstanceOf('Cake\Routing\Filter\RoutingFilter', $result);
-        $this->assertEquals($config['config'], $result->config('config'));
-        $this->assertEquals($config['priority'], $result->config('priority'));
+        $this->assertEquals($config['config'], $result->getConfig('config'));
+        $this->assertEquals($config['priority'], $result->getConfig('priority'));
     }
 
     /**

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -34,7 +34,7 @@ class DispatcherFilterTest extends TestCase
     public function testConstructConfig()
     {
         $filter = new DispatcherFilter(['one' => 'value', 'on' => '/blog']);
-        $this->assertEquals('value', $filter->config('one'));
+        $this->assertEquals('value', $filter->getConfig('one'));
     }
 
     /**
@@ -45,10 +45,10 @@ class DispatcherFilterTest extends TestCase
     public function testConstructPriority()
     {
         $filter = new DispatcherFilter();
-        $this->assertEquals(10, $filter->config('priority'));
+        $this->assertEquals(10, $filter->getConfig('priority'));
 
         $filter = new DispatcherFilter(['priority' => 100]);
-        $this->assertEquals(100, $filter->config('priority'));
+        $this->assertEquals(100, $filter->getConfig('priority'));
     }
 
     /**

--- a/tests/TestCase/Shell/CacheShellTest.php
+++ b/tests/TestCase/Shell/CacheShellTest.php
@@ -32,7 +32,7 @@ class CacheShellTest extends ConsoleIntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        Cache::config('test', ['engine' => 'File', 'path' => CACHE]);
+        Cache::setConfig('test', ['engine' => 'File', 'path' => CACHE]);
     }
 
     /**

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -211,7 +211,7 @@ class TableHelperTest extends TestCase
             ['short', 'Longish thing', 'short'],
             ['Longer thing', 'short', 'Longest Value'],
         ];
-        $this->helper->config(['headerStyle' => false]);
+        $this->helper->setConfig(['headerStyle' => false]);
         $this->helper->output($data);
         $expected = [
             '+--------------+---------------+---------------+',
@@ -235,7 +235,7 @@ class TableHelperTest extends TestCase
             ['short', 'Longish thing', 'short'],
             ['Longer thing', 'short', 'Longest Value'],
         ];
-        $this->helper->config(['headerStyle' => 'error']);
+        $this->helper->setConfig(['headerStyle' => 'error']);
         $this->helper->output($data);
         $expected = [
             '+--------------+---------------+---------------+',
@@ -259,7 +259,7 @@ class TableHelperTest extends TestCase
             ['short', 'Longish thing', 'short'],
             ['Longer thing', 'short', 'Longest Value'],
         ];
-        $this->helper->config(['headers' => false]);
+        $this->helper->setConfig(['headers' => false]);
         $this->helper->output($data);
         $expected = [
             '+--------------+---------------+---------------+',
@@ -282,7 +282,7 @@ class TableHelperTest extends TestCase
             ['short', 'Longish thing', 'short'],
             ['Longer thing', 'short', 'Longest Value']
         ];
-        $this->helper->config(['rowSeparator' => true]);
+        $this->helper->setConfig(['rowSeparator' => true]);
         $this->helper->output($data);
         $expected = [
             '+--------------+---------------+---------------+',
@@ -308,7 +308,7 @@ class TableHelperTest extends TestCase
             ['short', 'Longish thing', 'short'],
             ['Longer thing', 'short', 'Longest Value'],
         ];
-        $this->helper->config(['rowSeparator' => true]);
+        $this->helper->setConfig(['rowSeparator' => true]);
         $this->helper->output($data);
         $expected = [
             '+--------------+---------------+---------------+',
@@ -353,7 +353,7 @@ class TableHelperTest extends TestCase
      */
     public function testOutputHeaderDisabledNoData()
     {
-        $this->helper->config(['header' => false]);
+        $this->helper->setConfig(['header' => false]);
         $this->helper->output([]);
         $this->assertEquals([], $this->stub->messages());
     }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -77,7 +77,7 @@ class FixtureManagerTest extends TestCase
 
         $this->manager->setDebug(true);
         $buffer = new ConsoleOutput();
-        Log::config('testQueryLogger', [
+        Log::setConfig('testQueryLogger', [
             'className' => 'Console',
             'stream' => $buffer
         ]);
@@ -109,7 +109,7 @@ class FixtureManagerTest extends TestCase
 
         $this->manager->setDebug(true);
         $buffer = new ConsoleOutput();
-        Log::config('testQueryLogger', [
+        Log::setConfig('testQueryLogger', [
             'className' => 'Console',
             'stream' => $buffer
         ]);
@@ -314,8 +314,8 @@ class FixtureManagerTest extends TestCase
             ->method('execute')
             ->will($this->returnValue($statement));
 
-        ConnectionManager::config('other', $other);
-        ConnectionManager::config('test_other', $testOther);
+        ConnectionManager::setConfig('other', $other);
+        ConnectionManager::setConfig('test_other', $testOther);
 
         // Connect the alias making test_other an alias of other.
         ConnectionManager::alias('test_other', 'other');

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -403,7 +403,7 @@ class CellTest extends TestCase
         $mock->expects($this->once())
             ->method('write')
             ->with('cell_test_app_view_cell_articles_cell_display_default', "dummy\n");
-        Cache::config('default', $mock);
+        Cache::setConfig('default', $mock);
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
@@ -425,7 +425,7 @@ class CellTest extends TestCase
             ->will($this->returnValue("dummy\n"));
         $mock->expects($this->never())
             ->method('write');
-        Cache::config('default', $mock);
+        Cache::setConfig('default', $mock);
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
@@ -448,7 +448,7 @@ class CellTest extends TestCase
         $mock->expects($this->once())
             ->method('write')
             ->with('my_key', "dummy\n");
-        Cache::config('cell', $mock);
+        Cache::setConfig('cell', $mock);
 
         $cell = $this->View->cell('Articles', [], [
             'cache' => ['key' => 'my_key', 'config' => 'cell']
@@ -473,7 +473,7 @@ class CellTest extends TestCase
         $mock->expects($this->once())
             ->method('write')
             ->with('cell_test_app_view_cell_articles_cell_customTemplate_default', "<h1>This is the alternate template</h1>\n");
-        Cache::config('default', $mock);
+        Cache::setConfig('default', $mock);
 
         $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);
         $result = $cell->render();
@@ -490,7 +490,7 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimpleCustomTemplateViewBuilder()
     {
-        Cache::config('default', [
+        Cache::setConfig('default', [
             'className' => 'File',
             'path' => CACHE,
         ]);
@@ -512,7 +512,7 @@ class CellTest extends TestCase
      */
     public function testACachedViewCellReRendersWhenGivenADifferentTemplate()
     {
-        Cache::config('default', [
+        Cache::setConfig('default', [
             'className' => 'File',
             'path' => CACHE,
         ]);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -178,7 +178,7 @@ class TimeHelperTest extends TestCase
      */
     public function testNiceOutputTimezone()
     {
-        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $time = '2014-04-20 20:00';
         $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $this->Time->nice($time));
     }
@@ -211,7 +211,7 @@ class TimeHelperTest extends TestCase
      */
     public function testToAtomOutputTimezone()
     {
-        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new Time;
         $vancouver = clone $dateTime;
         $vancouver->timezone('America/Vancouver');
@@ -245,7 +245,7 @@ class TimeHelperTest extends TestCase
      */
     public function testToRssOutputTimezone()
     {
-        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new Time;
         $vancouver = clone $dateTime;
         $vancouver->timezone('America/Vancouver');
@@ -548,7 +548,7 @@ class TimeHelperTest extends TestCase
      */
     public function testFormatOutputTimezone()
     {
-        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->format($time);
@@ -568,7 +568,7 @@ class TimeHelperTest extends TestCase
      */
     public function testI18nFormatOutputTimezone()
     {
-        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->i18nFormat($time, \IntlDateFormatter::SHORT);

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -98,7 +98,7 @@ class HelperTest extends TestCase
             'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'newval'],
             'key3' => 'val3'
         ];
-        $this->assertEquals($expected, $Helper->config());
+        $this->assertEquals($expected, $Helper->getConfig());
     }
 
     /**

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -85,7 +85,7 @@ class StringTemplateTraitTest extends TestCase
      */
     public function testInitStringTemplatesArrayForm()
     {
-        $this->Template->config(
+        $this->Template->setConfig(
             'templates.text',
             '<p>{{text}}</p>'
         );

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -989,7 +989,7 @@ class ViewTest extends TestCase
     public function testElementCache()
     {
         Cache::drop('test_view');
-        Cache::config('test_view', [
+        Cache::setConfig('test_view', [
             'engine' => 'File',
             'duration' => '+1 day',
             'path' => CACHE . 'views/',
@@ -1074,7 +1074,7 @@ class ViewTest extends TestCase
         $View->loadHelper('Html', ['foo' => 'bar']);
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 
-        $config = $View->Html->config();
+        $config = $View->Html->getConfig();
         $this->assertEquals('bar', $config['foo']);
     }
 
@@ -1112,10 +1112,10 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
 
-        $config = $View->Html->config();
+        $config = $View->Html->getConfig();
         $this->assertEquals('bar', $config['foo']);
 
-        $config = $View->Form->config();
+        $config = $View->Form->getConfig();
         $this->assertEquals('baz', $config['foo']);
     }
 
@@ -1141,7 +1141,7 @@ class ViewTest extends TestCase
     public function testInitialize()
     {
         $View = new TestView();
-        $config = $View->Html->config();
+        $config = $View->Html->getConfig();
         $this->assertEquals('myval', $config['mykey']);
     }
 

--- a/tests/test_app/TestApp/Controller/CookieComponentTestController.php
+++ b/tests/test_app/TestApp/Controller/CookieComponentTestController.php
@@ -38,7 +38,7 @@ class CookieComponentTestController extends Controller
     public function view($key = null)
     {
         if (isset($key)) {
-            $this->Cookie->config('key', $key);
+            $this->Cookie->setConfig('key', $key);
         }
         $this->set('ValueFromRequest', $this->request->cookie('NameOfCookie'));
         $this->set('ValueFromCookieComponent', $this->Cookie->read('NameOfCookie'));
@@ -54,7 +54,7 @@ class CookieComponentTestController extends Controller
     {
         $this->autoRender = false;
         if (isset($key)) {
-            $this->Cookie->config('key', $key);
+            $this->Cookie->setConfig('key', $key);
         }
         $this->Cookie->write('NameOfCookie', 'abc');
     }


### PR DESCRIPTION
Add runtime warnings to deprecated methods in Core. `InstanceConfigTrait` and `StaticConfigTrait` had a ton of use so this is a fairly big pull request :cry:

Refs #11385