### PR TITLE
Avoid double parenthesis when nesting functions and query expressions

### DIFF
--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -168,7 +168,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
         $parts = [];
         foreach ($this->_conditions as $condition) {
             if ($condition instanceof ExpressionInterface) {
-                $condition = sprintf('(%s)', $condition->sql($generator));
+                $condition = sprintf('%s', $condition->sql($generator));
             } elseif (is_array($condition)) {
                 $p = $generator->placeholder('param');
                 $generator->bind($p, $condition['value'], $condition['type']);

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -79,7 +79,7 @@ class FunctionExpressionTest extends TestCase
         $binder = new ValueBinder;
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
-        $this->assertEquals('Wrapper(bar, (MyFunction(:param0, :param1)))', $g->sql($binder));
+        $this->assertEquals('Wrapper(bar, MyFunction(:param0, :param1))', $g->sql($binder));
     }
 
     /**

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -14,6 +14,7 @@
 namespace Cake\Test\TestCase\Database\Expression;
 
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 
@@ -79,6 +80,20 @@ class FunctionExpressionTest extends TestCase
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
         $this->assertEquals('Wrapper(bar, (MyFunction(:param0, :param1)))', $g->sql($binder));
+    }
+
+    /**
+     * Tests to avoid regression, prevents double parenthesis
+     * In particular nesting with QueryExpression
+     *
+     * @return void
+     */
+    public function testFunctionNestingQueryExpression()
+    {
+        $binder = new ValueBinder;
+        $q = new QueryExpression('a');
+        $f = new FunctionExpression('MyFunction', [$q]);
+        $this->assertEquals('MyFunction(a)', $f->sql($binder));
     }
 
     /**

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -158,7 +158,7 @@ class ExpressionTypeCastingTest extends TestCase
         $function = new FunctionExpression('DATE', ['2016-01'], ['test']);
         $binder = new ValueBinder;
         $sql = $function->sql($binder);
-        $this->assertEquals('DATE((CONCAT(:param0, :param1)))', $sql);
+        $this->assertEquals('DATE(CONCAT(:param0, :param1))', $sql);
         $this->assertEquals('2016-01', $binder->bindings()[':param0']['value']);
 
         $expressions = [];


### PR DESCRIPTION
For current behavior/examples see my post: [COUNT DISTINCT using Query->newExpr()?](http://discourse.cakephp.org/t/count-distinct-using-query-newexpr/3442)
In short: the following code generates an invalid SQL (at least for mysql)
```php
return $query->select([
    'required_approved' => $query->func()->count(
        $query->func()->DISTINCT(
            [
                $query->newExpr()->addCase(
                    (clone $baseExpr)
                        ->add($query->newExpr()->eq('DocumentTypes.required', 1))
                        ->add($query->newExpr()->eq('Documents.approved', 2)),
                    new IdentifierExpression('DocumentTypes.id')
                )
            ],
            ['literal'],
            ['integer']
        )
    ),
    // ...
);
```
```sql
SELECT (
    COUNT((  -- double parens breaking sql
        DISTINCT((
            CASE WHEN (
              DocumentTypes.entity_id = 1
              AND (DocumentTypes.id) IS NOT NULL
              AND IF(
                Providers.relation = 1, DocumentTypes.applyDep = 1,
                DocumentTypes.applyAuto = 1
              )
              AND DocumentTypes.required = 1
              AND Documents.approved = 1
            ) THEN DocumentTypes.id END
        ))
    ))
) AS `required_approved`,
-- ....
FROM ....
```

Then I thought that the double parenthesis are being generated somewhere, I found QueryExpression adds when it has more than one condition, and FunctionExpressions adds again even if QueryExpression is complex, resulting in two parenthesis

This PR attempts to fix that, I didn't know if split in two commits (first add a test and then the fix)