### PR TITLE
[2.x] Fix 'order' not working with a single expressions

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3083,7 +3083,11 @@ class Model extends CakeObject implements CakeEventListener {
 			$query['order'] = $this->order;
 		}
 
-		$query['order'] = (array)$query['order'];
+		if (is_object($query['order'])) {
+			$query['order'] = array($query['order']);
+		} else {
+			$query['order'] = (array)$query['order'];
+		}
 
 		if ($query['callbacks'] === true || $query['callbacks'] === 'before') {
 			$event = new CakeEvent('Model.beforeFind', $this, array($query));

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7423,7 +7423,7 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
- * Test find(count) with Db::expression
+ * Test find(count) with DboSource::expression
  *
  * @return void
  */
@@ -7443,6 +7443,38 @@ class ModelReadTest extends BaseModelTest {
 			'Project.name' => $db->expression('\'Project 3\'')
 		)));
 		$this->assertEquals(1, $result);
+	}
+
+/**
+ * Test 'order' with DboSource::expression
+ */
+	public function testOrderWithDbExpressions() {
+		$this->loadFixtures('User');
+
+		$User = new User();
+
+		$results = $User->find('all', array(
+			'fields' => array('id'),
+			'recursive' => -1,
+			'order' => $this->db->expression('CASE id WHEN 4 THEN 0 ELSE id END'),
+		));
+
+		$expected = array(
+			array(
+				'User' => array('id' => 4),
+			),
+			array(
+				'User' => array('id' => 1),
+			),
+			array(
+				'User' => array('id' => 2),
+			),
+			array(
+				'User' => array('id' => 3),
+			),
+		);
+
+		$this->assertEquals($expected, $results);
 	}
 
 /**


### PR DESCRIPTION
Prior to 2.8.0, we could pass a single expressions to the 'order' option of the `Model::find()`. But in the latest 2.x series, those are converted into arrays, and DboSource will generate incorrect ORDER clauses like the following:
```mysql
ORDER `type` expression, `value` foo 
```

Relates to #7436