### PR TITLE
Add missing core dependencies and bump versions.

### DIFF
--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -23,7 +23,8 @@
         "source": "https://github.com/cakephp/event"
     },
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.6.0",
+        "cakephp/core": "^3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Filesystem/composer.json
+++ b/src/Filesystem/composer.json
@@ -23,7 +23,8 @@
         "source": "https://github.com/cakephp/filesystem"
     },
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.6.0",
+        "cakephp/core": "^3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": ">=5.6.0",
         "ext-intl": "*",
-        "cakephp/core": "^3.0.0",
+        "cakephp/core": "^3.6.0",
         "cakephp/chronos": "^1.0.0",
         "aura/intl": "^3.0.0"
     },

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "cakephp/core": "^3.0.0",
+        "cakephp/core": "^3.6.0",
         "psr/log": "^1.0.0"
     },
     "autoload": {

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -25,12 +25,12 @@
     "require": {
         "php": ">=5.6.0",
         "cakephp/collection": "^3.0.0",
-        "cakephp/core": "^3.0.0",
+        "cakephp/core": "^3.6.0",
         "cakephp/datasource": "^3.1.2",
         "cakephp/database": "^3.1.4",
-        "cakephp/event": "^3.0.0",
-        "cakephp/utility": "^3.0.0",
-        "cakephp/validation": "^3.0.0"
+        "cakephp/event": "^3.6.0",
+        "cakephp/utility": "^3.6.0",
+        "cakephp/validation": "^3.6.0"
     },
     "suggest": {
         "cakephp/i18n": "If you are using Translate / Timestamp Behavior."

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -25,7 +25,8 @@
         "source": "https://github.com/cakephp/utility"
     },
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.6.0",
+        "cakephp/core": "^3.6.0"
     },
     "suggest": {
         "ext-intl": "To use Text::transliterate() or Text::slug()",

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -23,8 +23,8 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "cakephp/core": "^3.0.0",
-        "cakephp/utility": "^3.0.0",
+        "cakephp/core": "^3.6.0",
+        "cakephp/utility": "^3.6.0",
         "psr/http-message": "^1.0.0"
     },
     "suggest": {


### PR DESCRIPTION
Most packages contain deprecation warnings now, which mean they rely on cakephp/core. They will also need at 3.6.0 as that will be the first version with deprecationWarning() in it.
