### PR TITLE
Use recommended testsuite names

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,13 +14,13 @@
     </php>
 
     <testsuites>
-        <testsuite name="CakePHP Test Suite">
+        <testsuite name="cakephp">
             <directory>./tests/TestCase/</directory>
             <!-- Excludes are required in order to let DatabaseSuite decorate the tests -->
             <exclude>./tests/TestCase/Database/</exclude>
             <exclude>./tests/TestCase/ORM/</exclude>
         </testsuite>
-        <testsuite name="Database Test Suite">
+        <testsuite name="database">
             <file>./tests/TestCase/DatabaseSuite.php</file>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
as per https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration

also, `--testsuite foobar` doesnt require quoting, with spaces it does: `--testsuite "Foo Bar"`, besides the way more typing to get the desired testsuite to run standalone.