### PR TITLE
Refactoring tests

### DIFF
--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -73,7 +73,7 @@ class FallbackPasswordHasherTest extends TestCase
 
         $hash = $simple->hash('foo');
         $legacyHash = $legacy->hash('foo');
-        $this->assertTrue($hash !== $legacyHash);
+        $this->assertNotSame($hash, $legacyHash);
         $this->assertTrue($hasher->check('foo', $hash));
         $this->assertTrue($hasher->check('foo', $legacyHash));
     }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -598,13 +598,13 @@ class CacheTest extends TestCase
     {
         $this->_configCache();
         Cache::write('App.falseTest', false, 'tests');
-        $this->assertSame(Cache::read('App.falseTest', 'tests'), false);
+        $this->assertFalse(Cache::read('App.falseTest', 'tests'));
 
         Cache::write('App.trueTest', true, 'tests');
-        $this->assertSame(Cache::read('App.trueTest', 'tests'), true);
+        $this->assertTrue(Cache::read('App.trueTest', 'tests'));
 
         Cache::write('App.nullTest', null, 'tests');
-        $this->assertSame(Cache::read('App.nullTest', 'tests'), null);
+        $this->assertNull(Cache::read('App.nullTest', 'tests'));
 
         Cache::write('App.zeroTest', 0, 'tests');
         $this->assertSame(Cache::read('App.zeroTest', 'tests'), 0);
@@ -645,9 +645,9 @@ class CacheTest extends TestCase
 
         $read = Cache::readMany(array_keys($data), 'tests');
 
-        $this->assertSame($read['App.falseTest'], false);
-        $this->assertSame($read['App.trueTest'], true);
-        $this->assertSame($read['App.nullTest'], null);
+        $this->assertFalse($read['App.falseTest']);
+        $this->assertTrue($read['App.trueTest']);
+        $this->assertNull($read['App.nullTest']);
         $this->assertSame($read['App.zeroTest'], 0);
         $this->assertSame($read['App.zeroTest2'], '0');
     }
@@ -672,11 +672,11 @@ class CacheTest extends TestCase
         Cache::deleteMany(array_keys($data), 'tests');
         $read = Cache::readMany(array_merge(array_keys($data), ['App.keepTest']), 'tests');
 
-        $this->assertSame($read['App.falseTest'], false);
-        $this->assertSame($read['App.trueTest'], false);
-        $this->assertSame($read['App.nullTest'], false);
-        $this->assertSame($read['App.zeroTest'], false);
-        $this->assertSame($read['App.zeroTest2'], false);
+        $this->assertFalse($read['App.falseTest']);
+        $this->assertFalse($read['App.trueTest']);
+        $this->assertFalse($read['App.nullTest']);
+        $this->assertFalse($read['App.zeroTest']);
+        $this->assertFalse($read['App.zeroTest2']);
         $this->assertSame($read['App.keepTest'], 'keepMe');
     }
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -494,12 +494,12 @@ class MemcachedEngineTest extends TestCase
 
         $read = Cache::readMany(array_merge(array_keys($data), ['App.doesNotExist']), 'memcached');
 
-        $this->assertSame($read['App.falseTest'], false);
-        $this->assertSame($read['App.trueTest'], true);
-        $this->assertSame($read['App.nullTest'], null);
+        $this->assertFalse($read['App.falseTest']);
+        $this->assertTrue($read['App.trueTest']);
+        $this->assertNull($read['App.nullTest']);
         $this->assertSame($read['App.zeroTest'], 0);
         $this->assertSame($read['App.zeroTest2'], '0');
-        $this->assertSame($read['App.doesNotExist'], false);
+        $this->assertFalse($read['App.doesNotExist']);
     }
 
     /**
@@ -519,9 +519,9 @@ class MemcachedEngineTest extends TestCase
         ];
         Cache::writeMany($data, 'memcached');
 
-        $this->assertSame(Cache::read('App.falseTest', 'memcached'), false);
-        $this->assertSame(Cache::read('App.trueTest', 'memcached'), true);
-        $this->assertSame(Cache::read('App.nullTest', 'memcached'), null);
+        $this->assertFalse(Cache::read('App.falseTest', 'memcached'));
+        $this->assertTrue(Cache::read('App.trueTest', 'memcached'));
+        $this->assertNull(Cache::read('App.nullTest', 'memcached'));
         $this->assertSame(Cache::read('App.zeroTest', 'memcached'), 0);
         $this->assertSame(Cache::read('App.zeroTest2', 'memcached'), '0');
     }
@@ -608,11 +608,11 @@ class MemcachedEngineTest extends TestCase
 
         Cache::deleteMany(array_merge(array_keys($data), ['App.doesNotExist']), 'memcached');
 
-        $this->assertSame(Cache::read('App.falseTest', 'memcached'), false);
-        $this->assertSame(Cache::read('App.trueTest', 'memcached'), false);
-        $this->assertSame(Cache::read('App.nullTest', 'memcached'), false);
-        $this->assertSame(Cache::read('App.zeroTest', 'memcached'), false);
-        $this->assertSame(Cache::read('App.zeroTest2', 'memcached'), false);
+        $this->assertFalse(Cache::read('App.falseTest', 'memcached'));
+        $this->assertFalse(Cache::read('App.trueTest', 'memcached'));
+        $this->assertFalse(Cache::read('App.nullTest', 'memcached'));
+        $this->assertFalse(Cache::read('App.zeroTest', 'memcached'));
+        $this->assertFalse(Cache::read('App.zeroTest2', 'memcached'));
         $this->assertSame(Cache::read('App.keepTest', 'memcached'), 'keepMe');
     }
 

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -589,7 +589,7 @@ class ConsoleIoTest extends TestCase
 
         $this->assertTrue($result);
         $this->assertFileExists($file);
-        $this->assertEquals($contents, file_get_contents($file));
+        $this->assertStringEqualsFile($file, $contents);
     }
 
     /**
@@ -660,7 +660,7 @@ class ConsoleIoTest extends TestCase
 
         $this->assertFalse($result);
         $this->assertFileExists($file);
-        $this->assertEquals('original', file_get_contents($file));
+        $this->assertStringEqualsFile($file, 'original');
     }
 
     /**
@@ -682,7 +682,7 @@ class ConsoleIoTest extends TestCase
 
         $this->assertTrue($result);
         $this->assertFileExists($file);
-        $this->assertEquals($contents, file_get_contents($file));
+        $this->assertStringEqualsFile($file, $contents);
     }
 
     /**
@@ -704,15 +704,15 @@ class ConsoleIoTest extends TestCase
             ->will($this->returnValue('a'));
 
         $this->io->createFile($file, 'new content');
-        $this->assertEquals('new content', file_get_contents($file));
+        $this->assertStringEqualsFile($file, 'new content');
 
         $this->io->createFile($file, 'newer content');
-        $this->assertEquals('newer content', file_get_contents($file));
+        $this->assertStringEqualsFile($file, 'newer content');
 
         $this->io->createFile($file, 'newest content', false);
-        $this->assertEquals(
+        $this->assertStringEqualsFile(
+            $file,
             'newest content',
-            file_get_contents($file),
             'overwrite state replaces parameter'
         );
     }

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -583,7 +583,7 @@ class ShellTest extends TestCase
         $result = $this->Shell->createFile($file, $contents);
         $this->assertTrue($result);
         $this->assertFileExists($file);
-        $this->assertEquals(file_get_contents($file), $contents);
+        $this->assertStringEqualsFile($file, $contents);
     }
 
     /**
@@ -660,7 +660,7 @@ class ShellTest extends TestCase
         $this->Shell->interactive = false;
         $result = $this->Shell->createFile($file, 'My content');
         $this->assertTrue($result);
-        $this->assertEquals(file_get_contents($file), 'My content');
+        $this->assertStringEqualsFile($file, 'My content');
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -108,7 +108,7 @@ class ConfigureTest extends TestCase
         $this->assertEquals('something_else', $result);
 
         $result = Configure::read('debug');
-        $this->assertTrue($result >= 0);
+        $this->assertGreaterThanOrEqual(0, $result);
 
         $result = Configure::read();
         $this->assertInternalType('array', $result);
@@ -198,7 +198,7 @@ class ConfigureTest extends TestCase
 
         Configure::delete('SomeName.someKey');
         $result = Configure::read('SomeName.someKey');
-        $this->assertTrue($result === null);
+        $this->assertNull($result);
 
         Configure::write('SomeName', ['someKey' => 'myvalue', 'otherKey' => 'otherValue']);
 
@@ -211,10 +211,10 @@ class ConfigureTest extends TestCase
         Configure::delete('SomeName');
 
         $result = Configure::read('SomeName.someKey');
-        $this->assertTrue($result === null);
+        $this->assertNull($result);
 
         $result = Configure::read('SomeName.otherKey');
-        $this->assertTrue($result === null);
+        $this->assertNull($result);
     }
 
     /**
@@ -482,7 +482,7 @@ class ConfigureTest extends TestCase
         Configure::config('test', $engine);
         $configured = Configure::configured();
 
-        $this->assertTrue(in_array('test', $configured));
+        $this->assertContains('test', $configured);
 
         $this->assertTrue(Configure::configured('test'));
         $this->assertFalse(Configure::configured('fake_garbage'));

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -183,7 +183,7 @@ class FileTest extends TestCase
         $result = $this->File->read();
         $expecting = file_get_contents(__FILE__);
         $this->assertEquals($expecting, $result);
-        $this->assertTrue(!is_resource($this->File->handle));
+        $this->assertNotInternalType('resource', $this->File->handle);
 
         $this->File->lock = true;
         $result = $this->File->read();
@@ -251,12 +251,12 @@ class FileTest extends TestCase
         $handle = $this->File->handle;
         $r = $this->File->open();
         $this->assertTrue($r);
-        $this->assertTrue($handle === $this->File->handle);
+        $this->assertSame($handle, $this->File->handle);
         $this->assertInternalType('resource', $this->File->handle);
 
         $r = $this->File->open('r', true);
         $this->assertTrue($r);
-        $this->assertFalse($handle === $this->File->handle);
+        $this->assertNotSame($handle, $this->File->handle);
         $this->assertInternalType('resource', $this->File->handle);
     }
 
@@ -442,7 +442,7 @@ class FileTest extends TestCase
             $r = $TmpFile->write($data);
             $this->assertTrue($r);
             $this->assertFileExists($tmpFile);
-            $this->assertEquals($data, file_get_contents($tmpFile));
+            $this->assertStringEqualsFile($tmpFile, $data);
             $this->assertInternalType('resource', $TmpFile->handle);
             $TmpFile->close();
         }
@@ -474,7 +474,7 @@ class FileTest extends TestCase
             $this->assertTrue($r);
             $this->assertFileExists($tmpFile);
             $data = $data . $fragment;
-            $this->assertEquals($data, file_get_contents($tmpFile));
+            $this->assertStringEqualsFile($tmpFile, $data);
             $newSize = $TmpFile->size();
             $this->assertTrue($newSize > $size);
             $size = $newSize;
@@ -482,7 +482,7 @@ class FileTest extends TestCase
         }
 
         $TmpFile->append('');
-        $this->assertEquals($data, file_get_contents($tmpFile));
+        $this->assertStringEqualsFile($tmpFile, $data);
         $TmpFile->close();
     }
 

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1068,8 +1068,8 @@ class FolderTest extends TestCase
         $result = $Folder->copy(['to' => $folderThree, 'scheme' => Folder::SKIP]);
         $this->assertTrue($result);
         $this->assertFileExists($folderThree . DS . 'file2.php');
-        $this->assertEquals('touched', file_get_contents($folderThree . DS . 'file2.php'));
-        $this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folderB' . DS . 'fileB.php'));
+        $this->assertStringEqualsFile($folderThree . DS . 'file2.php', 'touched');
+        $this->assertStringEqualsFile($folderThree . DS . 'folderB' . DS . 'fileB.php', 'untouched');
     }
 
     /**
@@ -1092,7 +1092,7 @@ class FolderTest extends TestCase
         $Folder = new Folder($folderOne);
         $result = $Folder->copy(['to' => $folderTwo, 'scheme' => Folder::SKIP]);
         $this->assertTrue($result);
-        $this->assertEquals('Folder Two File', file_get_contents($folderTwo . DS . 'fileA.txt'));
+        $this->assertStringEqualsFile($folderTwo . DS . 'fileA.txt', 'Folder Two File');
     }
 
     /**
@@ -1260,7 +1260,7 @@ class FolderTest extends TestCase
         $result = $Folder->move($folderTwo);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertEquals('', file_get_contents($folderTwoB . '/fileB.php'));
+        $this->assertStringEqualsFile($folderTwoB . '/fileB.php', '');
         $this->assertFileNotExists($fileOne);
         $this->assertFileNotExists($folderOneA);
         $this->assertFileNotExists($fileOneA);
@@ -1327,7 +1327,7 @@ class FolderTest extends TestCase
         $result = $Folder->move(['to' => $folderTwo, 'scheme' => Folder::SKIP]);
         $this->assertTrue($result);
         $this->assertFileExists($folderTwo . '/file1.php');
-        $this->assertEquals('untouched', file_get_contents($folderTwoB . '/fileB.php'));
+        $this->assertStringEqualsFile($folderTwoB . '/fileB.php', 'untouched');
         $this->assertFileNotExists($fileOne);
         $this->assertFileNotExists($folderOneA);
         $this->assertFileNotExists($fileOneA);

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -718,7 +718,7 @@ class ResponseTest extends TestCase
         $_SERVER['HTTP_ACCEPT_ENCODING'] = 'gzip';
         $result = $response->compress();
         $this->assertTrue($result);
-        $this->assertTrue(in_array('ob_gzhandler', ob_list_handlers()));
+        $this->assertContains('ob_gzhandler', ob_list_handlers());
 
         ob_get_clean();
     }
@@ -2039,7 +2039,7 @@ class ResponseTest extends TestCase
             $result = $response->send();
             $output = ob_get_clean();
             $this->assertEquals("/* this is the test asset css file */\n", $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
             $this->assertEquals('text/css', $response->getType());
             $this->assertEquals('bytes', $response->getHeaderLine('Accept-Ranges'));
             $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
@@ -2075,7 +2075,7 @@ class ResponseTest extends TestCase
             $result = $response->send();
             $output = ob_get_clean();
             $this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
             $this->assertEquals('text/html', $response->getType());
             $this->assertEquals('bytes', $response->getHeaderLine('Accept-Ranges'));
             $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
@@ -2131,7 +2131,7 @@ class ResponseTest extends TestCase
             $result = $response->send();
             $output = ob_get_clean();
             $this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
             $this->assertEquals('application/octet-stream', $response->getType());
             $this->assertEquals('bytes', $response->getHeaderLine('Accept-Ranges'));
             $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
@@ -2187,7 +2187,7 @@ class ResponseTest extends TestCase
             $result = $response->send();
             $output = ob_get_clean();
             $this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
             $this->assertEquals('application/force-download', $response->getType());
             $this->assertEquals('bytes', $response->getHeaderLine('Accept-Ranges'));
             $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
@@ -2459,7 +2459,7 @@ class ResponseTest extends TestCase
             $result = $response->send();
             $output = ob_get_clean();
             $this->assertEquals('is the test asset ', $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
 
             $this->assertEquals(
                 'attachment; filename="test_asset.css"',
@@ -2707,7 +2707,7 @@ class ResponseTest extends TestCase
             $this->assertEquals('text/css', $response->getType());
             $this->assertEquals(206, $response->getStatusCode());
             $this->assertEquals('is the test asset ', $output);
-            $this->assertNotSame(false, $result);
+            $this->assertNotFalse($result);
         });
     }
 

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -450,7 +450,7 @@ class SessionTest extends TestCase
 
         $session->write('SessionTestCase', '0');
         $this->assertEquals('0', $session->read('SessionTestCase'));
-        $this->assertFalse($session->read('SessionTestCase') === 0);
+        $this->assertNotSame($session->read('SessionTestCase'), 0);
 
         $session->write('SessionTestCase', false);
         $this->assertFalse($session->read('SessionTestCase'));

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -143,14 +143,14 @@ class SocketTest extends TestCase
             $this->assertEquals('127.0.0.1', $this->Socket->address());
             $this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
             $this->assertNull($this->Socket->lastError());
-            $this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
+            $this->assertContains('127.0.0.1', $this->Socket->addresses());
 
             $this->Socket = new Socket(['host' => '127.0.0.1']);
             $this->Socket->connect();
             $this->assertEquals('127.0.0.1', $this->Socket->address());
             $this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
             $this->assertNull($this->Socket->lastError());
-            $this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
+            $this->assertContains('127.0.0.1', $this->Socket->addresses());
         } catch (SocketException $e) {
             $this->markTestSkipped('Cannot test network, skipping.');
         }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -981,7 +981,7 @@ class MarshallerTest extends TestCase
 
         $this->assertTrue($article->tags[0]->isNew());
         $this->assertTrue($article->tags[1]->isNew());
-        $this->assertEquals($article->tags[2]->isNew(), false);
+        $this->assertFalse($article->tags[2]->isNew());
 
         $tagCount = $tags->find()->count();
         $this->articles->save($article);

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -130,7 +130,7 @@ class AssetMiddlewareTest extends TestCase
         $res = $middleware($request, $response, $next);
 
         $body = $res->getBody()->getContents();
-        $this->assertEquals(file_get_contents($expectedFile), $body);
+        $this->assertStringEqualsFile($expectedFile, $body);
     }
 
     /**

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -65,7 +65,7 @@ class TextTest extends TestCase
             $result = Text::uuid();
             $match = (bool)preg_match($pattern, $result);
             $this->assertTrue($match);
-            $this->assertFalse(in_array($result, $check));
+            $this->assertNotContains($result, $check);
             $check[] = $result;
         }
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2438,7 +2438,7 @@ class FormHelperTest extends TestCase
         $this->Form->text('Article.title');
 
         $this->assertEquals(1, $this->Form->fields['Article.id'], 'Hidden input should be secured.');
-        $this->assertTrue(in_array('Article.title', $this->Form->fields), 'Field should be secured.');
+        $this->assertContains('Article.title', $this->Form->fields, 'Field should be secured.');
 
         $this->Form->unlockField('Article.title');
         $this->Form->unlockField('Article.id');
@@ -7347,7 +7347,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->postButton('Send', '/', ['data' => ['extra' => 'value']]);
-        $this->assertTrue(strpos($result, '<input type="hidden" name="extra" value="value"') !== false);
+        $this->assertNotFalse(strpos($result, '<input type="hidden" name="extra" value="value"'));
     }
 
     /**


### PR DESCRIPTION
Continuing to refactory test, like #11480, I've used:
- `assertNotInternalType` instead of `is_*` methods;
- `assertNull` instead of strict comparisons with `null` keyword;
- `assertTrue` instead of strict comparisons with `true` keyword;
- `assertFalse` and `assertNotFalse` instead of strict comparisons with `false` keyword;
- `assertGreaterThanOrEqual` for matematical comparisions;
- `assertStringEqualsFile` when comparing a `string` with a `file`;
- `assertSame` and `assertNotSame` instead of strict comparisons;
- `assertContains` and `assertNotContains` instead of `in_array` method.