### PR TITLE
Allow registering middleware as string with RouteCollection.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -970,7 +970,7 @@ class RouteBuilder
      * scope or any child scopes that share the same RouteCollection.
      *
      * @param string $name The name of the middleware. Used when applying middleware to a scope.
-     * @param callable $middleware The middleware object to register.
+     * @param callable|string $middleware The middleware callable or class name to register.
      * @return $this
      * @see \Cake\Routing\RouteCollection
      */

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -418,14 +418,11 @@ class RouteCollection
      * scope or any child scopes that share the same RouteCollection.
      *
      * @param string $name The name of the middleware. Used when applying middleware to a scope.
-     * @param callable $middleware The middleware object to register.
+     * @param callable|string $middleware The middleware callable or class name to register.
      * @return $this
      */
-    public function registerMiddleware($name, callable $middleware)
+    public function registerMiddleware($name, $middleware)
     {
-        if (is_string($middleware)) {
-            throw new RuntimeException("The '$name' middleware is not a callable object.");
-        }
         $this->_middleware[$name] = $middleware;
 
         return $this;

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -18,9 +18,9 @@ use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use TestApp\Application;
+use TestApp\Middleware\DumbMiddleware;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
-use TestApp\Middleware\DumbMiddleware;
 
 /**
  * Test for RoutingMiddleware

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use TestApp\Application;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
+use TestApp\Middleware\DumbMiddleware;
 
 /**
  * Test for RoutingMiddleware
@@ -247,8 +248,10 @@ class RoutingMiddlewareTest extends TestCase
 
                 return $next($req, $res);
             });
+            $routes->registerMiddleware('dumb', DumbMiddleware::class);
+
             // Connect middleware in reverse to test ordering.
-            $routes->applyMiddleware('second', 'first');
+            $routes->applyMiddleware('second', 'first', 'dumb');
 
             $routes->connect('/ping', ['controller' => 'Pings']);
         });

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -872,19 +872,6 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
-     * Test registering invalid middleware
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The 'bad' middleware is not a callable object.
-     * @return void
-     */
-    public function testRegisterMiddlewareString()
-    {
-        $routes = new RouteBuilder($this->collection, '/api');
-        $routes->registerMiddleware('bad', 'strlen');
-    }
-
-    /**
      * Test middleware group
      *
      * @return void

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -631,18 +631,6 @@ class RouteCollectionTest extends TestCase
     }
 
     /**
-     * String methods are not acceptable.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The 'bad' middleware is not a callable object.
-     * @return void
-     */
-    public function testRegisterMiddlewareNoCallableString()
-    {
-        $this->collection->registerMiddleware('bad', 'strlen');
-    }
-
-    /**
      * Test adding middleware to the collection.
      *
      * @return void
@@ -661,6 +649,8 @@ class RouteCollectionTest extends TestCase
 
         $this->assertTrue($this->collection->hasMiddleware('closure'));
         $this->assertTrue($this->collection->hasMiddleware('callable'));
+
+        $this->collection->registerMiddleware('class', 'Dumb');
     }
 
     /**

--- a/tests/test_app/TestApp/Middleware/DumbMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/DumbMiddleware.php
@@ -17,7 +17,7 @@ namespace TestApp\Middleware;
 /**
  * Testing stub for middleware tests.
  */
-class DumbMiddleWare
+class DumbMiddleware
 {
     public function __invoke($request, $response, $next)
     {


### PR DESCRIPTION
Given that `MiddlewareQueue` accepts string names for middlewares, I don't see any reason for preventing use of strings when registering middlewares with `RouteBuilder`/`RouteCollection`.