### PR TITLE
Clarify migration path to 3.x

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1688,6 +1688,9 @@ class Model extends CakeObject implements CakeEventListener {
  * Saves the value of a single field to the database, based on the current
  * model ID.
  *
+ * @deprecated 3.0.0 To ease migration to the new major, do not use this method anymore.
+ *   Stateful model usage will be removed. Use the existing save() methods instead.
+ *
  * @param string $name Name of the table field
  * @param mixed $value Value of the field
  * @param bool|array $validate Either a boolean, or an array.


### PR DESCRIPTION
saveField() uses $this->id on the model itself which is discouraged.

What do you think about a more clear migration path for those still on the last 2.x version?
Many always ask how to do that, and still use this a lot in 2.x code, even though they might very well be upgrading that code.
It would clarify to do the same we do forward also in a backport way and more clearly express certain API to be not useful to be used for new code.

There are few more we could clarify.