### PR TITLE
Fix PHP7 Throwable to be caught by low level try catch.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -766,7 +766,7 @@ class Debugger
     /**
      * Takes a processed array of data from an error and displays it in the chosen format.
      *
-     * @param string $data Data to output.
+     * @param array $data Data to output.
      * @return void
      */
     public function outputError($data)

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -160,11 +160,11 @@ class ErrorHandler extends BaseErrorHandler
     }
 
     /**
-     * Log both PHP5 and PHP7 errors.
+     * Logs both PHP5 and PHP7 errors.
      *
      * The PHP5 part will be removed with 4.0.
      *
-     * @param \Throwable|\Exception $exception
+     * @param \Throwable|\Exception $exception Exception.
      *
      * @return void
      */

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -122,7 +122,7 @@ class ErrorHandler extends BaseErrorHandler
     /**
      * Displays an exception response body.
      *
-     * @param \Exception $exception The exception to display
+     * @param \Exception $exception The exception to display.
      * @return void
      * @throws \Exception When the chosen exception renderer is invalid.
      */
@@ -138,10 +138,10 @@ class ErrorHandler extends BaseErrorHandler
             $response = $renderer->render();
             $this->_clearOutput();
             $this->_sendResponse($response);
-        } catch (Throwable $t) {
-            $this->_logInternalError($t);
-        } catch (Exception $e) {
-            $this->_logInternalError($e);
+        } catch (Throwable $exception) {
+            $this->_logInternalError($exception);
+        } catch (Exception $exception) {
+            $this->_logInternalError($exception);
         }
     }
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -137,10 +137,9 @@ class ErrorHandlerMiddleware
     {
         $body = $response->getBody();
         $body->write('An Internal Server Error Occurred');
-        $response = $response->withStatus(500)
-            ->withBody($body);
 
-        return $response;
+        return $response->withStatus(500)
+            ->withBody($body);
     }
 
     /**


### PR DESCRIPTION
With PHP7 support we should probably consider fixing the low level error handling in terms of Throwable.
Refs https://github.com/cakephp/cakephp/issues/9043#issuecomment-346676574
On PHP5 that part will just be ignored.

http://php.net/manual/de/language.errors.php7.php#119652 and https://trowski.com/2015/06/24/throwable-exceptions-and-errors-in-php7/ document this guideline if one must support PHP5 code.
In Spryker we already use it this way for this reason.

We should also check what other places might need this and can be considered "low level" enough.
Of course we do not need to add this where we know a Throwable kind of exception cannot be thrown or should not be caught (high level functionality).