### PR TITLE
Deprecate Xcache engine.

### DIFF
--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -20,6 +20,7 @@ use Cake\Cache\CacheEngine;
  * Xcache storage engine for cache
  *
  * @link          http://trac.lighttpd.net/xcache/ Xcache
+ * @deprecated 3.6.0 Xcache engine has been deprecated and will be remove in 4.0.
  */
 class XcacheEngine extends CacheEngine
 {

--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -20,7 +20,7 @@ use Cake\Cache\CacheEngine;
  * Xcache storage engine for cache
  *
  * @link          http://trac.lighttpd.net/xcache/ Xcache
- * @deprecated 3.6.0 Xcache engine has been deprecated and will be remove in 4.0.
+ * @deprecated 3.6.0 Xcache engine has been deprecated and will be removed in 4.0.0.
  */
 class XcacheEngine extends CacheEngine
 {


### PR DESCRIPTION
Xcache doesn't seem to be actively maintained and to date doesn't have a PHP 7 compatible release.