### PR TITLE
update deprecated-method use ServerRequest::createFromGlobalss

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -15,7 +15,7 @@
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Http\ServerRequest;
+use Cake\Http\ServerRequestFactory;
 use Cake\I18n\Time;
 use Cake\Utility\CookieCryptTrait;
 use Cake\Utility\Hash;
@@ -124,7 +124,7 @@ class CookieComponent extends Component
         $controller = $this->_registry->getController();
 
         if ($controller === null) {
-            $this->request = ServerRequest::createFromGlobals();
+            $this->request = ServerRequestFactory::fromGlobals();
         }
 
         if (empty($this->_config['path'])) {

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -21,7 +21,7 @@ use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Event\Event;
 use Cake\Http\Response;
-use Cake\Http\ServerRequest;
+use Cake\Http\ServerRequestFactory;
 use Cake\Network\Exception\HttpException;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
@@ -115,7 +115,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
     protected function _getController()
     {
         if (!$request = Router::getRequest(true)) {
-            $request = ServerRequest::createFromGlobals();
+            $request = ServerRequestFactory::fromGlobals();
         }
         $response = new Response();
         $controller = null;

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Routing\Route;
 
-use Cake\Http\ServerRequest;
+use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -434,7 +434,7 @@ class Route
         if (isset($this->defaults['_method'])) {
             if (empty($method)) {
                 // Deprecated reading the global state is deprecated and will be removed in 4.x
-                $request = Router::getRequest(true) ?: ServerRequest::createFromGlobals();
+                $request = Router::getRequest(true) ?: ServerRequestFactory::fromGlobals();
                 $method = $request->getMethod();
             }
             if (!in_array($method, (array)$this->defaults['_method'], true)) {


### PR DESCRIPTION
`ServerRequest::createFromGlobals` was deprecated in 3.4.0,
catch up with `ServerRequestFactory`. (just replaced.)