### PR TITLE
Fix access to inner iterator methods in some cases.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -82,7 +82,7 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
      *
      * @param string $name Method name.
      * @param array $args Method arguments.
-     * @return void
+     * @return mixed
      * @throws \BadMethodCallException
      */
     public function __call($name, $args)

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -73,9 +73,12 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
     }
 
     /**
-     * Throws an exception.
+     * Dynamic method handler
      *
-     * Collection doesn't permit access to methods of the inner iterator.
+     * Collections do not allow access to methods of the inner iterator,
+     * if that iterator is one of the PHP base classes as many of
+     * these methods allow in-place mutation which breaks the immutability
+     * Collection tries to provide.
      *
      * @param string $name Method name.
      * @param array $args Method arguments.
@@ -84,6 +87,10 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
      */
     public function __call($name, $args)
     {
+        if (!method_exists(ArrayIterator::class, $name)) {
+            $inner = $this->getInnerIterator();
+            return call_user_func_array([$inner, $name], $args);
+        }
         throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()', get_class($this), $name));
     }
 

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -89,6 +89,7 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
     {
         if (!method_exists(ArrayIterator::class, $name)) {
             $inner = $this->getInnerIterator();
+
             return call_user_func_array([$inner, $name], $args);
         }
         throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()', get_class($this), $name));

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2547,7 +2547,7 @@ class CollectionTest extends TestCase
         $this->assertTrue(method_exists($iterator, 'checkValues'));
         $this->assertTrue($iterator->checkValues());
 
-        //We need to perform at least two collection operation to trigger the issue.
+        // We need to perform at least two collection operation to trigger the issue.
         $newIterator = $iterator
             ->filter(function ($item) {
                 return $item < 5;
@@ -2556,7 +2556,6 @@ class CollectionTest extends TestCase
                 return $item > 2;
             });
 
-        $this->assertTrue(method_exists($newIterator, 'checkValues'), 'Our method has gone missing!');
         $this->assertTrue($newIterator->checkValues());
         $this->assertCount(3, $newIterator->toArray());
     }


### PR DESCRIPTION
A fix was made to 3.5 that allows subclasses of ArrayIterator to have userland methods defined on collections via IteratorIterator's __call features. However a conflicting change was made in 3.next to block access to the in-place mutation methods available on ArrayIterator. This set of changes attempts to compromise between those two goals.

This also fixes the 3.next build which is currently broken.

Refs #11045
Refs #11396

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
