### PR TITLE
[2.x] Fix CakeRequest::referer(true) returning scheme-relative URLs

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1688,9 +1688,6 @@ class Model extends CakeObject implements CakeEventListener {
  * Saves the value of a single field to the database, based on the current
  * model ID.
  *
- * @deprecated 3.0.0 To ease migration to the new major, do not use this method anymore.
- *   Stateful model usage will be removed. Use the existing save() methods instead.
- *
  * @param string $name Name of the table field
  * @param mixed $value Value of the field
  * @param bool|array $validate Either a boolean, or an array.
@@ -1698,6 +1695,8 @@ class Model extends CakeObject implements CakeEventListener {
  *   If an array, allows control of 'validate', 'callbacks' and 'counterCache' options.
  *   See Model::save() for details of each options.
  * @return bool|array See Model::save() False on failure or an array of model data on success.
+ * @deprecated 3.0.0 To ease migration to the new major, do not use this method anymore.
+ *   Stateful model usage will be removed. Use the existing save() methods instead.
  * @see Model::save()
  * @link https://book.cakephp.org/2.0/en/models/saving-your-data.html#model-savefield-string-fieldname-string-fieldvalue-validate-false
  */

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -439,7 +439,7 @@ class CakeRequest implements ArrayAccess {
 		if (!empty($ref) && !empty($base)) {
 			if ($local && strpos($ref, $base) === 0) {
 				$ref = substr($ref, strlen($base));
-				if (empty($ref)) {
+				if (!strlen($ref) || strpos($ref, '//') === 0) {
 					$ref = '/';
 				}
 				if ($ref[0] !== '/') {

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -739,6 +739,9 @@ class CakeRequestTest extends CakeTestCase {
 		$result = $request->referer();
 		$this->assertSame($result, 'https://cakephp.org');
 
+		$result = $request->referer(true);
+		$this->assertSame('/', $result);
+
 		$_SERVER['HTTP_REFERER'] = '';
 		$result = $request->referer();
 		$this->assertSame($result, '/');
@@ -750,6 +753,18 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['HTTP_REFERER'] = Configure::read('App.fullBaseUrl') . '/some/path';
 		$result = $request->referer(true);
 		$this->assertSame($result, '/some/path');
+
+		$_SERVER['HTTP_REFERER'] = Configure::read('App.fullBaseUrl') . '///cakephp.org/';
+		$result = $request->referer(true);
+		$this->assertSame('/', $result); // Avoid returning scheme-relative URLs.
+
+		$_SERVER['HTTP_REFERER'] = Configure::read('App.fullBaseUrl') . '/0';
+		$result = $request->referer(true);
+		$this->assertSame('/0', $result);
+
+		$_SERVER['HTTP_REFERER'] = Configure::read('App.fullBaseUrl') . '/';
+		$result = $request->referer(true);
+		$this->assertSame('/', $result);
 
 		$_SERVER['HTTP_REFERER'] = Configure::read('App.fullBaseUrl') . '/some/path';
 		$result = $request->referer(false);


### PR DESCRIPTION
Backport of #11503 (and #8795)