### PR TITLE
Allow mariadb current_tiemstmap() default vlaue

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -426,7 +426,7 @@ class MysqlSchema extends BaseSchema
         }
         if (isset($data['default']) &&
             in_array($data['type'], [TableSchema::TYPE_TIMESTAMP, TableSchema::TYPE_DATETIME]) &&
-            strtolower($data['default']) === 'current_timestamp'
+            in_array(strtolower($data['default']), ['current_timestamp', 'current_timestamp()'])
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';
             unset($data['default']);

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -730,6 +730,11 @@ SQL;
                 '`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'
             ],
             [
+                'created',
+                ['type' => 'timestamp', 'null' => false, 'default' => 'current_timestamp()'],
+                '`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'
+            ],
+            [
                 'open_date',
                 ['type' => 'timestamp', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 '`open_date` TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\''


### PR DESCRIPTION
Upgraded MariaDB to 10.2 on testing environment. fixtures stopped working because MariaDB reported timestamp default as `current_timestamp()`, generating this code when attemp to insert fixures
```
/src/TestSuite/Fixture/TestFixture.php (line 296)
########## DEBUG ##########
'CREATE TABLE `orden_fotos` (
`id` INTEGER(11) UNSIGNED NOT NULL AUTO_INCREMENT,
`orden_id` INTEGER(11) UNSIGNED NOT NULL,
`foto` VARCHAR(255) COLLATE utf8mb4_unicode_520_ci,
`descripcion` VARCHAR(255) COLLATE utf8mb4_unicode_520_ci,
`tipo` INTEGER(11) UNSIGNED NOT NULL COMMENT '0 problema, 1 resolucion',
`created` TIMESTAMP NOT NULL DEFAULT 'current_timestamp()',
PRIMARY KEY (`id`),
KEY `orden_id` (`orden_id`)
) ENGINE=InnoDB'
###########################
Warning Error: Fixture creation for "orden_fotos" failed "
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'created'" in 
[/app/vendor/cakephp/cakephp/src/TestSuite/Fixture/TestFixture.php, line 308]
```
Baking a new Fixture resulted in same default
```php
public $fields = [
    'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
    // ....
    'created' => ['type' => 'timestamp', 'length' => null, 'null' => false, 'default' => 'current_timestamp()', 'comment' => '', 'precision' => null],
    '_indexes' => [
        'orden_id' => ['type' => 'index', 'columns' => ['orden_id'], 'length' => []],
    ],
];
```
This PR attempts to fix that behavior.