### PR TITLE
accept array of "_method"s  on route::match()

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -741,11 +741,14 @@ class Route
         if (empty($url['_method'])) {
             return false;
         }
-        if (!in_array(strtoupper($url['_method']), (array)$this->defaults['_method'])) {
-            return false;
+        $methods = array_map('strtoupper', (array)$url['_method']);
+        foreach ($methods as $value) {
+            if (in_array($value, (array)$this->defaults['_method'])) {
+                return true;
+            }
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1199,6 +1199,13 @@ class RouteTest extends TestCase
             '_method' => 'POST',
         ];
         $this->assertEquals('/sample', $route->match($url));
+
+        $url = [
+            'controller' => 'posts',
+            'action' => 'index',
+            '_method' => ['PUT', 'POST'],
+        ];
+        $this->assertEquals('/sample', $route->match($url));
     }
 
     /**


### PR DESCRIPTION
array of _method
`"_method" => ['PUT ','POST']`  
comes from
https://github.com/cakephp/cakephp/blob/c159efc166a7936ef96f8e9e22dd7543d4e9ce61/src/Routing/RouteCollection.php#L316
when someone set 
```php
$routes->connect('/login', ['controller' => 'Users', 'action' => 'login'], ['_name' => 'login'])->setMethods(['PUT', 'POST']);
or
$routes->connect('/login', ['controller' => 'Users', 'action' => 'login', '_method' => ['PUT', 'POST']], ['_name' => 'login'])
```
`$url + $route->defaults` just merge when someone set `_name` now 
but probably we need to this for non-named route (in other PR)

Refs : https://github.com/cakephp/cakephp/issues/11467