### PR TITLE
Split ValidationSet setters.

### DIFF
--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -36,7 +36,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Denotes whether the fieldname key must be present in data array
      *
-     * @var bool|string
+     * @var bool|string|callable
      */
     protected $_validatePresent = false;
 
@@ -52,7 +52,8 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      *
      * If no argument is passed the currently set `validatePresent` value will be returned.
      *
-     * @param bool|string|null $validatePresent Valid values are true, false, 'create', 'update'
+     * @param bool|string|callable|null $validatePresent Deprecated since 3.6.0 ValidationSet::isPresenceRequired() is deprecated as a setter
+     * Use ValidationSet::requirePresence() instead.
      * @return bool|string
      */
     public function isPresenceRequired($validatePresent = null)
@@ -61,16 +62,34 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
             return $this->_validatePresent;
         }
 
-        return $this->_validatePresent = $validatePresent;
+        deprecationWarning(
+            'ValidationSet::isPresenceRequired() is deprecated as a setter. ' .
+            'Use ValidationSet::requirePresence() instead.'
+        );
+
+        return $this->requirePresence($validatePresent);
     }
 
     /**
-     * Sets whether a field value is allowed to be empty
+     * Sets whether a field is required to be present in data array.
+     *
+     * @param bool|string|callable $validatePresent Valid values are true, false, 'create', 'update' or a callable.
+     * @return $this
+     */
+    public function requirePresence($validatePresent)
+    {
+        $this->_validatePresent = $validatePresent;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether a field value is allowed to be empty.
      *
      * If no argument is passed the currently set `allowEmpty` value will be returned.
      *
-     * @param bool|string|callable|null $allowEmpty Valid values are true, false,
-     * 'create', 'update'
+     * @param bool|string|callable|null $allowEmpty Deprecated since 3.6.0 ValidationSet::isEmptyAllowed() is deprecated as a setter.
+     * Use ValidationSet::allowEmpty() instead.
      * @return bool|string|callable
      */
     public function isEmptyAllowed($allowEmpty = null)
@@ -79,14 +98,33 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
             return $this->_allowEmpty;
         }
 
-        return $this->_allowEmpty = $allowEmpty;
+        deprecationWarning(
+            'ValidationSet::isEmptyAllowed() is deprecated as a setter. ' .
+            'Use ValidationSet::allowEmpty() instead.'
+        );
+
+        return $this->allowEmpty($allowEmpty);
+    }
+
+    /**
+     * Sets whether a field value is allowed to be empty.
+     *
+     * @param bool|string|callable $allowEmpty Valid values are true, false,
+     * 'create', 'update' or a callable.
+     * @return $this
+     */
+    public function allowEmpty($allowEmpty)
+    {
+        $this->_allowEmpty = $allowEmpty;
+
+        return $this;
     }
 
     /**
      * Gets a rule for a given name if exists
      *
      * @param string $name The name under which the rule is set.
-     * @return \Cake\Validation\ValidationRule
+     * @return \Cake\Validation\ValidationRule|null
      */
     public function rule($name)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -541,7 +541,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $settings = $this->_convertValidatorToArray($fieldName, $defaults, $setting);
             $fieldName = current(array_keys($settings));
 
-            $this->field($fieldName)->isPresenceRequired($settings[$fieldName]['mode']);
+            $this->field($fieldName)->requirePresence($settings[$fieldName]['mode']);
             if ($settings[$fieldName]['message']) {
                 $this->_presenceMessages[$fieldName] = $settings[$fieldName]['message'];
             }
@@ -631,7 +631,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $settings = $this->_convertValidatorToArray($fieldName, $settingsDefault, $setting);
             $fieldName = current(array_keys($settings));
 
-            $this->field($fieldName)->isEmptyAllowed($settings[$fieldName]['when']);
+            $this->field($fieldName)->allowEmpty($settings[$fieldName]['when']);
             if ($settings[$fieldName]['message']) {
                 $this->_allowEmptyMessages[$fieldName] = $settings[$fieldName]['message'];
             }
@@ -754,7 +754,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 };
             }
 
-            $this->field($fieldName)->isEmptyAllowed($whenSetting);
+            $this->field($fieldName)->allowEmpty($whenSetting);
             if ($settings[$fieldName]['message']) {
                 $this->_allowEmptyMessages[$fieldName] = $settings[$fieldName]['message'];
             }

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Validation;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
+use PHPUnit\Framework\Error\Deprecated;
 
 /**
  * ValidationSetTest
@@ -207,5 +208,113 @@ class ValidationSetTest extends TestCase
         $this->assertTrue(isset($set['other']));
         $set->remove('other');
         $this->assertFalse(isset($set['other']));
+    }
+
+    /**
+     * Test requirePresence and isPresenceRequired methods
+     *
+     * @return void
+     */
+    public function testRequirePresence()
+    {
+        $set = new ValidationSet();
+
+        $this->assertFalse($set->isPresenceRequired());
+
+        $set->requirePresence(true);
+        $this->assertTrue($set->isPresenceRequired());
+
+        $set->requirePresence(false);
+        $this->assertFalse($set->isPresenceRequired());
+    }
+
+    /**
+     * Test isPresenceRequired deprecated setter
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testRequirePresenceDeprecated()
+    {
+        $this->deprecated(function () {
+            $set = new ValidationSet();
+
+            $this->assertFalse($set->isPresenceRequired());
+
+            $set->isPresenceRequired(true);
+            $this->assertTrue($set->isPresenceRequired());
+
+            $set->isPresenceRequired(false);
+            $this->assertFalse($set->isPresenceRequired());
+        });
+    }
+
+    /**
+     * Test isPresenceRequired method deprecation
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testIsPresenceRequiredDeprecation()
+    {
+        $this->expectException(Deprecated::class);
+        $this->expectExceptionMessage('ValidationSet::isPresenceRequired() is deprecated as a setter. Use ValidationSet::requirePresence() instead.');
+
+        $set = new ValidationSet();
+        $set->isPresenceRequired(true);
+    }
+
+    /**
+     * Test allowEmpty and isEmptyAllowed methods
+     *
+     * @return void
+     */
+    public function testAllowEmpty()
+    {
+        $set = new ValidationSet();
+
+        $this->assertFalse($set->isEmptyAllowed());
+
+        $set->allowEmpty(true);
+        $this->assertTrue($set->isEmptyAllowed());
+
+        $set->allowEmpty(false);
+        $this->assertFalse($set->isEmptyAllowed());
+    }
+
+    /**
+     * Test isEmptyAllowed deprecated setter
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testAllowEmptyDeprecated()
+    {
+        $this->deprecated(function () {
+            $set = new ValidationSet();
+
+            $this->assertFalse($set->isEmptyAllowed());
+
+            $set->isEmptyAllowed(true);
+            $this->assertTrue($set->isEmptyAllowed());
+
+            $set->isEmptyAllowed(false);
+            $this->assertFalse($set->isEmptyAllowed());
+        });
+    }
+
+    /**
+     * Test isEmptyAllowed method deprecation
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testIsEmptyAllowedDeprecation()
+    {
+        $this->expectException(Deprecated::class);
+        $this->expectExceptionMessage('ValidationSet::isEmptyAllowed() is deprecated as a setter. Use ValidationSet::allowEmpty() instead.');
+
+        $set = new ValidationSet();
+        $set->isEmptyAllowed(true);
     }
 }

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -191,19 +191,20 @@ class ValidationSetTest extends TestCase
      */
     public function testRemoveRule()
     {
-        $set = new ValidationSet('title', [
-            '_validatePresent' => true,
-            'notBlank' => ['rule' => 'notBlank'],
-            'numeric' => ['rule' => 'numeric'],
-            'other' => ['rule' => ['other', 1]],
-        ]);
+        $set = (new ValidationSet)
+            ->add('notBlank', ['rule' => 'notBlank'])
+            ->add('numeric', ['rule' => 'numeric'])
+            ->add('other', ['rule' => 'email']);
 
+        $this->assertTrue(isset($set['notBlank']));
         $set->remove('notBlank');
         $this->assertFalse(isset($set['notBlank']));
 
+        $this->assertTrue(isset($set['numeric']));
         $set->remove('numeric');
         $this->assertFalse(isset($set['numeric']));
 
+        $this->assertTrue(isset($set['other']));
         $set->remove('other');
         $this->assertFalse(isset($set['other']));
     }


### PR DESCRIPTION
Deprecate `ValidationSet::isPresenceRequired()` and `ValidationSet::isEmptyAllowed()` as setters.

The method name for a getter is fine, so only the parameters are deprecated. I'm not sure this is a good way to do it though.