### PR TITLE
Add deprecation warnings to ORM/Association

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -279,6 +279,10 @@ abstract class Association
      */
     public function name($name = null)
     {
+        deprecationWarning(
+            get_called_class() . '::name() is deprecated. ' .
+            'Use setName()/getName() instead.'
+        );
         if ($name !== null) {
             $this->setName($name);
         }
@@ -319,6 +323,10 @@ abstract class Association
      */
     public function cascadeCallbacks($cascadeCallbacks = null)
     {
+        deprecationWarning(
+            get_called_class() . '::cascadeCallbacks() is deprecated. ' .
+            'Use setCascadeCallbacks()/getCascadeCallbacks() instead.'
+        );
         if ($cascadeCallbacks !== null) {
             $this->setCascadeCallbacks($cascadeCallbacks);
         }
@@ -369,6 +377,10 @@ abstract class Association
      */
     public function source(Table $table = null)
     {
+        deprecationWarning(
+            get_called_class() . '::source() is deprecated. ' .
+            'Use setSource()/getSource() instead.'
+        );
         if ($table === null) {
             return $this->_sourceTable;
         }
@@ -445,6 +457,10 @@ abstract class Association
      */
     public function target(Table $table = null)
     {
+        deprecationWarning(
+            get_called_class() . '::target() is deprecated. ' .
+            'Use setTarget()/getTarget() instead.'
+        );
         if ($table !== null) {
             $this->setTarget($table);
         }
@@ -490,6 +506,10 @@ abstract class Association
      */
     public function conditions($conditions = null)
     {
+        deprecationWarning(
+            get_called_class() . '::conditions() is deprecated. ' .
+            'Use setConditions()/getConditions() instead.'
+        );
         if ($conditions !== null) {
             $this->setConditions($conditions);
         }
@@ -540,6 +560,10 @@ abstract class Association
      */
     public function bindingKey($key = null)
     {
+        deprecationWarning(
+            get_called_class() . '::bindingKey() is deprecated. ' .
+            'Use setBindingKey()/getBindingKey() instead.'
+        );
         if ($key !== null) {
             $this->setBindingKey($key);
         }
@@ -580,6 +604,10 @@ abstract class Association
      */
     public function foreignKey($key = null)
     {
+        deprecationWarning(
+            get_called_class() . '::foreignKey() is deprecated. ' .
+            'Use setForeignKey()/getForeignKey() instead.'
+        );
         if ($key !== null) {
             $this->setForeignKey($key);
         }
@@ -632,6 +660,10 @@ abstract class Association
      */
     public function dependent($dependent = null)
     {
+        deprecationWarning(
+            get_called_class() . '::dependent() is deprecated. ' .
+            'Use setDependent()/getDependent() instead.'
+        );
         if ($dependent !== null) {
             $this->setDependent($dependent);
         }
@@ -685,6 +717,10 @@ abstract class Association
      */
     public function joinType($type = null)
     {
+        deprecationWarning(
+            get_called_class() . '::joinType() is deprecated. ' .
+            'Use setJoinType()/getJoinType() instead.'
+        );
         if ($type !== null) {
             $this->setJoinType($type);
         }
@@ -740,6 +776,10 @@ abstract class Association
      */
     public function property($name = null)
     {
+        deprecationWarning(
+            get_called_class() . '::property() is deprecated. ' .
+            'Use setProperty()/getProperty() instead.'
+        );
         if ($name !== null) {
             $this->setProperty($name);
         }
@@ -805,6 +845,10 @@ abstract class Association
      */
     public function strategy($name = null)
     {
+        deprecationWarning(
+            get_called_class() . '::strategy() is deprecated. ' .
+            'Use setStrategy()/getStrategy() instead.'
+        );
         if ($name !== null) {
             $this->setStrategy($name);
         }
@@ -846,6 +890,10 @@ abstract class Association
      */
     public function finder($finder = null)
     {
+        deprecationWarning(
+            get_called_class() . '::finder() is deprecated. ' .
+            'Use setFinder()/getFinder() instead.'
+        );
         if ($finder !== null) {
             $this->setFinder($finder);
         }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -194,6 +194,10 @@ class BelongsToMany extends Association
      */
     public function targetForeignKey($key = null)
     {
+        deprecationWarning(
+            'BelongToMany::targetForeignKey() is deprecated. ' .
+            'Use setTargetForeignKey()/getTargetForeignKey() instead.'
+        );
         if ($key !== null) {
             $this->setTargetForeignKey($key);
         }
@@ -260,6 +264,10 @@ class BelongsToMany extends Association
      */
     public function sort($sort = null)
     {
+        deprecationWarning(
+            'BelongToMany::sort() is deprecated. ' .
+            'Use setSort()/getSort() instead.'
+        );
         if ($sort !== null) {
             $this->setSort($sort);
         }
@@ -664,6 +672,10 @@ class BelongsToMany extends Association
      */
     public function saveStrategy($strategy = null)
     {
+        deprecationWarning(
+            'BelongsToMany::saveStrategy() is deprecated. ' .
+            'Use setSaveStrategy()/getSaveStrategy() instead.'
+        );
         if ($strategy !== null) {
             $this->setSaveStrategy($strategy);
         }

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -38,6 +38,10 @@ trait DependentDeleteTrait
      */
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
+        deprecationWarning(
+            'The DependentDeleteTrait is deprecated. ' .
+            'You should use Cake\ORM\Association\DependentDeleteHelper instead.'
+        );
         $helper = new DependentDeleteHelper();
 
         return $helper->cascadeDelete($this, $entity, $options);

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -141,6 +141,10 @@ class HasMany extends Association
      */
     public function saveStrategy($strategy = null)
     {
+        deprecationWarning(
+            'HasMany::saveStrategy() is deprecated. ' .
+            'Use setSaveStrategy()/getSaveStrategy() instead.'
+        );
         if ($strategy !== null) {
             $this->setSaveStrategy($strategy);
         }
@@ -630,6 +634,10 @@ class HasMany extends Association
      */
     public function sort($sort = null)
     {
+        deprecationWarning(
+            'HasMany::sort() is deprecated. ' .
+            'Use setSort()/getSort() instead.'
+        );
         if ($sort !== null) {
             $this->setSort($sort);
         }

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -160,6 +160,10 @@ class AssociationCollection implements IteratorAggregate
      */
     public function type($class)
     {
+        deprecationWarning(
+            'AssociationCollection::type() is deprecated. ' .
+            'Use getByType() instead.'
+        );
         return $this->getByType($class);
     }
 

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -164,6 +164,7 @@ class AssociationCollection implements IteratorAggregate
             'AssociationCollection::type() is deprecated. ' .
             'Use getByType() instead.'
         );
+
         return $this->getByType($class);
     }
 

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -228,6 +228,10 @@ class EagerLoadable
     public function canBeJoined($possible = null)
     {
         if ($possible !== null) {
+            deprecationWarning(
+                'Using EagerLoadable::canBeJoined() as a setter is deprecated. ' .
+                'Use setCanBeJoined() instead.'
+            );
             $this->setCanBeJoined($possible);
         }
 
@@ -272,6 +276,10 @@ class EagerLoadable
      */
     public function config(array $config = null)
     {
+        deprecationWarning(
+            'EagerLoadable::config() is deprecated. ' .
+            'Use setConfig()/getConfig() instead.'
+        );
         if ($config !== null) {
             $this->setConfig($config);
         }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -208,6 +208,10 @@ class EagerLoader
      */
     public function autoFields($enable = null)
     {
+        deprecationWarning(
+            'EagerLoader::autoFields() is deprecated. ' .
+            'Use enableAutoFields()/isAutoFieldsEnabled() instead.'
+        );
         if ($enable !== null) {
             $this->enableAutoFields($enable);
         }
@@ -295,6 +299,10 @@ class EagerLoader
      */
     public function matching($assoc = null, callable $builder = null, $options = [])
     {
+        deprecationWarning(
+            'EagerLoader::matching() is deprecated. ' .
+            'Use setMatch()/getMatching() instead.'
+        );
         if ($assoc !== null) {
             $this->setMatching($assoc, $builder, $options);
         }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -521,7 +521,7 @@ class EntityContext implements ContextInterface
                 return false;
             }
 
-            $table = $assoc->target();
+            $table = $assoc->getTarget();
         }
 
         return $this->_tables[$path] = $table;

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -96,14 +96,30 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests sort() method
      *
+     * @group deprecated
      * @return void
      */
     public function testSort()
     {
+        $this->deprecated(function () {
+            $assoc = new BelongsToMany('Test');
+            $this->assertNull($assoc->sort());
+            $assoc->sort(['id' => 'ASC']);
+            $this->assertEquals(['id' => 'ASC'], $assoc->sort());
+        });
+    }
+
+    /**
+     * Tests setSort() method
+     *
+     * @return void
+     */
+    public function testSetSort()
+    {
         $assoc = new BelongsToMany('Test');
-        $this->assertNull($assoc->sort());
-        $assoc->sort(['id' => 'ASC']);
-        $this->assertEquals(['id' => 'ASC'], $assoc->sort());
+        $this->assertNull($assoc->getSort());
+        $assoc->setSort(['id' => 'ASC']);
+        $this->assertEquals(['id' => 'ASC'], $assoc->getSort());
     }
 
     /**
@@ -247,16 +263,36 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests saveStrategy
      *
+     * @group deprecated
      * @return void
      */
     public function testSaveStrategy()
     {
+        $this->deprecated(function () {
+            $assoc = new BelongsToMany('Test');
+            $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+            $assoc->saveStrategy(BelongsToMany::SAVE_APPEND);
+            $this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
+            $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+            $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+        });
+    }
+
+    /**
+     * Tests saveStrategy
+     *
+     * @return void
+     */
+    public function testSetSaveStrategy()
+    {
         $assoc = new BelongsToMany('Test');
-        $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
-        $assoc->saveStrategy(BelongsToMany::SAVE_APPEND);
-        $this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
-        $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
-        $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+        $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->getSaveStrategy());
+
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_APPEND);
+        $this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->getSaveStrategy());
+
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
+        $this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->getSaveStrategy());
     }
 
     /**
@@ -267,7 +303,7 @@ class BelongsToManyTest extends TestCase
     public function testSaveStrategyInOptions()
     {
         $assoc = new BelongsToMany('Test', ['saveStrategy' => BelongsToMany::SAVE_APPEND]);
-        $this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
+        $this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->getSaveStrategy());
     }
 
     /**
@@ -862,7 +898,7 @@ class BelongsToManyTest extends TestCase
             'tags' => $value,
         ], ['markNew' => true]);
 
-        $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->never())
             ->method('replaceLinks');
         $assoc->expects($this->never())
@@ -891,7 +927,7 @@ class BelongsToManyTest extends TestCase
             'tags' => $value,
         ], ['markNew' => false]);
 
-        $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->once())
             ->method('replaceLinks')
             ->with($entity, [])
@@ -926,7 +962,7 @@ class BelongsToManyTest extends TestCase
         ]);
 
         $options = ['foo' => 'bar'];
-        $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->once())->method('replaceLinks')
             ->with($entity, $entity->tags, $options)
             ->will($this->returnValue(true));
@@ -956,7 +992,7 @@ class BelongsToManyTest extends TestCase
         ]);
 
         $options = ['foo' => 'bar'];
-        $assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+        $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->once())->method('replaceLinks')
             ->with($entity, $entity->tags, $options)
             ->will($this->returnValue(false));
@@ -1002,24 +1038,50 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests that targetForeignKey() returns the correct configured value
      *
+     * @group deprecated
      * @return void
      */
     public function testTargetForeignKey()
+    {
+        $this->deprecated(function () {
+            $assoc = new BelongsToMany('Test', [
+                'sourceTable' => $this->article,
+                'targetTable' => $this->tag
+            ]);
+            $this->assertEquals('tag_id', $assoc->targetForeignKey());
+            $this->assertEquals('another_key', $assoc->targetForeignKey('another_key'));
+            $this->assertEquals('another_key', $assoc->targetForeignKey());
+
+            $assoc = new BelongsToMany('Test', [
+                'sourceTable' => $this->article,
+                'targetTable' => $this->tag,
+                'targetForeignKey' => 'foo'
+            ]);
+            $this->assertEquals('foo', $assoc->targetForeignKey());
+        });
+    }
+
+    /**
+     * Tests that setTargetForeignKey() returns the correct configured value
+     *
+     * @return void
+     */
+    public function testSetTargetForeignKey()
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag
         ]);
-        $this->assertEquals('tag_id', $assoc->targetForeignKey());
-        $this->assertEquals('another_key', $assoc->targetForeignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->targetForeignKey());
+        $this->assertEquals('tag_id', $assoc->getTargetForeignKey());
+        $assoc->setTargetForeignKey('another_key');
+        $this->assertEquals('another_key', $assoc->getTargetForeignKey());
 
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
             'targetForeignKey' => 'foo'
         ]);
-        $this->assertEquals('foo', $assoc->targetForeignKey());
+        $this->assertEquals('foo', $assoc->getTargetForeignKey());
     }
 
     /**
@@ -1037,12 +1099,12 @@ class BelongsToManyTest extends TestCase
             'targetForeignKey' => 'Tag'
         ]);
         $junction = $assoc->junction();
-        $this->assertEquals('Art', $junction->getAssociation('Articles')->foreignKey());
-        $this->assertEquals('Tag', $junction->getAssociation('Tags')->foreignKey());
+        $this->assertEquals('Art', $junction->getAssociation('Articles')->getForeignKey());
+        $this->assertEquals('Tag', $junction->getAssociation('Tags')->getForeignKey());
 
         $inverseRelation = $this->tag->getAssociation('Articles');
-        $this->assertEquals('Tag', $inverseRelation->foreignKey());
-        $this->assertEquals('Art', $inverseRelation->targetForeignKey());
+        $this->assertEquals('Tag', $inverseRelation->getForeignKey());
+        $this->assertEquals('Art', $inverseRelation->getTargetForeignKey());
     }
 
     /**
@@ -1054,7 +1116,7 @@ class BelongsToManyTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsToMany('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->property());
+        $this->assertEquals('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -1072,7 +1134,7 @@ class BelongsToManyTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new BelongsToMany('Contacts.Tags', $config);
-        $this->assertEquals('tags', $association->property());
+        $this->assertEquals('tags', $association->getProperty());
     }
 
     /**
@@ -1098,26 +1160,26 @@ class BelongsToManyTest extends TestCase
 
         $tagAssoc = $articles->getAssociation('Tags');
         $this->assertNotEmpty($tagAssoc, 'btm should exist');
-        $this->assertEquals($conditions, $tagAssoc->conditions());
-        $this->assertEquals('target_foreign_key', $tagAssoc->targetForeignKey());
-        $this->assertEquals('foreign_key', $tagAssoc->foreignKey());
+        $this->assertEquals($conditions, $tagAssoc->getConditions());
+        $this->assertEquals('target_foreign_key', $tagAssoc->getTargetForeignKey());
+        $this->assertEquals('foreign_key', $tagAssoc->getForeignKey());
 
         $jointAssoc = $articles->getAssociation('SpecialTags');
         $this->assertNotEmpty($jointAssoc, 'has many to junction should exist');
         $this->assertInstanceOf('Cake\ORM\Association\HasMany', $jointAssoc);
-        $this->assertEquals('foreign_key', $jointAssoc->foreignKey());
+        $this->assertEquals('foreign_key', $jointAssoc->getForeignKey());
 
         $articleAssoc = $tags->getAssociation('Articles');
         $this->assertNotEmpty($articleAssoc, 'reverse btm should exist');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $articleAssoc);
-        $this->assertEquals($conditions, $articleAssoc->conditions());
-        $this->assertEquals('foreign_key', $articleAssoc->targetForeignKey(), 'keys should swap');
-        $this->assertEquals('target_foreign_key', $articleAssoc->foreignKey(), 'keys should swap');
+        $this->assertEquals($conditions, $articleAssoc->getConditions());
+        $this->assertEquals('foreign_key', $articleAssoc->getTargetForeignKey(), 'keys should swap');
+        $this->assertEquals('target_foreign_key', $articleAssoc->getForeignKey(), 'keys should swap');
 
         $jointAssoc = $tags->getAssociation('SpecialTags');
         $this->assertNotEmpty($jointAssoc, 'has many to junction should exist');
         $this->assertInstanceOf('Cake\ORM\Association\HasMany', $jointAssoc);
-        $this->assertEquals('target_foreign_key', $jointAssoc->foreignKey());
+        $this->assertEquals('target_foreign_key', $jointAssoc->getForeignKey());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -84,19 +84,38 @@ class BelongsToTest extends TestCase
     }
 
     /**
-     * Test that foreignKey generation ignores database names in target table.
+     * Test that foreignKey generation
      *
      * @return void
      */
-    public function testForeignKey()
+    public function testSetForeignKey()
     {
         $assoc = new BelongsTo('Companies', [
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ]);
-        $this->assertEquals('company_id', $assoc->foreignKey());
-        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->foreignKey());
+        $this->assertEquals('company_id', $assoc->getForeignKey());
+        $this->assertSame($assoc, $assoc->setForeignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->getForeignKey());
+    }
+
+    /**
+     * Test that foreignKey generation
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testForeignKey()
+    {
+        $this->deprecated(function () {
+            $assoc = new BelongsTo('Companies', [
+                'sourceTable' => $this->client,
+                'targetTable' => $this->company,
+            ]);
+            $this->assertEquals('company_id', $assoc->foreignKey());
+            $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+            $this->assertEquals('another_key', $assoc->foreignKey());
+        });
     }
 
     /**
@@ -112,7 +131,7 @@ class BelongsToTest extends TestCase
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ]);
-        $this->assertEquals('company_id', $assoc->foreignKey());
+        $this->assertEquals('company_id', $assoc->getForeignKey());
     }
 
     /**
@@ -336,7 +355,7 @@ class BelongsToTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsTo('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->property());
+        $this->assertEquals('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -354,7 +373,7 @@ class BelongsToTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new BelongsTo('Contacts.Companies', $config);
-        $this->assertEquals('company', $association->property());
+        $this->assertEquals('company', $association->getProperty());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -99,14 +99,32 @@ class HasManyTest extends TestCase
      *
      * @return void
      */
-    public function testForeignKey()
+    public function testSetForeignKey()
     {
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author
         ]);
-        $this->assertEquals('author_id', $assoc->foreignKey());
-        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->foreignKey());
+        $this->assertEquals('author_id', $assoc->getForeignKey());
+        $this->assertSame($assoc, $assoc->setForeignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->getForeignKey());
+    }
+
+    /**
+     * Tests that foreignKey() returns the correct configured value
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testForeignKey()
+    {
+        $this->deprecated(function () {
+            $assoc = new HasMany('Articles', [
+                'sourceTable' => $this->author
+            ]);
+            $this->assertEquals('author_id', $assoc->foreignKey());
+            $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+            $this->assertEquals('another_key', $assoc->foreignKey());
+        });
     }
 
     /**
@@ -120,7 +138,7 @@ class HasManyTest extends TestCase
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author
         ]);
-        $this->assertEquals('author_id', $assoc->foreignKey());
+        $this->assertEquals('author_id', $assoc->getForeignKey());
     }
 
     /**
@@ -173,10 +191,10 @@ class HasManyTest extends TestCase
         $assoc = new HasMany('Test');
         $this->assertTrue($assoc->requiresKeys());
 
-        $assoc->strategy(HasMany::STRATEGY_SUBQUERY);
+        $assoc->setStrategy(HasMany::STRATEGY_SUBQUERY);
         $this->assertFalse($assoc->requiresKeys());
 
-        $assoc->strategy(HasMany::STRATEGY_SELECT);
+        $assoc->setStrategy(HasMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
     }
 
@@ -190,7 +208,7 @@ class HasManyTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid strategy "join" was provided');
         $assoc = new HasMany('Test');
-        $assoc->strategy(HasMany::STRATEGY_JOIN);
+        $assoc->setStrategy(HasMany::STRATEGY_JOIN);
     }
 
     /**
@@ -287,7 +305,7 @@ class HasManyTest extends TestCase
         $association = new HasMany('Articles', $config);
         $keys = [1, 2, 3, 4];
         $query = $this->article->query();
-        $query->addDefaultTypes($this->article->Comments->source());
+        $query->addDefaultTypes($this->article->Comments->getSource());
 
         $this->article->method('find')
             ->with('all')
@@ -552,7 +570,7 @@ class HasManyTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new hasMany('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->property());
+        $this->assertEquals('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -570,7 +588,7 @@ class HasManyTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new HasMany('Contacts.Addresses', $config);
-        $this->assertEquals('addresses', $association->property());
+        $this->assertEquals('addresses', $association->getProperty());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -929,12 +929,43 @@ class HasManyTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidStrategy()
+    public function testInvalidSaveStrategy()
     {
         $this->expectException(\InvalidArgumentException::class);
         $articles = TableRegistry::get('Articles');
 
         $association = $articles->hasMany('Comments');
-        $association->setStrategy('anotherThing');
+        $association->setSaveStrategy('anotherThing');
+    }
+
+    /**
+     * Tests saveStrategy
+     *
+     * @return void
+     */
+    public function testSetSaveStrategy()
+    {
+        $articles = TableRegistry::get('Articles');
+
+        $association = $articles->hasMany('Comments');
+        $this->assertSame($association, $association->setSaveStrategy(HasMany::SAVE_REPLACE));
+        $this->assertSame(HasMany::SAVE_REPLACE, $association->getSaveStrategy());
+    }
+
+    /**
+     * Tests saveStrategy
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testSaveStrategy()
+    {
+        $this->deprecated(function () {
+            $articles = TableRegistry::get('Articles');
+
+            $association = $articles->hasMany('Comments');
+            $this->assertSame(HasMany::SAVE_REPLACE, $association->saveStrategy(HasMany::SAVE_REPLACE));
+            $this->assertSame(HasMany::SAVE_REPLACE, $association->saveStrategy());
+        });
     }
 }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -923,4 +923,18 @@ class HasManyTest extends TestCase
         ]);
         $this->assertEmpty($entity->get('comments'));
     }
+
+    /**
+     * Tests that providing an invalid strategy throws an exception
+     *
+     * @return void
+     */
+    public function testInvalidStrategy()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $articles = TableRegistry::get('Articles');
+
+        $association = $articles->hasMany('Comments');
+        $association->setStrategy('anotherThing');
+    }
 }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -137,14 +137,30 @@ class HasManyTest extends TestCase
     /**
      * Tests sort() method
      *
+     * @group deprecated
      * @return void
      */
     public function testSort()
     {
+        $this->deprecated(function () {
+            $assoc = new HasMany('Test');
+            $this->assertNull($assoc->sort());
+            $assoc->sort(['id' => 'ASC']);
+            $this->assertEquals(['id' => 'ASC'], $assoc->sort());
+        });
+    }
+
+    /**
+     * Tests setSort() method
+     *
+     * @return void
+     */
+    public function testSetSort()
+    {
         $assoc = new HasMany('Test');
-        $this->assertNull($assoc->sort());
-        $assoc->sort(['id' => 'ASC']);
-        $this->assertEquals(['id' => 'ASC'], $assoc->sort());
+        $this->assertNull($assoc->getSort());
+        $assoc->setSort(['id' => 'ASC']);
+        $this->assertEquals(['id' => 'ASC'], $assoc->getSort());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -66,16 +66,34 @@ class HasOneTest extends TestCase
     /**
      * Tests that foreignKey() returns the correct configured value
      *
+     * @group deprecated
      * @return void
      */
     public function testForeignKey()
     {
+        $this->deprecated(function () {
+            $assoc = new HasOne('Profiles', [
+                'sourceTable' => $this->user
+            ]);
+            $this->assertEquals('user_id', $assoc->foreignKey());
+            $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+            $this->assertEquals('another_key', $assoc->foreignKey());
+        });
+    }
+
+    /**
+     * Tests that setForeignKey() returns the correct configured value
+     *
+     * @return void
+     */
+    public function testSetForeignKey()
+    {
         $assoc = new HasOne('Profiles', [
             'sourceTable' => $this->user
         ]);
-        $this->assertEquals('user_id', $assoc->foreignKey());
-        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->foreignKey());
+        $this->assertEquals('user_id', $assoc->getForeignKey());
+        $this->assertEquals($assoc, $assoc->setForeignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->getForeignKey());
     }
 
     /**
@@ -250,7 +268,7 @@ class HasOneTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new hasOne('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->property());
+        $this->assertEquals('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -265,7 +283,7 @@ class HasOneTest extends TestCase
             'targetTable' => $this->profile,
         ];
         $association = new HasOne('Contacts.Profiles', $config);
-        $this->assertEquals('profile', $association->property());
+        $this->assertEquals('profile', $association->getProperty());
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -159,7 +159,7 @@ class AssociationCollectionTest extends TestCase
         $belongsTo = new BelongsTo('Users', [
             'sourceTable' => $table
         ]);
-        $this->assertEquals('user', $belongsTo->property());
+        $this->assertEquals('user', $belongsTo->getProperty());
         $this->associations->add('Users', $belongsTo);
         $this->assertNull($this->associations->get('user'));
 

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -100,13 +100,28 @@ class AssociationTest extends TestCase
     /**
      * Tests that name() returns the correct configure association name
      *
+     * @group deprecated
      * @return void
      */
     public function testName()
     {
-        $this->assertEquals('Foo', $this->association->name());
-        $this->association->name('Bar');
-        $this->assertEquals('Bar', $this->association->name());
+        $this->deprecated(function () {
+            $this->assertEquals('Foo', $this->association->name());
+            $this->association->name('Bar');
+            $this->assertEquals('Bar', $this->association->name());
+        });
+    }
+
+    /**
+     * Tests that setName()
+     *
+     * @return void
+     */
+    public function testSetName()
+    {
+        $this->assertEquals('Foo', $this->association->getName());
+        $this->assertSame($this->association, $this->association->setName('Bar'));
+        $this->assertEquals('Bar', $this->association->getName());
     }
 
     /**
@@ -231,13 +246,42 @@ class AssociationTest extends TestCase
     /**
      * Tests that cascadeCallbacks() returns the correct configured value
      *
+     * @group deprecated
      * @return void
      */
     public function testCascadeCallbacks()
     {
-        $this->assertSame(false, $this->association->cascadeCallbacks());
-        $this->association->cascadeCallbacks(true);
-        $this->assertSame(true, $this->association->cascadeCallbacks());
+        $this->deprecated(function () {
+            $this->assertSame(false, $this->association->cascadeCallbacks());
+            $this->association->cascadeCallbacks(true);
+            $this->assertSame(true, $this->association->cascadeCallbacks());
+        });
+    }
+
+    /**
+     * Tests that cascadeCallbacks() returns the correct configured value
+     *
+     * @return void
+     */
+    public function testSetCascadeCallbacks()
+    {
+        $this->assertFalse($this->association->getCascadeCallbacks());
+        $this->assertSame($this->association, $this->association->setCascadeCallbacks(true));
+        $this->assertTrue($this->association->getCascadeCallbacks());
+    }
+
+    /**
+     * Tests the bindingKey method as a setter/getter
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testBindingKey()
+    {
+        $this->deprecated(function () {
+            $this->association->bindingKey('foo_id');
+            $this->assertEquals('foo_id', $this->association->bindingKey());
+        });
     }
 
     /**
@@ -245,10 +289,10 @@ class AssociationTest extends TestCase
      *
      * @return void
      */
-    public function testBindingKey()
+    public function testSetBindingKey()
     {
-        $this->association->bindingKey('foo_id');
-        $this->assertEquals('foo_id', $this->association->bindingKey());
+        $this->assertSame($this->association, $this->association->setBindingKey('foo_id'));
+        $this->assertEquals('foo_id', $this->association->getBindingKey());
     }
 
     /**
@@ -263,7 +307,7 @@ class AssociationTest extends TestCase
             ->expects($this->once())
             ->method('isOwningSide')
             ->will($this->returnValue(true));
-        $result = $this->association->bindingKey();
+        $result = $this->association->getBindingKey();
         $this->assertEquals(['id', 'site_id'], $result);
     }
 
@@ -277,39 +321,70 @@ class AssociationTest extends TestCase
     {
         $target = new Table;
         $target->primaryKey(['foo', 'site_id']);
-        $this->association->target($target);
+        $this->association->setTarget($target);
 
         $this->association
             ->expects($this->once())
             ->method('isOwningSide')
             ->will($this->returnValue(false));
-        $result = $this->association->bindingKey();
+        $result = $this->association->getBindingKey();
         $this->assertEquals(['foo', 'site_id'], $result);
     }
 
     /**
      * Tests that name() returns the correct configured value
      *
+     * @group deprecated
      * @return void
      */
     public function testForeignKey()
     {
-        $this->assertEquals('a_key', $this->association->foreignKey());
-        $this->association->foreignKey('another_key');
-        $this->assertEquals('another_key', $this->association->foreignKey());
+        $this->deprecated(function () {
+            $this->assertEquals('a_key', $this->association->foreignKey());
+            $this->association->foreignKey('another_key');
+            $this->assertEquals('another_key', $this->association->foreignKey());
+        });
+    }
+
+    /**
+     * Tests setForeignKey()
+     *
+     * @return void
+     */
+    public function testSetForeignKey()
+    {
+        $this->assertEquals('a_key', $this->association->getForeignKey());
+        $this->assertSame($this->association, $this->association->setForeignKey('another_key'));
+        $this->assertEquals('another_key', $this->association->getForeignKey());
     }
 
     /**
      * Tests that conditions() returns the correct configured value
      *
+     * @group deprecated
      * @return void
      */
     public function testConditions()
     {
-        $this->assertEquals(['field' => 'value'], $this->association->conditions());
+        $this->deprecated(function () {
+            $this->assertEquals(['field' => 'value'], $this->association->conditions());
+            $conds = ['another_key' => 'another value'];
+            $this->association->conditions($conds);
+            $this->assertEquals($conds, $this->association->conditions());
+        });
+    }
+
+    /**
+     * Tests setConditions()
+     *
+     * @return void
+     */
+    public function testSetConditions()
+    {
+        $this->assertEquals(['field' => 'value'], $this->association->getConditions());
         $conds = ['another_key' => 'another value'];
-        $this->association->conditions($conds);
-        $this->assertEquals($conds, $this->association->conditions());
+        $this->assertSame($this->association, $this->association->setConditions($conds));
+        $this->assertEquals($conds, $this->association->getConditions());
     }
 
     /**
@@ -325,16 +400,34 @@ class AssociationTest extends TestCase
     /**
      * Tests that target() returns the correct Table object
      *
+     * @group deprecated
      * @return void
      */
     public function testTarget()
     {
-        $table = $this->association->target();
+        $this->deprecated(function () {
+            $table = $this->association->target();
+            $this->assertInstanceOf(__NAMESPACE__ . '\TestTable', $table);
+
+            $other = new Table;
+            $this->association->target($other);
+            $this->assertSame($other, $this->association->target());
+        });
+    }
+
+    /**
+     * Tests that setTarget()
+     *
+     * @return void
+     */
+    public function testSetTarget()
+    {
+        $table = $this->association->getTarget();
         $this->assertInstanceOf(__NAMESPACE__ . '\TestTable', $table);
 
         $other = new Table;
-        $this->association->target($other);
-        $this->assertSame($other, $this->association->target());
+        $this->assertSame($this->association, $this->association->setTarget($other));
+        $this->assertSame($other, $this->association->getTarget());
     }
 
     /**
@@ -362,7 +455,7 @@ class AssociationTest extends TestCase
             ->setConstructorArgs(['ThisAssociationName', $config])
             ->getMock();
 
-        $table = $this->association->target();
+        $table = $this->association->getTarget();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $table);
 
         $this->assertTrue(
@@ -375,9 +468,27 @@ class AssociationTest extends TestCase
 
         $plugin = TableRegistry::get('TestPlugin.ThisAssociationName');
         $this->assertSame($table, $plugin, 'Should be an instance of TestPlugin.Comments');
-        $this->assertSame('TestPlugin.ThisAssociationName', $table->registryAlias());
-        $this->assertSame('comments', $table->table());
-        $this->assertSame('ThisAssociationName', $table->alias());
+        $this->assertSame('TestPlugin.ThisAssociationName', $table->getRegistryAlias());
+        $this->assertSame('comments', $table->getTable());
+        $this->assertSame('ThisAssociationName', $table->getAlias());
+    }
+
+    /**
+     * Tests that source() returns the correct Table object
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testSource()
+    {
+        $this->deprecated(function () {
+            $table = $this->association->source();
+            $this->assertSame($this->source, $table);
+
+            $other = new Table;
+            $this->association->source($other);
+            $this->assertSame($other, $this->association->source());
+        });
     }
 
     /**
@@ -385,26 +496,56 @@ class AssociationTest extends TestCase
      *
      * @return void
      */
-    public function testSource()
+    public function testSetSource()
     {
-        $table = $this->association->source();
+        $table = $this->association->getSource();
         $this->assertSame($this->source, $table);
 
         $other = new Table;
-        $this->association->source($other);
-        $this->assertSame($other, $this->association->source());
+        $this->assertSame($this->association, $this->association->setSource($other));
+        $this->assertSame($other, $this->association->getSource());
     }
 
     /**
      * Tests joinType method
      *
+     * @group deprecated
      * @return void
      */
     public function testJoinType()
     {
-        $this->assertEquals('INNER', $this->association->joinType());
-        $this->association->joinType('LEFT');
-        $this->assertEquals('LEFT', $this->association->joinType());
+        $this->deprecated(function () {
+            $this->assertEquals('INNER', $this->association->joinType());
+            $this->association->joinType('LEFT');
+            $this->assertEquals('LEFT', $this->association->joinType());
+        });
+    }
+
+    /**
+     * Tests setJoinType method
+     *
+     * @return void
+     */
+    public function testSetJoinType()
+    {
+        $this->assertEquals('INNER', $this->association->getJoinType());
+        $this->assertSame($this->association, $this->association->setJoinType('LEFT'));
+        $this->assertEquals('LEFT', $this->association->getJoinType());
+    }
+
+    /**
+     * Tests property method
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testProperty()
+    {
+        $this->deprecated(function () {
+            $this->assertEquals('foo', $this->association->property());
+            $this->association->property('thing');
+            $this->assertEquals('thing', $this->association->property());
+        });
     }
 
     /**
@@ -412,11 +553,11 @@ class AssociationTest extends TestCase
      *
      * @return void
      */
-    public function testProperty()
+    public function testSetProperty()
     {
-        $this->assertEquals('foo', $this->association->property());
-        $this->association->property('thing');
-        $this->assertEquals('thing', $this->association->property());
+        $this->assertEquals('foo', $this->association->getProperty());
+        $this->assertSame($this->association, $this->association->setProperty('thing'));
+        $this->assertEquals('thing', $this->association->getProperty());
     }
 
     /**
@@ -429,7 +570,7 @@ class AssociationTest extends TestCase
         $this->expectException(\PHPUnit\Framework\Error\Warning::class);
         $this->expectExceptionMessageRegExp('/^Association property name "foo" clashes with field of same name of table "test"/');
         $this->source->schema(['foo' => ['type' => 'string']]);
-        $this->assertEquals('foo', $this->association->property());
+        $this->assertEquals('foo', $this->association->getProperty());
     }
 
     /**
@@ -458,7 +599,7 @@ class AssociationTest extends TestCase
             ->setConstructorArgs(['Foo', $config])
             ->getMock();
 
-        $this->assertEquals('foo', $association->property());
+        $this->assertEquals('foo', $association->getProperty());
     }
 
     /**
@@ -468,11 +609,13 @@ class AssociationTest extends TestCase
      */
     public function testStrategy()
     {
-        $this->assertEquals('join', $this->association->strategy());
-        $this->association->strategy('select');
-        $this->assertEquals('select', $this->association->strategy());
-        $this->association->strategy('subquery');
-        $this->assertEquals('subquery', $this->association->strategy());
+        $this->assertEquals('join', $this->association->getStrategy());
+
+        $this->association->setStrategy('select');
+        $this->assertEquals('select', $this->association->getStrategy());
+
+        $this->association->setStrategy('subquery');
+        $this->assertEquals('subquery', $this->association->getStrategy());
     }
 
     /**
@@ -483,20 +626,34 @@ class AssociationTest extends TestCase
     public function testInvalidStrategy()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->association->strategy('anotherThing');
-        $this->assertEquals('subquery', $this->association->strategy());
+        $this->association->setStrategy('anotherThing');
     }
 
     /**
      * Tests test finder() method as getter and setter
      *
+     * @group deprecated
      * @return void
      */
     public function testFinderMethod()
     {
-        $this->assertEquals('all', $this->association->finder());
-        $this->assertEquals('published', $this->association->finder('published'));
-        $this->assertEquals('published', $this->association->finder());
+        $this->deprecated(function () {
+            $this->assertEquals('all', $this->association->finder());
+            $this->assertEquals('published', $this->association->finder('published'));
+            $this->assertEquals('published', $this->association->finder());
+        });
+    }
+
+    /**
+     * Tests test setFinder() method
+     *
+     * @return void
+     */
+    public function testSetFinderMethod()
+    {
+        $this->assertEquals('all', $this->association->getFinder());
+        $this->assertSame($this->association, $this->association->setFinder('published'));
+        $this->assertEquals('published', $this->association->getFinder());
     }
 
     /**
@@ -522,7 +679,7 @@ class AssociationTest extends TestCase
             ])
             ->setConstructorArgs(['Foo', $config])
             ->getMock();
-        $this->assertEquals('published', $assoc->finder());
+        $this->assertEquals('published', $assoc->getFinder());
     }
 
     /**
@@ -533,7 +690,7 @@ class AssociationTest extends TestCase
      */
     public function testCustomFinderIsUsed()
     {
-        $this->association->finder('published');
+        $this->association->setFinder('published');
         $this->assertEquals(
             ['this' => 'worked'],
             $this->association->find()->getOptions()

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -534,6 +534,22 @@ class AssociationTest extends TestCase
     }
 
     /**
+     * Tests dependent method
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testDependent()
+    {
+        $this->deprecated(function () {
+            $this->assertTrue($this->association->dependent());
+            $this->association->dependent(false);
+            $this->assertFalse($this->association->dependent());
+        });
+    }
+
+
+    /**
      * Tests property method
      *
      * @group deprecated
@@ -605,9 +621,28 @@ class AssociationTest extends TestCase
     /**
      * Tests strategy method
      *
+     * @group deprecated
      * @return void
      */
     public function testStrategy()
+    {
+        $this->deprecated(function () {
+            $this->assertEquals('join', $this->association->strategy());
+
+            $this->association->strategy('select');
+            $this->assertEquals('select', $this->association->strategy());
+
+            $this->association->strategy('subquery');
+            $this->assertEquals('subquery', $this->association->strategy());
+        });
+    }
+
+    /**
+     * Tests strategy method
+     *
+     * @return void
+     */
+    public function testSetStrategy()
     {
         $this->assertEquals('join', $this->association->getStrategy());
 

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -548,7 +548,6 @@ class AssociationTest extends TestCase
         });
     }
 
-
     /**
      * Tests property method
      *

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -440,7 +440,7 @@ class CounterCacheBehaviorTest extends TestCase
             'bindingKey' => ['category_id', 'user_id'],
             'foreignKey' => ['category_id', 'user_id']
         ]);
-        $this->post->getAssociation('UserCategoryPosts')->target($this->userCategoryPosts);
+        $this->post->getAssociation('UserCategoryPosts')->setTarget($this->userCategoryPosts);
         $this->post->addBehavior('CounterCache', [
             'UserCategoryPosts' => ['post_count']
         ]);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -96,10 +96,10 @@ class TranslateBehaviorTest extends TestCase
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->name());
-        $this->assertInstanceOf('TestApp\Model\Table\I18nTable', $i18n->target());
-        $this->assertEquals('test_custom_i18n_datasource', $i18n->target()->connection()->configName());
-        $this->assertEquals('custom_i18n_table', $i18n->target()->table());
+        $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->getName());
+        $this->assertInstanceOf('TestApp\Model\Table\I18nTable', $i18n->getTarget());
+        $this->assertEquals('test_custom_i18n_datasource', $i18n->getTarget()->connection()->configName());
+        $this->assertEquals('custom_i18n_table', $i18n->getTarget()->getTable());
     }
 
     /**
@@ -119,7 +119,7 @@ class TranslateBehaviorTest extends TestCase
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals('select', $i18n->strategy());
+        $this->assertEquals('select', $i18n->getStrategy());
     }
 
     /**
@@ -297,7 +297,7 @@ class TranslateBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testFindSingleLocaleWithConditions()
+    public function testFindSingleLocaleWithgetConditions()
     {
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -569,7 +569,7 @@ class TranslateBehaviorTest extends TestCase
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->target();
+        $comments = $table->hasMany('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $table->locale('eng');
@@ -599,7 +599,7 @@ class TranslateBehaviorTest extends TestCase
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->target();
+        $comments = $table->hasMany('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $results = $table->find('translations')->contain([
@@ -640,7 +640,7 @@ class TranslateBehaviorTest extends TestCase
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->target();
+        $comments = $table->hasMany('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $table->locale('cze');
@@ -692,7 +692,7 @@ class TranslateBehaviorTest extends TestCase
     {
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $authors = $table->belongsTo('Authors')->target();
+        $authors = $table->belongsTo('Authors')->getTarget();
         $authors->addBehavior('Translate', ['fields' => ['name']]);
 
         $table->locale('eng');
@@ -1169,7 +1169,7 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNotEmpty($association, 'Translation association not found');
 
         $found = false;
-        foreach ($association->conditions() as $key => $value) {
+        foreach ($association->getConditions() as $key => $value) {
             if (strpos($key, 'comment_translation.model') !== false) {
                 $found = true;
                 $this->assertEquals('Comments', $value);
@@ -1199,7 +1199,7 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNotEmpty($association, 'Translation association not found');
 
         $found = false;
-        foreach ($association->conditions() as $key => $value) {
+        foreach ($association->getConditions() as $key => $value) {
             if (strpos($key, 'body_translation.model') !== false) {
                 $found = true;
                 $this->assertEquals('Posts', $value);

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -212,7 +212,7 @@ class CompositeKeyTest extends TestCase
             ->toArray();
         $expected[0]['articles'] = [];
         $this->assertEquals($expected, $results);
-        $this->assertEquals($table->getAssociation('SiteArticles')->strategy(), $strategy);
+        $this->assertEquals($table->getAssociation('SiteArticles')->getStrategy(), $strategy);
     }
 
     /**
@@ -301,7 +301,7 @@ class CompositeKeyTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $results);
-        $this->assertEquals($articles->getAssociation('SiteTags')->strategy(), $strategy);
+        $this->assertEquals($articles->getAssociation('SiteTags')->getStrategy(), $strategy);
     }
 
     /**

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -560,6 +560,35 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
+     * Test for autoFields()
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testAutoFields()
+    {
+        $this->deprecated(function () {
+            $loader = new EagerLoader();
+            $this->assertTrue($loader->autoFields());
+            $this->assertFalse($loader->autoFields(false));
+            $this->assertFalse($loader->autoFields());
+        });
+    }
+
+    /**
+     * Test for enableAutoFields()
+     *
+     * @return void
+     */
+    public function testEnableAutoFields()
+    {
+        $loader = new EagerLoader();
+        $this->assertTrue($loader->isAutoFieldsEnabled());
+        $this->assertSame($loader, $loader->enableAutoFields(false));
+        $this->assertFalse($loader->isAutoFieldsEnabled());
+    }
+
+    /**
      * Helper function sued to quoted both keys and values in an array in case
      * the test suite is running with auto quoting enabled
      *

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -551,12 +551,12 @@ class EagerLoaderTest extends TestCase
 
         $loader = new EagerLoader();
         $loader->contain($contains);
-        $loader->matching('clients.addresses');
+        $loader->setMatching('clients.addresses');
 
         $this->assertNull($loader->clearContain());
         $result = $loader->normalized($this->table);
         $this->assertEquals([], $result);
-        $this->assertArrayHasKey('clients', $loader->matching());
+        $this->assertArrayHasKey('clients', $loader->getMatching());
     }
 
     /**
@@ -585,6 +585,26 @@ class EagerLoaderTest extends TestCase
     /**
      * Asserts that matching('something') and setMatching('something') return consistent type.
      *
+     * @group deprecated
+     * @return void
+     */
+    public function testMatchingReturnType()
+    {
+        $this->deprecated(function () {
+            $loader = new EagerLoader();
+            $result = $loader->setMatching('clients');
+            $this->assertInstanceOf(EagerLoader::class, $result);
+            $this->assertArrayHasKey('clients', $loader->getMatching());
+
+            $result = $loader->matching('customers');
+            $this->assertArrayHasKey('customers', $result);
+            $this->assertArrayHasKey('customers', $loader->getMatching());
+        });
+    }
+
+    /**
+     * Asserts that matching('something') and setMatching('something') return consistent type.
+     *
      * @return void
      */
     public function testSetMatchingReturnType()
@@ -593,9 +613,5 @@ class EagerLoaderTest extends TestCase
         $result = $loader->setMatching('clients');
         $this->assertInstanceOf(EagerLoader::class, $result);
         $this->assertArrayHasKey('clients', $loader->getMatching());
-
-        $result = $loader->matching('customers');
-        $this->assertArrayHasKey('customers', $result);
-        $this->assertArrayHasKey('customers', $loader->getMatching());
     }
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -228,11 +228,11 @@ class QueryRegressionTest extends TestCase
         $table = TableRegistry::get('Articles');
         $table->belongsTo('Authors');
         $table->hasOne('Things', ['propertyName' => 'articles_tag']);
-        $table->Authors->target()->hasOne('Stuff', [
+        $table->Authors->getTarget()->hasOne('Stuff', [
             'foreignKey' => 'id',
             'propertyName' => 'favorite_tag'
         ]);
-        $table->Things->target()->belongsTo('Stuff', [
+        $table->Things->getTarget()->belongsTo('Stuff', [
             'foreignKey' => 'tag_id',
             'propertyName' => 'foo'
         ]);
@@ -1704,11 +1704,11 @@ class QueryRegressionTest extends TestCase
         $this->loadFixtures('Authors', 'Articles', 'Tags', 'ArticlesTags');
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
-        $articles = $table->getAssociation('articles')->target();
+        $articles = $table->getAssociation('articles')->getTarget();
         $articles->hasMany('articlesTags');
-        $tags = $articles->getAssociation('articlesTags')->target()->belongsTo('tags');
+        $tags = $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
-        $tags->target()->getEventManager()->on('Model.beforeFind', function ($e, $query) {
+        $tags->getTarget()->getEventManager()->on('Model.beforeFind', function ($e, $query) {
             return $query->formatResults(function ($results) {
                 return $results->map(function (\Cake\ORM\Entity $tag) {
                     $tag->name .= ' - visited';

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -273,7 +273,7 @@ class QueryTest extends TestCase
             ->toArray();
         $expected[0]['articles'] = [];
         $this->assertEquals($expected, $results);
-        $this->assertEquals($table->getAssociation('articles')->strategy(), $strategy);
+        $this->assertEquals($table->getAssociation('articles')->getStrategy(), $strategy);
     }
 
     /**
@@ -657,7 +657,7 @@ class QueryTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $results);
-        $this->assertEquals($table->getAssociation('Tags')->strategy(), $strategy);
+        $this->assertEquals($table->getAssociation('Tags')->getStrategy(), $strategy);
     }
 
     /**
@@ -2323,7 +2323,7 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('ArticlesTags');
         $table->belongsTo('Articles');
-        $table->getAssociation('Articles')->target()->belongsTo('Authors');
+        $table->getAssociation('Articles')->getTarget()->belongsTo('Authors');
 
         $builder = function ($q) {
             return $q
@@ -2371,9 +2371,9 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
-        $articles = $table->getAssociation('articles')->target();
+        $articles = $table->getAssociation('articles')->getTarget();
         $articles->hasMany('articlesTags');
-        $articles->getAssociation('articlesTags')->target()->belongsTo('tags');
+        $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
         $query = $table->find()->contain(['articles.articlesTags.tags' => function ($q) {
             return $q->formatResults(function ($results) {
@@ -2447,7 +2447,7 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('ArticlesTags');
         $table->belongsTo('Articles');
-        $table->getAssociation('Articles')->target()->belongsTo('Authors');
+        $table->getAssociation('Articles')->getTarget()->belongsTo('Authors');
 
         $query = $table->find()
             ->order(['Articles.id' => 'ASC'])
@@ -2469,9 +2469,9 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
-        $articles = $table->getAssociation('articles')->target();
+        $articles = $table->getAssociation('articles')->getTarget();
         $articles->hasMany('articlesTags');
-        $articles->getAssociation('articlesTags')->target()->belongsTo('tags');
+        $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
         $query = $table->find()->matching('articles.articlesTags', function ($q) {
             return $q->matching('tags', function ($q) {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -66,11 +66,11 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = TableRegistry::get('articles');
         $table->belongsTo('authors');
         $table->getAssociation('authors')
-            ->target()
+            ->getTarget()
             ->rulesChecker()
             ->add(
                 function (Entity $author, array $options) use ($table) {
-                    $this->assertSame($options['repository'], $table->getAssociation('authors')->target());
+                    $this->assertSame($options['repository'], $table->getAssociation('authors')->getTarget());
 
                     return false;
                 },
@@ -105,7 +105,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = TableRegistry::get('authors');
         $table->hasOne('articles');
         $table->getAssociation('articles')
-            ->target()
+            ->getTarget()
             ->rulesChecker()
             ->add(
                 function (Entity $entity) {
@@ -150,7 +150,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
         $table->getAssociation('articles')
-            ->target()
+            ->getTarget()
             ->rulesChecker()
             ->add(
                 function (Entity $entity, $options) use ($table) {
@@ -199,7 +199,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
         $table->getAssociation('articles')
-            ->target()
+            ->getTarget()
             ->rulesChecker()
             ->add(
                 function (Entity $article) {
@@ -1320,7 +1320,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = TableRegistry::get('authors');
         $table->hasMany('articles');
         $table->getAssociation('articles')->belongsTo('authors');
-        $checker = $table->getAssociation('articles')->target()->rulesChecker();
+        $checker = $table->getAssociation('articles')->getTarget()->rulesChecker();
         $checker->add(function ($entity, $options) use ($checker) {
             $rule = $checker->existsIn('author_id', 'authors');
             $id = $entity->author_id;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -27,8 +27,10 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\I18n\Time;
 use Cake\ORM\AssociationCollection;
+use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
+use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -544,12 +546,12 @@ class TableTest extends TestCase
         $options = ['foreignKey' => 'fake_id', 'conditions' => ['a' => 'b']];
         $table = new Table(['table' => 'dates']);
         $belongsTo = $table->belongsTo('user', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $belongsTo);
+        $this->assertInstanceOf(BelongsTo::class, $belongsTo);
         $this->assertSame($belongsTo, $table->getAssociation('user'));
-        $this->assertEquals('user', $belongsTo->name());
-        $this->assertEquals('fake_id', $belongsTo->foreignKey());
-        $this->assertEquals(['a' => 'b'], $belongsTo->conditions());
-        $this->assertSame($table, $belongsTo->source());
+        $this->assertEquals('user', $belongsTo->getName());
+        $this->assertEquals('fake_id', $belongsTo->getForeignKey());
+        $this->assertEquals(['a' => 'b'], $belongsTo->getConditions());
+        $this->assertSame($table, $belongsTo->getSource());
     }
 
     /**
@@ -562,12 +564,12 @@ class TableTest extends TestCase
         $options = ['foreignKey' => 'user_id', 'conditions' => ['b' => 'c']];
         $table = new Table(['table' => 'users']);
         $hasOne = $table->hasOne('profile', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\HasOne', $hasOne);
+        $this->assertInstanceOf(HasOne::class, $hasOne);
         $this->assertSame($hasOne, $table->getAssociation('profile'));
-        $this->assertEquals('profile', $hasOne->name());
-        $this->assertEquals('user_id', $hasOne->foreignKey());
-        $this->assertEquals(['b' => 'c'], $hasOne->conditions());
-        $this->assertSame($table, $hasOne->source());
+        $this->assertEquals('profile', $hasOne->getName());
+        $this->assertEquals('user_id', $hasOne->getForeignKey());
+        $this->assertEquals(['b' => 'c'], $hasOne->getConditions());
+        $this->assertSame($table, $hasOne->getSource());
     }
 
     /**
@@ -581,23 +583,23 @@ class TableTest extends TestCase
         $table = new Table(['table' => 'users']);
 
         $hasOne = $table->hasOne('Comments', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\HasOne', $hasOne);
-        $this->assertSame('Comments', $hasOne->name());
+        $this->assertInstanceOf(HasOne::class, $hasOne);
+        $this->assertSame('Comments', $hasOne->getName());
 
-        $hasOneTable = $hasOne->target();
-        $this->assertSame('Comments', $hasOne->alias());
-        $this->assertSame('TestPlugin.Comments', $hasOne->registryAlias());
+        $hasOneTable = $hasOne->getTarget();
+        $this->assertSame('Comments', $hasOne->getAlias());
+        $this->assertSame('TestPlugin.Comments', $hasOne->getRegistryAlias());
 
         $options = ['className' => 'TestPlugin.Comments'];
         $table = new Table(['table' => 'users']);
 
         $hasOne = $table->hasOne('TestPlugin.Comments', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\HasOne', $hasOne);
-        $this->assertSame('Comments', $hasOne->name());
+        $this->assertInstanceOf(HasOne::class, $hasOne);
+        $this->assertSame('Comments', $hasOne->getName());
 
-        $hasOneTable = $hasOne->target();
-        $this->assertSame('Comments', $hasOne->alias());
-        $this->assertSame('TestPlugin.Comments', $hasOne->registryAlias());
+        $hasOneTable = $hasOne->getTarget();
+        $this->assertSame('Comments', $hasOne->getAlias());
+        $this->assertSame('TestPlugin.Comments', $hasOne->getRegistryAlias());
     }
 
     /**
@@ -619,9 +621,9 @@ class TableTest extends TestCase
         $options = ['className' => 'TestPlugin.Comments'];
         $Categories->hasMany('Comments', $options);
 
-        $this->assertInstanceOf('Cake\ORM\Table', $Users->Comments->target());
-        $this->assertInstanceOf('Cake\ORM\Table', $Articles->Comments->target());
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $Categories->Comments->target());
+        $this->assertInstanceOf('Cake\ORM\Table', $Users->Comments->getTarget());
+        $this->assertInstanceOf('Cake\ORM\Table', $Articles->Comments->getTarget());
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $Categories->Comments->getTarget());
     }
 
     /**
@@ -636,14 +638,14 @@ class TableTest extends TestCase
         $Categories->hasMany('Children', ['foreignKey' => 'parent_id'] + $options);
         $Categories->belongsTo('Parent', $options);
 
-        $this->assertSame('categories', $Categories->Children->target()->table());
-        $this->assertSame('categories', $Categories->Parent->target()->table());
+        $this->assertSame('categories', $Categories->Children->getTarget()->getTable());
+        $this->assertSame('categories', $Categories->Parent->getTarget()->getTable());
 
-        $this->assertSame('Children', $Categories->Children->alias());
-        $this->assertSame('Children', $Categories->Children->target()->alias());
+        $this->assertSame('Children', $Categories->Children->getAlias());
+        $this->assertSame('Children', $Categories->Children->getTarget()->getAlias());
 
-        $this->assertSame('Parent', $Categories->Parent->alias());
-        $this->assertSame('Parent', $Categories->Parent->target()->alias());
+        $this->assertSame('Parent', $Categories->Parent->getAlias());
+        $this->assertSame('Parent', $Categories->Parent->getTarget()->getAlias());
 
         $expected = [
             'id' => 2,
@@ -693,13 +695,13 @@ class TableTest extends TestCase
         ];
         $table = new Table(['table' => 'authors']);
         $hasMany = $table->hasMany('article', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\HasMany', $hasMany);
+        $this->assertInstanceOf(HasMany::class, $hasMany);
         $this->assertSame($hasMany, $table->getAssociation('article'));
-        $this->assertEquals('article', $hasMany->name());
-        $this->assertEquals('author_id', $hasMany->foreignKey());
-        $this->assertEquals(['b' => 'c'], $hasMany->conditions());
-        $this->assertEquals(['foo' => 'asc'], $hasMany->sort());
-        $this->assertSame($table, $hasMany->source());
+        $this->assertEquals('article', $hasMany->getName());
+        $this->assertEquals('author_id', $hasMany->getForeignKey());
+        $this->assertEquals(['b' => 'c'], $hasMany->getConditions());
+        $this->assertEquals(['foo' => 'asc'], $hasMany->getSort());
+        $this->assertSame($table, $hasMany->getSource());
     }
 
     /**
@@ -774,7 +776,7 @@ class TableTest extends TestCase
         $table = new Table(['table' => 'authors']);
 
         $table->hasMany('TestPlugin.Comments');
-        $comments = $table->Comments->target();
+        $comments = $table->Comments->getTarget();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $comments);
     }
 
@@ -792,7 +794,7 @@ class TableTest extends TestCase
         $table = new Table(['table' => 'authors']);
 
         $table->hasMany('Comments', ['className' => 'TestPlugin.Comments']);
-        $comments = $table->Comments->target();
+        $comments = $table->Comments->getTarget();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $comments);
     }
 
@@ -811,14 +813,14 @@ class TableTest extends TestCase
         ];
         $table = new Table(['table' => 'authors', 'connection' => $this->connection]);
         $belongsToMany = $table->belongsToMany('tag', $options);
-        $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
+        $this->assertInstanceOf(BelongsToMany::class, $belongsToMany);
         $this->assertSame($belongsToMany, $table->getAssociation('tag'));
-        $this->assertEquals('tag', $belongsToMany->name());
-        $this->assertEquals('thing_id', $belongsToMany->foreignKey());
-        $this->assertEquals(['b' => 'c'], $belongsToMany->conditions());
-        $this->assertEquals(['foo' => 'asc'], $belongsToMany->sort());
-        $this->assertSame($table, $belongsToMany->source());
-        $this->assertSame('things_tags', $belongsToMany->junction()->table());
+        $this->assertEquals('tag', $belongsToMany->getName());
+        $this->assertEquals('thing_id', $belongsToMany->getForeignKey());
+        $this->assertEquals(['b' => 'c'], $belongsToMany->getConditions());
+        $this->assertEquals(['foo' => 'asc'], $belongsToMany->getSort());
+        $this->assertSame($table, $belongsToMany->getSource());
+        $this->assertSame('things_tags', $belongsToMany->junction()->getTable());
     }
 
     /**
@@ -852,24 +854,24 @@ class TableTest extends TestCase
 
         $belongsTo = $associations->get('users');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $belongsTo);
-        $this->assertEquals('users', $belongsTo->name());
-        $this->assertEquals('fake_id', $belongsTo->foreignKey());
-        $this->assertEquals(['a' => 'b'], $belongsTo->conditions());
-        $this->assertSame($table, $belongsTo->source());
+        $this->assertEquals('users', $belongsTo->getName());
+        $this->assertEquals('fake_id', $belongsTo->getForeignKey());
+        $this->assertEquals(['a' => 'b'], $belongsTo->getConditions());
+        $this->assertSame($table, $belongsTo->getSource());
 
         $hasOne = $associations->get('profiles');
-        $this->assertInstanceOf('Cake\ORM\Association\HasOne', $hasOne);
-        $this->assertEquals('profiles', $hasOne->name());
+        $this->assertInstanceOf(HasOne::class, $hasOne);
+        $this->assertEquals('profiles', $hasOne->getName());
 
         $hasMany = $associations->get('authors');
-        $this->assertInstanceOf('Cake\ORM\Association\hasMany', $hasMany);
-        $this->assertEquals('authors', $hasMany->name());
+        $this->assertInstanceOf(HasMany::class, $hasMany);
+        $this->assertEquals('authors', $hasMany->getName());
 
         $belongsToMany = $associations->get('tags');
-        $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
-        $this->assertEquals('tags', $belongsToMany->name());
-        $this->assertSame('things_tags', $belongsToMany->junction()->table());
-        $this->assertSame(['Tags.starred' => true], $belongsToMany->conditions());
+        $this->assertInstanceOf(BelongsToMany::class, $belongsToMany);
+        $this->assertEquals('tags', $belongsToMany->getName());
+        $this->assertSame('things_tags', $belongsToMany->junction()->getTable());
+        $this->assertSame(['Tags.starred' => true], $belongsToMany->getConditions());
     }
 
     /**
@@ -1948,7 +1950,7 @@ class TableTest extends TestCase
             ]
         );
         $authors->hasMany('Articles', ['saveStrategy' => 'append']);
-        $this->assertEquals('append', $authors->getAssociation('articles')->saveStrategy());
+        $this->assertEquals('append', $authors->getAssociation('articles')->getSaveStrategy());
     }
 
     /**
@@ -2132,16 +2134,16 @@ class TableTest extends TestCase
         $article = $Articles->save($article);
         $this->assertNotEmpty($article);
 
-        $comment3 = $Comments->target()->newEntity([
+        $comment3 = $Comments->getTarget()->newEntity([
             'article_id' => $article->get('id'),
             'user_id' => 1,
             'comment' => 'Third comment',
             'published' => 'N'
         ]);
-        $comment3 = $Comments->target()->save($comment3);
+        $comment3 = $Comments->getTarget()->save($comment3);
         $this->assertNotEmpty($comment3);
 
-        $this->assertEquals(3, $Comments->target()->find()->where(['Comments.article_id' => $article->get('id')])->count());
+        $this->assertEquals(3, $Comments->getTarget()->find()->where(['Comments.article_id' => $article->get('id')])->count());
 
         unset($article->comments[1]);
         $article->setDirty('comments', true);
@@ -2153,7 +2155,7 @@ class TableTest extends TestCase
         // it is expected that only one of the three linked comments are
         // actually being deleted, as only one of them matches the
         // association condition.
-        $this->assertEquals(2, $Comments->target()->find()->where(['Comments.article_id' => $article->get('id')])->count());
+        $this->assertEquals(2, $Comments->getTarget()->find()->where(['Comments.article_id' => $article->get('id')])->count());
     }
 
     /**
@@ -2193,16 +2195,16 @@ class TableTest extends TestCase
         $author = $Authors->save($author);
         $this->assertNotEmpty($author);
 
-        $article3 = $Articles->target()->newEntity([
+        $article3 = $Articles->getTarget()->newEntity([
             'author_id' => $author->get('id'),
             'title' => 'Third article',
             'body' => 'Third article',
             'published' => 'N'
         ]);
-        $article3 = $Articles->target()->save($article3);
+        $article3 = $Articles->getTarget()->save($article3);
         $this->assertNotEmpty($article3);
 
-        $this->assertEquals(3, $Articles->target()->find()->where(['Articles.author_id' => $author->get('id')])->count());
+        $this->assertEquals(3, $Articles->getTarget()->find()->where(['Articles.author_id' => $author->get('id')])->count());
 
         $article2 = $author->articles[1];
         unset($author->articles[1]);
@@ -2215,7 +2217,7 @@ class TableTest extends TestCase
         // it is expected that only one of the three linked articles are
         // actually being unlinked (nulled), as only one of them matches the
         // association condition.
-        $this->assertEquals(2, $Articles->target()->find()->where(['Articles.author_id' => $author->get('id')])->count());
+        $this->assertEquals(2, $Articles->getTarget()->find()->where(['Articles.author_id' => $author->get('id')])->count());
         $this->assertNull($Articles->get($article2->get('id'))->get('author_id'));
         $this->assertEquals($author->get('id'), $Articles->get($article3->get('id'))->get('author_id'));
     }
@@ -3046,7 +3048,7 @@ class TableTest extends TestCase
         $entity = $table->get(1);
         $result = $table->delete($entity);
 
-        $articles = $table->getAssociation('articles')->target();
+        $articles = $table->getAssociation('articles')->getTarget();
         $query = $articles->find('all', [
             'conditions' => [
                 'author_id' => $entity->id
@@ -3091,7 +3093,7 @@ class TableTest extends TestCase
         $entity = $query->first();
         $result = $table->delete($entity);
 
-        $articles = $table->getAssociation('articles')->target();
+        $articles = $table->getAssociation('articles')->getTarget();
         $query = $articles->find('all')->where(['author_id' => $entity->id]);
         $this->assertCount(2, $query->execute(), 'Should find rows.');
     }
@@ -4687,7 +4689,7 @@ class TableTest extends TestCase
             'table' => 'authors',
             'associations' => $associations
         ]);
-        $authors->Articles->source($authors);
+        $authors->Articles->setSource($authors);
 
         $author = $authors->newEntity(['name' => 'mylux']);
         $author = $authors->save($author);
@@ -5037,9 +5039,9 @@ class TableTest extends TestCase
         $articles = TableRegistry::get('Articles');
 
         $tags = $articles->belongsToMany('Tags');
-        $tags->saveStrategy(BelongsToMany::SAVE_REPLACE);
-        $tags->dependent(true);
-        $tags->cascadeCallbacks(true);
+        $tags->setSaveStrategy(BelongsToMany::SAVE_REPLACE)
+            ->setDependent(true)
+            ->setCascadeCallbacks(true);
 
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
@@ -5086,7 +5088,7 @@ class TableTest extends TestCase
 
         $article = $articles->get(1);
 
-        $result = $tags->link($article, [$tags->target()->get(2)], ['foo' => 'bar']);
+        $result = $tags->link($article, [$tags->getTarget()->get(2)], ['foo' => 'bar']);
         $this->assertTrue($result);
 
         $expected = [
@@ -5123,7 +5125,7 @@ class TableTest extends TestCase
 
         $article = $articles->get(1);
 
-        $tags->unlink($article, [$tags->target()->get(2)], ['foo' => 'bar']);
+        $tags->unlink($article, [$tags->getTarget()->get(2)], ['foo' => 'bar']);
 
         $expected = [
             '_primary' => true,
@@ -5165,8 +5167,8 @@ class TableTest extends TestCase
         $result = $tags->replaceLinks(
             $article,
             [
-                $tags->target()->newEntity(['name' => 'new']),
-                $tags->target()->get(2)
+                $tags->getTarget()->newEntity(['name' => 'new']),
+                $tags->getTarget()->get(2)
             ],
             ['foo' => 'bar']
         );
@@ -5201,12 +5203,12 @@ class TableTest extends TestCase
         $authors = TableRegistry::get('Authors');
 
         $articles = $authors->hasMany('Articles');
-        $articles->saveStrategy(HasMany::SAVE_REPLACE);
-        $articles->dependent(true);
-        $articles->cascadeCallbacks(true);
+        $articles->setSaveStrategy(HasMany::SAVE_REPLACE)
+            ->setDependent(true)
+            ->setCascadeCallbacks(true);
 
         $actualOptions = null;
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualOptions) {
                 $actualOptions = $options->getArrayCopy();
@@ -5242,7 +5244,7 @@ class TableTest extends TestCase
         $articles = $authors->hasMany('Articles');
 
         $actualOptions = null;
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualOptions) {
                 $actualOptions = $options->getArrayCopy();
@@ -5253,7 +5255,7 @@ class TableTest extends TestCase
         $author->articles = [];
         $author->setDirty('articles', true);
 
-        $result = $articles->link($author, [$articles->target()->get(2)], ['foo' => 'bar']);
+        $result = $articles->link($author, [$articles->getTarget()->get(2)], ['foo' => 'bar']);
         $this->assertTrue($result);
 
         $expected = [
@@ -5281,11 +5283,11 @@ class TableTest extends TestCase
     {
         $authors = TableRegistry::get('Authors');
         $articles = $authors->hasMany('Articles');
-        $articles->dependent(true);
-        $articles->cascadeCallbacks(true);
+        $articles->setDependent(true);
+        $articles->setCascadeCallbacks(true);
 
         $actualOptions = null;
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualOptions) {
                 $actualOptions = $options->getArrayCopy();
@@ -5296,7 +5298,7 @@ class TableTest extends TestCase
         $author->articles = [];
         $author->setDirty('articles', true);
 
-        $articles->unlink($author, [$articles->target()->get(1)], ['foo' => 'bar']);
+        $articles->unlink($author, [$articles->getTarget()->get(1)], ['foo' => 'bar']);
 
         $expected = [
             '_primary' => true,
@@ -5317,18 +5319,18 @@ class TableTest extends TestCase
     {
         $authors = TableRegistry::get('Authors');
         $articles = $authors->hasMany('Articles');
-        $articles->dependent(true);
-        $articles->cascadeCallbacks(true);
+        $articles->setDependent(true);
+        $articles->setCascadeCallbacks(true);
 
         $actualSaveOptions = null;
         $actualDeleteOptions = null;
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualSaveOptions) {
                 $actualSaveOptions = $options->getArrayCopy();
             }
         );
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualDeleteOptions) {
                 $actualDeleteOptions = $options->getArrayCopy();
@@ -5340,8 +5342,8 @@ class TableTest extends TestCase
         $result = $articles->replace(
             $author,
             [
-                $articles->target()->newEntity(['title' => 'new', 'body' => 'new']),
-                $articles->target()->get(1)
+                $articles->getTarget()->newEntity(['title' => 'new', 'body' => 'new']),
+                $articles->getTarget()->get(1)
             ],
             ['foo' => 'bar']
         );
@@ -5392,12 +5394,12 @@ class TableTest extends TestCase
 
         $article = $articles->get(1);
 
-        $tags->unlink($article, [$tags->target()->get(1)], false);
+        $tags->unlink($article, [$tags->getTarget()->get(1)], false);
         $this->assertArrayHasKey('cleanProperty', $actualOptions);
         $this->assertFalse($actualOptions['cleanProperty']);
 
         $actualOptions = null;
-        $tags->unlink($article, [$tags->target()->get(2)]);
+        $tags->unlink($article, [$tags->getTarget()->get(2)]);
         $this->assertArrayHasKey('cleanProperty', $actualOptions);
         $this->assertTrue($actualOptions['cleanProperty']);
     }
@@ -5411,11 +5413,11 @@ class TableTest extends TestCase
     {
         $authors = TableRegistry::get('Authors');
         $articles = $authors->hasMany('Articles');
-        $articles->dependent(true);
-        $articles->cascadeCallbacks(true);
+        $articles->setDependent(true);
+        $articles->setCascadeCallbacks(true);
 
         $actualOptions = null;
-        $articles->target()->getEventManager()->on(
+        $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
             function (Event $event, Entity $entity, ArrayObject $options) use (&$actualOptions) {
                 $actualOptions = $options->getArrayCopy();
@@ -5426,12 +5428,12 @@ class TableTest extends TestCase
         $author->articles = [];
         $author->setDirty('articles', true);
 
-        $articles->unlink($author, [$articles->target()->get(1)], false);
+        $articles->unlink($author, [$articles->getTarget()->get(1)], false);
         $this->assertArrayHasKey('cleanProperty', $actualOptions);
         $this->assertFalse($actualOptions['cleanProperty']);
 
         $actualOptions = null;
-        $articles->unlink($author, [$articles->target()->get(3)]);
+        $articles->unlink($author, [$articles->getTarget()->get(3)]);
         $this->assertArrayHasKey('cleanProperty', $actualOptions);
         $this->assertTrue($actualOptions['cleanProperty']);
     }
@@ -6115,7 +6117,7 @@ class TableTest extends TestCase
         $eventManager = $table->getEventManager();
 
         $associationBeforeFindCount = 0;
-        $table->getAssociation('authors')->target()->getEventManager()->on(
+        $table->getAssociation('authors')->getTarget()->getEventManager()->on(
             'Model.beforeFind',
             function (Event $event, Query $query, ArrayObject $options, $primary) use (&$associationBeforeFindCount) {
                 $this->assertInternalType('bool', $primary);


### PR DESCRIPTION
Add deprecation warnings to ORM/Association classes. I didn't want to make another monster pull request which is why this only covers a subset of the deprecations in the ORM package.

Refs #11385 