### PR TITLE
3.next - Deprecated ServerRequest::addPaths()

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -945,6 +945,10 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      */
     public function addPaths(array $paths)
     {
+        deprecationWarning(
+            'ServerRequest::addPaths() is deprecated. ' .
+            'Use `withAttribute($key, $value)` instead.'
+        );
         foreach (['webroot', 'here', 'base'] as $element) {
             if (isset($paths[$element])) {
                 $this->{$element} = $paths[$element];

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -212,11 +212,10 @@ class UrlHelperTest extends TestCase
      */
     public function testAssetUrlNoRewrite()
     {
-        $this->Helper->request->addPaths([
-            'base' => '/cake_dev/index.php',
-            'webroot' => '/cake_dev/app/webroot/',
-            'here' => '/cake_dev/index.php/tasks',
-        ]);
+        $this->Helper->request = $this->Helper->request
+            ->withAttribute('base', '/cake_dev/index.php')
+            ->withAttribute('webroot', '/cake_dev/app/webroot/')
+            ->withRequestTarget('/cake_dev/index.php/tasks');
         $result = $this->Helper->assetUrl('img/cake.icon.png', ['fullBase' => true]);
         $expected = Configure::read('App.fullBaseUrl') . '/cake_dev/app/webroot/img/cake.icon.png';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
This method modifies requests in place, we can't have that with PSR7 requests.

Refs #11385