### PR TITLE
3.next - Deprecate Request::addParams()

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -383,7 +383,7 @@ class AuthComponent extends Component
         if ($auth === false) {
             throw new Exception('At least one authenticate object must be available.');
         }
-        $result = $auth->unauthenticated($this->request, $response);
+        $result = $auth->unauthenticated($controller->request, $response);
         if ($result !== null) {
             return $result;
         }
@@ -535,7 +535,7 @@ class AuthComponent extends Component
             $user = $this->user();
         }
         if (empty($request)) {
-            $request = $this->request;
+            $request = $this->getController()->getRequest();
         }
         if (empty($this->_authorizeObjects)) {
             $this->constructAuthorize();
@@ -749,7 +749,7 @@ class AuthComponent extends Component
             $this->constructAuthenticate();
         }
         foreach ($this->_authenticateObjects as $auth) {
-            $result = $auth->getUser($this->request);
+            $result = $auth->getUser($this->getController()->getRequest());
             if (!empty($result) && is_array($result)) {
                 $this->_authenticationProvider = $auth;
                 $event = $this->dispatchEvent('Auth.afterIdentify', [$result, $auth]);
@@ -785,7 +785,7 @@ class AuthComponent extends Component
      */
     public function redirectUrl($url = null)
     {
-        $redirectUrl = $this->request->getQuery(static::QUERY_STRING_REDIRECT);
+        $redirectUrl = $this->getController()->getRequest()->getQuery(static::QUERY_STRING_REDIRECT);
         if ($redirectUrl && (substr($redirectUrl, 0, 1) !== '/' || substr($redirectUrl, 0, 2) === '//')) {
             $redirectUrl = null;
         }
@@ -825,7 +825,7 @@ class AuthComponent extends Component
             $this->constructAuthenticate();
         }
         foreach ($this->_authenticateObjects as $auth) {
-            $result = $auth->authenticate($this->request, $this->response);
+            $result = $auth->authenticate($this->getController()->getRequest(), $this->response);
             if (!empty($result)) {
                 $this->_authenticationProvider = $auth;
                 $event = $this->dispatchEvent('Auth.afterIdentify', [$result, $auth]);
@@ -911,7 +911,9 @@ class AuthComponent extends Component
         if (!class_exists($className)) {
             throw new Exception(sprintf('Auth storage adapter "%s" was not found.', $class));
         }
-        $this->_storage = new $className($this->request, $this->response, $config);
+        $request = $this->getController()->getRequest();
+        $response = $this->getController()->getResponse();
+        $this->_storage = new $className($request, $response, $config);
 
         return $this->_storage;
     }

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -266,12 +266,11 @@ class PaginatorComponent extends Component
      */
     protected function _setPagingParams()
     {
-        $request = $this->_registry->getController()->request;
+        $controller = $this->getController();
+        $request = $controller->getRequest();
+        $paging = $this->_paginator->getPagingParams() + (array)$request->getParam('paging');
 
-        $request->addParams([
-            'paging' => $this->_paginator->getPagingParams()
-                + (array)$request->getParam('paging')
-        ]);
+        $controller->setRequest($request->withParam('paging', $paging));
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -921,9 +921,15 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param array $params Array of parameters to merge in
      * @return $this The current object, you can chain this method.
+     * @deprecated 3.6.0 ServerRequest::addParams() is deprecated. Use `withParam()` or
+     *   `withAttribute('params')` instead.
      */
     public function addParams(array $params)
     {
+        deprecationWarning(
+            'ServerRequest::addParams() is deprecated. ' .
+            'Use `withParam()` or `withAttribute("params", $params)` instead.'
+        );
         $this->params = array_merge($this->params, $params);
 
         return $this;
@@ -935,6 +941,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param array $paths Array of paths to merge in
      * @return $this The current object, you can chain this method.
+     * @deprecated 3.6.0 Mutating a request in place is deprecated. Use `withAttribute()` to modify paths instead.
      */
     public function addPaths(array $paths)
     {

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -129,9 +129,8 @@ class BasicAuthenticateTest extends TestCase
             'environment' => [
                 'PHP_AUTH_USER' => '> 1',
                 'PHP_AUTH_PW' => "' OR 1 = 1"
-            ]
+            ],
         ]);
-        $request->addParams(['pass' => []]);
 
         $this->assertFalse($this->auth->getUser($request));
         $this->assertFalse($this->auth->authenticate($request, $this->response));
@@ -172,7 +171,6 @@ class BasicAuthenticateTest extends TestCase
     public function testAuthenticateChallenge()
     {
         $request = new ServerRequest('posts/index');
-        $request->addParams(['pass' => []]);
 
         try {
             $this->auth->unauthenticated($request, $this->response);
@@ -199,7 +197,6 @@ class BasicAuthenticateTest extends TestCase
                 'PHP_AUTH_PW' => 'password'
             ]
         ]);
-        $request->addParams(['pass' => []]);
 
         $result = $this->auth->authenticate($request, $this->response);
         $expected = [
@@ -228,7 +225,6 @@ class BasicAuthenticateTest extends TestCase
                 'PHP_AUTH_PW' => 'password'
             ]
         ]);
-        $request->addParams(['pass' => []]);
 
         $this->auth->unauthenticated($request, $this->response);
     }

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -113,8 +113,7 @@ class DigestAuthenticateTest extends TestCase
     {
         $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
         $this->expectExceptionCode(401);
-        $request = new ServerRequest('posts/index');
-        $request->addParams(['pass' => []]);
+        $request = new ServerRequest(['url' => 'posts/index']);
 
         $data = [
             'username' => 'incorrect_user',
@@ -142,7 +141,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         try {
             $this->auth->unauthenticated($request, $this->response);
@@ -169,7 +167,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
         $data = [
             'uri' => '/dir/index.html',
             'nonce' => $this->generateNonce(null, 5, strtotime('-10 minutes')),
@@ -201,7 +198,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'uri' => '/dir/index.html',
@@ -227,7 +223,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'username' => 'mariano',
@@ -255,7 +250,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'uri' => '/dir/index.html',
@@ -291,7 +285,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'uri' => '/dir/index.html',
@@ -325,7 +318,6 @@ class DigestAuthenticateTest extends TestCase
             'post' => ['_method' => 'PUT'],
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'username' => 'mariano',
@@ -362,7 +354,6 @@ class DigestAuthenticateTest extends TestCase
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']
         ]);
-        $request->addParams(['pass' => []]);
 
         $data = [
             'username' => 'invalid',

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -215,11 +215,11 @@ class SecurityComponentTest extends TestCase
         $this->expectException(\Cake\Http\Exception\BadRequestException::class);
         $request = new ServerRequest([
             'url' => 'posts/index',
-            'session' => $this->Security->session
-        ]);
-        $request->addParams([
-            'controller' => 'posts',
-            'action' => 'index'
+            'session' => $this->Security->session,
+            'params' => [
+                'controller' => 'posts',
+                'action' => 'index'
+            ]
         ]);
         $Controller = new \TestApp\Controller\SomePagesController($request);
         $event = new Event('Controller.startup', $Controller);
@@ -240,10 +240,10 @@ class SecurityComponentTest extends TestCase
      */
     public function testExceptionWhenActionIsBlackholeCallback()
     {
-        $this->Controller->request->addParams([
-            'controller' => 'posts',
-            'action' => 'fail'
-        ]);
+        $this->Controller->request = $this->Controller->request
+            ->withParam('controller', 'posts')
+            ->withParam('action', 'fail');
+
         $event = new Event('Controller.startup', $this->Controller);
         $this->assertFalse($this->Controller->failed);
         $this->Controller->Security->startup($event);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -812,8 +812,10 @@ class ControllerTest extends TestCase
     {
         $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::missing() could not be found, or is not accessible.');
-        $url = new ServerRequest('test/missing');
-        $url->addParams(['controller' => 'Test', 'action' => 'missing']);
+        $url = new ServerRequest([
+            'url' => 'test/missing',
+            'params' => ['controller' => 'Test', 'action' => 'missing']
+        ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $Controller = new TestController($url, $response);
@@ -829,8 +831,10 @@ class ControllerTest extends TestCase
     {
         $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::private_m() could not be found, or is not accessible.');
-        $url = new ServerRequest('test/private_m/');
-        $url->addParams(['controller' => 'Test', 'action' => 'private_m']);
+        $url = new ServerRequest([
+            'url' => 'test/private_m/',
+            'params' => ['controller' => 'Test', 'action' => 'private_m']
+        ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $Controller = new TestController($url, $response);
@@ -846,8 +850,10 @@ class ControllerTest extends TestCase
     {
         $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::protected_m() could not be found, or is not accessible.');
-        $url = new ServerRequest('test/protected_m/');
-        $url->addParams(['controller' => 'Test', 'action' => 'protected_m']);
+        $url = new ServerRequest([
+            'url' => 'test/protected_m/',
+            'params' => ['controller' => 'Test', 'action' => 'protected_m']
+        ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $Controller = new TestController($url, $response);
@@ -863,8 +869,10 @@ class ControllerTest extends TestCase
     {
         $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::redirect() could not be found, or is not accessible.');
-        $url = new ServerRequest('test/redirect/');
-        $url->addParams(['controller' => 'Test', 'action' => 'redirect']);
+        $url = new ServerRequest([
+            'url' => 'test/redirect/',
+            'params' => ['controller' => 'Test', 'action' => 'redirect']
+        ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $Controller = new TestController($url, $response);
@@ -878,11 +886,13 @@ class ControllerTest extends TestCase
      */
     public function testInvokeActionReturnValue()
     {
-        $url = new ServerRequest('test/returner/');
-        $url->addParams([
-            'controller' => 'Test',
-            'action' => 'returner',
-            'pass' => []
+        $url = new ServerRequest([
+            'url' => 'test/returner/',
+            'params' => [
+                'controller' => 'Test',
+                'action' => 'returner',
+                'pass' => []
+            ]
         ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
@@ -898,11 +908,13 @@ class ControllerTest extends TestCase
      */
     public function testInvokeActionWithPassedParams()
     {
-        $url = new ServerRequest('test/index/1/2');
-        $url->addParams([
-            'controller' => 'Test',
-            'action' => 'index',
-            'pass' => ['param1' => '1', 'param2' => '2']
+        $url = new ServerRequest([
+            'url' => 'test/index/1/2',
+            'params' => [
+                'controller' => 'Test',
+                'action' => 'index',
+                'pass' => ['param1' => '1', 'param2' => '2']
+            ]
         ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
@@ -921,9 +933,9 @@ class ControllerTest extends TestCase
      */
     public function testViewPathConventions()
     {
-        $request = new ServerRequest('admin/posts');
-        $request->addParams([
-            'prefix' => 'admin'
+        $request = new ServerRequest([
+            'url' => 'admin/posts',
+            'params' => ['prefix' => 'admin']
         ]);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
@@ -933,9 +945,7 @@ class ControllerTest extends TestCase
         $Controller->render();
         $this->assertEquals('Admin' . DS . 'Posts', $Controller->viewBuilder()->templatePath());
 
-        $request->addParams([
-            'prefix' => 'admin/super'
-        ]);
+        $request = $request->withParam('prefix', 'admin/super');
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
         $Controller->getEventManager()->on('Controller.beforeRender', function (Event $e) {
@@ -944,9 +954,11 @@ class ControllerTest extends TestCase
         $Controller->render();
         $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->templatePath());
 
-        $request = new ServerRequest('pages/home');
-        $request->addParams([
-            'prefix' => false
+        $request = new ServerRequest([
+            'url' => 'pages/home',
+            'params' => [
+                'prefix' => false
+            ]
         ]);
         $Controller = new \TestApp\Controller\PagesController($request, $response);
         $Controller->getEventManager()->on('Controller.beforeRender', function (Event $e) {

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -214,21 +214,24 @@ class ServerRequestTest extends TestCase
     /**
      * Test addParams() method
      *
+     * @group deprecated
      * @return void
      */
     public function testAddParams()
     {
-        $request = new ServerRequest();
-        $request = $request
-            ->withParam('controller', 'posts')
-            ->withParam('action', 'view');
-        $result = $request->addParams(['plugin' => null, 'action' => 'index']);
+        $this->deprecated(function () {
+            $request = new ServerRequest();
+            $request = $request
+                ->withParam('controller', 'posts')
+                ->withParam('action', 'view');
+            $result = $request->addParams(['plugin' => null, 'action' => 'index']);
 
-        $this->assertSame($result, $request, 'Method did not return itself. %s');
+            $this->assertSame($result, $request, 'Method did not return itself. %s');
 
-        $this->assertEquals('posts', $request->getParam('controller'));
-        $this->assertEquals('index', $request->getParam('action'));
-        $this->assertEquals(null, $request->getParam('plugin'));
+            $this->assertEquals('posts', $request->getParam('controller'));
+            $this->assertEquals('index', $request->getParam('action'));
+            $this->assertEquals(null, $request->getParam('plugin'));
+        });
     }
 
     /**
@@ -2669,22 +2672,25 @@ class ServerRequestTest extends TestCase
     /**
      * Test reading params
      *
+     * @group deprecated
      * @dataProvider paramReadingDataProvider
      */
     public function testGetParam($toRead, $expected)
     {
-        $request = new ServerRequest('/');
-        $request->addParams([
-            'action' => 'index',
-            'foo' => 'bar',
-            'baz' => [
-                'a' => [
-                    'b' => 'c',
+        $request = new ServerRequest([
+            'url' => '/',
+            'params' => [
+                'action' => 'index',
+                'foo' => 'bar',
+                'baz' => [
+                    'a' => [
+                        'b' => 'c',
+                    ],
                 ],
-            ],
-            'admin' => true,
-            'truthy' => 1,
-            'zero' => '0',
+                'admin' => true,
+                'truthy' => 1,
+                'zero' => '0',
+            ]
         ]);
         $this->deprecated(function () use ($expected, $request, $toRead) {
             $this->assertSame($expected, $request->param($toRead));
@@ -3074,21 +3080,23 @@ XML;
      */
     public function testIsRequested()
     {
-        $request = new ServerRequest();
-        $request->addParams([
-            'controller' => 'posts',
-            'action' => 'index',
-            'plugin' => null,
-            'requested' => 1
+        $request = new ServerRequest([
+            'params' => [
+                'controller' => 'posts',
+                'action' => 'index',
+                'plugin' => null,
+                'requested' => 1
+            ]
         ]);
         $this->assertTrue($request->is('requested'));
         $this->assertTrue($request->isRequested());
 
-        $request = new ServerRequest();
-        $request->addParams([
-            'controller' => 'posts',
-            'action' => 'index',
-            'plugin' => null,
+        $request = new ServerRequest([
+            'params' => [
+                'controller' => 'posts',
+                'action' => 'index',
+                'plugin' => null,
+            ]
         ]);
         $this->assertFalse($request->is('requested'));
         $this->assertFalse($request->isRequested());

--- a/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
@@ -37,9 +37,10 @@ class ControllerFactoryFilterTest extends TestCase
 
         $filter = new ControllerFactoryFilter();
 
-        $request = new ServerRequest();
+        $request = new ServerRequest([
+            'params' => ['prefix' => 'admin', 'controller' => 'Posts', 'action' => 'index']
+        ]);
         $response = new Response();
-        $request->addParams(['prefix' => 'admin', 'controller' => 'Posts', 'action' => 'index']);
         $event = new Event(__CLASS__, $this, compact('request', 'response'));
         $filter->beforeDispatch($event);
 
@@ -48,7 +49,9 @@ class ControllerFactoryFilterTest extends TestCase
             get_class($event->getData('controller'))
         );
 
-        $request->addParams(['prefix' => 'admin/sub', 'controller' => 'Posts', 'action' => 'index']);
+        $request = new ServerRequest([
+            'params' => ['prefix' => 'admin/sub', 'controller' => 'Posts', 'action' => 'index']
+        ]);
         $event = new Event(__CLASS__, $this, compact('request', 'response'));
         $filter->beforeDispatch($event);
 

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -23,6 +23,8 @@ use Cake\TestSuite\TestCase;
 
 /**
  * Routing filter test.
+ *
+ * @group deprecated
  */
 class RoutingFilterTest extends TestCase
 {
@@ -56,18 +58,20 @@ class RoutingFilterTest extends TestCase
      */
     public function testBeforeDispatchSetsParameters()
     {
-        Router::connect('/:controller/:action/*');
-        $filter = new RoutingFilter();
+        $this->deprecated(function () {
+            Router::connect('/:controller/:action/*');
+            $filter = new RoutingFilter();
 
-        $request = new ServerRequest('/testcontroller/testaction/params1/params2/params3');
-        $event = new Event(__CLASS__, $this, compact('request'));
-        $filter->beforeDispatch($event);
+            $request = new ServerRequest('/testcontroller/testaction/params1/params2/params3');
+            $event = new Event(__CLASS__, $this, compact('request'));
+            $filter->beforeDispatch($event);
 
-        $this->assertSame($request->getParam('controller'), 'testcontroller');
-        $this->assertSame($request->getParam('action'), 'testaction');
-        $this->assertSame($request->getParam('pass.0'), 'params1');
-        $this->assertSame($request->getParam('pass.1'), 'params2');
-        $this->assertSame($request->getParam('pass.2'), 'params3');
+            $this->assertSame($request->getParam('controller'), 'testcontroller');
+            $this->assertSame($request->getParam('action'), 'testaction');
+            $this->assertSame($request->getParam('pass.0'), 'params1');
+            $this->assertSame($request->getParam('pass.1'), 'params2');
+            $this->assertSame($request->getParam('pass.2'), 'params3');
+        });
     }
 
     /**
@@ -103,31 +107,34 @@ class RoutingFilterTest extends TestCase
      */
     public function testQueryStringOnRoot()
     {
-        Router::reload();
-        Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
-        Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
-        Router::connect('/:controller/:action/*');
+        $this->deprecated(function () {
+            Router::reload();
+            Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
+            Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
+            Router::connect('/:controller/:action/*');
 
-        $_GET = ['coffee' => 'life', 'sleep' => 'sissies'];
-        $filter = new RoutingFilter();
-        $request = new ServerRequest('posts/home/?coffee=life&sleep=sissies');
+            $_GET = ['coffee' => 'life', 'sleep' => 'sissies'];
+            $filter = new RoutingFilter();
+            $request = new ServerRequest('posts/home/?coffee=life&sleep=sissies');
 
-        $event = new Event(__CLASS__, $this, compact('request'));
-        $filter->beforeDispatch($event);
+            $event = new Event(__CLASS__, $this, compact('request'));
+            $filter->beforeDispatch($event);
 
-        $this->assertRegExp('/posts/', $request->getParam('controller'));
-        $this->assertRegExp('/home/', $request->getParam('action'));
-        $this->assertSame('sissies', $request->getQuery('sleep'));
-        $this->assertSame('life', $request->getQuery('coffee'));
+            $this->assertRegExp('/posts/', $request->getParam('controller'));
+            $this->assertRegExp('/home/', $request->getParam('action'));
+            $this->assertSame('sissies', $request->getQuery('sleep'));
+            $this->assertSame('life', $request->getQuery('coffee'));
 
-        $request = new ServerRequest('/?coffee=life&sleep=sissy');
-        $event = new Event(__CLASS__, $this, compact('request'));
-        $filter->beforeDispatch($event);
+            $request = new ServerRequest('/?coffee=life&sleep=sissy');
 
-        $this->assertRegExp('/pages/', $request->getParam('controller'));
-        $this->assertRegExp('/display/', $request->getParam('action'));
-        $this->assertSame('sissy', $request->getQuery('sleep'));
-        $this->assertSame('life', $request->getQuery('coffee'));
-        $this->assertEquals('life', $request->getQuery('coffee'));
+            $event = new Event(__CLASS__, $this, compact('request'));
+            $filter->beforeDispatch($event);
+
+            $this->assertRegExp('/pages/', $request->getParam('controller'));
+            $this->assertRegExp('/display/', $request->getParam('action'));
+            $this->assertSame('sissy', $request->getQuery('sleep'));
+            $this->assertSame('life', $request->getQuery('coffee'));
+            $this->assertEquals('life', $request->getQuery('coffee'));
+        });
     }
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -104,15 +104,16 @@ class RouterTest extends TestCase
     public function testCurrentUrlWithBasePath()
     {
         Router::fullBaseUrl('http://example.com');
-        $request = new ServerRequest();
-        $request->addParams([
-            'action' => 'view',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['1']
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'view',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['1']
+            ],
+            'here' => '/cakephp',
+            'url' => '/cakephp/pages/view/1',
         ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/view/1';
         Router::setRequestInfo($request);
         $this->assertEquals('http://example.com/cakephp/pages/view/1', Router::url(null, true));
         $this->assertEquals('/cakephp/pages/view/1', Router::url());
@@ -555,15 +556,16 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithBasePath()
     {
         Router::connect('/:controller/:action/*');
-        $request = new ServerRequest();
-        $request->addParams([
-            'action' => 'index',
-            'plugin' => null,
-            'controller' => 'subscribe',
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'index',
+                'plugin' => null,
+                'controller' => 'subscribe',
+            ],
+            'here' => '/magazine/',
+            'base' => '/magazine',
+            'webroot' => '/magazine/'
         ]);
-        $request->base = '/magazine';
-        $request->here = '/magazine/';
-        $request->webroot = '/magazine/';
         Router::pushRequest($request);
 
         $result = Router::url();
@@ -696,15 +698,13 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/:controller/:action');
-        $request = new ServerRequest();
-        $request->addParams([
-            'action' => 'index',
-            'plugin' => null,
-            'controller' => 'users',
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'index',
+                'plugin' => null,
+                'controller' => 'users',
+            ]
         ]);
-        $request->base = '/';
-        $request->here = '/';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         $result = Router::url(['action' => 'login']);
@@ -725,15 +725,13 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/:controller', ['action' => 'index']);
-        $request = new ServerRequest();
-        $request->addParams([
-            'action' => 'index',
-            'plugin' => 'myplugin',
-            'controller' => 'mycontroller',
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'index',
+                'plugin' => 'myplugin',
+                'controller' => 'mycontroller',
+            ]
         ]);
-        $request->base = '/';
-        $request->here = '/';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'myothercontroller']);
@@ -897,17 +895,16 @@ class RouterTest extends TestCase
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
         Router::extensions('rss', false);
 
-        $request = new ServerRequest();
-        $request->addParams([
-            'controller' => 'registrations',
-            'action' => 'admin_index',
-            'plugin' => null,
-            'prefix' => 'admin',
-            '_ext' => 'html'
+        $request = new ServerRequest([
+            'params' => [
+                'controller' => 'registrations',
+                'action' => 'admin_index',
+                'plugin' => null,
+                'prefix' => 'admin',
+                '_ext' => 'html'
+            ],
+            'url' => '/admin/registrations/index',
         ]);
-        $request->base = '';
-        $request->here = '/admin/registrations/index';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         $result = Router::url([]);
@@ -918,16 +915,17 @@ class RouterTest extends TestCase
         Router::connect('/admin/subscriptions/:action/*', ['controller' => 'subscribe', 'prefix' => 'admin']);
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
 
-        $request = new ServerRequest();
-        $request->addParams([
-            'action' => 'index',
-            'plugin' => null,
-            'controller' => 'subscribe',
-            'prefix' => 'admin',
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'index',
+                'plugin' => null,
+                'controller' => 'subscribe',
+                'prefix' => 'admin',
+            ],
+            'webroot' => '/magazine/',
+            'base' => '/magazine',
+            'url' => '/magazine/admin/subscriptions/edit/1',
         ]);
-        $request->base = '/magazine';
-        $request->here = '/magazine/admin/subscriptions/edit/1';
-        $request->webroot = '/magazine/';
         Router::setRequestInfo($request);
 
         $result = Router::url(['action' => 'edit', 1]);
@@ -939,16 +937,16 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        $request = new ServerRequest();
-        $request->addParams([
-            'prefix' => 'admin',
-            'action' => 'index',
-            'plugin' => null,
-            'controller' => 'users',
+        $request = new ServerRequest([
+            'params' => [
+                'prefix' => 'admin',
+                'action' => 'index',
+                'plugin' => null,
+                'controller' => 'users',
+            ],
+            'webroot' => '/',
+            'url' => '/admin/users/index',
         ]);
-        $request->base = '/';
-        $request->here = '/';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         Router::connect('/page/*', ['controller' => 'pages', 'action' => 'view', 'prefix' => 'admin']);
@@ -960,16 +958,16 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
 
-        $request = new ServerRequest();
-        $request->addParams([
-            'plugin' => null,
-            'controller' => 'pages',
-            'action' => 'add',
-            'prefix' => 'admin'
+        $request = new ServerRequest([
+            'params' => [
+                'plugin' => null,
+                'controller' => 'pages',
+                'action' => 'add',
+                'prefix' => 'admin'
+            ],
+            'webroot' => '/',
+            'url' => '/admin/pages/add',
         ]);
-        $request->base = '';
-        $request->here = '/admin/pages/add';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
@@ -978,16 +976,16 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
-        $request = new ServerRequest();
-        $request->addParams([
-            'plugin' => null,
-            'controller' => 'pages',
-            'action' => 'add',
-            'prefix' => 'admin'
+        $request = new ServerRequest([
+            'params' => [
+                'plugin' => null,
+                'controller' => 'pages',
+                'action' => 'add',
+                'prefix' => 'admin'
+            ],
+            'webroot' => '/',
+            'url' => '/admin/pages/add',
         ]);
-        $request->base = '';
-        $request->here = '/admin/pages/add';
-        $request->webroot = '/';
         Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
@@ -996,20 +994,17 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/admin/:controller/:action/:id', ['prefix' => 'admin'], ['id' => '[0-9]+']);
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'params' => [
                 'plugin' => null,
                 'controller' => 'pages',
                 'action' => 'edit',
                 'pass' => ['284'],
                 'prefix' => 'admin'
-            ])->addPaths([
-                'base' => '',
-                'here' => '/admin/pages/edit/284',
-                'webroot' => '/'
-            ])
-        );
+            ],
+            'url' => '/admin/pages/edit/284',
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'id' => '284']);
         $expected = '/admin/pages/edit/284';
@@ -1018,14 +1013,13 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'params' => [
                 'plugin' => null, 'controller' => 'pages', 'action' => 'add', 'prefix' => 'admin',
-            ])->addPaths([
-                'base' => '', 'here' => '/admin/pages/add', 'webroot' => '/'
-            ])
-        );
+            ],
+            'url' => '/admin/pages/add',
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
         $expected = '/admin/pages/add';
@@ -1034,15 +1028,13 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'params' => [
                 'plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'prefix' => 'admin',
-                'pass' => ['284']
-            ])->addPaths([
-                'base' => '', 'here' => '/admin/pages/edit/284', 'webroot' => '/'
-            ])
-        );
+            ],
+            'url' => '/admin/pages/edit/284',
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 284]);
         $expected = '/admin/pages/edit/284';
@@ -1050,14 +1042,14 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/admin/posts/*', ['controller' => 'posts', 'action' => 'index', 'prefix' => 'admin']);
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'params' => [
                 'plugin' => null, 'controller' => 'posts', 'action' => 'index', 'prefix' => 'admin',
                 'pass' => ['284']
-            ])->addPaths([
-                'base' => '', 'here' => '/admin/posts', 'webroot' => '/'
-            ])
-        );
+            ],
+            'url' => '/admin/pages/edit/284',
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['all']);
         $expected = '/admin/posts/all';
@@ -1163,8 +1155,9 @@ class RouterTest extends TestCase
         Router::scope('/', function ($r) {
             $r->fallbacks('InflectedRoute');
         });
-        $request = new ServerRequest();
-        $request->addParams(['controller' => 'Tasks', 'action' => 'index', '_ext' => 'rss']);
+        $request = new ServerRequest([
+            'params' => ['plugin' => null, 'controller' => 'Tasks', 'action' => 'index', '_ext' => 'rss']
+        ]);
         Router::pushRequest($request);
 
         $result = Router::url([
@@ -1277,14 +1270,13 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithUrlFilter()
     {
         Router::connect('/:lang/:controller/:action/*');
-        $request = new ServerRequest();
-        $request->addParams([
-            'lang' => 'en',
-            'controller' => 'posts',
-            'action' => 'index'
-        ])->addPaths([
-            'base' => '',
-            'here' => '/'
+        $request = new ServerRequest([
+            'params' => [
+                'plugin' => null,
+                'lang' => 'en',
+                'controller' => 'posts',
+                'action' => 'index'
+            ]
         ]);
         Router::pushRequest($request);
 
@@ -1314,14 +1306,14 @@ class RouterTest extends TestCase
     public function testUrlParamPersistence()
     {
         Router::connect('/:lang/:controller/:action/*', [], ['persist' => ['lang']]);
-        $request = new ServerRequest();
-        $request->addParams([
-            'lang' => 'en',
-            'controller' => 'posts',
-            'action' => 'index'
-        ])->addPaths([
-            'base' => '',
-            'here' => '/'
+        $request = new ServerRequest([
+            'url' => '/en/posts/index',
+            'params' => [
+                'plugin' => null,
+                'lang' => 'en',
+                'controller' => 'posts',
+                'action' => 'index'
+            ]
         ]);
         Router::pushRequest($request);
 
@@ -1358,20 +1350,17 @@ class RouterTest extends TestCase
     {
         Router::connect('/admin/:controller', ['action' => 'index', 'prefix' => 'admin']);
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/admin/this/interesting/index',
+            'params' => [
                 'pass' => [],
                 'prefix' => 'admin',
                 'plugin' => 'this',
                 'action' => 'index',
                 'controller' => 'interesting',
-            ])->addPaths([
-                'base' => '',
-                'here' => '/admin/this/interesting/index',
-                'webroot' => '/',
-            ])
-        );
+            ]
+        ]);
+        Router::setRequestInfo($request);
         $result = Router::url(['plugin' => null, 'controller' => 'posts', 'action' => 'index']);
         $this->assertEquals('/admin/posts', $result);
     }
@@ -2002,17 +1991,14 @@ class RouterTest extends TestCase
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
         Router::connect('/:controller/:action/*');
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/images/index',
+            'params' => [
                 'plugin' => null, 'controller' => 'images', 'action' => 'index',
                 'prefix' => null, 'protected' => false, 'url' => ['url' => 'images/index']
-            ])->addPaths([
-                'base' => '',
-                'here' => '/images/index',
-                'webroot' => '/',
-            ])
-        );
+            ],
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add']);
         $expected = '/images/add';
@@ -2059,19 +2045,14 @@ class RouterTest extends TestCase
     public function testGenerationWithSslOption()
     {
         Router::connect('/:controller/:action/*');
-
         $request = new ServerRequest([
+            'url' => '/images/index',
+            'params' => [
+                'plugin' => null, 'controller' => 'images', 'action' => 'index'
+            ],
             'environment' => ['HTTP_HOST' => 'localhost']
         ]);
-        Router::pushRequest(
-            $request->addParams([
-                'plugin' => null, 'controller' => 'images', 'action' => 'index'
-            ])->addPaths([
-                'base' => '',
-                'here' => '/images/index',
-                'webroot' => '/',
-            ])
-        );
+        Router::pushRequest($request);
 
         $result = Router::url([
             '_ssl' => true
@@ -2092,21 +2073,16 @@ class RouterTest extends TestCase
     public function testGenerateWithSslInSsl()
     {
         Router::connect('/:controller/:action/*');
-
         $request = new ServerRequest([
-            'environment' => ['HTTP_HOST' => 'localhost', 'HTTPS' => 'on']
-        ]);
-        Router::pushRequest(
-            $request->addParams([
+            'url' => '/images/index',
+            'environment' => ['HTTP_HOST' => 'localhost', 'HTTPS' => 'on'],
+            'params' => [
                 'plugin' => null,
                 'controller' => 'images',
                 'action' => 'index'
-            ])->addPaths([
-                'base' => '',
-                'here' => '/images/index',
-                'webroot' => '/',
-            ])
-        );
+            ]
+        ]);
+        Router::pushRequest($request);
 
         $result = Router::url([
             '_ssl' => false
@@ -2130,19 +2106,16 @@ class RouterTest extends TestCase
         Router::connect('/protected/:controller/:action', ['prefix' => 'protected']);
         Router::connect('/:controller/:action');
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/protected/images/index',
+            'params' => [
                 'plugin' => null,
                 'controller' => 'images',
                 'action' => 'index',
                 'prefix' => 'protected',
-            ])->addPaths([
-                'base' => '',
-                'here' => '/protected/images/index',
-                'webroot' => '/',
-            ])
-        );
+            ]
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['prefix' => 'protected', 'controller' => 'images', 'action' => 'add']);
         $expected = '/protected/images/add';
@@ -2167,34 +2140,25 @@ class RouterTest extends TestCase
         Router::connect('/admin/:controller/:action', ['prefix' => 'admin']);
         Router::connect('/protected/:controller/:action', ['prefix' => 'protected']);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/protected/images/index',
+            'params' => [
                 'plugin' => null, 'controller' => 'images', 'action' => 'index', 'prefix' => 'protected',
-            ])->addPaths([
-                'base' => '',
-                'here' => '/protected/images/index',
-                'webroot' => '/',
-            ])
-        );
+            ],
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'admin']);
         $expected = '/admin/images/add';
         $this->assertEquals($expected, $result);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
-                'plugin' => null,
-                'controller' => 'images',
-                'action' => 'index',
-                'prefix' => 'admin',
-            ])->addPaths([
-                'base' => '',
-                'here' => '/admin/images/index',
-                'webroot' => '/',
-            ])
-        );
+        $request = new ServerRequest([
+            'url' => '/admin/images/index',
+            'params' => [
+                'plugin' => null, 'controller' => 'images', 'action' => 'index', 'prefix' => 'admin',
+            ],
+        ]);
+        Router::setRequestInfo($request);
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'protected']);
         $expected = '/protected/images/add';
         $this->assertEquals($expected, $result);
@@ -2236,17 +2200,14 @@ class RouterTest extends TestCase
     public function testRemoveBase()
     {
         Router::connect('/:controller/:action');
-
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/',
+            'base' => '/base',
+            'params' => [
                 'plugin' => null, 'controller' => 'controller', 'action' => 'index',
-            ])->addPaths([
-                'base' => '/base',
-                'here' => '/',
-                'webroot' => '/base/',
-            ])
-        );
+            ]
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['controller' => 'my_controller', 'action' => 'my_action']);
         $expected = '/base/my_controller/my_action';
@@ -2408,16 +2369,12 @@ class RouterTest extends TestCase
         Router::connect('/admin/:controller', $adminParams);
         Router::connect('/admin/:controller/:action/*', $adminParams);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
-                'plugin' => null, 'controller' => 'controller', 'action' => 'index'
-            ])->addPaths([
-                'base' => '/base',
-                'here' => '/',
-                'webroot' => '/base/',
-            ])
-        );
+        $request = new ServerRequest([
+            'url' => '/',
+            'base' => '/base',
+            'params' => ['plugin' => null, 'controller' => 'controller', 'action' => 'index']
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::parseRequest($this->makeRequest('/admin/posts/', 'GET'));
         $expected = [
@@ -2444,16 +2401,12 @@ class RouterTest extends TestCase
         Router::connect('/members/:controller/:action', $prefixParams);
         Router::connect('/members/:controller/:action/*', $prefixParams);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
-                'plugin' => null, 'controller' => 'controller', 'action' => 'index',
-            ])->addPaths([
-                'base' => '/base',
-                'here' => '/',
-                'webroot' => '/',
-            ])
-        );
+        $request = new ServerRequest([
+            'url' => '/',
+            'base' => '/base',
+            'params' => ['plugin' => null, 'controller' => 'controller', 'action' => 'index']
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::parseRequest($this->makeRequest('/members/posts/index', 'GET'));
         $expected = [
@@ -2485,19 +2438,16 @@ class RouterTest extends TestCase
         $expected = '/company/users/login';
         $this->assertEquals($expected, $result);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/',
+            'params' => [
                 'plugin' => null,
                 'controller' => 'users',
                 'action' => 'login',
                 'prefix' => 'company'
-            ])->addPaths([
-                'base' => '/',
-                'here' => '/',
-                'webroot' => '/base/',
-            ])
-        );
+            ]
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['controller' => 'users', 'action' => 'login', 'prefix' => false]);
         $expected = '/login';
@@ -2515,17 +2465,17 @@ class RouterTest extends TestCase
             '/admin/login',
             ['controller' => 'users', 'action' => 'login', 'prefix' => 'admin']
         );
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
-                'plugin' => null, 'controller' => 'posts', 'action' => 'index',
+        $request = new ServerRequest([
+            'url' => '/',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'posts',
+                'action' => 'index',
                 'prefix' => 'admin'
-            ])->addPaths([
-                'base' => '/',
-                'here' => '/',
-                'webroot' => '/',
-            ])
-        );
+            ],
+            'webroot' => '/'
+        ]);
+        Router::setRequestInfo($request);
         $result = Router::url(['controller' => 'users', 'action' => 'login']);
         $this->assertEquals('/admin/login', $result);
 
@@ -2603,19 +2553,16 @@ class RouterTest extends TestCase
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect('/:locale/:controller/:action/*', [], ['locale' => 'dan|eng']);
 
-        $request = new ServerRequest();
-        Router::setRequestInfo(
-            $request->addParams([
+        $request = new ServerRequest([
+            'url' => '/test/test_action',
+            'params' => [
                 'plugin' => null,
                 'controller' => 'test',
                 'action' => 'index',
-                'url' => ['url' => 'test/test_action']
-            ])->addPaths([
-                'base' => '',
-                'here' => '/test/test_action',
-                'webroot' => '/',
-            ])
-        );
+            ],
+            'webroot' => '/'
+        ]);
+        Router::setRequestInfo($request);
 
         $result = Router::url(['action' => 'test_another_action', 'locale' => 'eng']);
         $expected = '/eng/test/test_another_action';
@@ -2748,14 +2695,16 @@ class RouterTest extends TestCase
     public function testReverseCakeRequestQuery()
     {
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
-        $request = new ServerRequest('/eng/posts/view/1');
-        $request->addParams([
-            'lang' => 'eng',
-            'controller' => 'posts',
-            'action' => 'view',
-            'pass' => [1],
+        $request = new ServerRequest([
+            'url' => '/eng/posts/view/1',
+            'params' => [
+                'lang' => 'eng',
+                'controller' => 'posts',
+                'action' => 'view',
+                'pass' => [1],
+            ],
+            'query' => ['url' => 'eng/posts/view/1', 'test' => 'value']
         ]);
-        $request->query = ['url' => 'eng/posts/view/1', 'test' => 'value'];
         $result = Router::reverse($request);
         $expected = '/eng/posts/view/1?test=value';
         $this->assertEquals($expected, $result);
@@ -2784,14 +2733,15 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
         Router::extensions('json', false);
 
-        $request = new ServerRequest('/posts/view/1.json');
-        $request->addParams([
-            'controller' => 'posts',
-            'action' => 'view',
-            'pass' => [1],
-            '_ext' => 'json',
+        $request = new ServerRequest([
+            'url' => '/posts/view/1.json',
+            'params' => [
+                'controller' => 'posts',
+                'action' => 'view',
+                'pass' => [1],
+                '_ext' => 'json',
+            ]
         ]);
-        $request->query = [];
         $result = Router::reverse($request);
         $expected = '/posts/view/1.json';
         $this->assertEquals($expected, $result);
@@ -2823,22 +2773,22 @@ class RouterTest extends TestCase
     public function testReverseToArrayRequestQuery()
     {
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
-        $request = new ServerRequest('/eng/posts/view/1');
-        $request->addParams([
-            'lang' => 'eng',
-            'controller' => 'posts',
-            'action' => 'view',
-            'pass' => [123],
+        $request = new ServerRequest([
+            'url' => '/eng/posts/view/1',
+            'params' => [
+                'lang' => 'eng',
+                'controller' => 'posts',
+                'action' => 'view',
+                'pass' => [123],
+            ],
+            'query' => ['url' => 'eng/posts/view/1', 'test' => 'value']
         ]);
-        $request->query = ['url' => 'eng/posts/view/1', 'test' => 'value'];
         $actual = Router::reverseToArray($request);
         $expected = [
             'lang' => 'eng',
-            'plugin' => null,
             'controller' => 'posts',
             'action' => 'view',
             123,
-            '_ext' => null,
             '?' => [
                 'test' => 'value',
             ],
@@ -2906,21 +2856,24 @@ class RouterTest extends TestCase
         Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action');
 
-        $firstRequest = new ServerRequest('/posts/index');
-        $firstRequest->addParams([
-            'plugin' => null,
-            'controller' => 'posts',
-            'action' => 'index'
-        ])->addPaths(['base' => '']);
+        $firstRequest = new ServerRequest([
+            'url' => '/posts/index',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'posts',
+                'action' => 'index'
+            ]
+        ]);
 
-        $secondRequest = new ServerRequest('/posts/index');
-        $secondRequest->addParams([
-            'requested' => 1,
-            'plugin' => null,
-            'controller' => 'comments',
-            'action' => 'listing'
-        ])->addPaths(['base' => '']);
-
+        $secondRequest = new ServerRequest([
+            'url' => '/posts/index',
+            'params' => [
+                'requested' => 1,
+                'plugin' => null,
+                'controller' => 'comments',
+                'action' => 'listing'
+            ]
+        ]);
         Router::setRequestInfo($firstRequest);
         Router::setRequestInfo($secondRequest);
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -54,19 +54,21 @@ class PaginatorHelperTest extends TestCase
         Configure::write('Config.language', 'eng');
         $this->View = new View();
         $this->Paginator = new PaginatorHelper($this->View);
-        $this->Paginator->request = new ServerRequest();
-        $this->Paginator->request->addParams([
-            'paging' => [
-                'Article' => [
-                    'page' => 1,
-                    'current' => 9,
-                    'count' => 62,
-                    'prevPage' => false,
-                    'nextPage' => true,
-                    'pageCount' => 7,
-                    'sort' => null,
-                    'direction' => null,
-                    'limit' => null,
+        $this->Paginator->request = new ServerRequest([
+            'url' => '/',
+            'params' => [
+                'paging' => [
+                    'Article' => [
+                        'page' => 1,
+                        'current' => 9,
+                        'count' => 62,
+                        'prevPage' => false,
+                        'nextPage' => true,
+                        'pageCount' => 7,
+                        'sort' => null,
+                        'direction' => null,
+                        'limit' => null,
+                    ]
                 ]
             ]
         ]);


### PR DESCRIPTION
Deprecate and remove usage of addParams(). This method mutates the request in place and is something we can't have alongside PSR7 support.

Refs #11385 