### PR TITLE
Fix map() resetting cached object allowing build() to use the updated object

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -162,7 +162,9 @@ class Type implements TypeInterface
         if ($className === null) {
             return isset(self::$_types[$type]) ? self::$_types[$type] : null;
         }
+
         self::$_types[$type] = $className;
+        unset(self::$_builtTypes[$type]);
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -17,18 +17,8 @@ namespace Cake\Test\TestCase\Database;
 use Cake\Database\Type;
 use Cake\TestSuite\TestCase;
 use PDO;
-
-/**
- * Mock class for testing type registering
- */
-class FooType extends \Cake\Database\Type
-{
-
-    public function getBaseType()
-    {
-        return 'text';
-    }
-}
+use TestApp\Database\Type\BarType;
+use TestApp\Database\Type\FooType;
 
 /**
  * Tests Type class
@@ -131,7 +121,7 @@ class TypeTest extends TestCase
         $this->assertNotEmpty($map);
         $this->assertFalse(isset($map['foo']));
 
-        $fooType = __NAMESPACE__ . '\FooType';
+        $fooType = FooType::class;
         Type::map('foo', $fooType);
         $map = Type::map();
         $this->assertEquals($fooType, $map['foo']);
@@ -142,11 +132,31 @@ class TypeTest extends TestCase
         $this->assertEquals('foo', $type->getName());
         $this->assertEquals('text', $type->getBaseType());
 
-        $fooType = new FooType();
         Type::map('foo2', $fooType);
         $map = Type::map();
         $this->assertSame($fooType, $map['foo2']);
         $this->assertSame($fooType, Type::map('foo2'));
+
+        $type = Type::build('foo2');
+        $this->assertInstanceOf($fooType, $type);
+    }
+
+    /**
+     * Tests overwriting type map works for building
+     *
+     * @return void
+     */
+    public function testReMapAndBuild()
+    {
+        $fooType = FooType::class;
+        $map = Type::map('foo', $fooType);
+        $type = Type::build('foo');
+        $this->assertInstanceOf($fooType, $type);
+
+        $barType = BarType::class;
+        Type::map('foo', $barType);
+        $type = Type::build('foo');
+        $this->assertInstanceOf($barType, $type);
     }
 
     /**

--- a/tests/test_app/TestApp/Database/Type/BarType.php
+++ b/tests/test_app/TestApp/Database/Type/BarType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Type;
+
+use Cake\Database\Type;
+
+class BarType extends Type
+{
+    public function getBaseType()
+    {
+        return 'text';
+    }
+}

--- a/tests/test_app/TestApp/Database/Type/FooType.php
+++ b/tests/test_app/TestApp/Database/Type/FooType.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Type;
+
+use Cake\Database\Type;
+
+class FooType extends Type
+{
+    public function getBaseType()
+    {
+        return 'text';
+    }
+}


### PR DESCRIPTION
map() does not reset internal object cache for this key, and there is no way to tell build() to make a fresh one.

As Travis around https://github.com/dereuromark/cakephp-ide-helper/pull/64/commits/f3128fed1c4f99afe9c7f3b74b0b6c5c85d27c88 shows, mapping a different type after building has already been done still uses the old object.
Using set() and an actual instance (`Type::set('uuid', new UuidType());`) works, but I think resetting here is the expected and intuitive behavior after remapping.

With this fix `Type::map('uuid', UuidType::class);` etc works.