### PR TITLE
More phpstan related fixes.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,7 @@ parameters:
         - '#Result of method Cake\\Http\\Response::send\(\) \(void\) is used#'
         - '#Method Cake\\View\\Form\\ContextInterface::val\(\) invoked with 2 parameters, 1 required#'
         - '#Access to an undefined property Exception::\$queryString#'
+        - '#Access to an undefined property PHPUnit\\Framework\\Test::\$fixtureManager#'
         - '#Method Redis::#'
         - '#Call to an undefined method Traversable::getArrayCopy().#'
     earlyTerminatingMethodCalls:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,7 +20,6 @@ parameters:
         - '#Result of method Cake\\Http\\Response::send\(\) \(void\) is used#'
         - '#Method Cake\\View\\Form\\ContextInterface::val\(\) invoked with 2 parameters, 1 required#'
         - '#Access to an undefined property Exception::\$queryString#'
-        - '#Access to an undefined property PHPUnit\\Framework\\Test::\$fixtureManager#'
         - '#Method Redis::#'
         - '#Call to an undefined method Traversable::getArrayCopy().#'
     earlyTerminatingMethodCalls:

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -37,7 +37,6 @@ class NullEngine extends CacheEngine
      */
     public function gc($expires = null)
     {
-        return false;
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -205,7 +205,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Automatically set to the name of a plugin.
      *
-     * @var string
+     * @var string|null
      */
     public $plugin;
 

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -31,7 +31,7 @@ if (!function_exists('h')) {
      * @param bool $double Encode existing html entities.
      * @param string|null $charset Character set to use when escaping. Defaults to config value in `mb_internal_encoding()`
      * or 'UTF-8'.
-     * @return string Wrapped text.
+     * @return string|array Wrapped text.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#h
      */
     function h($text, $double = true, $charset = null)
@@ -189,7 +189,7 @@ if (!function_exists('env')) {
      *
      * @param string $key Environment variable name.
      * @param string|null $default Specify a default value in case the environment variable is not defined.
-     * @return string|null Environment variable setting.
+     * @return string|bool|null Environment variable setting.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
      */
     function env($key, $default = null)

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -21,7 +21,7 @@ use PDO;
  * Represents a database driver containing all specificities for
  * a database engine including its SQL dialect.
  *
- * @property \Cake\Datasource\ConnectionInterface $_connection
+ * @property \Cake\Datasource\ConnectionInterface|null $_connection
  */
 abstract class Driver
 {

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -41,7 +41,7 @@ interface FixtureInterface
      * Should insert all the records into the test database.
      *
      * @param \Cake\Datasource\ConnectionInterface $db An instance of the connection into which the records will be inserted.
-     * @return bool on success or if there are no records to insert, or false on failure.
+     * @return \Cake\Database\StatementInterface|bool on success or if there are no records to insert, or false on failure.
      */
     public function insert(ConnectionInterface $db);
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -87,8 +87,8 @@ trait QueryTrait
      * When called with a Table argument, the default table object will be set
      * and this query object will be returned for chaining.
      *
-     * @param \Cake\Datasource\RepositoryInterface|null $table The default table object to use
-     * @return \Cake\Datasource\RepositoryInterface|$this
+     * @param \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table|null $table The default table object to use
+     * @return \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table|$this
      */
     public function repository(RepositoryInterface $table = null)
     {

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -49,7 +49,7 @@ class File
     /**
      * Holds the file handler resource if the file is opened
      *
-     * @var resource
+     * @var resource|null
      * https://book.cakephp.org/3.0/en/core-libraries/file-folder.html#Cake\Filesystem\File::$handle
      */
     public $handle;
@@ -57,7 +57,7 @@ class File
     /**
      * Enable locking for file reading and writing
      *
-     * @var bool
+     * @var bool|null
      * https://book.cakephp.org/3.0/en/core-libraries/file-folder.html#Cake\Filesystem\File::$lock
      */
     public $lock;
@@ -67,7 +67,7 @@ class File
      *
      * Current file's absolute path
      *
-     * @var mixed
+     * @var string|null
      * https://book.cakephp.org/3.0/en/core-libraries/file-folder.html#Cake\Filesystem\File::$path
      */
     public $path;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1834,7 +1834,7 @@ class Response implements ResponseInterface
      * If called with no arguments returns the last Content-Length set
      *
      * @param int|null $bytes Number of bytes
-     * @return int|null
+     * @return string|null
      * @deprecated 3.4.0 Use withLength() to set length instead.
      */
     public function length($bytes = null)
@@ -1844,7 +1844,7 @@ class Response implements ResponseInterface
         }
 
         if ($this->hasHeader('Content-Length')) {
-            return (int)$this->getHeaderLine('Content-Length');
+            return $this->getHeaderLine('Content-Length');
         }
 
         return null;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -365,7 +365,7 @@ class Response implements ResponseInterface
     /**
      * File object for file to be read out as response
      *
-     * @var \Cake\Filesystem\File
+     * @var \Cake\Filesystem\File|null
      */
     protected $_file;
 
@@ -493,7 +493,8 @@ class Response implements ResponseInterface
 
         if ($this->_file) {
             $this->_sendFile($this->_file, $this->_fileRange);
-            $this->_file = $this->_fileRange = null;
+            $this->_file = null;
+            $this->_fileRange = [];
         } else {
             $this->_sendContent($this->body());
         }
@@ -809,7 +810,7 @@ class Response implements ResponseInterface
      * if $content is null the current buffer is returned
      *
      * @param string|callable|null $content the string or callable message to be sent
-     * @return string Current message buffer if $content param is passed as null
+     * @return string|null Current message buffer if $content param is passed as null
      * @deprecated 3.4.0 Mutable response methods are deprecated. Use `withBody()` and `getBody()` instead.
      */
     public function body($content = null)
@@ -1843,7 +1844,7 @@ class Response implements ResponseInterface
         }
 
         if ($this->hasHeader('Content-Length')) {
-            return $this->getHeaderLine('Content-Length');
+            return (int)$this->getHeaderLine('Content-Length');
         }
 
         return null;

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -33,7 +33,7 @@ class Runner
     /**
      * The middleware queue being run.
      *
-     * @var MiddlewareQueue
+     * @var \Cake\Http\MiddlewareQueue
      */
     protected $middleware;
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -37,7 +37,7 @@ trait DateFormatTrait
     /**
      * In-memory cache of date formatters
      *
-     * @var IntlDateFormatter[]
+     * @var \IntlDateFormatter[]
      */
     protected static $_formatters = [];
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -243,7 +243,7 @@ class Number
      * @param string|bool|null $currency Default currency string to be used by currency()
      * if $currency argument is not provided. If boolean false is passed, it will clear the
      * currently stored value
-     * @return string Currency
+     * @return string|null Currency
      */
     public static function defaultCurrency($currency = null)
     {

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1830,7 +1830,7 @@ class Email implements JsonSerializable, Serializable
      * Get generated message (used by transport classes)
      *
      * @param string|null $type Use MESSAGE_* constants or null to return the full message as array
-     * @return string|array String if have type, array if type is null
+     * @return string|array String if type is given, array if type is null
      */
     public function message($type = null)
     {
@@ -2218,7 +2218,7 @@ class Email implements JsonSerializable, Serializable
         $this->_headers = [];
         $this->_textMessage = '';
         $this->_htmlMessage = '';
-        $this->_message = '';
+        $this->_message = [];
         $this->_emailFormat = 'text';
         $this->_transport = null;
         $this->_priority = null;

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -179,7 +179,7 @@ abstract class Mailer implements EventListenerInterface
      * Cloned Email instance for restoring instance after email is sent by
      * mailer action.
      *
-     * @var string
+     * @var \Cake\Mailer\Email
      */
     protected $_clonedEmail;
 
@@ -245,7 +245,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @param string $method Method name.
      * @param array $args Method arguments
-     * @return $this
+     * @return $this|mixed
      */
     public function __call($method, $args)
     {

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -327,8 +327,11 @@ class Socket
     /**
      * Write data to the socket.
      *
+     * The bool false return value is deprecated and will be int 0 in the next major.
+     * Please code respectively to be future proof.
+     *
      * @param string $data The data to write to the socket.
-     * @return int Bytes written.
+     * @return int|false Bytes written.
      */
     public function write($data)
     {
@@ -351,6 +354,9 @@ class Socket
     /**
      * Read data from the socket. Returns false if no data is available or no connection could be
      * established.
+     *
+     * The bool false return value is deprecated and will be null in the next major.
+     * Please code respectively to be future proof.
      *
      * @param int $length Optional buffer length to read; defaults to 1024
      * @return mixed Socket data

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1059,7 +1059,7 @@ abstract class Association
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @see \Cake\ORM\Table::updateAll()
-     * @return bool Success Returns true if one or more rows are affected.
+     * @return int Count Returns the affected rows.
      */
     public function updateAll($fields, $conditions)
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -609,7 +609,9 @@ class BelongsToMany extends Association
 
         $conditions = array_merge($conditions, $hasMany->getConditions());
 
-        return $table->deleteAll($conditions);
+        $table->deleteAll($conditions);
+
+        return true;
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -170,7 +170,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Connection instance
      *
-     * @var \Cake\Database\Connection
+     * @var \Cake\Database\Connection|\Cake\Datasource\ConnectionInterface
      */
     protected $_connection;
 
@@ -482,7 +482,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the connection instance.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection instance
+     * @param \Cake\Database\Connection|\Cake\Datasource\ConnectionInterface $connection The connection instance
      * @return $this
      */
     public function setConnection(ConnectionInterface $connection)
@@ -495,7 +495,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the connection instance.
      *
-     * @return \Cake\Database\Connection
+     * @return \Cake\Database\Connection|\Cake\Datasource\ConnectionInterface
      */
     public function getConnection()
     {

--- a/src/TestSuite/ConsoleIntegrationTestCase.php
+++ b/src/TestSuite/ConsoleIntegrationTestCase.php
@@ -35,28 +35,28 @@ class ConsoleIntegrationTestCase extends TestCase
     /**
      * Last exit code
      *
-     * @var int
+     * @var int|null
      */
     protected $_exitCode;
 
     /**
      * Console output stub
      *
-     * @var ConsoleOutput
+     * @var \Cake\Console\ConsoleOutput|\PHPUnit_Framework_MockObject_MockObject|null
      */
     protected $_out;
 
     /**
      * Console error output stub
      *
-     * @var ConsoleOutput
+     * @var \Cake\Console\ConsoleOutput|\PHPUnit_Framework_MockObject_MockObject|null
      */
     protected $_err;
 
     /**
      * Console input mock
      *
-     * @var ConsoleInput
+     * @var \Cake\Console\ConsoleInput|\PHPUnit_Framework_MockObject_MockObject|null
      */
     protected $_in;
 
@@ -190,7 +190,7 @@ class ConsoleIntegrationTestCase extends TestCase
         }, $row);
         $cells = implode('\s+\|\s+', $row);
         $pattern = '/' . $cells . '/';
-        $this->assertOutputRegexp($pattern);
+        $this->assertOutputRegExp($pattern);
     }
 
     /**

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -19,14 +19,14 @@ class EventFired extends Constraint
     /**
      * Array of fired events
      *
-     * @var EventManager
+     * @var \Cake\Event\EventManager
      */
     protected $_eventManager;
 
     /**
      * Constructor
      *
-     * @param EventManager $eventManager Event manager to check
+     * @param \Cake\Event\EventManager $eventManager Event manager to check
      */
     public function __construct($eventManager)
     {

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -22,7 +22,7 @@ class EventFiredWith extends Constraint
     /**
      * Array of fired events
      *
-     * @var EventManager
+     * @var \Cake\Event\EventManager
      */
     protected $_eventManager;
 
@@ -43,7 +43,7 @@ class EventFiredWith extends Constraint
     /**
      * Constructor
      *
-     * @param EventManager $eventManager Event manager to check
+     * @param \Cake\Event\EventManager $eventManager Event manager to check
      * @param string $dataKey Data key
      * @param string $dataValue Data value
      */

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -79,7 +79,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface, TableSchema
     /**
      * The schema for this fixture.
      *
-     * @var \Cake\Database\Schema\TableSchema
+     * @var \Cake\Database\Schema\TableSchema|\Cake\Database\Schema\TableSchemaInterface
      */
     protected $_schema;
 
@@ -264,8 +264,8 @@ class TestFixture implements FixtureInterface, TableSchemaInterface, TableSchema
     /**
      * Gets/Sets the TableSchema instance used by this fixture.
      *
-     * @param \Cake\Database\Schema\TableSchema|null $schema The table to set.
-     * @return \Cake\Database\Schema\TableSchema|null
+     * @param \Cake\Database\Schema\TableSchema|\Cake\Database\Schema\TableSchemaInterface|null $schema The table to set.
+     * @return \Cake\Database\Schema\TableSchema|\Cake\Database\Schema\TableSchemaInterface|null
      * @deprecated 3.5.0 Use getTableSchema/setTableSchema instead.
      */
     public function schema(TableSchema $schema = null)

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -476,7 +476,7 @@ class FormHelper extends Helper
      *
      * @param \Cake\View\Form\ContextInterface $context The context object to use.
      * @param array $options An array of options from create()
-     * @return string The action attribute for the form.
+     * @return string|array The action attribute for the form.
      */
     protected function _formUrl($context, $options)
     {

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -25,17 +25,17 @@ use Cake\TestSuite\TestCase;
 class TableHelperTest extends TestCase
 {
     /**
-     * @var ConsoleOutput
+     * @var \Cake\Console\ConsoleOutput
      */
     public $stub;
 
     /**
-     * @var ConsoleIo
+     * @var \Cake\Console\ConsoleIo
      */
     public $io;
 
     /**
-     * @var TableHelper
+     * @var \Cake\Shell\Helper\TableHelper
      */
     public $helper;
 


### PR DESCRIPTION
PHPSTAN level 3

    [ERROR] Found 62 errors    

=>

    [ERROR] Found 25 errors       


:-)


We should also start inline deprecations for specific (and really bad) default values like bool where in future API it will actually have to be null (as per strict php7.1+).
This way people can already be a bit more aware and maybe adjust already the code to reflect this.