### PR TITLE
Make sure that CommandScanner scans proper classes.

### DIFF
--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -147,11 +147,16 @@ class CommandScanner
                 continue;
             }
 
+            $class = $namespace . $shell;
+            if (!is_subclass_of($class, Shell::class) && !is_subclass_of($class, Command::class)) {
+                continue;
+            }
+
             $shells[] = [
                 'file' => $path . $file,
                 'fullName' => $prefix . $name,
                 'name' => $name,
-                'class' => $namespace . $shell
+                'class' => $class
             ];
         }
 


### PR DESCRIPTION
Matching e.g. symfony commands under `Command` namespace shouldn't be detected by the `CommandScanner`.