### PR TITLE
Add BehaviorRegistry::className().

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -85,7 +85,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * Resolve a behavior classname.
      *
      * @param string $class Partial classname to resolve.
-     * @return string|false Either the correct classname or false.
+     * @return string|null Either the correct classname or null.
      * @since 3.5.7
      */
     public static function className($class)
@@ -95,7 +95,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
             $result = App::className($class, 'ORM/Behavior', 'Behavior');
         }
 
-        return $result;
+        return $result ?: null;
     }
 
     /**
@@ -108,7 +108,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      */
     protected function _resolveClassName($class)
     {
-        return static::className($class);
+        return static::className($class) ?: false;
     }
 
     /**

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -84,12 +84,11 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Resolve a behavior classname.
      *
-     * Part of the template method for Cake\Core\ObjectRegistry::load()
-     *
      * @param string $class Partial classname to resolve.
      * @return string|false Either the correct classname or false.
+     * @since 3.5.7
      */
-    protected function _resolveClassName($class)
+    public static function className($class)
     {
         $result = App::className($class, 'Model/Behavior', 'Behavior');
         if (!$result) {
@@ -97,6 +96,19 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         return $result;
+    }
+
+    /**
+     * Resolve a behavior classname.
+     *
+     * Part of the template method for Cake\Core\ObjectRegistry::load()
+     *
+     * @param string $class Partial classname to resolve.
+     * @return string|false Either the correct classname or false.
+     */
+    protected function _resolveClassName($class)
+    {
+        return static::className($class);
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -52,6 +52,24 @@ class BehaviorRegistryTest extends TestCase
     }
 
     /**
+     * Test classname resolution.
+     *
+     * @return void
+     */
+    public function testClassName()
+    {
+        Plugin::load('TestPlugin');
+
+        $expected = 'Cake\ORM\Behavior\TranslateBehavior';
+        $result = BehaviorRegistry::className('Translate');
+        $this->assertSame($expected, $result);
+
+        $expected = 'TestPlugin\Model\Behavior\PersisterOneBehavior';
+        $result = BehaviorRegistry::className('TestPlugin.PersisterOne');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Test loading behaviors.
      *
      * @return void

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -67,6 +67,8 @@ class BehaviorRegistryTest extends TestCase
         $expected = 'TestPlugin\Model\Behavior\PersisterOneBehavior';
         $result = BehaviorRegistry::className('TestPlugin.PersisterOne');
         $this->assertSame($expected, $result);
+
+        $this->assertNull(BehaviorRegistry::className('NonExistent'));
     }
 
     /**


### PR DESCRIPTION
This helps in behavior class resolution since core behaviors are
under ORM/Behavior while in app they are under Model/Behavior.