### PR TITLE
CounterCacheBehavior: Allow callback to refuse update

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -766,7 +766,7 @@ class Debugger
     /**
      * Takes a processed array of data from an error and displays it in the chosen format.
      *
-     * @param string $data Data to output.
+     * @param array $data Data to output.
      * @return void
      */
     public function outputError($data)

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -160,11 +160,11 @@ class ErrorHandler extends BaseErrorHandler
     }
 
     /**
-     * Log both PHP5 and PHP7 errors.
+     * Logs both PHP5 and PHP7 errors.
      *
      * The PHP5 part will be removed with 4.0.
      *
-     * @param \Throwable|\Exception $exception
+     * @param \Throwable|\Exception $exception Exception.
      *
      * @return void
      */

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -122,7 +122,7 @@ class ErrorHandler extends BaseErrorHandler
     /**
      * Displays an exception response body.
      *
-     * @param \Exception $exception The exception to display
+     * @param \Exception $exception The exception to display.
      * @return void
      * @throws \Exception When the chosen exception renderer is invalid.
      */
@@ -138,10 +138,10 @@ class ErrorHandler extends BaseErrorHandler
             $response = $renderer->render();
             $this->_clearOutput();
             $this->_sendResponse($response);
-        } catch (Throwable $t) {
-            $this->_logInternalError($t);
-        } catch (Exception $e) {
-            $this->_logInternalError($e);
+        } catch (Throwable $exception) {
+            $this->_logInternalError($exception);
+        } catch (Exception $exception) {
+            $this->_logInternalError($exception);
         }
     }
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -137,10 +137,9 @@ class ErrorHandlerMiddleware
     {
         $body = $response->getBody();
         $body->write('An Internal Server Error Occurred');
-        $response = $response->withStatus(500)
-            ->withBody($body);
 
-        return $response;
+        return $response->withStatus(500)
+            ->withBody($body);
     }
 
     /**

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -237,8 +237,10 @@ class CounterCacheBehavior extends Behavior
             } else {
                 $count = $this->_getCount($config, $countConditions);
             }
-
-            $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
+            if (!is_null($count)) {
+                $assoc->getTarget()->updateAll([$field => $count],
+                    $updateConditions);
+            }
 
             if (isset($updateOriginalConditions)) {
                 if (is_callable($config)) {
@@ -249,7 +251,10 @@ class CounterCacheBehavior extends Behavior
                 } else {
                     $count = $this->_getCount($config, $countOriginalConditions);
                 }
-                $assoc->getTarget()->updateAll([$field => $count], $updateOriginalConditions);
+                if (!is_null($count)) {
+                    $assoc->getTarget()->updateAll([$field => $count],
+                        $updateOriginalConditions);
+                }
             }
         }
     }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -238,7 +238,7 @@ class CounterCacheBehavior extends Behavior
                 $count = $this->_getCount($config, $countConditions);
             }
             if ($count !== false) {
-                $assoc->getTarget()->updateAll([$field => $count], updateConditions);
+                $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
             }
 
             if (isset($updateOriginalConditions)) {
@@ -251,7 +251,7 @@ class CounterCacheBehavior extends Behavior
                     $count = $this->_getCount($config, $countOriginalConditions);
                 }
                 if ($count !== false) {
-                    $assoc->getTarget()->updateAll([$field => $count], updateOriginalConditions);
+                    $assoc->getTarget()->updateAll([$field => $count], $updateOriginalConditions);
                 }
             }
         }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -238,8 +238,7 @@ class CounterCacheBehavior extends Behavior
                 $count = $this->_getCount($config, $countConditions);
             }
             if ($count !== false) {
-                $assoc->getTarget()->updateAll([$field => $count],
-                    $updateConditions);
+                $assoc->getTarget()->updateAll([$field => $count], updateConditions);
             }
 
             if (isset($updateOriginalConditions)) {
@@ -252,8 +251,7 @@ class CounterCacheBehavior extends Behavior
                     $count = $this->_getCount($config, $countOriginalConditions);
                 }
                 if ($count !== false) {
-                    $assoc->getTarget()->updateAll([$field => $count],
-                        $updateOriginalConditions);
+                    $assoc->getTarget()->updateAll([$field => $count], updateOriginalConditions);
                 }
             }
         }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -237,7 +237,7 @@ class CounterCacheBehavior extends Behavior
             } else {
                 $count = $this->_getCount($config, $countConditions);
             }
-            if (!is_null($count)) {
+            if ($count !== false) {
                 $assoc->getTarget()->updateAll([$field => $count],
                     $updateConditions);
             }
@@ -251,7 +251,7 @@ class CounterCacheBehavior extends Behavior
                 } else {
                     $count = $this->_getCount($config, $countOriginalConditions);
                 }
-                if (!is_null($count)) {
+                if ($count !== false) {
                     $assoc->getTarget()->updateAll([$field => $count],
                         $updateOriginalConditions);
                 }

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -331,6 +331,37 @@ class CounterCacheBehaviorTest extends TestCase
     }
 
     /**
+     * Testing counter cache with lambda returning false
+     *
+     * @return void
+     */
+    public function testLambdaFalse()
+    {
+        $this->post->belongsTo('Users');
+
+        $table = $this->post;
+        $entity = $this->_getEntity();
+
+        $this->post->addBehavior('CounterCache', [
+            'Users' => [
+                'posts_published' => function (Event $orgEvent, EntityInterface $orgEntity, Table $orgTable) use ($entity, $table) {
+                    $this->assertSame($orgTable, $table);
+                    $this->assertSame($orgEntity, $entity);
+
+                    return false;
+                }
+            ]
+        ]);
+
+        $before = $this->_getUser();
+        $this->post->save($entity);
+        $after = $this->_getUser();
+
+        $this->assertEquals(1, $before->get('posts_published'));
+        $this->assertEquals(1, $after->get('posts_published'));
+    }
+
+    /**
      * Testing counter cache with lambda returning number and changing of related ID
      *
      * @return void


### PR DESCRIPTION
In some circumstances (see below) it is desirable to allow the refusal of updating a counter field. This is easy to do with a callback function, as the function may just return `null` instead of a count. A simple patch that you might like to accept.

My Motivation:
Currently, the CounterCacheBehavior only works if there is no condition on the association. A counter example for a Comments table:

```php
$this->belongsTo('Articles')
    ->setConditions(['belongs_to' => 'articles'])
    ->setForeignKey('foreign_id');
$this->addBehavior('CounterCache', [
    'Articles' => [ 'comment_count' => ['conditions' => ['belongs_to' => 'articles']]]
```
This works for all Comment entities that are associated with an Article. Comments that are not associated with an Article will still lead the behavior to try an update on the Articles table. With the patch, a custom callback can be used instead:
```php
$this->addBehavior('CounterCache', [
    'Articles' => [ 'comment_count' => function ($event, $entity, $table) {
        if ($entity->belongs_to != 'articles')
            return null;
        …
    ]]);
```


I am happy to provide corresponding tests if you would like to accept this pull request.