### PR TITLE
Digest secret is not defaulting to Salt

### DIFF
--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -86,7 +86,7 @@ class DigestAuthenticate extends BasicAuthenticate
     {
         $this->setConfig([
             'nonceLifetime' => 300,
-            'secret' => Configure::read('Security.salt'),
+            'secret' => Security::getSalt(),
             'realm' => null,
             'qop' => 'auth',
             'opaque' => null,

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -277,7 +277,7 @@ class DigestAuthenticate extends BasicAuthenticate
         if ($expires < microtime(true)) {
             return false;
         }
-        $check = hash_hmac('sha1', $expires . ':' . $this->getConfig('secret'), $this->getConfig('secret'));
+        $check = hash_hmac('sha256', $expires . ':' . $this->getConfig('secret'), $this->getConfig('secret'));
 
         return hash_equals($check, $checksum);
     }


### PR DESCRIPTION
Digest secret is returning null. Because we use Salt and Secret interchangeably in the code, this causes chaos.  The reason for this is that ```Configure::read('Security.salt')``` returns null and not the Salt.