### PR TITLE
Fix duplicate subdirectories for file type views.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1243,11 +1243,15 @@ class View implements EventDispatcherInterface
     {
         $templatePath = $subDir = '';
 
-        if ($this->subDir !== null) {
-            $subDir = $this->subDir . DIRECTORY_SEPARATOR;
-        }
         if ($this->templatePath) {
             $templatePath = $this->templatePath . DIRECTORY_SEPARATOR;
+        }
+        if (strlen($this->subDir)) {
+            $subDir = $this->subDir . DIRECTORY_SEPARATOR;
+            // Check if templatePath already terminates with subDir
+            if (strrpos($templatePath, $subDir) == strlen($templatePath) - strlen($subDir)) {
+                $subDir = '';
+            }
         }
 
         if ($name === null) {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -651,6 +651,31 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test getViewFileName doesn't re-apply existing subdirectories
+     *
+     * @return void
+     */
+    public function testGetViewFileNameSubDir()
+    {
+        $viewOptions = [
+            'plugin' => null,
+            'name' => 'Posts',
+            'viewPath' => 'Posts/json',
+            'layoutPath' => 'json',
+        ];
+        $view = new TestView(null, null, null, $viewOptions);
+
+        $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'json' . DS . 'index.ctp';
+        $result = $view->getViewFileName('index');
+        $this->assertPathEquals($expected, $result);
+
+        $view->subDir = 'json';
+        $result = $view->getViewFileName('index');
+        $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'json' . DS . 'index.ctp';
+        $this->assertPathEquals($expected, $result);
+    }
+
+    /**
      * Test getting layout filenames
      *
      * @return void


### PR DESCRIPTION
When a template path ends with the current subDir property we shouldn't re-apply that subDir as it will result in bad paths.

Refs #11316