### PR TITLE
Remove _expires cache keys

### DIFF
--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -59,29 +59,9 @@ class ApcuEngine extends CacheEngine
     public function write($key, $value)
     {
         $key = $this->_key($key);
-
-        $expires = 0;
         $duration = $this->_config['duration'];
-        if ($duration) {
-            $expires = time() + $duration;
-        }
 
-        $values = [
-            $key . '_expires' => $expires,
-            $key => $value,
-        ];
-
-        $errors = apcu_store($values, null, $duration);
-
-        if ($errors !== []) {
-            $this->warning(
-                sprintf('Failed to store %s into APCu cache.', json_encode($errors))
-            );
-
-            return false;
-        }
-
-        return true;
+        return apcu_store($key, $value, $duration);
     }
 
     /**
@@ -95,13 +75,6 @@ class ApcuEngine extends CacheEngine
     public function read($key)
     {
         $key = $this->_key($key);
-
-        $time = time();
-        $success = false;
-        $cachetime = (int)apcu_fetch($key . '_expires', $success);
-        if ($success && $cachetime !== 0 && ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime)) {
-            return false;
-        }
 
         return apcu_fetch($key);
     }
@@ -196,15 +169,9 @@ class ApcuEngine extends CacheEngine
     public function add($key, $value)
     {
         $key = $this->_key($key);
-
-        $expires = 0;
         $duration = $this->_config['duration'];
-        if ($duration) {
-            $expires = time() + $duration;
-        }
 
-        return apcu_add($key, $value, $duration) === true
-            && apcu_add($key . '_expires', $expires, $duration) === true;
+        return apcu_add($key, $value, $duration);
     }
 
     /**

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -61,17 +61,9 @@ class WincacheEngine extends CacheEngine
     public function write($key, $value)
     {
         $key = $this->_key($key);
-
         $duration = $this->_config['duration'];
-        $expires = time() + $duration;
 
-        $data = [
-            $key . '_expires' => $expires,
-            $key => $value
-        ];
-        $result = wincache_ucache_set($data, null, $duration);
-
-        return empty($result);
+        return wincache_ucache_set($key, $value, $duration);
     }
 
     /**
@@ -84,12 +76,6 @@ class WincacheEngine extends CacheEngine
     public function read($key)
     {
         $key = $this->_key($key);
-
-        $time = time();
-        $cachetime = (int)wincache_ucache_get($key . '_expires');
-        if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
-            return false;
-        }
 
         return wincache_ucache_get($key);
     }

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -23,6 +23,34 @@ use Cake\TestSuite\TestCase;
  */
 class ApcuEngineTest extends TestCase
 {
+    /**
+     * useRequestTime original value
+     *
+     * @var bool
+     */
+    static protected $useRequestTime = null;
+
+    /**
+     * Ensure use_request_time is turned off
+     *
+     * If use_request_time is on, all cache entries are inserted with the same
+     * timestamp and ttl comparisons within the same request are effectively
+     * meaningless
+     */
+    public static function setUpBeforeClass()
+    {
+        static::$useRequestTime = ini_get('apc.use_request_time');
+        ini_set('apc.use_request_time', 0);
+    }
+
+    /**
+     * Reset apc.user_request_time to original value
+     *
+     */
+    public static function teardownAfterClass()
+    {
+        ini_set('apc.use_request_time', static::$useRequestTime);
+    }
 
     /**
      * setUp method


### PR DESCRIPTION
All of these cache engines implement ttl - it shouldn't be necessary to
set two cache keys and double-confirm that the cache entry has not
expired before returning the cache hit.

This code originates from wanting to expire existing cache keys if a cache-config is changed (https://github.com/cakephp/cakephp/commit/caa7bb621871706baf664b5e2e4f562353f3671f) - Although a possible convenience for some - I don't think that's worth the overhead of two cache keys + checking expiry on all cache reads.

Should result in a modest performance increase.