### PR TITLE
Add DebugInfo and deprecate bad object usage.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -313,8 +313,6 @@ class Type implements TypeInterface
     {
         return [
             'name' => $this->_name,
-            'types' => static::$_types,
-            'builtTypes' => static::$_builtTypes,
         ];
     }
 }

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -106,9 +106,7 @@ class Type implements TypeInterface
             throw new InvalidArgumentException(sprintf('Unknown type "%s"', $name));
         }
         if (is_string(static::$_types[$name])) {
-            static::$_types[$name] = new static::$_types[$name]($name);
-
-            return static::$_builtTypes[$name] = static::$_types[$name];
+            return static::$_builtTypes[$name] = new static::$_types[$name]($name);
         }
 
         return static::$_builtTypes[$name] = static::$_types[$name];
@@ -145,6 +143,9 @@ class Type implements TypeInterface
      * Registers a new type identifier and maps it to a fully namespaced classname,
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
+     *
+     * Deprecated: The usage of $type as \Cake\Database\Type[] is deprecated. Please always use string[] if you pass an array
+     * as first argument.
      *
      * @param string|string[]|\Cake\Database\Type[]|null $type If string name of type to map, if array list of arrays to be mapped
      * @param string|\Cake\Database\Type|null $className The classname or object instance of it to register.

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -107,6 +107,7 @@ class Type implements TypeInterface
         }
         if (is_string(static::$_types[$name])) {
             static::$_types[$name] = new static::$_types[$name]($name);
+
             return static::$_builtTypes[$name] = static::$_types[$name];
         }
 

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -106,7 +106,8 @@ class Type implements TypeInterface
             throw new InvalidArgumentException(sprintf('Unknown type "%s"', $name));
         }
         if (is_string(static::$_types[$name])) {
-            return static::$_builtTypes[$name] = new static::$_types[$name]($name);
+            static::$_types[$name] = new static::$_types[$name]($name);
+            return static::$_builtTypes[$name] = static::$_types[$name];
         }
 
         return static::$_builtTypes[$name] = static::$_types[$name];
@@ -144,9 +145,9 @@ class Type implements TypeInterface
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
      *
-     * @param string|array|\Cake\Database\Type|null $type if string name of type to map, if array list of arrays to be mapped
-     * @param string|null $className The classname to register.
-     * @return array|string|null if $type is null then array with current map, if $className is null string
+     * @param string|string[]|\Cake\Database\Type[]|null $type if string name of type to map, if array list of arrays to be mapped
+     * @param string|\Cake\Database\Type|null $className The classname or object instance of it to register.
+     * @return array|string|null If $type is null then array with current map, if $className is null string
      * configured class name for give $type, null otherwise
      */
     public static function map($type = null, $className = null)
@@ -299,5 +300,20 @@ class Type implements TypeInterface
     public function marshal($value)
     {
         return $this->_basicTypeCast($value);
+    }
+
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'name' => $this->_name,
+            'types' => static::$_types,
+            'builtTypes' => static::$_builtTypes,
+        ];
     }
 }

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -29,7 +29,7 @@ class Type implements TypeInterface
      * identifier is used as key and a complete namespaced class name as value
      * representing the class that will do actual type conversions.
      *
-     * @var array
+     * @var string[]|\Cake\Database\Type[]
      */
     protected static $_types = [
         'tinyinteger' => 'Cake\Database\Type\IntegerType',
@@ -69,7 +69,7 @@ class Type implements TypeInterface
     /**
      * Contains a map of type object instances to be reused if needed.
      *
-     * @var array
+     * @var \Cake\Database\Type[]
      */
     protected static $_builtTypes = [];
 

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -121,7 +121,7 @@ class Type implements TypeInterface
     public static function buildAll()
     {
         $result = [];
-        foreach (self::$_types as $name => $type) {
+        foreach (static::$_types as $name => $type) {
             $result[$name] = isset(static::$_builtTypes[$name]) ? static::$_builtTypes[$name] : static::build($name);
         }
 
@@ -153,19 +153,19 @@ class Type implements TypeInterface
     public static function map($type = null, $className = null)
     {
         if ($type === null) {
-            return self::$_types;
+            return static::$_types;
         }
         if (is_array($type)) {
-            self::$_types = $type;
+            static::$_types = $type;
 
             return null;
         }
         if ($className === null) {
-            return isset(self::$_types[$type]) ? self::$_types[$type] : null;
+            return isset(static::$_types[$type]) ? static::$_types[$type] : null;
         }
 
-        self::$_types[$type] = $className;
-        unset(self::$_builtTypes[$type]);
+        static::$_types[$type] = $className;
+        unset(static::$_builtTypes[$type]);
     }
 
     /**
@@ -175,8 +175,8 @@ class Type implements TypeInterface
      */
     public static function clear()
     {
-        self::$_types = [];
-        self::$_builtTypes = [];
+        static::$_types = [];
+        static::$_builtTypes = [];
     }
 
     /**
@@ -228,8 +228,8 @@ class Type implements TypeInterface
         if ($value === null) {
             return null;
         }
-        if (!empty(self::$_basicTypes[$this->_name])) {
-            $typeInfo = self::$_basicTypes[$this->_name];
+        if (!empty(static::$_basicTypes[$this->_name])) {
+            $typeInfo = static::$_basicTypes[$this->_name];
             if (isset($typeInfo['callback'])) {
                 return $typeInfo['callback']($value);
             }

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -52,7 +52,7 @@ class Type implements TypeInterface
 
     /**
      * List of basic type mappings, used to avoid having to instantiate a class
-     * for doing conversion on these
+     * for doing conversion on these.
      *
      * @var array
      * @deprecated 3.1 All types will now use a specific class
@@ -67,7 +67,7 @@ class Type implements TypeInterface
     ];
 
     /**
-     * Contains a map of type object instances to be reused if needed
+     * Contains a map of type object instances to be reused if needed.
      *
      * @var array
      */
@@ -91,7 +91,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Returns a Type object capable of converting a type identified by $name
+     * Returns a Type object capable of converting a type identified by name.
      *
      * @param string $name type identifier
      * @throws \InvalidArgumentException If type identifier is unknown
@@ -115,7 +115,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Returns an arrays with all the mapped type objects, indexed by name
+     * Returns an arrays with all the mapped type objects, indexed by name.
      *
      * @return array
      */
@@ -146,7 +146,7 @@ class Type implements TypeInterface
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
      *
-     * @param string|string[]|\Cake\Database\Type[]|null $type if string name of type to map, if array list of arrays to be mapped
+     * @param string|string[]|\Cake\Database\Type[]|null $type If string name of type to map, if array list of arrays to be mapped
      * @param string|\Cake\Database\Type|null $className The classname or object instance of it to register.
      * @return array|string|null If $type is null then array with current map, if $className is null string
      * configured class name for give $type, null otherwise
@@ -207,8 +207,8 @@ class Type implements TypeInterface
     /**
      * Casts given value from a database type to PHP equivalent
      *
-     * @param mixed $value value to be converted to PHP equivalent
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
+     * @param mixed $value Value to be converted to PHP equivalent
+     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted
      * @return mixed
      */
     public function toPHP($value, Driver $driver)
@@ -220,7 +220,7 @@ class Type implements TypeInterface
      * Checks whether this type is a basic one and can be converted using a callback
      * If it is, returns converted value
      *
-     * @param mixed $value value to be converted to PHP equivalent
+     * @param mixed $value Value to be converted to PHP equivalent
      * @return mixed
      * @deprecated 3.1 All types should now be a specific class
      */

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -177,9 +177,11 @@ class TypeTest extends TestCase
 
         $this->assertEmpty(Type::map());
         Type::map($map);
-        $this->assertEquals($map, Type::map());
+        $newMap = Type::map();
 
-        $this->assertNotSame($type, Type::build('float'));
+        $this->assertEquals(array_keys($map), array_keys($newMap));
+        $this->assertEquals($map['integer'], $newMap['integer']);
+        $this->assertSame($type, Type::build('float'));
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -15,6 +15,9 @@
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Type;
+use Cake\Database\Type\BoolType;
+use Cake\Database\Type\IntegerType;
+use Cake\Database\Type\UuidType;
 use Cake\TestSuite\TestCase;
 use PDO;
 use TestApp\Database\Type\BarType;
@@ -250,5 +253,34 @@ class TypeTest extends TestCase
         $instance = $this->getMockBuilder('Cake\Database\Type')->getMock();
         Type::set('random', $instance);
         $this->assertSame($instance, Type::build('random'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $type = new Type('foo');
+        Type::clear();
+        Type::map('bool', BoolType::class);
+        Type::map('int', IntegerType::class);
+        $uuidType = new UuidType('uuid');
+        Type::map('uuid', $uuidType);
+        Type::build('bool');
+
+        $result = $type->__debugInfo();
+        $boolType = new BoolType('bool');
+        $expected = [
+            'name' => 'foo',
+            'types' => [
+                'bool' => $boolType,
+                'int' => IntegerType::class,
+                'uuid' => $uuidType,
+            ],
+            'builtTypes' => [
+                'bool' => $boolType,
+            ],
+        ];
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -152,7 +152,7 @@ class TypeTest extends TestCase
     public function testReMapAndBuild()
     {
         $fooType = FooType::class;
-        $map = Type::map('foo', $fooType);
+        Type::map('foo', $fooType);
         $type = Type::build('foo');
         $this->assertInstanceOf($fooType, $type);
 

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -163,6 +163,23 @@ class TypeTest extends TestCase
     }
 
     /**
+     * Tests new types can be registered and built as objects
+     *
+     * @return void
+     */
+    public function testMapAndBuildWithObjects()
+    {
+        $map = Type::map();
+        Type::clear();
+
+        $uuidType = new UuidType('uuid');
+        Type::map('uuid', $uuidType);
+
+        $this->assertSame($uuidType, Type::build('uuid'));
+        Type::map($map);
+    }
+
+    /**
      * Tests clear function in conjunction with map
      *
      * @return void
@@ -181,7 +198,7 @@ class TypeTest extends TestCase
 
         $this->assertEquals(array_keys($map), array_keys($newMap));
         $this->assertEquals($map['integer'], $newMap['integer']);
-        $this->assertSame($type, Type::build('float'));
+        $this->assertEquals($type, Type::build('float'));
     }
 
     /**
@@ -263,25 +280,9 @@ class TypeTest extends TestCase
     public function testDebugInfo()
     {
         $type = new Type('foo');
-        Type::clear();
-        Type::map('bool', BoolType::class);
-        Type::map('int', IntegerType::class);
-        $uuidType = new UuidType('uuid');
-        Type::map('uuid', $uuidType);
-        Type::build('bool');
-
         $result = $type->__debugInfo();
-        $boolType = new BoolType('bool');
         $expected = [
             'name' => 'foo',
-            'types' => [
-                'bool' => $boolType,
-                'int' => IntegerType::class,
-                'uuid' => $uuidType,
-            ],
-            'builtTypes' => [
-                'bool' => $boolType,
-            ],
         ];
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
`__debugInfo()` doest help with the `dd(Type::buildAll())` bug, but it does output only the relevant info when doing dd($type).

Also tweaked performance by caching the object, and fixed up doc blocks.
The _types also can already contain objects instead of just class names.
map() itself cannot take objects unless it is an array of it.

In 3.6 we should also split that super-method into getMap and setMap parts, it does way too much and that pretty badly.