### PR TITLE
DX PHPUnit - use dedicated assertions

### DIFF
--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -418,7 +418,7 @@ class FileEngineTest extends TestCase
         ]);
 
         Cache::read('Test', 'file_test');
-        $this->assertTrue(file_exists($dir), 'Dir should exist.');
+        $this->assertFileExists($dir, 'Dir should exist.');
 
         // Cleanup
         rmdir($dir);
@@ -441,7 +441,7 @@ class FileEngineTest extends TestCase
         ]);
 
         Cache::read('Test', 'file_test');
-        $this->assertTrue(file_exists($dir), 'Dir should exist.');
+        $this->assertFileExists($dir, 'Dir should exist.');
 
         // Cleanup
         rmdir($dir);

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -488,8 +488,8 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['CONTENT_TYPE'] = 'application/xml';
         $this->Controller->request = new ServerRequest();
         $this->RequestHandler->beforeRender($event);
-        $this->assertTrue(is_array($this->Controller->request->data));
-        $this->assertFalse(is_object($this->Controller->request->data));
+        $this->assertInternalType('array', $this->Controller->request->data);
+        $this->assertNotInternalType('object', $this->Controller->request->data);
     }
 
     /**
@@ -505,8 +505,8 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['CONTENT_TYPE'] = 'application/xml; charset=UTF-8';
         $this->Controller->request = new ServerRequest();
         $this->RequestHandler->startup($event);
-        $this->assertTrue(is_array($this->Controller->request->data));
-        $this->assertFalse(is_object($this->Controller->request->data));
+        $this->assertInternalType('array', $this->Controller->request->data);
+        $this->assertNotInternalType('object', $this->Controller->request->data);
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -111,7 +111,7 @@ class ConfigureTest extends TestCase
         $this->assertTrue($result >= 0);
 
         $result = Configure::read();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertTrue(isset($result['debug']));
         $this->assertTrue(isset($result['level1']));
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -103,12 +103,12 @@ class DebuggerTest extends TestCase
     public function testExcerpt()
     {
         $result = Debugger::excerpt(__FILE__, __LINE__ - 1, 2);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(5, $result);
         $this->assertRegExp('/function(.+)testExcerpt/', $result[1]);
 
         $result = Debugger::excerpt(__FILE__, 2, 2);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(4, $result);
 
         $this->skipIf(defined('HHVM_VERSION'), 'HHVM does not highlight php code');

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -195,7 +195,7 @@ class FileTest extends TestCase
         $expecting = substr($data, 0, 3);
         $result = $this->File->read(3);
         $this->assertEquals($expecting, $result);
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
 
         $expecting = substr($data, 3, 3);
         $result = $this->File->read(3);
@@ -214,10 +214,10 @@ class FileTest extends TestCase
         $result = $this->File->offset();
         $this->assertFalse($result);
 
-        $this->assertFalse(is_resource($this->File->handle));
+        $this->assertNotInternalType('resource', $this->File->handle);
         $success = $this->File->offset(0);
         $this->assertTrue($success);
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
 
         $result = $this->File->offset();
         $expected = 0;
@@ -245,19 +245,19 @@ class FileTest extends TestCase
         $this->File->handle = null;
 
         $r = $this->File->open();
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
         $this->assertTrue($r);
 
         $handle = $this->File->handle;
         $r = $this->File->open();
         $this->assertTrue($r);
         $this->assertTrue($handle === $this->File->handle);
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
 
         $r = $this->File->open('r', true);
         $this->assertTrue($r);
         $this->assertFalse($handle === $this->File->handle);
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
     }
 
     /**
@@ -268,12 +268,12 @@ class FileTest extends TestCase
     public function testClose()
     {
         $this->File->handle = null;
-        $this->assertFalse(is_resource($this->File->handle));
+        $this->assertNotInternalType('resource', $this->File->handle);
         $this->assertTrue($this->File->close());
-        $this->assertFalse(is_resource($this->File->handle));
+        $this->assertNotInternalType('resource', $this->File->handle);
 
         $this->File->handle = fopen(__FILE__, 'r');
-        $this->assertTrue(is_resource($this->File->handle));
+        $this->assertInternalType('resource', $this->File->handle);
         $this->assertTrue($this->File->close());
         $this->assertFalse(is_resource($this->File->handle));
     }
@@ -435,7 +435,7 @@ class FileTest extends TestCase
 
         $TmpFile = new File($tmpFile);
         $this->assertFileNotExists($tmpFile);
-        $this->assertFalse(is_resource($TmpFile->handle));
+        $this->assertNotInternalType('resource', $TmpFile->handle);
 
         $testData = ['CakePHP\'s', ' test suite', ' was here ...', ''];
         foreach ($testData as $data) {
@@ -443,7 +443,7 @@ class FileTest extends TestCase
             $this->assertTrue($r);
             $this->assertFileExists($tmpFile);
             $this->assertEquals($data, file_get_contents($tmpFile));
-            $this->assertTrue(is_resource($TmpFile->handle));
+            $this->assertInternalType('resource', $TmpFile->handle);
             $TmpFile->close();
         }
         unlink($tmpFile);

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -211,7 +211,7 @@ class FolderTest extends TestCase
         $result = $Folder->create($path);
         $this->assertTrue($result);
 
-        $this->assertTrue(is_dir($path), 'Folder was not made');
+        $this->assertDirectoryExists($path, 'Folder was not made');
 
         $Folder = new Folder(TMP . 'tests' . DS . 'trailing');
         $this->assertTrue($Folder->delete());
@@ -229,7 +229,7 @@ class FolderTest extends TestCase
         $result = $folder->create('tests' . DS . 'relative-test');
         $this->assertTrue($result, 'should create');
 
-        $this->assertTrue(is_dir($path), 'Folder was not made');
+        $this->assertDirectoryExists($path, 'Folder was not made');
         $folder = new Folder($path);
         $folder->delete();
     }
@@ -855,7 +855,7 @@ class FolderTest extends TestCase
     {
         $path = TMP . 'tests' . DS;
         $Folder = new Folder($path . 'config_non_existent', true);
-        $this->assertTrue(is_dir($path . 'config_non_existent'));
+        $this->assertDirectoryExists($path . 'config_non_existent');
         $Folder->cd($path);
     }
 
@@ -1142,7 +1142,7 @@ class FolderTest extends TestCase
         $result = $Folder->copy(['to' => $folderThree, 'recursive' => false]);
 
         $this->assertFileExists($folderThree . DS . 'file1.php');
-        $this->assertFalse(is_dir($folderThree . DS . 'folderA'));
+        $this->assertDirectoryNotExists($folderThree . DS . 'folderA');
         $this->assertFileNotExists($folderThree . DS . 'folderA' . DS . 'fileA.php');
     }
 
@@ -1215,7 +1215,7 @@ class FolderTest extends TestCase
         $result = $Folder->move($folderTwo);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertTrue(is_dir($folderTwo . '/folderB'));
+        $this->assertDirectoryExists($folderTwo . '/folderB');
         $this->assertFileExists($folderTwo . '/folderB/fileB.php');
         $this->assertFileNotExists($fileOne);
         $this->assertFileExists($folderTwo . '/folderA');
@@ -1234,7 +1234,7 @@ class FolderTest extends TestCase
         $result = $Folder->move($folderTwo);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertTrue(is_dir($folderTwo . '/folderA'));
+        $this->assertDirectoryExists($folderTwo . '/folderA');
         $this->assertFileExists($folderTwo . '/folderA/fileA.php');
         $this->assertFileNotExists($fileOne);
         $this->assertFileNotExists($folderOneA);
@@ -1284,7 +1284,7 @@ class FolderTest extends TestCase
         $result = $Folder->move(['to' => $folderTwo, 'scheme' => Folder::SKIP]);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertTrue(is_dir($folderTwo . '/folderB'));
+        $this->assertDirectoryExists($folderTwo . '/folderB');
         $this->assertFileExists($folderTwoB . '/fileB.php');
         $this->assertFileNotExists($fileOne);
         $this->assertFileNotExists($folderOneA);
@@ -1303,7 +1303,7 @@ class FolderTest extends TestCase
         $result = $Folder->move(['to' => $folderTwo, 'scheme' => Folder::SKIP]);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertTrue(is_dir($folderTwo . '/folderA'));
+        $this->assertDirectoryExists($folderTwo . '/folderA');
         $this->assertFileExists($folderTwo . '/folderA/fileA.php');
         $this->assertFileNotExists($fileOne);
         $this->assertFileNotExists($folderOneA);
@@ -1341,7 +1341,7 @@ class FolderTest extends TestCase
         $result = $Folder->move(['to' => $folderTwo, 'recursive' => false]);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertFalse(is_dir($folderTwo . '/folderA'));
+        $this->assertDirectoryNotExists($folderTwo . '/folderA');
         $this->assertFileNotExists($folderTwo . '/folderA/fileA.php');
     }
 

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -297,7 +297,7 @@ class StreamTest extends TestCase
         foreach ($expected as $k => $v) {
             $this->assertEquals($v, $result[$k]);
         }
-        $this->assertTrue(is_readable($result['cafile']));
+        $this->assertIsReadable($result['cafile']);
     }
 
     /**
@@ -333,7 +333,7 @@ class StreamTest extends TestCase
         foreach ($expected as $k => $v) {
             $this->assertEquals($v, $result[$k]);
         }
-        $this->assertTrue(is_readable($result['cafile']));
+        $this->assertIsReadable($result['cafile']);
     }
 
     /**

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -134,7 +134,7 @@ class ResponseTest extends TestCase
 
         $data = json_encode([]);
         $response = new Response([], $data);
-        $this->assertTrue(is_array($response->json));
+        $this->assertInternalType('array', $response->json);
 
         $data = json_encode(null);
         $response = new Response([], $data);

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1139,7 +1139,7 @@ class ServerRequestTest extends TestCase
 
         $this->assertTrue(isset($request->controller));
         $this->assertFalse(isset($request->notthere));
-        $this->assertFalse(empty($request->controller));
+        $this->assertNotEmpty($request->controller);
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1890,7 +1890,7 @@ class EmailTest extends TestCase
 
         $message = $this->Email->message();
         $boundary = $this->Email->getBoundary();
-        $this->assertFalse(empty($boundary));
+        $this->assertNotEmpty($boundary);
         $this->assertContains('--' . $boundary, $message);
         $this->assertContains('--' . $boundary . '--', $message);
 
@@ -1899,7 +1899,7 @@ class EmailTest extends TestCase
 
         $message = $this->Email->message();
         $boundary = $this->Email->getBoundary();
-        $this->assertFalse(empty($boundary));
+        $this->assertNotEmpty($boundary);
         $this->assertContains('--' . $boundary, $message);
         $this->assertContains('--' . $boundary . '--', $message);
         $this->assertContains('--alt-' . $boundary, $message);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6094,7 +6094,7 @@ class TableTest extends TestCase
         $table->association('authors')->target()->getEventManager()->on(
             'Model.beforeFind',
             function (Event $event, Query $query, ArrayObject $options, $primary) use (&$associationBeforeFindCount) {
-                $this->assertTrue(is_bool($primary));
+                $this->assertInternalType('bool', $primary);
                 $associationBeforeFindCount ++;
             }
         );
@@ -6103,7 +6103,7 @@ class TableTest extends TestCase
         $eventManager->on(
             'Model.beforeFind',
             function (Event $event, Query $query, ArrayObject $options, $primary) use (&$beforeFindCount) {
-                $this->assertTrue(is_bool($primary));
+                $this->assertInternalType('bool', $primary);
                 $beforeFindCount ++;
             }
         );
@@ -6115,7 +6115,7 @@ class TableTest extends TestCase
         $eventManager->on(
             'Model.buildValidator',
             $callback = function (Event $event, Validator $validator, $name) use (&$buildValidatorCount) {
-                $this->assertTrue(is_string($name));
+                $this->assertInternalType('string', $name);
                 $buildValidatorCount ++;
             }
         );
@@ -6136,15 +6136,15 @@ class TableTest extends TestCase
         $eventManager->on(
             'Model.beforeRules',
             function (Event $event, Entity $entity, ArrayObject $options, $operation) use (&$beforeRulesCount) {
-                $this->assertTrue(is_string($operation));
+                $this->assertInternalType('string', $operation);
                 $beforeRulesCount ++;
             }
         );
         $eventManager->on(
             'Model.afterRules',
             function (Event $event, Entity $entity, ArrayObject $options, $result, $operation) use (&$afterRulesCount) {
-                $this->assertTrue(is_bool($result));
-                $this->assertTrue(is_string($operation));
+                $this->assertInternalType('bool', $result);
+                $this->assertInternalType('string', $operation);
                 $afterRulesCount ++;
             }
         );

--- a/tests/TestCase/Shell/Task/AssetsTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssetsTaskTest.php
@@ -133,7 +133,7 @@ class AssetsTaskTest extends TestCase
             ->setConstructorArgs([$this->io])
             ->getMock();
 
-        $this->assertTrue(is_dir(WWW_ROOT . 'test_theme'));
+        $this->assertDirectoryExists(WWW_ROOT . 'test_theme');
 
         $shell->expects($this->never())->method('_createSymlink');
         $shell->expects($this->never())->method('_copyDirectory');

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -159,7 +159,7 @@ class ViewVarsTraitTest extends TestCase
     {
         $result = $this->subject->viewOptions([], false);
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEmpty($result);
     }
 


### PR DESCRIPTION
as requested in https://github.com/cakephp/cakephp/pull/11422#discussion_r150408734

Brought to you by [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)

automatically applied via
`php-cs-fixer fix -v --rules=@PHPUnit60Migration:risky,-php_unit_no_expectation_annotation --allow-risky=yes tests`