### PR TITLE
3.next- Deprecate Query::orWhere().

### DIFF
--- a/src/Database/Dialect/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Dialect/TupleComparisonTranslatorTrait.php
@@ -78,15 +78,15 @@ trait TupleComparisonTranslatorTrait
             $value = [$value];
         }
 
+        $conditions = ['OR' => []];
         foreach ($value as $tuple) {
-            $surrogate->orWhere(function ($exp) use ($fields, $tuple) {
-                foreach (array_values($tuple) as $i => $value) {
-                    $exp->add([$fields[$i] => $value]);
-                }
-
-                return $exp;
-            });
+            $item = [];
+            foreach (array_values($tuple) as $i => $value) {
+                $item[] = [$fields[$i] => $value];
+            }
+            $conditions['OR'][] = $item;
         }
+        $surrogate->where($conditions);
 
         $expression->setField($true);
         $expression->setValue($surrogate);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -811,6 +811,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * `$query->where(['OR' => [['published' => false], ['published' => true]])`
      *
+     * Would result in:
+     *
+     * `WHERE (published = false) OR (published = true)`
+     *
      * Keep in mind that every time you call where() with the third param set to false
      * (default), it will join the passed conditions to the previous stored list using
      * the `AND` operator. Also, using the same array key twice in consecutive calls to
@@ -1008,6 +1012,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function orWhere($conditions, $types = [])
     {
+        deprecationWarning(
+            'Query::orWhere() is deprecated as it creates hard to predict SQL based on the ' .
+            'current query state. Use `Query::where()` instead.'
+        );
         $this->_conjugate('where', $conditions, 'OR', $types);
 
         return $this;

--- a/src/Database/README.md
+++ b/src/Database/README.md
@@ -240,9 +240,6 @@ $query->where(['id >' => 1, 'title' => 'My title']);
 It is possible to generate `OR` conditions as well
 
 ```php
-$query->where(['id >' => 1])->orWhere(['title' => 'My Title']);
-
-// Equivalent to
 $query->where(['OR' => ['id >' => 1, 'title' => 'My title']]);
 ```
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -555,7 +555,14 @@ class TableTest extends TestCase
         ];
         $this->assertSame($expected, $query->toArray());
 
-        $query->orWhere(['users.created' => new Time('2008-03-17 01:18:23')]);
+        $query= $table->find()
+            ->enableHydration(false)
+            ->select(['id', 'username'])
+            ->where(['OR' => [
+                'created >=' => new Time('2010-01-22 00:00'),
+                'users.created' => new Time('2008-03-17 01:18:23')
+            ]])
+            ->order('id');
         $expected = [
             ['id' => 2, 'username' => 'nate'],
             ['id' => 3, 'username' => 'larry'],

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -555,7 +555,7 @@ class TableTest extends TestCase
         ];
         $this->assertSame($expected, $query->toArray());
 
-        $query= $table->find()
+        $query = $table->find()
             ->enableHydration(false)
             ->select(['id', 'username'])
             ->where(['OR' => [


### PR DESCRIPTION
I made time to circle back on this as I'd really like to not have this method in the future. It is easy to replace after I thought through the problem a bit more.

Refs #11385