### PR TITLE
3.next - Add deprecation warnings for public request properties

### DIFF
--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -41,7 +41,7 @@ class SessionStorage implements StorageInterface
     /**
      * Session object.
      *
-     * @var \Cake\Network\Session
+     * @var \Cake\Http\Session
      */
     protected $_session;
 

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -441,10 +441,7 @@ class AuthComponent extends Component
      */
     protected function _isLoginAction(Controller $controller)
     {
-        $url = '';
-        if (isset($controller->request->url)) {
-            $url = $controller->request->url;
-        }
+        $url = $controller->request->getRequestTarget();
         $url = Router::normalize($url);
         $loginAction = Router::normalize($this->_config['loginAction']);
 

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -221,7 +221,7 @@ class AuthComponent extends Component
     /**
      * Instance of the Session object
      *
-     * @var \Cake\Network\Session
+     * @var \Cake\Http\Session
      * @deprecated 3.1.0 Will be removed in 4.0
      */
     public $session;

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -128,7 +128,7 @@ class CookieComponent extends Component
         }
 
         if (empty($this->_config['path'])) {
-            $this->setConfig('path', $this->request->webroot);
+            $this->setConfig('path', $this->request->getAttribute('webroot'));
         }
     }
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -34,7 +34,7 @@ class FlashComponent extends Component
     /**
      * The Session object instance
      *
-     * @var \Cake\Network\Session
+     * @var \Cake\Http\Session
      */
     protected $_session;
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -201,9 +201,10 @@ class RequestHandlerComponent extends Component
             $this->_setExtension($request, $response);
         }
 
-        $request->params['isAjax'] = $request->is('ajax');
+        $isAjax = $request->is('ajax');
+        $controller->request = $request->withParam('isAjax', $isAjax);
 
-        if (!$this->ext && $request->is('ajax')) {
+        if (!$this->ext && $isAjax) {
             $this->ext = 'ajax';
         }
 
@@ -217,7 +218,7 @@ class RequestHandlerComponent extends Component
             }
             if ($this->requestedWith($type)) {
                 $input = $request->input(...$handler);
-                $request->data = (array)$input;
+                $controller->request = $request->withParsedBody((array)$input);
             }
         }
     }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -87,7 +87,7 @@ class SecurityComponent extends Component
     /**
      * The Session object
      *
-     * @var \Cake\Network\Session
+     * @var \Cake\Http\Session
      */
     public $session;
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -2026,6 +2026,8 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Returns an updated request object. This method returns
      * a *new* request object and does not mutate the request in-place.
      *
+     * Use `withParsedBody()` if you need to replace the all request data.
+     *
      * @param string $name The dot separated path to insert $value at.
      * @param mixed $value The value to insert into the request data.
      * @return static

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -659,6 +659,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
                 "Setting {$name} as a property will be removed in 4.0.0. " .
                 "Use {$method} instead."
             );
+
             return $this->{$name} = $value;
         }
         throw new BadMethodCallException("Cannot set {$name} it is not a known property.");
@@ -682,6 +683,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
                 "Accessing `{$name}` as a property will be removed in 4.0.0. " .
                 "Use request->{$method} instead."
             );
+
             return $this->{$name};
         }
 
@@ -716,6 +718,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
                 "Accessing {$name} as a property will be removed in 4.0.0. " .
                 "Use {$method} instead."
             );
+
             return isset($this->{$name});
         }
 

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -65,7 +65,7 @@ class Dispatcher
         );
         $actionDispatcher = new ActionDispatcher(null, $this->getEventManager(), $this->_filters);
         $response = $actionDispatcher->dispatch($request, $response);
-        if (isset($request->params['return'])) {
+        if ($request->getParam('return')) {
             return $response->body();
         }
 

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -65,7 +65,7 @@ class Dispatcher
         );
         $actionDispatcher = new ActionDispatcher(null, $this->getEventManager(), $this->_filters);
         $response = $actionDispatcher->dispatch($request, $response);
-        if ($request->getParam('return')) {
+        if ($request->getParam('return', null) !== null) {
             return $response->body();
         }
 

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -69,7 +69,7 @@ class AssetFilter extends DispatcherFilter
         /* @var \Cake\Http\ServerRequest $request */
         $request = $event->getData('request');
 
-        $url = urldecode($request->url);
+        $url = urldecode($request->getUri()->getPath());
         if (strpos($url, '..') !== false || strpos($url, '.') === false) {
             return null;
         }
@@ -101,7 +101,7 @@ class AssetFilter extends DispatcherFilter
      */
     protected function _getAssetFile($url)
     {
-        $parts = explode('/', $url);
+        $parts = explode('/', ltrim($url, '/'));
         $pluginPart = [];
         for ($i = 0; $i < 2; $i++) {
             if (!isset($parts[$i])) {

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -16,7 +16,7 @@ namespace Cake\Routing;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
-use Cake\Network\Session;
+use Cake\Http\Session;
 use Cake\Routing\Filter\ControllerFactoryFilter;
 use Cake\Routing\Filter\RoutingFilter;
 

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -136,8 +136,8 @@ trait RequestActionTrait
         }
         $current = Router::getRequest();
         if ($current) {
-            $params['base'] = $current->base;
-            $params['webroot'] = $current->webroot;
+            $params['base'] = $current->getAttribute('base');
+            $params['webroot'] = $current->getAttribute('webroot');
         }
 
         $params['post'] = $params['query'] = [];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -620,8 +620,8 @@ class Router
         // In 4.x this should be replaced with state injected via setRequestContext
         $request = static::getRequest(true);
         if ($request) {
-            $params = $request->params;
-            $here = $request->here;
+            $params = $request->getAttribute('params');
+            $here = $request->getRequestTarget();
             $base = $request->getAttribute('base');
         } else {
             $base = Configure::read('App.base');
@@ -750,8 +750,8 @@ class Router
     {
         $url = [];
         if ($params instanceof ServerRequest) {
-            $url = $params->query;
-            $params = $params->params;
+            $url = $params->getQueryParams();
+            $params = $params->getAttribute('params');
         } elseif (isset($params['url'])) {
             $url = $params['url'];
         }
@@ -820,8 +820,11 @@ class Router
         }
         $request = static::getRequest();
 
-        if (!empty($request->base) && stristr($url, $request->base)) {
-            $url = preg_replace('/^' . preg_quote($request->base, '/') . '/', '', $url, 1);
+        if ($request) {
+            $base = $request->getAttribute('base');
+            if (strlen($base) && stristr($url, $base)) {
+                $url = preg_replace('/^' . preg_quote($base, '/') . '/', '', $url, 1);
+            }
         }
         $url = '/' . $url;
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -902,17 +902,15 @@ class Router
             '2.x backwards compatible named parameter support will be removed in 4.0'
         );
         $options += ['separator' => ':'];
-        if (empty($request->params['pass'])) {
-            $request->params['named'] = [];
-
-            return $request;
+        if (!$request->getParam('pass')) {
+            return $request->withParam('named', []);
         }
         $named = [];
         foreach ($request->getParam('pass') as $key => $value) {
             if (strpos($value, $options['separator']) === false) {
                 continue;
             }
-            unset($request->params['pass'][$key]);
+            $request = $request->withoutParam("pass.{$key}");
             list($key, $value) = explode($options['separator'], $value, 2);
 
             if (preg_match_all('/\[([A-Za-z0-9_-]+)?\]/', $key, $matches, PREG_SET_ORDER)) {
@@ -933,9 +931,7 @@ class Router
             }
             $named = array_merge_recursive($named, [$key => $value]);
         }
-        $request->params['named'] = $named;
-
-        return $request;
+        return $request->withParam('named', $named);
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -931,6 +931,7 @@ class Router
             }
             $named = array_merge_recursive($named, [$key => $value]);
         }
+
         return $request->withParam('named', $named);
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -906,11 +906,12 @@ class Router
             return $request->withParam('named', []);
         }
         $named = [];
-        foreach ($request->getParam('pass') as $key => $value) {
+        $pass = $request->getParam('pass');
+        foreach ((array)$pass as $key => $value) {
             if (strpos($value, $options['separator']) === false) {
                 continue;
             }
-            $request = $request->withoutParam("pass.{$key}");
+            unset($pass[$key]);
             list($key, $value) = explode($options['separator'], $value, 2);
 
             if (preg_match_all('/\[([A-Za-z0-9_-]+)?\]/', $key, $matches, PREG_SET_ORDER)) {
@@ -932,7 +933,9 @@ class Router
             $named = array_merge_recursive($named, [$key => $value]);
         }
 
-        return $request->withParam('named', $named);
+        return $request
+            ->withParam('pass', $pass)
+            ->withParam('named', $named);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -22,7 +22,7 @@ if (class_exists('PHPUnit_Runner_Version') && !interface_exists('PHPUnit\Excepti
 
 use Cake\Core\Configure;
 use Cake\Database\Exception as DatabaseException;
-use Cake\Network\Session;
+use Cake\Http\Session;
 use Cake\Routing\Router;
 use Cake\TestSuite\Stub\TestExceptionRenderer;
 use Cake\Utility\CookieCryptTrait;
@@ -130,7 +130,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * The session instance from the last request
      *
-     * @var \Cake\Network\Session|null
+     * @var \Cake\Http\Session|null
      */
     protected $_requestSession;
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -104,7 +104,7 @@ class PaginatorHelper extends Helper
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
         $this->setConfig(
             'options.url',
-            array_merge($this->request->getParam('pass'), ['?' => $query])
+            array_merge($this->request->getParam('pass', []), ['?' => $query])
         );
     }
 
@@ -153,19 +153,19 @@ class PaginatorHelper extends Helper
     public function options(array $options = [])
     {
         if (!empty($options['paging'])) {
-            if (!$this->request->getParam('paging')) {
-                $this->request->params['paging'] = [];
-            }
-            $this->request->params['paging'] = $options['paging'] + $this->request->getParam('paging');
+            $this->request = $this->request->withParam(
+                'paging',
+                $options['paging'] + $this->request->getParam('paging', [])
+            );
             unset($options['paging']);
         }
         $model = $this->defaultModel();
 
         if (!empty($options[$model])) {
-            if (!$this->request->getParam('paging.' . $model)) {
-                $this->request->params['paging'][$model] = [];
-            }
-            $this->request->params['paging'][$model] = $options[$model] + $this->request->getParam('paging.' . $model);
+            $this->request = $this->request->withParam(
+                'paging.' . $model,
+                $options[$model] + (array)$this->request->getParam('paging.' . $model, [])
+            );
             unset($options[$model]);
         }
         $this->_config['options'] = array_filter($options + $this->_config['options']);

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -147,7 +147,7 @@ class BasicAuthenticateTest extends TestCase
         $User->updateAll(['username' => '0'], ['username' => 'mariano']);
 
         $request = new ServerRequest([
-            'url' =>  'posts/index',
+            'url' => 'posts/index',
             'data' => [
                 'User' => [
                     'user' => '0',

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -146,11 +146,15 @@ class BasicAuthenticateTest extends TestCase
         $User = TableRegistry::get('Users');
         $User->updateAll(['username' => '0'], ['username' => 'mariano']);
 
-        $request = new ServerRequest('posts/index');
-        $request->data = ['User' => [
-            'user' => '0',
-            'password' => 'password'
-        ]];
+        $request = new ServerRequest([
+            'url' =>  'posts/index',
+            'data' => [
+                'User' => [
+                    'user' => '0',
+                    'password' => 'password'
+                ]
+            ]
+        ]);
         $_SERVER['PHP_AUTH_USER'] = '0';
         $_SERVER['PHP_AUTH_PW'] = 'password';
 

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -86,8 +86,10 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoData()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -98,8 +100,10 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoUsername()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = ['password' => 'foobar'];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => ['password' => 'foobar'],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -110,8 +114,10 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoPassword()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = ['username' => 'mariano'];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => ['username' => 'mariano'],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -123,10 +129,13 @@ class FormAuthenticateTest extends TestCase
     public function testAuthenticatePasswordIsFalse()
     {
         $request = new ServerRequest('posts/index', false);
-        $request->data = [
-            'username' => 'mariano',
-            'password' => null
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => null
+            ],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -138,11 +147,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticatePasswordIsEmptyString()
     {
-        $request = new ServerRequest('posts/index', false);
-        $request->data = [
-            'username' => 'mariano',
-            'password' => ''
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => ''
+            ],
+        ]);
 
         $this->auth = $this->getMockBuilder(FormAuthenticate::class)
             ->setMethods(['_checkFields'])
@@ -167,17 +178,22 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateFieldsAreNotString()
     {
-        $request = new ServerRequest('posts/index', false);
-        $request->data = [
-            'username' => ['mariano', 'phpnut'],
-            'password' => 'my password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => ['mariano', 'phpnut'],
+                'password' => 'my password'
+            ],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
 
-        $request->data = [
-            'username' => 'mariano',
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
             'password' => ['password1', 'password2']
-        ];
+            ],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -188,11 +204,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateInjection()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => '> 1',
-            'password' => "' OR 1 = 1"
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => '> 1',
+                'password' => "' OR 1 = 1"
+            ],
+        ]);
         $this->assertFalse($this->auth->authenticate($request, $this->response));
     }
 
@@ -203,11 +221,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateSuccess()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
         $result = $this->auth->authenticate($request, $this->response);
         $expected = [
             'id' => 1,
@@ -228,11 +248,13 @@ class FormAuthenticateTest extends TestCase
         $users = TableRegistry::get('Users');
         $users->setEntityClass('TestApp\Model\Entity\VirtualUser');
 
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
         $result = $this->auth->authenticate($request, $this->response);
         $expected = [
             'id' => 1,
@@ -261,11 +283,13 @@ class FormAuthenticateTest extends TestCase
 
         $this->auth->setConfig('userModel', 'TestPlugin.AuthUsers');
 
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'gwoo',
-            'password' => 'cake'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'gwoo',
+                'password' => 'cake'
+            ],
+        ]);
 
         $result = $this->auth->authenticate($request, $this->response);
         $expected = [
@@ -285,11 +309,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testFinder()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
 
         $this->auth->setConfig([
             'userModel' => 'AuthUsers',
@@ -323,11 +349,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testFinderOptions()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
 
         $this->auth->setConfig([
             'userModel' => 'AuthUsers',
@@ -376,11 +404,13 @@ class FormAuthenticateTest extends TestCase
             ['username' => 'mariano']
         );
 
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'mypass'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'mypass'
+            ],
+        ]);
 
         $result = $this->auth->authenticate($request, $this->response);
         $expected = [
@@ -414,11 +444,13 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoRehash()
     {
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertNotEmpty($result);
         $this->assertFalse($this->auth->needsPasswordRehash());
@@ -439,11 +471,13 @@ class FormAuthenticateTest extends TestCase
         $password = $this->auth->passwordHasher()->hash('password');
         TableRegistry::get('Users')->updateAll(['password' => $password], []);
 
-        $request = new ServerRequest('posts/index');
-        $request->data = [
-            'username' => 'mariano',
-            'password' => 'password'
-        ];
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'post' => [
+                'username' => 'mariano',
+                'password' => 'password'
+            ],
+        ]);
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertNotEmpty($result);
         $this->assertTrue($this->auth->needsPasswordRehash());

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -130,12 +130,12 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->setAuthenticateObject(0, $AuthLoginFormAuthenticate);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'AuthUsers' => [
                 'username' => 'mark',
                 'password' => Security::hash('cake', null, true)
             ]
-        ];
+        ]);
 
         $user = [
             'id' => 1,
@@ -171,12 +171,12 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->setAuthenticateObject(0, $AuthLoginFormAuthenticate);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'AuthUsers' => [
                 'username' => 'mark',
                 'password' => Security::hash('cake', null, true)
             ]
-        ];
+        ]);
 
         $user = new \ArrayObject([
             'id' => 1,
@@ -1134,7 +1134,7 @@ class AuthComponentTest extends TestCase
             'url' => '/ajax_auth/add',
             'environment' => ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
         ]);
-        $this->Controller->request->params['action'] = 'add';
+        $this->Controller->request = $this->Controller->request->withParam('action', 'add');
 
         $event = new Event('Controller.startup', $this->Controller);
         $this->Auth->setConfig('ajaxLogin', 'test_element');
@@ -1162,7 +1162,7 @@ class AuthComponentTest extends TestCase
             'url' => '/ajax_auth/add',
             'environment' => ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
         ]);
-        $this->Controller->request->params['action'] = 'add';
+        $this->Controller->request = $this->Controller->request->withParam('action', 'add');
 
         $event = new Event('Controller.startup', $this->Controller);
         $response = $this->Auth->startup($event);
@@ -1411,7 +1411,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
             ->setConstructorArgs([$this->Controller->components()])
             ->getMock();
-        $this->Controller->request->params['action'] = 'add';
+        $this->Controller->request = $this->Controller->request->withParam('action', 'add');
         $this->Auth->startup(new Event('Controller.startup', $this->Controller));
 
         $this->Auth->Flash->expects($this->at(0))
@@ -1461,7 +1461,7 @@ class AuthComponentTest extends TestCase
     public function testRedirectQueryStringRead()
     {
         $this->Auth->setConfig('loginAction', ['controller' => 'users', 'action' => 'login']);
-        $this->Controller->request->query = ['redirect' => '/users/custom'];
+        $this->Controller->request = $this->Controller->request->withQueryParams(['redirect' => '/users/custom']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/custom', $result);
@@ -1474,10 +1474,10 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectQueryStringReadDuplicateBase()
     {
-        $this->Controller->request->webroot = '/waves/';
-        $this->Controller->request->base = '/waves';
-
-        $this->Controller->request->query = ['redirect' => '/waves/add'];
+        $this->Controller->request = $this->Controller->request
+            ->withAttribute('webroot', '/waves/')
+            ->withAttribute('base', '/waves')
+            ->withQueryParams(['redirect' => '/waves/add']);
 
         Router::setRequestInfo($this->Controller->request);
 
@@ -1497,7 +1497,7 @@ class AuthComponentTest extends TestCase
             'loginAction' => ['controller' => 'users', 'action' => 'login'],
             'loginRedirect' => ['controller' => 'users', 'action' => 'home']
         ]);
-        $this->Controller->request->query = ['redirect' => '/users/login'];
+        $this->Controller->request = $this->Controller->request->withQueryParams(['redirect' => '/users/login']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/home', $result);
@@ -1515,12 +1515,12 @@ class AuthComponentTest extends TestCase
             'loginAction' => ['controller' => 'users', 'action' => 'login'],
             'loginRedirect' => ['controller' => 'users', 'action' => 'home']
         ]);
-        $this->Controller->request->query = ['redirect' => 'http://some.domain.example/users/login'];
+        $this->Controller->request = $this->Controller->request->withQueryParams(['redirect' => 'http://some.domain.example/users/login']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/home', $result);
 
-        $this->Controller->request->query = ['redirect' => '//some.domain.example/users/login'];
+        $this->Controller->request = $this->Controller->request->withQueryParams(['redirect' => '//some.domain.example/users/login']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/home', $result);

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -167,9 +167,9 @@ class CookieComponentTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid encryption cipher. Must be one of aes, rijndael.');
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'Test' => $this->_encrypt('value'),
-        ];
+        ]);
         $this->Cookie->setConfig('encryption', 'derp');
         $this->Cookie->read('Test');
     }
@@ -215,14 +215,14 @@ class CookieComponentTest extends TestCase
      */
     public function testReadMultipleNames()
     {
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'CakeCookie' => [
                 'key' => 'value'
             ],
             'OtherCookie' => [
                 'key' => 'other value'
             ]
-        ];
+        ]);
         $this->assertEquals('value', $this->Cookie->read('CakeCookie.key'));
         $this->assertEquals(['key' => 'value'], $this->Cookie->read('CakeCookie'));
         $this->assertEquals('other value', $this->Cookie->read('OtherCookie.key'));
@@ -261,9 +261,9 @@ class CookieComponentTest extends TestCase
      */
     public function testWriteThanRead()
     {
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'User' => ['name' => 'mark']
-        ];
+        ]);
         $this->Cookie->write('Testing', 'value');
         $this->assertEquals('mark', $this->Cookie->read('User.name'));
     }
@@ -617,7 +617,7 @@ class CookieComponentTest extends TestCase
         $data = $this->Cookie->read('Plain_multi_cookies');
         $this->assertNull($data);
 
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'Encrypted_array' => $this->_encrypt(['name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!']),
             'Encrypted_multi_cookies' => [
                 'name' => $this->_encrypt('CakePHP'),
@@ -630,7 +630,7 @@ class CookieComponentTest extends TestCase
                 'version' => '1.2.0.x',
                 'tag' => 'CakePHP Rocks!'
             ]
-        ];
+        ]);
 
         $data = $this->Cookie->read('Encrypted_array');
         $expected = ['name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!'];
@@ -656,9 +656,9 @@ class CookieComponentTest extends TestCase
      */
     public function testReadLegacyCookieValue()
     {
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'Legacy' => ['value' => $this->_oldImplode([1, 2, 3])]
-        ];
+        ]);
         $result = $this->Cookie->read('Legacy.value');
         $expected = [1, 2, 3];
         $this->assertEquals($expected, $result);
@@ -671,12 +671,12 @@ class CookieComponentTest extends TestCase
      */
     public function testReadEmpty()
     {
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'JSON' => '{"name":"value"}',
             'Empty' => '',
             'String' => '{"somewhat:"broken"}',
             'Array' => '{}'
-        ];
+        ]);
         $this->assertEquals(['name' => 'value'], $this->Cookie->read('JSON'));
         $this->assertEquals('value', $this->Cookie->read('JSON.name'));
         $this->assertEquals('', $this->Cookie->read('Empty'));
@@ -743,10 +743,10 @@ class CookieComponentTest extends TestCase
      */
     public function testDeleteRemovesChildren()
     {
-        $this->request->cookies = [
+        $this->Controller->request = $this->request->withCookieParams([
             'User' => ['email' => 'example@example.com', 'name' => 'mark'],
             'other' => 'value'
-        ];
+        ]);
         $this->assertEquals('mark', $this->Cookie->read('User.name'));
 
         $this->Cookie->delete('User');

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -214,7 +214,7 @@ class CsrfComponentTest extends TestCase
         $event = new Event('Controller.startup', $controller);
         $result = $this->component->startup($event);
         $this->assertNull($result, 'No exception means valid.');
-        $this->assertFalse(isset($controller->request->data['_csrfToken']));
+        $this->assertNull($controller->request->getData('_csrfToken'));
     }
 
     /**
@@ -313,7 +313,7 @@ class CsrfComponentTest extends TestCase
         $event = new Event('Controller.startup', $controller);
         $result = $this->component->startup($event);
         $this->assertNull($result, 'No error.');
-        $this->assertEquals('testing123', $controller->request->params['_csrfToken']);
+        $this->assertEquals('testing123', $controller->request->getParam('_csrfToken'));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -1294,7 +1294,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateQueryWithLimit()
     {
-        $this->controller->request->query = ['page' => '-1'];
+        $this->controller->request = $this->controller->request->withQueryParams(['page' => '-1']);
         $settings = [
             'PaginatorPosts' => [
                 'contain' => ['PaginatorAuthor'],

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -129,7 +129,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeCallback()
     {
         $this->assertNull($this->RequestHandler->ext);
-        $this->Controller->request->params['_ext'] = 'rss';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'rss');
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('rss', $this->RequestHandler->ext);
     }
@@ -411,7 +411,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->initialize([]);
         $this->Controller->beforeFilter($event);
         $this->RequestHandler->startup($event);
-        $this->assertTrue($this->Controller->request->params['isAjax']);
+        $this->assertTrue($this->Controller->request->getParam('isAjax'));
     }
 
     /**
@@ -431,10 +431,10 @@ class RequestHandlerComponentTest extends TestCase
 
         $this->assertEquals($this->Controller->viewClass, 'Cake\View\AjaxView');
         $view = $this->Controller->createView();
-        $this->assertEquals('ajax', $view->layout);
+        $this->assertEquals('ajax', $view->getLayout());
 
         $this->_init();
-        $this->Controller->request->params['_ext'] = 'js';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'js');
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);
         $this->assertNotEquals($this->Controller->viewClass, 'Cake\View\AjaxView');
@@ -449,7 +449,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testJsonViewLoaded()
     {
         Router::extensions(['json', 'xml', 'ajax'], false);
-        $this->Controller->request->params['_ext'] = 'json';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'json');
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);
@@ -457,7 +457,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $this->assertEquals('Cake\View\JsonView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
-        $this->assertEquals('json', $view->layoutPath);
+        $this->assertEquals('json', $view->getLayoutPath());
         $this->assertEquals('json', $view->subDir);
     }
 
@@ -470,7 +470,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testXmlViewLoaded()
     {
         Router::extensions(['json', 'xml', 'ajax'], false);
-        $this->Controller->request->params['_ext'] = 'xml';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'xml');
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);
@@ -478,7 +478,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $this->assertEquals('Cake\View\XmlView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
-        $this->assertEquals('xml', $view->layoutPath);
+        $this->assertEquals('xml', $view->getLayoutPath());
         $this->assertEquals('xml', $view->subDir);
     }
 
@@ -491,7 +491,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testAjaxViewLoaded()
     {
         Router::extensions(['json', 'xml', 'ajax'], false);
-        $this->Controller->request->params['_ext'] = 'ajax';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'ajax');
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);
@@ -499,7 +499,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $this->assertEquals('Cake\View\AjaxView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
-        $this->assertEquals('ajax', $view->layout);
+        $this->assertEquals('ajax', $view->getLayout());
     }
 
     /**
@@ -511,7 +511,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testNoViewClassExtension()
     {
         Router::extensions(['json', 'xml', 'ajax', 'csv'], false);
-        $this->Controller->request->params['_ext'] = 'csv';
+        $this->Controller->request = $this->Controller->request->withParam('_ext', 'csv');
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -446,10 +446,10 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = '';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => 'nate', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $this->assertTrue($this->validatePost());
     }
 
@@ -506,10 +506,10 @@ class SecurityComponentTest extends TestCase
 
         $fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3AModel.valid';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => 'nate', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $this->assertFalse($this->validatePost('AuthSecurityException', 'Unexpected field \'Model.password\' in POST data, Unexpected field \'Model.username\' in POST data'));
     }
 
@@ -529,10 +529,10 @@ class SecurityComponentTest extends TestCase
 
         $fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3AModel.valid';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => 'nate', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('fields')
-        ];
+        ]);
         $this->assertFalse($this->validatePost('AuthSecurityException', '\'_Token.unlocked\' was not found in request data.'));
     }
 
@@ -550,10 +550,10 @@ class SecurityComponentTest extends TestCase
         $this->Security->startup($event);
         $unlocked = '';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => 'nate', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('unlocked')
-        ];
+        ]);
         $result = $this->validatePost('AuthSecurityException', '\'_Token.fields\' was not found in request data.');
         $this->assertFalse($result, 'validatePost passed when fields were missing. %s');
     }
@@ -602,10 +602,10 @@ class SecurityComponentTest extends TestCase
         $attack = 'O:3:"App":1:{s:5:"__map";a:1:{s:3:"foo";s:7:"Hacked!";s:1:"fail"}}';
         $fields .= urlencode(':' . str_rot13($attack));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => 'mark', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $result = $this->validatePost('SecurityException', 'Bad Request');
         $this->assertFalse($result, 'validatePost passed when key was missing. %s');
     }
@@ -627,11 +627,11 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             '_csrfToken' => 'abc123',
             'Model' => ['multi_field' => ['1', '3']],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $this->assertTrue($this->validatePost());
     }
 
@@ -656,16 +656,16 @@ class SecurityComponentTest extends TestCase
             []
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['multi_field' => ['1', '3']],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $this->assertTrue($this->validatePost());
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['multi_field' => [12 => '1', 20 => '3']],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $this->assertTrue($this->validatePost());
     }
 
@@ -689,10 +689,10 @@ class SecurityComponentTest extends TestCase
             []
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             1 => 'value,',
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $this->assertTrue($this->validatePost());
     }
 
@@ -711,10 +711,10 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'anything' => 'some_data',
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -735,10 +735,10 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => '', 'password' => ''],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -761,7 +761,7 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Addresses' => [
                 '0' => [
                     'id' => '123456', 'title' => '', 'first_name' => '', 'last_name' => '',
@@ -773,7 +773,7 @@ class SecurityComponentTest extends TestCase
                 ]
             ],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -795,33 +795,33 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Tag' => ['Tag' => [1, 2]],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Tag' => ['Tag' => [1, 2, 3]],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Tag' => ['Tag' => [1, 2, 3, 4]],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
 
         $fields = '1e4c9269b64756e9b141d364497c5f037b428a37%3A';
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'User.password' => 'bar', 'User.name' => 'foo', 'User.is_valid' => '1',
             'Tag' => ['Tag' => [1]],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -843,31 +843,31 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => '', 'password' => '', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
 
         $fields = '3f368401f9a8610bcace7746039651066cdcdc38%3A';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => '', 'password' => '', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
 
-        $this->Controller->request->data = [];
+        $this->Controller->request = $this->Controller->request->withParsedBody([]);
         $this->Security->startup($event);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => '', 'password' => '', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -887,13 +887,13 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => '', 'password' => '', 'hidden' => '0',
                 'other_hidden' => 'some hidden value'
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -913,12 +913,12 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => '', 'password' => '', 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -943,14 +943,14 @@ class SecurityComponentTest extends TestCase
         );
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -971,14 +971,14 @@ class SecurityComponentTest extends TestCase
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
         $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields')
-        ];
+        ]);
 
         $result = $this->validatePost('SecurityException', '\'_Token.unlocked\' was not found in request data.');
         $this->assertFalse($result);
@@ -1000,14 +1000,14 @@ class SecurityComponentTest extends TestCase
         $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
         $unlocked = '';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked')
-        ];
+        ]);
 
         $result = $this->validatePost('SecurityException', '\'_Token.debug\' was not found in request data.');
         $this->assertFalse($result);
@@ -1029,14 +1029,14 @@ class SecurityComponentTest extends TestCase
         $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
         $unlocked = '';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked')
-        ];
+        ]);
         Configure::write('debug', false);
         $result = $this->validatePost('SecurityException', 'The request has been black-holed');
     }
@@ -1065,14 +1065,14 @@ class SecurityComponentTest extends TestCase
         // Tamper the values.
         $unlocked = 'Model.username|Model.password';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
 
         $result = $this->validatePost('SecurityException', 'Missing field \'Model.password\' in POST data, Unexpected unlocked field \'Model.password\' in POST data');
         $this->assertFalse($result);
@@ -1092,12 +1092,12 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => ['username' => '', 'password' => '', 'valid' => '0'],
             'Model2' => ['valid' => '0'],
             'Model3' => ['valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -1117,7 +1117,7 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 [
                     'username' => 'username', 'password' => 'password',
@@ -1129,7 +1129,7 @@ class SecurityComponentTest extends TestCase
                 ]
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -1150,7 +1150,7 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Address' => [
                 0 => [
                     'id' => '123',
@@ -1174,7 +1174,7 @@ class SecurityComponentTest extends TestCase
                 ]
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -1199,13 +1199,13 @@ class SecurityComponentTest extends TestCase
         );
         $debug = 'not used';
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'TaxonomyData' => [
                 1 => [[2]],
                 2 => [[3]]
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -1248,7 +1248,7 @@ class SecurityComponentTest extends TestCase
             []
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Address' => [
                 0 => [
                     'id' => '123',
@@ -1272,7 +1272,7 @@ class SecurityComponentTest extends TestCase
                 ]
             ],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost('SecurityException', 'Bad Request');
         $this->assertFalse($result);
     }
@@ -1296,20 +1296,20 @@ class SecurityComponentTest extends TestCase
             []
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'MyModel' => ['name' => 'some data'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost('SecurityException', 'Unexpected field \'MyModel.name\' in POST data');
         $this->assertFalse($result);
 
         $this->Security->startup($event);
         $this->Security->setConfig('disabledFields', ['MyModel.name']);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'MyModel' => ['name' => 'some data'],
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
 
         $result = $this->validatePost();
         $this->assertTrue($result);
@@ -1335,30 +1335,30 @@ class SecurityComponentTest extends TestCase
             []
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             '_Token' => compact('fields', 'unlocked', 'debug'),
-        ];
+        ]);
         $result = $this->validatePost('SecurityException', 'Bad Request');
         $this->assertFalse($result);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             '_Token' => compact('fields', 'unlocked', 'debug'),
             'Test' => ['test' => '']
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             '_Token' => compact('fields', 'unlocked', 'debug'),
             'Test' => ['test' => '1']
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             '_Token' => compact('fields', 'unlocked', 'debug'),
             'Test' => ['test' => '2']
-        ];
+        ]);
         $result = $this->validatePost();
         $this->assertTrue($result);
     }
@@ -1432,10 +1432,10 @@ class SecurityComponentTest extends TestCase
     public function testGenerateToken()
     {
         $request = $this->Controller->request;
-        $this->Security->generateToken($request);
+        $request = $this->Security->generateToken($request);
 
-        $this->assertNotEmpty($request->params['_Token']);
-        $this->assertTrue(isset($request->params['_Token']['unlockedFields']));
+        $this->assertNotEmpty($request->getParam('_Token'));
+        $this->assertSame([], $request->getParam('_Token.unlockedFields'));
     }
 
     /**
@@ -1450,7 +1450,7 @@ class SecurityComponentTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->request->data = ['data'];
+        $this->Controller->request = $this->Controller->request->withParsedBody(['data']);
         $this->Security->unlockedActions = 'index';
         $this->Security->blackHoleCallback = null;
         $result = $this->Controller->Security->startup($event);
@@ -1479,14 +1479,14 @@ class SecurityComponentTest extends TestCase
             ['not expected']
         ]));
 
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'username' => 'mark',
                 'password' => 'sekret',
                 'hidden' => '0'
             ],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
 
         $result = $this->validatePost('SecurityException', 'Invalid security debug token.');
         $this->assertFalse($result);
@@ -1555,13 +1555,13 @@ class SecurityComponentTest extends TestCase
         ]));
         $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $fields .= urlencode(':Model.hidden|Model.id');
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'hidden' => 'tampered',
                 'id' => '1',
             ],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
 
         $result = $this->validatePost('SecurityException', 'Tampered field \'Model.hidden\' in POST data (expected value \'value\' but found \'tampered\')');
         $this->assertFalse($result);
@@ -1621,13 +1621,13 @@ class SecurityComponentTest extends TestCase
         ]));
         $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $fields .= urlencode(':Model.hidden|Model.id');
-        $this->Controller->request->data = [
+        $this->Controller->request = $this->Controller->request->withParsedBody([
             'Model' => [
                 'hidden' => ['some-key' => 'some-value'],
                 'id' => '1',
             ],
             '_Token' => compact('fields', 'unlocked', 'debug')
-        ];
+        ]);
         Configure::write('debug', false);
         $result = $this->validatePost('SecurityException', 'Unexpected \'_Token.debug\' found in request data');
         $this->assertFalse($result);

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -86,11 +86,11 @@ class ErrorHandlerTest extends TestCase
         Router::reload();
 
         $request = new ServerRequest([
+            'base' => '',
             'environment' => [
                 'HTTP_REFERER' => '/referer'
             ]
         ]);
-        $request->base = '';
 
         Router::setRequestInfo($request);
         Configure::write('debug', true);

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -165,8 +165,7 @@ class ExceptionRendererTest extends TestCase
         Configure::write('Config.language', 'eng');
         Router::reload();
 
-        $request = new ServerRequest();
-        $request->base = '';
+        $request = new ServerRequest(['base' => '']);
         Router::setRequestInfo($request);
         Configure::write('debug', true);
     }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -136,7 +136,7 @@ class ServerRequestTest extends TestCase
             'one' => 'param'
         ];
         $request = new ServerRequest();
-        $this->assertFalse(isset($request->query['one']));
+        $this->assertNull($request->getQuery('one'));
     }
 
     /**
@@ -154,8 +154,8 @@ class ServerRequestTest extends TestCase
             'url' => 'some/path'
         ];
         $request = new ServerRequest($data);
-        $this->assertEquals($request->query, $data['query']);
-        $this->assertEquals('some/path', $request->url);
+        $this->assertEquals($request->getQueryParams(), $data['query']);
+        $this->assertEquals('/some/path', $request->getRequestTarget());
     }
 
     /**
@@ -168,8 +168,8 @@ class ServerRequestTest extends TestCase
         $_GET = [];
         $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
         $expected = ['one' => 'something', 'two' => 'else'];
-        $this->assertEquals($expected, $request->query);
-        $this->assertEquals('some/path', $request->url);
+        $this->assertEquals($expected, $request->getQueryParams());
+        $this->assertEquals('/some/path', $request->getUri()->getPath());
         $this->assertEquals('one=something&two=else', $request->getUri()->getQuery());
     }
 
@@ -182,19 +182,19 @@ class ServerRequestTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/tasks/index?ts=123456';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('tasks/index', $request->url);
+        $this->assertEquals('/tasks/index', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/tasks/index/?ts=123456';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('tasks/index/', $request->url);
+        $this->assertEquals('/tasks/index/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/some/path?url=http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('some/path', $request->url);
+        $this->assertEquals('/some/path', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/other/path?url=http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('other/path', $request->url);
+        $this->assertEquals('/other/path', $request->getRequestTarget());
     }
 
     /**
@@ -204,11 +204,11 @@ class ServerRequestTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/jump/http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('jump/http://cakephp.org', $request->url);
+        $this->assertEquals('/jump/http://cakephp.org', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/jump/http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('jump/http://cakephp.org', $request->url);
+        $this->assertEquals('/jump/http://cakephp.org', $request->getRequestTarget());
     }
 
     /**
@@ -268,18 +268,18 @@ class ServerRequestTest extends TestCase
             'Article' => ['title']
         ];
         $request = new ServerRequest(compact('post'));
-        $this->assertEquals($post, $request->data);
+        $this->assertEquals($post, $request->getData());
 
         $post = ['one' => 1, 'two' => 'three'];
         $request = new ServerRequest(compact('post'));
-        $this->assertEquals($post, $request->data);
+        $this->assertEquals($post, $request->getData());
 
         $post = [
             'Article' => ['title' => 'Testing'],
             'action' => 'update'
         ];
         $request = new ServerRequest(compact('post'));
-        $this->assertEquals($post, $request->data);
+        $this->assertEquals($post, $request->getData());
     }
 
     /**
@@ -299,7 +299,7 @@ class ServerRequestTest extends TestCase
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8'
             ]
         ]);
-        $this->assertEquals($data, $request->data);
+        $this->assertEquals($data, $request->getData());
 
         $data = ['one' => 1, 'two' => 'three'];
         $request = new ServerRequest([
@@ -309,7 +309,7 @@ class ServerRequestTest extends TestCase
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8'
             ]
         ]);
-        $this->assertEquals($data, $request->data);
+        $this->assertEquals($data, $request->getData());
 
         $request = new ServerRequest([
             'input' => 'Article[title]=Testing&action=update',
@@ -322,7 +322,7 @@ class ServerRequestTest extends TestCase
             'Article' => ['title' => 'Testing'],
             'action' => 'update'
         ];
-        $this->assertEquals($expected, $request->data);
+        $this->assertEquals($expected, $request->getData());
 
         $data = [
             'Article' => ['title'],
@@ -335,7 +335,7 @@ class ServerRequestTest extends TestCase
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8'
             ]
         ]);
-        $this->assertEquals($data, $request->data);
+        $this->assertEquals($data, $request->getData());
     }
 
     /**
@@ -353,7 +353,7 @@ class ServerRequestTest extends TestCase
                 'CONTENT_TYPE' => 'application/json'
             ]
         ]);
-        $this->assertEquals([], $request->data);
+        $this->assertEquals([], $request->getData());
         $result = $request->input('json_decode', true);
         $this->assertEquals(['title'], $result['Article']);
     }
@@ -456,7 +456,7 @@ class ServerRequestTest extends TestCase
                 ]
             ]
         ];
-        $this->assertEquals($expected, $request->data);
+        $this->assertEquals($expected, $request->getData());
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(3, $uploads);
@@ -498,7 +498,7 @@ class ServerRequestTest extends TestCase
                 'size' => 123
             ]
         ];
-        $this->assertEquals($expected, $request->data);
+        $this->assertEquals($expected, $request->getData());
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
@@ -529,7 +529,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest([
             'files' => $files
         ]);
-        $this->assertEquals($files, $request->data);
+        $this->assertEquals($files, $request->getData());
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
@@ -725,8 +725,7 @@ class ServerRequestTest extends TestCase
      */
     public function testReferer()
     {
-        $request = new ServerRequest();
-        $request->webroot = '/';
+        $request = new ServerRequest(['webroot' => '/']);
 
         $request = $request->withEnv('HTTP_REFERER', 'http://cakephp.org');
         $result = $request->referer();
@@ -768,12 +767,11 @@ class ServerRequestTest extends TestCase
      */
     public function testRefererBasePath()
     {
-        $request = new ServerRequest('some/path');
-        $request->url = 'users/login';
-        $request->webroot = '/waves/';
-        $request->base = '/waves';
-        $request->here = '/waves/users/login';
-
+        $request = new ServerRequest([
+            'url' => '/waves/users/login',
+            'webroot' => '/waves/',
+            'base' => '/waves'
+        ]);
         $request = $request->withEnv('HTTP_REFERER', Configure::read('App.fullBaseUrl') . '/waves/waves/add');
 
         $result = $request->referer(true);
@@ -1259,8 +1257,10 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
-        ServerRequest::addDetector('callme', [$this, 'detectCallback']);
-        $request->return = true;
+        ServerRequest::addDetector('callme', function ($request) {
+            return $request->getAttribute('return');
+        });
+        $request = $request->withAttribute('return', true);;
         $request->clearDetectorCache();
         $this->assertTrue($request->isCallMe());
 
@@ -1272,17 +1272,6 @@ class ServerRequestTest extends TestCase
         $request = $request->withParam('_ext', 'exe');
         $request->clearDetectorCache();
         $this->assertFalse($request->isExtension());
-    }
-
-    /**
-     * Helper function for testing callbacks.
-     *
-     * @param $request
-     * @return bool
-     */
-    public function detectCallback($request)
-    {
-        return (bool)$request->return;
     }
 
     /**
@@ -1635,41 +1624,41 @@ class ServerRequestTest extends TestCase
         $_SERVER['PATH_INFO'] = '/posts/view/1';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/urlencode%20me', $request->base);
-        $this->assertEquals('/urlencode%20me/', $request->webroot);
-        $this->assertEquals('posts/view/1', $request->url);
+        $this->assertEquals('/urlencode%20me', $request->getAttribute('base'));
+        $this->assertEquals('/urlencode%20me/', $request->getAttribute('webroot'));
+        $this->assertEquals('/posts/view/1', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches';
         $_SERVER['PHP_SELF'] = '/1.2.x.x/webroot/index.php';
         $_SERVER['PATH_INFO'] = '/posts/view/1';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/1.2.x.x', $request->base);
-        $this->assertEquals('/1.2.x.x/', $request->webroot);
-        $this->assertEquals('posts/view/1', $request->url);
+        $this->assertEquals('/1.2.x.x', $request->getAttribute('base'));
+        $this->assertEquals('/1.2.x.x/', $request->getAttribute('webroot'));
+        $this->assertEquals('/posts/view/1', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/webroot';
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SERVER['PATH_INFO'] = '/posts/add';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->base);
-        $this->assertEquals('/', $request->webroot);
-        $this->assertEquals('posts/add', $request->url);
+        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertEquals('/', $request->getAttribute('webroot'));
+        $this->assertEquals('/posts/add', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/test/';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->base);
-        $this->assertEquals('/', $request->webroot);
+        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertEquals('/', $request->getAttribute('webroot'));
 
         $_SERVER['DOCUMENT_ROOT'] = '/some/apps/where';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->base);
-        $this->assertEquals('/', $request->webroot);
+        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertEquals('/', $request->getAttribute('webroot'));
 
         Configure::write('App.dir', 'auth');
 
@@ -1678,8 +1667,8 @@ class ServerRequestTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/demos', $request->base);
-        $this->assertEquals('/demos/', $request->webroot);
+        $this->assertEquals('/demos', $request->getAttribute('base'));
+        $this->assertEquals('/demos/', $request->getAttribute('webroot'));
 
         Configure::write('App.dir', 'code');
 
@@ -1687,8 +1676,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/clients/PewterReport/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/clients/PewterReport', $request->base);
-        $this->assertEquals('/clients/PewterReport/', $request->webroot);
+        $this->assertEquals('/clients/PewterReport', $request->getAttribute('base'));
+        $this->assertEquals('/clients/PewterReport/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1705,8 +1694,8 @@ class ServerRequestTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/control', $request->base);
-        $this->assertEquals('/control/', $request->webroot);
+        $this->assertEquals('/control', $request->getAttribute('base'));
+        $this->assertEquals('/control/', $request->getAttribute('webroot'));
 
         Configure::write('App.base', false);
         Configure::write('App.dir', 'affiliate');
@@ -1716,8 +1705,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/newaffiliate/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->base);
-        $this->assertEquals('/', $request->webroot);
+        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertEquals('/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1739,50 +1728,45 @@ class ServerRequestTest extends TestCase
         unset($_SERVER['PATH_INFO']);
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('', $request->url);
-        $this->assertEquals('/cakephp/', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/';
         $_SERVER['PATH_INFO'] = '/';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('', $request->url);
-        $this->assertEquals('/cakephp/', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/apples';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/apples';
         $_SERVER['PATH_INFO'] = '/apples';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('apples', $request->url);
-        $this->assertEquals('/cakephp/apples', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/apples', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/melons/share/';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/melons/share/';
         $_SERVER['PATH_INFO'] = '/melons/share/';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('melons/share/', $request->url);
-        $this->assertEquals('/cakephp/melons/share/', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/melons/share/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/bananas/eat/tasty_banana';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/bananas/eat/tasty_banana';
         $_SERVER['PATH_INFO'] = '/bananas/eat/tasty_banana';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('bananas/eat/tasty_banana', $request->url);
-        $this->assertEquals('/cakephp/bananas/eat/tasty_banana', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/bananas/eat/tasty_banana', $request->getRequestTarget());
     }
 
     /**
@@ -1798,10 +1782,9 @@ class ServerRequestTest extends TestCase
         $_SERVER['PATH_INFO'] = '/bananas/eat';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->base);
-        $this->assertEquals('/cakephp/', $request->webroot);
-        $this->assertEquals('bananas/eat', $request->url);
-        $this->assertEquals('/cakephp/bananas/eat', $request->here);
+        $this->assertEquals('/cakephp', $request->getAttribute('base'));
+        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertEquals('/bananas/eat', $request->getRequestTarget());
     }
 
     /**
@@ -1824,9 +1807,9 @@ class ServerRequestTest extends TestCase
         ]);
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake/index.php', $request->base);
-        $this->assertEquals('/cake/webroot/', $request->webroot);
-        $this->assertEquals('posts/index', $request->url);
+        $this->assertEquals('/cake/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/cake/webroot/', $request->getAttribute('webroot'));
+        $this->assertEquals('/posts/index', $request->getRequestTarget());
     }
 
     /**
@@ -1840,43 +1823,43 @@ class ServerRequestTest extends TestCase
         Configure::write('App.baseUrl', '/App/webroot/index.php');
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/webroot/index.php', $request->base);
-        $this->assertEquals('/App/webroot/', $request->webroot);
+        $this->assertEquals('/App/webroot/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/App/webroot/test.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/webroot/test.php', $request->base);
-        $this->assertEquals('/App/webroot/', $request->webroot);
+        $this->assertEquals('/App/webroot/test.php', $request->getAttribute('base'));
+        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/App/index.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/index.php', $request->base);
-        $this->assertEquals('/App/webroot/', $request->webroot);
+        $this->assertEquals('/App/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/App/webroot/index.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/CakeBB/App/webroot/index.php', $request->base);
-        $this->assertEquals('/CakeBB/App/webroot/', $request->webroot);
+        $this->assertEquals('/CakeBB/App/webroot/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/App/index.php');
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/CakeBB/App/index.php', $request->base);
-        $this->assertEquals('/CakeBB/App/webroot/', $request->webroot);
+        $this->assertEquals('/CakeBB/App/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/index.php');
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/CakeBB/index.php', $request->base);
-        $this->assertEquals('/CakeBB/webroot/', $request->webroot);
+        $this->assertEquals('/CakeBB/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/CakeBB/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/dbhauser/index.php');
         $_SERVER['DOCUMENT_ROOT'] = '/kunden/homepages/4/d181710652/htdocs/joomla';
         $_SERVER['SCRIPT_FILENAME'] = '/kunden/homepages/4/d181710652/htdocs/joomla/dbhauser/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/dbhauser/index.php', $request->base);
-        $this->assertEquals('/dbhauser/webroot/', $request->webroot);
+        $this->assertEquals('/dbhauser/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/dbhauser/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1891,8 +1874,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/index.php', $request->base);
-        $this->assertEquals('/webroot/', $request->webroot);
+        $this->assertEquals('/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1907,16 +1890,16 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/approval/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/approval/index.php', $request->base);
-        $this->assertEquals('/approval/webroot/', $request->webroot);
+        $this->assertEquals('/approval/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/approval/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/webrootable/index.php');
         $_SERVER['DOCUMENT_ROOT'] = '/Users/markstory/Sites/';
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/webrootable/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/webrootable/index.php', $request->base);
-        $this->assertEquals('/webrootable/webroot/', $request->webroot);
+        $this->assertEquals('/webrootable/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/webrootable/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1931,8 +1914,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/webroot/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/index.php', $request->base);
-        $this->assertEquals('/', $request->webroot);
+        $this->assertEquals('/index.php', $request->getAttribute('base'));
+        $this->assertEquals('/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1948,7 +1931,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('', $request->base);
+        $this->assertEquals('', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
@@ -1956,7 +1939,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake_dev', $request->base);
+        $this->assertEquals('/cake_dev', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
     }
 
@@ -1972,7 +1955,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('', $request->base);
+        $this->assertEquals('', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
@@ -1980,7 +1963,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake_dev', $request->base);
+        $this->assertEquals('/cake_dev', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
     }
 
@@ -2404,18 +2387,19 @@ class ServerRequestTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $uri = $request->getUri();
 
-        $this->assertEquals($expected['url'], $request->url, 'URL is incorrect');
         $this->assertEquals('/' . $expected['url'], $uri->getPath(), 'Uri->getPath() is incorrect');
-
-        $this->assertEquals($expected['base'], $request->base, 'base is incorrect');
         $this->assertEquals($expected['base'], $request->getAttribute('base'), 'base is incorrect');
-
-        $this->assertEquals($expected['webroot'], $request->webroot, 'webroot error');
         $this->assertEquals($expected['webroot'], $request->getAttribute('webroot'), 'webroot is incorrect');
 
         if (isset($expected['urlParams'])) {
-            $this->assertEquals($expected['urlParams'], $request->query, 'GET param mismatch');
+            $this->assertEquals($expected['urlParams'], $request->getQueryParams(), 'GET param mismatch');
         }
+
+        $this->deprecated(function () use ($request, $expected) {
+            $this->assertEquals($expected['url'], $request->url, 'URL is incorrect');
+            $this->assertEquals($expected['base'], $request->base, 'base is incorrect');
+            $this->assertEquals($expected['webroot'], $request->webroot, 'webroot error');
+        });
     }
 
     /**
@@ -3008,11 +2992,23 @@ XML;
     public function testGetUri()
     {
         $request = new ServerRequest(['url' => 'articles/view/3']);
-        $this->assertEquals('articles/view/3', $request->url);
-
         $result = $request->getUri();
         $this->assertInstanceOf('Psr\Http\Message\UriInterface', $result);
         $this->assertEquals('/articles/view/3', $result->getPath());
+    }
+
+    /**
+     * test url property
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testUrlProperty()
+    {
+        $this->deprecated(function () {
+            $request = new ServerRequest(['url' => 'articles/view/3']);
+            $this->assertEquals('articles/view/3', $request->url);
+        });
     }
 
     /**
@@ -3033,9 +3029,32 @@ XML;
         $this->assertNotSame($new, $request);
         $this->assertNotSame($uri, $request->getUri());
         $this->assertSame($uri, $new->getUri());
-        $this->assertSame('articles/view/3', $new->url);
-        $this->assertSame('articles/view/3', $request->url);
-        $this->assertSame('example.com', $new->getHeaderLine('Host'));
+    }
+
+    /**
+     * Test withUri
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testWithUriCompatibility()
+    {
+        $this->deprecated(function () {
+            $request = new ServerRequest([
+                'environment' => [
+                    'HTTP_HOST' => 'example.com',
+                ],
+                'url' => 'articles/view/3'
+            ]);
+            $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+            $new = $request->withUri($uri);
+            $this->assertNotSame($new, $request);
+            $this->assertNotSame($uri, $request->getUri());
+            $this->assertSame($uri, $new->getUri());
+            $this->assertSame('articles/view/3', $new->url);
+            $this->assertSame('articles/view/3', $request->url);
+            $this->assertSame('example.com', $new->getHeaderLine('Host'));
+        });
     }
 
     /**
@@ -3502,62 +3521,68 @@ XML;
     /**
      * Test that withAttribute() can modify the deprecated public properties.
      *
+     * @group deprecated
      * @return void
      */
     public function testWithAttributesCompatibility()
     {
-        $request = new ServerRequest([
-            'params' => [
-                'controller' => 'Articles',
-                'action' => 'index'
-            ],
-            'base' => '/cakeapp',
-            'webroot' => '/cakeapp/'
-        ]);
+        $this->deprecated(function () {
+            $request = new ServerRequest([
+                'params' => [
+                    'controller' => 'Articles',
+                    'action' => 'index'
+                ],
+                'base' => '/cakeapp',
+                'webroot' => '/cakeapp/'
+            ]);
 
-        $new = $request->withAttribute('base', '/replace')
-            ->withAttribute('webroot', '/replace/')
-            ->withAttribute('params', ['controller' => 'Tags']);
+            $new = $request->withAttribute('base', '/replace')
+                ->withAttribute('webroot', '/replace/')
+                ->withAttribute('params', ['controller' => 'Tags']);
 
-        // Original request should not change.
-        $this->assertSame('/cakeapp', $request->getAttribute('base'));
-        $this->assertSame('/cakeapp/', $request->getAttribute('webroot'));
-        $this->assertSame(
-            ['controller' => 'Articles', 'action' => 'index'],
-            $request->getAttribute('params')
-        );
+            // Original request should not change.
+            $this->assertSame('/cakeapp', $request->getAttribute('base'));
+            $this->assertSame('/cakeapp/', $request->getAttribute('webroot'));
+            $this->assertSame(
+                ['controller' => 'Articles', 'action' => 'index'],
+                $request->getAttribute('params')
+            );
 
-        $this->assertSame('/replace', $new->getAttribute('base'));
-        $this->assertSame('/replace', $new->base);
-        $this->assertSame('/replace/', $new->getAttribute('webroot'));
-        $this->assertSame('/replace/', $new->webroot);
+            $this->assertSame('/replace', $new->getAttribute('base'));
+            $this->assertSame('/replace', $new->base);
+            $this->assertSame('/replace/', $new->getAttribute('webroot'));
+            $this->assertSame('/replace/', $new->webroot);
 
-        $this->assertSame(['controller' => 'Tags'], $new->getAttribute('params'));
-        $this->assertSame(['controller' => 'Tags'], $new->params);
+            $this->assertSame(['controller' => 'Tags'], $new->getAttribute('params'));
+            $this->assertSame(['controller' => 'Tags'], $new->params);
+        });
     }
 
     /**
      * Test that getAttribute() can read deprecated public properties.
      *
+     * @group deprecated
      * @dataProvider emulatedPropertyProvider
      * @return void
      */
     public function testGetAttributesCompatibility($prop)
     {
-        $request = new ServerRequest([
-            'params' => [
-                'controller' => 'Articles',
-                'action' => 'index'
-            ],
-            'base' => '/cakeapp',
-            'webroot' => '/cakeapp/'
-        ]);
+        $this->deprecated(function () use ($prop) {
+            $request = new ServerRequest([
+                'params' => [
+                    'controller' => 'Articles',
+                    'action' => 'index'
+                ],
+                'base' => '/cakeapp',
+                'webroot' => '/cakeapp/'
+            ]);
 
-        if ($prop === 'session') {
-            $this->assertSame($request->getSession(), $request->getAttribute($prop));
-        } else {
-            $this->assertSame($request->{$prop}, $request->getAttribute($prop));
-        }
+            if ($prop === 'session') {
+                $this->assertSame($request->getSession(), $request->getAttribute($prop));
+            } else {
+                $this->assertSame($request->{$prop}, $request->getAttribute($prop));
+            }
+        });
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1260,7 +1260,7 @@ class ServerRequestTest extends TestCase
         ServerRequest::addDetector('callme', function ($request) {
             return $request->getAttribute('return');
         });
-        $request = $request->withAttribute('return', true);;
+        $request = $request->withAttribute('return', true);
         $request->clearDetectorCache();
         $this->assertTrue($request->isCallMe());
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -512,16 +512,14 @@ class RouterTest extends TestCase
         $result = Router::normalize('/recipe/recipes/add');
         $this->assertEquals('/recipe/recipes/add', $result);
 
-        $request = new ServerRequest();
-        $request->base = '/us';
+        $request = new ServerRequest(['base' => '/us']);
         Router::setRequestInfo($request);
         $result = Router::normalize('/us/users/logout/');
         $this->assertEquals('/users/logout', $result);
 
         Router::reload();
 
-        $request = new ServerRequest();
-        $request->base = '/cake_12';
+        $request = new ServerRequest(['base' => '/cake_12']);
         Router::setRequestInfo($request);
         $result = Router::normalize('/cake_12/users/logout/');
         $this->assertEquals('/users/logout', $result);
@@ -531,15 +529,13 @@ class RouterTest extends TestCase
         Configure::write('App.fullBaseUrl', '/');
 
         $request = new ServerRequest();
-        $request->base = '/';
         Router::setRequestInfo($request);
         $result = Router::normalize('users/login');
         $this->assertEquals('/users/login', $result);
         Configure::write('App.fullBaseUrl', $_back);
 
         Router::reload();
-        $request = new ServerRequest();
-        $request->base = 'beer';
+        $request = new ServerRequest(['base' => 'beer']);
         Router::setRequestInfo($request);
         $result = Router::normalize('beer/admin/beers_tags/add');
         $this->assertEquals('/admin/beers_tags/add', $result);
@@ -562,7 +558,7 @@ class RouterTest extends TestCase
                 'plugin' => null,
                 'controller' => 'subscribe',
             ],
-            'here' => '/magazine/',
+            'url' => '/magazine/',
             'base' => '/magazine',
             'webroot' => '/magazine/'
         ]);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3044,7 +3044,7 @@ class RouterTest extends TestCase
                 'action' => 'index',
                 'pass' => ['home', 'one:two', 'three:four', 'five[nested][0]:six', 'five[nested][1]:seven']
             ]);
-            Router::parseNamedParams($request);
+            $request = Router::parseNamedParams($request);
             $expected = [
                 'plugin' => null,
                 'controller' => 'posts',

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -135,12 +135,12 @@ class ArrayContextTest extends TestCase
      */
     public function testValPresent()
     {
-        $this->request->data = [
+        $this->request = $this->request->withParsedBody([
             'Articles' => [
                 'title' => 'New title',
                 'body' => 'My copy',
             ]
-        ];
+        ]);
         $context = new ArrayContext($this->request, [
             'defaults' => [
                 'Articles' => [

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -516,10 +516,10 @@ class EntityContextTest extends TestCase
      */
     public function testValReadsRequest()
     {
-        $this->request->data = [
+        $this->request = $this->request->withParsedBody([
             'title' => 'New title',
             'notInEntity' => 'yes',
-        ];
+        ]);
         $row = new Article([
             'title' => 'Test entity',
             'body' => 'Something new'

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -81,12 +81,12 @@ class FormContextTest extends TestCase
      */
     public function testValPresent()
     {
-        $this->request->data = [
+        $this->request = $this->request->withParsedBody([
             'Articles' => [
                 'title' => 'New title',
                 'body' => 'My copy',
             ]
-        ];
+        ]);
         $context = new FormContext($this->request, ['entity' => new Form()]);
         $this->assertEquals('New title', $context->val('Articles.title'));
         $this->assertEquals('My copy', $context->val('Articles.body'));

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -228,7 +228,7 @@ class FlashHelperTest extends TestCase
      */
     public function testFlashWithPrefix()
     {
-        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->request = $this->View->request->withParam('prefix', 'Admin');
         $result = $this->Flash->render('flash');
         $expected = 'flash element from Admin prefix folder';
         $this->assertContains($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -764,8 +764,9 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->article['defaults'] = ['id' => 1];
-        $this->Form->request->here = '/articles/edit/1';
-        $this->Form->request->params['action'] = 'delete';
+        $this->Form->request = $this->Form->request
+            ->withRequestTarget('/articles/edit/1')
+            ->withParam('action', 'delete');
         $result = $this->Form->create($this->article, ['url' => ['action' => 'edit']]);
         $expected = [
             'form' => [
@@ -779,7 +780,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->params['action'] = 'add';
+        $this->Form->request = $this->Form->request
+            ->withParam('action', 'add');
         $result = $this->Form->create($this->article, ['url' => ['action' => 'publish']]);
         $expected = [
             'form' => [
@@ -802,7 +804,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->params['controller'] = 'Pages';
+        $this->Form->request = $this->Form->request
+            ->withParam('controller', 'Pages');
         $result = $this->Form->create($this->article, ['url' => ['action' => 'signup']]);
         $expected = [
             'form' => [
@@ -846,7 +849,8 @@ class FormHelperTest extends TestCase
         Router::connect('/login', ['controller' => 'users', 'action' => 'login']);
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request->params['controller'] = 'users';
+        $this->Form->request = $this->Form->request
+            ->withParam('controller', 'users');
 
         $result = $this->Form->create(false, ['url' => ['action' => 'login']]);
         $expected = [
@@ -952,7 +956,7 @@ class FormHelperTest extends TestCase
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request->data['Article']['id'] = [1, 2];
+        $this->Form->request = $this->Form->request->withData('Article.id', [1, 2]);
         $result = $this->Form->create($this->article);
         $expected = [
             'form' => [
@@ -975,7 +979,7 @@ class FormHelperTest extends TestCase
     public function testCreatePassedArgs()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $this->Form->request->data['Article']['id'] = 1;
+        $this->Form->request = $this->Form->request->withData('Article.id', 1);
         $result = $this->Form->create($this->article, [
             'type' => 'post',
             'escape' => false,
@@ -1040,7 +1044,7 @@ class FormHelperTest extends TestCase
     public function testGetFormWithFalseModel()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $this->Form->request->params['controller'] = 'contact_test';
+        $this->Form->request = $this->Form->request->withParam('controller', 'contact_test');
         $result = $this->Form->create(false, [
             'type' => 'get', 'url' => ['controller' => 'contact_test']
         ]);
@@ -1067,7 +1071,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateWithSecurity()
     {
-        $this->Form->request->params['_csrfToken'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create($this->article, [
             'url' => '/articles/publish',
@@ -1100,7 +1104,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateEndGetNoSecurity()
     {
-        $this->Form->request->params['_csrfToken'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
         $article = new Article();
         $result = $this->Form->create($article, [
             'type' => 'get',
@@ -1131,7 +1135,7 @@ class FormHelperTest extends TestCase
      */
     public function testValidateHashNoModel()
     {
-        $this->Form->request->params['_Token'] = 'foo';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
 
         $fields = ['anything'];
         $result = $this->Form->secure($fields);
@@ -1147,7 +1151,7 @@ class FormHelperTest extends TestCase
      */
     public function testNoCheckboxLocking()
     {
-        $this->Form->request->params['_Token'] = 'foo';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
         $this->assertSame([], $this->Form->fields);
 
         $this->Form->checkbox('check', ['value' => '1']);
@@ -1165,7 +1169,7 @@ class FormHelperTest extends TestCase
     {
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1213,7 +1217,7 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1400,7 +1404,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleFields()
     {
-        $this->Form->request->params['_Token'] = 'foo';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
 
         $fields = [
             'Model.0.password', 'Model.0.username', 'Model.0.hidden' => 'value',
@@ -1451,7 +1455,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleSubmitButtons()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->create($this->article);
         $this->Form->text('Address.title');
@@ -1515,8 +1519,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecurityButtonNestedNamed()
     {
-        $key = 'testKey';
-        $this->Form->request->params['_csrfToken'] = $key;
+        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
 
         $this->Form->create('Addresses');
         $this->Form->button('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1531,7 +1534,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitNestedNamed()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->create($this->article);
         $this->Form->submit('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1546,7 +1549,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageNoName()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->create(false);
         $result = $this->Form->submit('save.png');
@@ -1566,7 +1569,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageName()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->create(null);
         $result = $this->Form->submit('save.png', ['name' => 'test']);
@@ -1588,7 +1591,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlFields()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1667,7 +1670,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityArrayFields()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->create();
         $this->Form->text('Address.primary.1');
@@ -1686,9 +1689,9 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlDisabledFields()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ];
+        ]);
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1762,11 +1765,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFields()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ];
+        ]);
         $this->Form->create();
-        $this->assertEquals($this->Form->request->params['_Token']['unlockedFields'], $this->Form->unlockField());
+        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1837,11 +1840,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ];
+        ]);
         $this->Form->create();
-        $this->assertEquals($this->Form->request->params['_Token']['unlockedFields'], $this->Form->unlockField());
+        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1911,11 +1914,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ];
+        ]);
         $this->Form->create();
-        $this->assertEquals($this->Form->request->params['_Token']['unlockedFields'], $this->Form->unlockField());
+        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1965,11 +1968,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ];
+        ]);
         $this->Form->create();
-        $this->assertEquals($this->Form->request->params['_Token']['unlockedFields'], $this->Form->unlockField());
+        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -2020,7 +2023,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecureWithCustomNameAttribute()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom]']);
         $this->assertEquals('User.custom', $this->Form->fields[0]);
@@ -2038,8 +2041,9 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredControl()
     {
-        $this->Form->request->params['_csrfToken'] = 'testKey';
-        $this->Form->request->params['_Token'] = 'stuff';
+        $this->Form->request = $this->Form->request
+            ->withParam('_Token', 'stuff')
+            ->withParam('_csrfToken', 'testKey');
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
             'population' => ['type' => 'decimal', 'length' => 15, 'precision' => 0],
@@ -2204,7 +2208,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlCustomName()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->text('text_input', [
@@ -2234,7 +2238,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlDuplicate()
     {
-        $this->Form->request->params['_Token'] = ['key' => 'testKey'];
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
@@ -2280,7 +2284,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredMultipleSelect()
     {
-        $this->Form->request->params['_csrfToken'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'one', '2' => 'two'];
 
@@ -2300,7 +2304,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredRadio()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'option1', '2' => 'option2'];
@@ -2331,7 +2335,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabledNotAssoc()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->select('Model.select', [1, 2], ['disabled']);
         $this->Form->checkbox('Model.checkbox', ['disabled']);
@@ -2356,7 +2360,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabled()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $this->Form->checkbox('Model.checkbox', ['disabled' => true]);
         $this->Form->text('Model.text', ['disabled' => true]);
@@ -2384,9 +2388,9 @@ class FormHelperTest extends TestCase
      */
     public function testDisableSecurityUsingForm()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'disabledFields' => []
-        ];
+        ]);
         $this->Form->create();
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -2411,9 +2415,9 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldAddsToList()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => []
-        ];
+        ]);
         $this->Form->unlockField('Contact.name');
         $this->Form->text('Contact.name');
 
@@ -2430,9 +2434,9 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldRemovingFromFields()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'unlockedFields' => []
-        ];
+        ]);
         $this->Form->create($this->article);
         $this->Form->hidden('Article.id', ['value' => 1]);
         $this->Form->text('Article.title');
@@ -2454,10 +2458,10 @@ class FormHelperTest extends TestCase
      */
     public function testResetUnlockFields()
     {
-        $this->Form->request->params['_Token'] = [
+        $this->Form->request = $this->Form->request->withParam('_Token', [
             'key' => 'testKey',
             'unlockedFields' => []
-        ];
+        ]);
 
         $this->Form->unlockField('Contact.id');
         $this->Form->create('Contact');
@@ -2479,7 +2483,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlIgnoresHost()
     {
-        $this->Form->request->params['_Token'] = ['key' => 'testKey'];
+        $this->Form->request = $this->Form->request->withParam('_Token', ['key' => 'testKey']);
 
         $expected = '2548654895b160d724042ed269a2a863fd9d66ee%3A';
         $this->Form->create($this->article, [
@@ -2510,7 +2514,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlHasHtmlAndIdentifier()
     {
-        $this->Form->request->params['_Token'] = ['key' => 'testKey'];
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
 
         $expected = '0a913f45b887b4d9cc2650ef1edc50183896959c%3A';
         $this->Form->create($this->article, [
@@ -3024,7 +3028,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['0']['OtherModel']['field'] = 'My value';
+        $this->Form->request = $this->Form->request->withData('Model.0.OtherModel.field', 'My value');
         $this->Form->create();
         $result = $this->Form->control('Model.0.OtherModel.field', ['id' => 'myId']);
         $expected = [
@@ -3040,7 +3044,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = [];
+        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->Form->create();
 
         $entity->setError('field', 'Badness!');
         $this->Form->create($entity, ['context' => ['table' => 'Contacts']]);
@@ -3657,8 +3662,8 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request->data = ['Model' => ['user_id' => 'value']];
-
+        $this->Form->request = $this->Form->request->withData('Model', ['user_id' => 'value']);
+        $this->Form->create();
         $result = $this->Form->control('Model.user_id', ['empty' => true]);
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3680,7 +3685,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request->data = ['Thing' => ['user_id' => null]];
+        $this->Form->request = $this->Form->request->withData('Thing', ['user_id' => null]);
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3703,7 +3708,8 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request->data = ['Thing' => ['user_id' => 'value']];
+        $this->Form->request = $this->Form->request->withData('Thing', ['user_id' => 'value']);
+        $this->Form->create();
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3725,12 +3731,11 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->data = [];
         $result = $this->Form->control('Publisher.id', [
-                'label' => 'Publisher',
-                'type' => 'select',
-                'multiple' => 'checkbox',
-                'options' => ['Value 1' => 'Label 1', 'Value 2' => 'Label 2']
+            'label' => 'Publisher',
+            'type' => 'select',
+            'multiple' => 'checkbox',
+            'options' => ['Value 1' => 'Label 1', 'Value 2' => 'Label 2']
         ]);
         $expected = [
             ['div' => ['class' => 'input select']],
@@ -4006,9 +4011,10 @@ class FormHelperTest extends TestCase
         $this->assertNotContains('<fieldset>', $result);
 
         $this->Form->create($this->article);
-        $this->Form->request->params['prefix'] = 'admin';
-        $this->Form->request->params['action'] = 'admin_edit';
-        $this->Form->request->params['controller'] = 'articles';
+        $this->Form->request = $this->Form->request
+            ->withParam('prefix', 'admin')
+            ->withParam('action', 'admin_edit')
+            ->withParam('controller', 'articles');
         $result = $this->Form->allControls();
         $expected = [
             '<fieldset',
@@ -4334,9 +4340,11 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'Contact' => ['text' => 'wrong']
         ];
+        $this->Form->request = $this->Form->request
+            ->withData('Model.text', 'test <strong>HTML</strong> values')
+            ->withData('Contact.text', 'test');
         $this->Form->create($this->article);
 
-        $this->Form->request->data['Model']['text'] = 'test <strong>HTML</strong> values';
         $result = $this->Form->text('Model.text');
         $expected = [
             'input' => [
@@ -4347,7 +4355,6 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Contact']['text'] = 'test';
         $result = $this->Form->text('Contact.text', ['id' => 'theID']);
         $expected = [
             'input' => [
@@ -4370,12 +4377,13 @@ class FormHelperTest extends TestCase
      */
     public function testTextDefaultValue()
     {
-        $this->Form->request->data['Model']['field'] = 'test';
+        $this->Form->request = $this->Form->request->withData('Model.field', 'test');
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'test']];
         $this->assertHtml($expected, $result);
 
-        unset($this->Form->request->data['Model']['field']);
+        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->Form->create();
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'default value']];
         $this->assertHtml($expected, $result);
@@ -4578,7 +4586,8 @@ class FormHelperTest extends TestCase
         $expected = ['input' => ['type' => 'password', 'name' => 'Contact[field]']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Contact']['passwd'] = 'test';
+        $this->Form->request = $this->Form->request->withData('Contact.passwd', 'test');
+        $this->Form->create($this->article);
         $result = $this->Form->password('Contact.passwd', ['id' => 'theID']);
         $expected = ['input' => ['type' => 'password', 'name' => 'Contact[passwd]', 'value' => 'test', 'id' => 'theID', 'class' => 'form-error']];
         $this->assertHtml($expected, $result);
@@ -4950,7 +4959,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = ['Model' => ['field' => 'value']];
+        $this->Form->request = $this->Form->request->withData('Model', ['field' => 'value']);
+        $this->Form->create();
         $result = $this->Form->select('Model.field', ['value' => 'good', 'other' => 'bad']);
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -4967,7 +4977,8 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select('Model.field', new Collection(['value' => 'good', 'other' => 'bad']));
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = [];
+        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->Form->create();
         $result = $this->Form->select('Model.field', ['value' => 'good', 'other' => 'bad']);
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5002,7 +5013,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = ['Model' => ['contact_id' => 228]];
+        $this->Form->request = $this->Form->request->withParsedBody(['Model' => ['contact_id' => 228]]);
+        $this->Form->create();
         $result = $this->Form->select(
             'Model.contact_id',
             ['228' => '228 value', '228-1' => '228-1 value', '228-2' => '228-2 value'],
@@ -5019,7 +5031,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = 0;
+        $this->Form->request = $this->Form->request->withData('Model.field', 0);
+        $this->Form->create();
         $result = $this->Form->select('Model.field', ['0' => 'No', '1' => 'Yes']);
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5526,7 +5539,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxRequestData()
     {
-        $this->Form->request->data = ['Model' => ['tags' => [1]]];
+        $this->Form->request = $this->Form->request->withData('Model', ['tags' => [1]]);
         $result = $this->Form->select(
             'Model.tags',
             ['1' => 'first', 'Array' => 'Array'],
@@ -5568,7 +5581,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxSecurity()
     {
-        $this->Form->request->params['_Token'] = 'testKey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5613,7 +5626,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectNoSecureWithNoOptions()
     {
-        $this->Form->request->params['_Token'] = 'testkey';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'testkey');
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5841,22 +5854,25 @@ class FormHelperTest extends TestCase
      */
     public function testCheckboxDefaultValue()
     {
-        $this->Form->request->data['Model']['field'] = false;
+        $this->Form->request = $this->Form->request->withData('Model.field', false);
         $result = $this->Form->checkbox('Model.field', ['default' => true, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1']];
         $this->assertHtml($expected, $result);
 
-        unset($this->Form->request->data['Model']['field']);
+        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => true, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = true;
+        $this->Form->request = $this->Form->request->withData('Model.field', true);
+        $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => false, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked']];
         $this->assertHtml($expected, $result);
 
-        unset($this->Form->request->data['Model']['field']);
+        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => false, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1']];
         $this->assertHtml($expected, $result);
@@ -5885,7 +5901,7 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'published' => true
         ];
-        $this->Form->request->data['published'] = 'myvalue';
+        $this->Form->request = $this->Form->request->withData('published', 'myvalue');
         $this->Form->create($this->article);
 
         $result = $this->Form->checkbox('published', ['id' => 'theID', 'value' => 'myvalue']);
@@ -5902,7 +5918,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['published'] = '';
+        $this->Form->request = $this->Form->request->withData('published', '');
+        $this->Form->create($this->article);
         $result = $this->Form->checkbox('published');
         $expected = [
             'input' => ['type' => 'hidden', 'class' => 'form-error', 'name' => 'published', 'value' => '0'],
@@ -6157,7 +6174,7 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeSecured()
     {
-        $this->Form->request->params['_Token'] = ['unlockedFields' => []];
+        $this->Form->request = $this->Form->request->withParam('_Token', ['unlockedFields' => []]);
         $this->Form->dateTime('Contact.date');
         $expected = [
             'Contact.date.year',
@@ -6187,7 +6204,7 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeSecuredDisabled()
     {
-        $this->Form->request->params['_Token'] = ['unlockedFields' => []];
+        $this->Form->request = $this->Form->request->withParam('_Token', ['unlockedFields' => []]);
         $this->Form->dateTime('Contact.date', ['secure' => false]);
         $expected = [];
         $this->assertEquals($expected, $this->Form->fields);
@@ -6322,7 +6339,7 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeRounding()
     {
-        $this->Form->request->data['Contact'] = [
+        $this->Form->request = $this->Form->request->withData('Contact', [
             'date' => [
                 'day' => '13',
                 'month' => '12',
@@ -6331,7 +6348,7 @@ class FormHelperTest extends TestCase
                 'minute' => '19',
                 'meridian' => 'AM'
             ]
-        ];
+        ]);
 
         $result = $this->Form->dateTime('Contact.date', ['interval' => 15]);
         $this->assertTextContains('<option value="15" selected="selected">15</option>', $result);
@@ -6554,7 +6571,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Project']['release'] = '2050-02-10';
+        $this->Form->request = $this->Form->request->withData('Project.release', '2050-02-10');
+        $this->Form->create();
         $result = $this->Form->month('Project.release');
 
         $expected = [
@@ -6604,7 +6622,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '2006-10-10 23:12:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 23:12:32');
+        $this->Form->create();
         $result = $this->Form->day('Model.field');
         $expected = [
             ['select' => ['name' => 'Model[field][day]']],
@@ -6625,7 +6644,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '';
+        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->Form->create();
         $result = $this->Form->day('Model.field', ['value' => '10']);
         $expected = [
             ['select' => ['name' => 'Model[field][day]']],
@@ -6646,7 +6666,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Project']['release'] = '2050-10-10';
+        $this->Form->request = $this->Form->request->withData('Project.release', '2050-10-10');
+        $this->Form->create();
         $result = $this->Form->day('Project.release');
 
         $expected = [
@@ -6704,7 +6725,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '2006-10-10 00:12:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->Form->create();
         $result = $this->Form->minute('Model.field');
         $expected = [
             ['select' => ['name' => 'Model[field][minute]']],
@@ -6728,7 +6750,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '';
+        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->Form->create();
         $result = $this->Form->minute('Model.field', ['interval' => 5]);
         $expected = [
             ['select' => ['name' => 'Model[field][minute]']],
@@ -6748,7 +6771,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '2006-10-10 00:10:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:10:32');
+        $this->Form->create();
         $result = $this->Form->minute('Model.field', ['interval' => 5]);
         $expected = [
             ['select' => ['name' => 'Model[field][minute]']],
@@ -6822,7 +6846,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '2006-10-10 00:12:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 12]);
         $expected = [
             ['select' => ['name' => 'Model[field][hour]']],
@@ -6842,14 +6867,16 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['field'] = '';
+        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24, 'value' => '23']);
         $this->assertContains('<option value="23" selected="selected">23</option>', $result);
 
         $result = $this->Form->hour('Model.field', ['format' => 12, 'value' => '23']);
         $this->assertContains('<option value="11" selected="selected">11</option>', $result);
 
-        $this->Form->request->data['Model']['field'] = '2006-10-10 00:12:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24]);
         $expected = [
             ['select' => ['name' => 'Model[field][hour]']],
@@ -6869,13 +6896,15 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        unset($this->Form->request->data['Model']['field']);
+        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24, 'value' => 'now']);
         $thisHour = date('H');
         $optValue = date('G');
         $this->assertRegExp('/<option value="' . $thisHour . '" selected="selected">' . $optValue . '<\/option>/', $result);
 
-        $this->Form->request->data['Model']['field'] = '2050-10-10 01:12:32';
+        $this->Form->request = $this->Form->request->withData('Model.field', '2050-10-10 01:12:32');
+        $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24]);
         $expected = [
             ['select' => ['name' => 'Model[field][hour]']],
@@ -6905,6 +6934,7 @@ class FormHelperTest extends TestCase
      */
     public function testYear()
     {
+        $this->Form->request = $this->Form->request->withData('Contact.published', '2006-10-10');
         $result = $this->Form->year('Model.field', ['value' => '', 'minYear' => 2006, 'maxYear' => 2007]);
         $expected = [
             ['select' => ['name' => 'Model[field][year]']],
@@ -6940,7 +6970,6 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Contact']['published'] = '2006-10-10';
         $result = $this->Form->year('Contact.published', [
             'empty' => false,
             'minYear' => 2006,
@@ -6995,7 +7024,7 @@ class FormHelperTest extends TestCase
      */
     public function testYearAutoExpandRange()
     {
-        $this->Form->request->data['User']['birthday'] = '1930-10-10';
+        $this->Form->request = $this->Form->request->withData('User.birthday', '1930-10-10');
         $result = $this->Form->year('User.birthday');
         preg_match_all('/<option value="([\d]+)"/', $result, $matches);
 
@@ -7003,7 +7032,8 @@ class FormHelperTest extends TestCase
         $expected = range(date('Y') + 5, 1930);
         $this->assertEquals($expected, $result);
 
-        $this->Form->request->data['Project']['release'] = '2050-10-10';
+        $this->Form->request = $this->Form->request->withData('Project.release', '2050-10-10');
+        $this->Form->create();
         $result = $this->Form->year('Project.release');
         preg_match_all('/<option value="([\d]+)"/', $result, $matches);
 
@@ -7011,7 +7041,8 @@ class FormHelperTest extends TestCase
         $expected = range(2050, date('Y') - 5);
         $this->assertEquals($expected, $result);
 
-        $this->Form->request->data['Project']['release'] = '1881-10-10';
+        $this->Form->request = $this->Form->request->withData('Project.release', '1881-10-10');
+        $this->Form->create();
         $result = $this->Form->year('Project.release', [
             'minYear' => 1890,
             'maxYear' => 1900
@@ -7032,9 +7063,9 @@ class FormHelperTest extends TestCase
      */
     public function testControlDate()
     {
-        $this->Form->request->data = [
+        $this->Form->request = $this->Form->request->withParsedBody([
             'month_year' => ['month' => date('m')],
-        ];
+        ]);
         $this->Form->create($this->article);
         $result = $this->Form->control('month_year', [
                 'label' => false,
@@ -7075,7 +7106,6 @@ class FormHelperTest extends TestCase
      */
     public function testControlDateMaxYear()
     {
-        $this->Form->request->data = [];
         $this->Form->create($this->article);
         $result = $this->Form->control('birthday', [
             'label' => false,
@@ -7099,7 +7129,7 @@ class FormHelperTest extends TestCase
      */
     public function testTextArea()
     {
-        $this->Form->request->data = ['field' => 'some test data'];
+        $this->Form->request = $this->Form->request->withData('field', 'some test data');
         $result = $this->Form->textarea('field');
         $expected = [
             'textarea' => ['name' => 'field', 'rows' => 5],
@@ -7115,7 +7145,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = ['field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars'];
+        $this->Form->request = $this->Form->request
+            ->withData('field', 'some <strong>test</strong> data with <a href="#">HTML</a> chars');
+        $this->Form->create();
         $result = $this->Form->textarea('field');
         $expected = [
             'textarea' => ['name' => 'field', 'rows' => 5],
@@ -7124,9 +7156,11 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = [
-            'Model' => ['field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars']
-        ];
+        $this->Form->request = $this->Form->request->withData(
+            'Model.field',
+            'some <strong>test</strong> data with <a href="#">HTML</a> chars'
+        );
+        $this->Form->create();
         $result = $this->Form->textarea('Model.field', ['escape' => false]);
         $expected = [
             'textarea' => ['name' => 'Model[field]', 'rows' => 5],
@@ -7216,7 +7250,7 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'field' => true
         ];
-        $this->Form->request->data['field'] = 'test';
+        $this->Form->request = $this->Form->request->withData('field', 'test');
         $this->Form->create($this->article);
         $result = $this->Form->hidden('field', ['id' => 'theID']);
         $expected = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7244,14 +7244,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['upload'] = [
+        $this->Form->request = $this->Form->request->withData('Model.upload', [
             'name' => '', 'type' => '', 'tmp_name' => '',
             'error' => 4, 'size' => 0
-        ];
+        ]);
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['Model']['upload'] = 'no data should be set in value';
+        $this->Form->request = $this->Form->request->withData('Model.upload', 'no data should be set in value');
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
     }
@@ -7318,7 +7318,7 @@ class FormHelperTest extends TestCase
      */
     public function testButtonUnlockedByDefault()
     {
-        $this->Form->request->params['_csrfToken'] = 'secured';
+        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'secured');
         $this->Form->button('Save', ['name' => 'save']);
         $this->Form->button('Clear');
 
@@ -7435,8 +7435,9 @@ class FormHelperTest extends TestCase
      */
     public function testSecurePostButton()
     {
-        $this->Form->request->params['_csrfToken'] = 'testkey';
-        $this->Form->request->params['_Token'] = ['unlockedFields' => []];
+        $this->Form->request = $this->Form->request
+            ->withParam('_csrfToken', 'testkey')
+            ->withParam('_Token.unlockedFields', []);
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
@@ -7628,7 +7629,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->Form->request->params['_Token']['key'] = 'test';
+        $this->Form->request = $this->Form->request->withParam('_Token.key', 'test');
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7681,7 +7682,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize([]) . session_id(), Security::getSalt());
         $hash .= '%3A';
-        $this->Form->request->params['_Token']['key'] = 'test';
+        $this->Form->request = $this->Form->request->withParam('_Token.key', 'test');
 
         $this->Form->create('Post', ['url' => ['action' => 'add']]);
         $this->Form->control('title');
@@ -7705,7 +7706,8 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->Form->request->params['_Token']['key'] = 'test';
+        $this->Form->request = $this->Form->request
+            ->withParam('_Token.key', 'test');
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7745,7 +7747,7 @@ class FormHelperTest extends TestCase
                 'two' => [
                     3, 4, 5
                 ]
-                ]
+            ]
         ];
         $result = $this->Form->postLink('Send', '/', ['data' => $data]);
         $this->assertContains('<input type="hidden" name="one[two][0]" value="3"', $result);
@@ -7762,8 +7764,9 @@ class FormHelperTest extends TestCase
      */
     public function testPostLinkAfterGetForm()
     {
-        $this->Form->request->params['_csrfToken'] = 'testkey';
-        $this->Form->request->params['_Token'] = 'val';
+        $this->Form->request = $this->Form->request
+            ->withParam('_csrfToken', 'testkey')
+            ->withParam('_Token', 'val');
 
         $this->Form->create($this->article, ['type' => 'get']);
         $this->Form->end();
@@ -7977,7 +7980,7 @@ class FormHelperTest extends TestCase
      */
     public function testSubmitUnlockedByDefault()
     {
-        $this->Form->request->params['_Token'] = 'secured';
+        $this->Form->request = $this->Form->request->withParam('_Token', 'secured');
         $this->Form->submit('Go go');
         $this->Form->submit('Save', ['name' => 'save']);
 
@@ -8060,7 +8063,8 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data = ['non_existing_nor_validated' => 'CakePHP magic'];
+        $this->Form->request = $this->Form->request->withData('non_existing_nor_validated', 'CakePHP magic');
+        $this->Form->create($this->article);
         $result = $this->Form->control('non_existing_nor_validated');
         $expected = [
             'label' => ['for' => 'non-existing-nor-validated'],
@@ -8646,21 +8650,18 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesSettersGetters()
     {
+        $this->Form->request = $this->Form->request
+            ->withData('id', '1')
+            ->withQueryParams(['id' => '2']);
+
         $expected = ['context'];
         $result = $this->Form->getValueSources();
-        $this->assertEquals($expected, $result);
-
-        $expected = null;
-        $result = $this->Form->getSourceValue('id');
         $this->assertEquals($expected, $result);
 
         $expected = ['query', 'data', 'context'];
         $this->Form->setValueSources(['query', 'data', 'invalid', 'context', 'foo']);
         $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
-
-        $this->Form->request->data['id'] = '1';
-        $this->Form->request->query['id'] = '2';
 
         $this->Form->setValueSources(['context']);
         $expected = '1';
@@ -8707,7 +8708,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->query['id'] = '5';
+        $this->Form->request = $this->Form->request->withQueryParams(['id' => 5]);
         $this->Form->setValueSources(['query']);
         $result = $this->Form->control('id');
         $expected = [
@@ -8715,8 +8716,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->query['id'] = '5a';
-        $this->Form->request->data['id'] = '5b';
+        $this->Form->request = $this->Form->request
+            ->withQueryParams(['id' => '5a'])
+            ->withData('id', '5b');
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article);
@@ -8800,8 +8802,8 @@ class FormHelperTest extends TestCase
         $articles = TableRegistry::get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
-        $this->Form->request->data['id'] = '4';
-        $this->Form->request->query['id'] = '5';
+
+        $this->Form->request = $this->Form->request->withData('id', 4)->withQueryParams(['id' => 5]);
 
         $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->control('id');
@@ -8856,8 +8858,7 @@ class FormHelperTest extends TestCase
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
 
-        $this->Form->request->data['id'] = '10';
-        $this->Form->request->query['id'] = '11';
+        $this->Form->request = $this->Form->request->withData('id', 10)->withQueryParams(['id' => 11]);
 
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
@@ -8869,7 +8870,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals('11', $result);
 
-        unset($this->Form->request->query['id']);
+        $this->Form->request = $this->Form->request->withQueryParams([]);
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->control('id');
@@ -8914,7 +8915,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesDefaults()
     {
-        $this->Form->request->query['password'] = 'open Sesame';
+        $this->Form->request = $this->Form->request->withQueryParams(['password' => 'open Sesame']);
         $this->Form->create();
 
         $result = $this->Form->password('password');

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -117,7 +117,7 @@ class HtmlHelperTest extends TestCase
     {
         Router::connect('/:controller/:action/*');
 
-        $this->Html->request->webroot = '';
+        $this->Html->request = $this->Html->request->withAttribute('webroot', '');
 
         $result = $this->Html->link('/home');
         $expected = ['a' => ['href' => '/home'], 'preg:/\/home/', '/a'];
@@ -330,8 +330,6 @@ class HtmlHelperTest extends TestCase
         Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action/*');
 
-        $this->Html->request->webroot = '';
-
         $result = $this->Html->image('test.gif');
         $expected = ['img' => ['src' => 'img/test.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
@@ -430,14 +428,13 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => $here . 'img/sub/test.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $request = $this->Html->request;
-        $request->webroot = '/myproject/';
-        $request->base = '/myproject';
-        Router::pushRequest($request);
+        $this->Html->Url->request = $this->Html->request
+            ->withAttribute('webroot', '/myproject/')
+            ->withAttribute('base', '/myproject');
 
         $result = $this->Html->image('sub/test.gif', ['fullBase' => true]);
         $here = $this->Html->Url->build('/', true);
-        $expected = ['img' => ['src' => $here . 'img/sub/test.gif', 'alt' => '']];
+        $expected = ['img' => ['src' => $here . 'myproject/img/sub/test.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
     }
 
@@ -450,7 +447,7 @@ class HtmlHelperTest extends TestCase
     {
         Configure::write('Asset.timestamp', 'force');
 
-        $this->Html->request->webroot = '/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
         $result = $this->Html->image('cake.icon.png');
         $expected = ['img' => ['src' => 'preg:/\/img\/cake\.icon\.png\?\d+/', 'alt' => '']];
         $this->assertHtml($expected, $result);
@@ -462,7 +459,7 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => 'preg:/\/img\/cake\.icon\.png\?\d+/', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/longer/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
         $result = $this->Html->image('cake.icon.png');
         $expected = [
             'img' => ['src' => 'preg:/\/testing\/longer\/img\/cake\.icon\.png\?[0-9]+/', 'alt' => '']
@@ -485,25 +482,26 @@ class HtmlHelperTest extends TestCase
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', true);
 
-        $this->Html->Url->request->webroot = '/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
         $this->Html->Url->theme = 'TestTheme';
         $result = $this->Html->image('__cake_test_image.gif');
         $expected = [
             'img' => [
                 'src' => 'preg:/\/test_theme\/img\/__cake_test_image\.gif\?\d+/',
                 'alt' => ''
-            ]];
-            $this->assertHtml($expected, $result);
+            ]
+        ];
+        $this->assertHtml($expected, $result);
 
-            $this->Html->Url->request->webroot = '/testing/';
-            $result = $this->Html->image('__cake_test_image.gif');
-            $expected = [
-            'img' => [
-                'src' => 'preg:/\/testing\/test_theme\/img\/__cake_test_image\.gif\?\d+/',
-                'alt' => ''
-            ]];
-            $this->assertHtml($expected, $result);
-            $File->delete();
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $result = $this->Html->image('__cake_test_image.gif');
+        $expected = [
+        'img' => [
+            'src' => 'preg:/\/testing\/test_theme\/img\/__cake_test_image\.gif\?\d+/',
+            'alt' => ''
+        ]];
+        $this->assertHtml($expected, $result);
+        $File->delete();
     }
 
     /**
@@ -735,12 +733,12 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'preg:/.*css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
         $result = $this->Html->css('cake.generic', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/longer/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
         $result = $this->Html->css('cake.generic', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/longer\/css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
@@ -778,12 +776,12 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
         $result = $this->Html->css('TestPlugin.test_plugin_asset', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/longer/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
         $result = $this->Html->css('TestPlugin.test_plugin_asset', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/longer\/test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
@@ -1093,7 +1091,7 @@ class HtmlHelperTest extends TestCase
         $testfile = WWW_ROOT . '/test_theme/js/__test_js.js';
         $File = new File($testfile, true);
 
-        $this->Html->Url->request->webroot = '/';
+        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
         $this->Html->Url->theme = 'TestTheme';
         $result = $this->Html->script('__test_js.js');
         $expected = [
@@ -1766,7 +1764,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/';
+        $this->Html->request = $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
         $result = $this->Html->meta('icon');
         $expected = [
             'link' => ['href' => '/testing/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],
@@ -1798,7 +1796,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->request->webroot = '/testing/';
+        $this->Html->request = $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
         $result = $this->Html->meta('icon');
         $expected = [
             'link' => ['href' => '/testing/test_theme/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -124,9 +124,8 @@ class PaginatorHelperTest extends TestCase
     public function testHasPrevious()
     {
         $this->assertFalse($this->Paginator->hasPrev());
-        $this->Paginator->request->params['paging']['Article']['prevPage'] = true;
+        $this->Paginator->request = $this->Paginator->withParam('paging.Article.prevPage', true);
         $this->assertTrue($this->Paginator->hasPrev());
-        $this->Paginator->request->params['paging']['Article']['prevPage'] = false;
     }
 
     /**
@@ -137,9 +136,8 @@ class PaginatorHelperTest extends TestCase
     public function testHasNext()
     {
         $this->assertTrue($this->Paginator->hasNext());
-        $this->Paginator->request->params['paging']['Article']['nextPage'] = false;
+        $this->Paginator->request = $this->Paginator->withParam('paging.Article.nextPage', false);
         $this->assertFalse($this->Paginator->hasNext());
-        $this->Paginator->request->params['paging']['Article']['nextPage'] = true;
     }
 
     /**
@@ -160,7 +158,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequestInfo($request);
 
         $this->Paginator->options(['url' => ['param']]);
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'current' => 9,
                 'count' => 62,
@@ -171,7 +169,7 @@ class PaginatorHelperTest extends TestCase
                 'direction' => 'asc',
                 'page' => 1,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->sort('title');
         $expected = [
@@ -2611,7 +2609,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounter()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2624,7 +2622,7 @@ class PaginatorHelperTest extends TestCase
                 'sort' => 'Client.name',
                 'order' => 'DESC',
             ]
-        ];
+        ]);
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
         $input .= 'starting on record {{start}}, ending on {{end}}';
 
@@ -2652,7 +2650,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounterBigNumbers()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->withParam('paging', [
             'Client' => [
                 'page' => 1523,
                 'current' => 1230,
@@ -2665,7 +2663,7 @@ class PaginatorHelperTest extends TestCase
                 'sort' => 'Client.name',
                 'order' => 'DESC',
             ]
-        ];
+        ]);
 
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
         $input .= 'starting on record {{start}}, ending on {{end}}';
@@ -2717,9 +2715,10 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
-        $this->Paginator->request->params['paging']['Article']['page'] = 1;
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc')
+            ->withParam('paging.Article.page', 1);
 
         $test = ['url' => [
             'page' => '1',
@@ -2750,7 +2749,7 @@ class PaginatorHelperTest extends TestCase
     public function testCurrent()
     {
         $result = $this->Paginator->current();
-        $this->assertEquals($this->Paginator->request->params['paging']['Article']['page'], $result);
+        $this->assertEquals($this->Paginator->request->getParam('paging.Article.page'), $result);
 
         $result = $this->Paginator->current('Incorrect');
         $this->assertEquals(1, $result);
@@ -2764,7 +2763,7 @@ class PaginatorHelperTest extends TestCase
     public function testTotal()
     {
         $result = $this->Paginator->total();
-        $this->assertSame($this->Paginator->request->params['paging']['Article']['pageCount'], $result);
+        $this->assertSame($this->Paginator->request->getParam('paging.Article.pageCount'), $result);
 
         $result = $this->Paginator->total('Incorrect');
         $this->assertSame(0, $result);
@@ -2794,7 +2793,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithOnePage()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => 1,
                 'current' => 2,
@@ -2803,7 +2802,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => true,
                 'pageCount' => 1,
             ]
-        ];
+        ]);
         $this->assertFalse($this->Paginator->numbers());
         $this->assertFalse($this->Paginator->first());
         $this->assertFalse($this->Paginator->last());
@@ -2816,7 +2815,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithZeroPages()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => 0,
                 'current' => 0,
@@ -2827,7 +2826,7 @@ class PaginatorHelperTest extends TestCase
                 'pageCount' => 0,
                 'limit' => 10,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->counter(['format' => 'pages']);
         $expected = '0 of 1';
@@ -2891,14 +2890,14 @@ class PaginatorHelperTest extends TestCase
      */
     public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected)
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => $page,
                 'prevPage' => $prevPage,
                 'nextPage' => $nextPage,
                 'pageCount' => $pageCount,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->meta($options);
         $this->assertSame($expected, $result);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -124,7 +124,7 @@ class PaginatorHelperTest extends TestCase
     public function testHasPrevious()
     {
         $this->assertFalse($this->Paginator->hasPrev());
-        $this->Paginator->request = $this->Paginator->withParam('paging.Article.prevPage', true);
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.prevPage', true);
         $this->assertTrue($this->Paginator->hasPrev());
     }
 
@@ -136,7 +136,7 @@ class PaginatorHelperTest extends TestCase
     public function testHasNext()
     {
         $this->assertTrue($this->Paginator->hasNext());
-        $this->Paginator->request = $this->Paginator->withParam('paging.Article.nextPage', false);
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.nextPage', false);
         $this->assertFalse($this->Paginator->hasNext());
     }
 
@@ -209,7 +209,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'title';
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.sort', 'title');
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -218,8 +218,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -228,8 +229,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -238,8 +240,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -248,8 +251,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'ASC']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -258,8 +262,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'asc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -268,8 +273,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc');
 
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
@@ -322,8 +328,9 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'full_name';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'full_name')
+            ->withParam('paging.Article.direction', 'asc');
 
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
@@ -341,8 +348,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'full_name';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'full_name')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
@@ -413,8 +421,9 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('Article.title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -423,8 +432,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -433,8 +443,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
@@ -443,8 +454,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Account.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Account.title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=title&amp;direction=asc'],
@@ -572,15 +584,16 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortKeyFallbackToParams()
     {
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.sort', 'Article.body');
         $result = $this->Paginator->sortKey();
         $this->assertEquals('Article.body', $result);
 
         $result = $this->Paginator->sortKey('Article');
         $this->assertEquals('Article.body', $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
-        $this->Paginator->request->params['paging']['Article']['order'] = 'DESC';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.body')
+            ->withParam('paging.Article.order', 'DESC');
         $result = $this->Paginator->sortKey();
         $this->assertEquals('Article.body', $result);
 
@@ -599,27 +612,31 @@ class PaginatorHelperTest extends TestCase
         $expected = 'asc';
         $this->assertEquals($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'title')
+            ->withParam('paging.Article.direction', 'desc');
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'title';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'title')
+            ->withParam('paging.Article.direction', 'asc');
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
-        unset($this->Paginator->request->params['paging']['Article']['direction']);
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.direction', null);
         $result = $this->Paginator->sortDir('Article', ['direction' => 'asc']);
         $this->assertEquals('asc', $result);
 
@@ -638,8 +655,9 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortDirFallbackToParams()
     {
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.body')
+            ->withParam('paging.Article.direction', 'asc');
 
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
@@ -647,8 +665,9 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->sortDir('Article');
         $this->assertEquals('asc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.sort', 'Article.body')
+            ->withParam('paging.Article.direction', 'DESC');
 
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
@@ -678,7 +697,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 1;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 1);
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -725,14 +744,14 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sortDefault' => 'Article.title', 'directionDefault' => 'ASC',
                 'sort' => null
             ]
-        ];
+        ]);
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -762,7 +781,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl();
         $this->assertEquals('/index', $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 2;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
         $result = $this->Paginator->generateUrl();
         $this->assertEquals('/index?page=2', $result);
 
@@ -770,23 +789,23 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl($options);
         $this->assertEquals('/index?page=2&amp;sort=Article&amp;direction=desc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
         $this->assertEquals('/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, ['escape' => false]);
         $this->assertEquals('/index?page=3&sort=Article.name&direction=desc', $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, ['fullBase' => true]);
         $this->assertEquals('http://localhost/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 
         // @deprecated 3.3.5 Use fullBase array option instead.
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, true);
         $this->assertEquals('http://localhost/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
@@ -814,8 +833,9 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 2;
-        $this->Paginator->request->params['paging']['Article']['prevPage'] = true;
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 2)
+            ->withParam('paging.Article.prevPage', true);
         $options = ['prefix' => 'members'];
 
         $result = $this->Paginator->generateUrl($options);
@@ -878,9 +898,10 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging']['Article']['scope'] = 'article';
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
-        $this->Paginator->request->params['paging']['Article']['prevPage'] = true;
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.scope', 'article')
+            ->withParam('paging.Article.page', 3)
+            ->withParam('paging.Article.prevPage', true);
         $this->Paginator->options(['model' => 'Article']);
 
         $result = $this->Paginator->generateUrl([]);
@@ -935,14 +956,15 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->View->request->params['paging']['Article']['scope'] = 'article';
-        $this->View->request->params['paging']['Article']['page'] = 3;
-        $this->View->request->params['paging']['Article']['prevPage'] = true;
-        $this->View->request->query = [
-            'article' => [
-                'puppy' => 'no'
-            ]
-        ];
+        $this->View->request = $this->Paginator->request
+            ->withParam('paging.Article.scope', 'article')
+            ->withParam('paging.Article.page', 3)
+            ->withParam('paging.Article.prevPage', true)
+            ->withQueryParams([
+                'article' => [
+                    'puppy' => 'no'
+                ]
+            ]);
         // Need to run __construct to update _config['url']
         $paginator = new PaginatorHelper($this->View);
         $paginator->options(['model' => 'Article']);
@@ -964,7 +986,7 @@ class PaginatorHelperTest extends TestCase
     public function testOptions()
     {
         $this->Paginator->options = [];
-        $this->Paginator->request->params = [];
+        $this->Paginator->request = $this->Paginator->request->withAttribute('params', []);
 
         $options = ['paging' => ['Article' => [
             'direction' => 'desc',
@@ -976,17 +998,17 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'title'
         ]];
-        $this->assertEquals($expected, $this->Paginator->request->params['paging']);
+        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
 
         $this->Paginator->options = [];
-        $this->Paginator->request->params = [];
+        $this->Paginator->request = $this->Paginator->request->withAttribute('params', []);
 
         $options = ['Article' => [
             'direction' => 'desc',
             'sort' => 'title'
         ]];
         $this->Paginator->options($options);
-        $this->assertEquals($expected, $this->Paginator->request->params['paging']);
+        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
 
         $options = ['paging' => ['Article' => [
             'direction' => 'desc',
@@ -998,7 +1020,7 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'Article.title'
         ]];
-        $this->assertEquals($expected, $this->Paginator->request->params['paging']);
+        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
     }
 
     /**
@@ -1016,16 +1038,17 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sort' => null, 'direction' => null,
             ]
-        ];
+        ]);
 
-        $this->Paginator->request->params['pass'] = [2];
-        $this->Paginator->request->query = ['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0];
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('pass', [2])
+            ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0]);
         $this->View->request = $this->Paginator->request;
         $this->Paginator = new PaginatorHelper($this->View);
 
@@ -1075,14 +1098,14 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sort' => 'Article.title', 'direction' => 'ASC',
                 'sortDefault' => 'Article.title', 'directionDefault' => 'ASC'
             ]
-        ];
+        ]);
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -1101,7 +1124,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrev()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1110,7 +1133,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => true,
                 'pageCount' => 5,
             ]
-        ];
+        ]);
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev disabled'],
@@ -1134,8 +1157,9 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->prev('<< Previous', ['disabledTitle' => false]);
         $this->assertEquals('', $result, 'disabled + no text = no link');
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 2;
-        $this->Paginator->request->params['paging']['Client']['prevPage'] = true;
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Client.page', 2)
+            ->withParam('paging.Client.prevPage', true);
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev'],
@@ -1166,13 +1190,13 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrevWithOptions()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 2, 'current' => 1, 'count' => 13, 'prevPage' => true,
                 'nextPage' => false, 'pageCount' => 2,
                 'limit' => 10,
             ]
-        ];
+        ]);
         $this->Paginator->options(['url' => [12, 'page' => 3]]);
         $result = $this->Paginator->prev('Prev', ['url' => ['foo' => 'bar']]);
         $expected = [
@@ -1232,7 +1256,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextDisabled()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 5,
                 'current' => 3,
@@ -1241,7 +1265,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ];
+        ]);
         $result = $this->Paginator->next('Next >>');
         $expected = [
             'li' => ['class' => 'next disabled'],
@@ -1273,7 +1297,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextAndPrevNonDefaultModel()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1290,7 +1314,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ];
+        ]);
         $result = $this->Paginator->next('Next', [
             'model' => 'Client'
         ]);
@@ -1335,7 +1359,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbers()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -1344,7 +1368,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
@@ -1413,7 +1437,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1422,7 +1446,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => ['class' => 'active']], '<a href=""', '1', '/a', '/li',
@@ -1437,7 +1461,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 14,
                 'current' => 3,
@@ -1446,7 +1470,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=7']], '7', '/a', '/li',
@@ -1461,7 +1485,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 3,
@@ -1470,7 +1494,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 9,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 1]);
         $expected = [
@@ -1500,7 +1524,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 15,
                 'current' => 3,
@@ -1509,7 +1533,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 1]);
         $expected = [
@@ -1527,7 +1551,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 10,
                 'current' => 3,
@@ -1536,7 +1560,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1555,7 +1579,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 6,
                 'current' => 15,
@@ -1564,7 +1588,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1583,7 +1607,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 37,
                 'current' => 15,
@@ -1592,7 +1616,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1814,17 +1838,16 @@ class PaginatorHelperTest extends TestCase
             'ellipsis' => '... ',
         ];
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'pageCount' => $pageCount,
             ]
-        ];
+        ]);
 
         $result = [];
-
         foreach ($pagesToCheck as $page) {
-            $this->Paginator->request->params['paging']['Client']['page'] = $page;
+            $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', $page);
 
             $result[$page] = $this->Paginator->numbers($options);
         }
@@ -1841,7 +1864,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersTemplates()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -1850,7 +1873,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers(['templates' => 'htmlhelper_tags']);
         $expected = [
             ['a' => ['href' => '/index?page=4']], '4', '/a',
@@ -1879,7 +1902,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersModulus()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 10,
@@ -1888,7 +1911,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 3,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['modulus' => 10]);
         $expected = [
@@ -1906,7 +1929,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 4895,
                 'current' => 10,
@@ -1915,7 +1938,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 4897,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
@@ -1929,7 +1952,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
 
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
@@ -1960,7 +1983,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 4893;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 4893);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -1979,7 +2002,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 58;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 58);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2002,7 +2025,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 5;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 5);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2021,7 +2044,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2034,7 +2057,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Client']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 0, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2129,7 +2152,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testModulusDisabled()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 2,
@@ -2138,7 +2161,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 6,
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->numbers(['modulus' => false]);
         $expected = [
@@ -2159,7 +2182,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersWithUrlOptions()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -2168,7 +2191,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers(['url' => ['#' => 'foo']]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=4#foo']], '4', '/a', '/li',
@@ -2183,7 +2206,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 3,
                 'current' => 10,
@@ -2192,7 +2215,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 4897,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers([
             'first' => 2,
             'modulus' => 2,
@@ -2217,7 +2240,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersRouting()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 2,
@@ -2226,7 +2249,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 3,
                 'pageCount' => 3,
             ]
-        ];
+        ]);
 
         $request = new ServerRequest([
             'params' => ['controller' => 'clients', 'action' => 'index', 'plugin' => null],
@@ -2250,7 +2273,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersNonDefaultModel()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2267,7 +2290,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ];
+        ]);
         $result = $this->Paginator->numbers(['model' => 'Server']);
         $this->assertContains('<li class="active"><a href="">5</a></li>', $result);
         $this->assertNotContains('<li class="active"><a href="">1</a></li>', $result);
@@ -2284,7 +2307,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstAndLastTag()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 2;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
         $result = $this->Paginator->first('<<');
         $expected = [
             'li' => ['class' => 'first'],
@@ -2334,8 +2357,9 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNoOutput()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 15;
-        $this->Paginator->request->params['paging']['Article']['pageCount'] = 15;
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 15)
+            ->withParam('paging.Article.pageCount', 15);
 
         $result = $this->Paginator->last();
         $expected = '';
@@ -2349,15 +2373,16 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstNonDefaultModel()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 1;
-        $this->Paginator->request->params['paging']['Client'] = [
-            'page' => 3,
-            'current' => 3,
-            'count' => 13,
-            'prevPage' => false,
-            'nextPage' => true,
-            'pageCount' => 5,
-        ];
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 1)
+            ->withParam('paging.Client', [
+                'page' => 3,
+                'current' => 3,
+                'count' => 13,
+                'prevPage' => false,
+                'nextPage' => true,
+                'pageCount' => 5,
+            ]);
 
         $result = $this->Paginator->first('first', ['model' => 'Article']);
         $this->assertEquals('', $result);
@@ -2380,7 +2405,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstEmpty()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 1;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 1);
 
         $result = $this->Paginator->first();
         $expected = '';
@@ -2394,9 +2419,10 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstFullBaseUrl()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
-        $this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
-        $this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 3)
+            ->withParam('paging.Article.direction', 'DESC')
+            ->withParam('paging.Article.sort', 'Article.title');
 
         $this->Paginator->options(['url' => ['_full' => true]]);
 
@@ -2420,7 +2446,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstBoundaries()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
         $result = $this->Paginator->first();
         $expected = [
             'li' => ['class' => 'first'],
@@ -2442,7 +2468,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 2;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
         $result = $this->Paginator->first(3);
         $this->assertEquals('', $result, 'When inside the first links range, no links should be made');
     }
@@ -2503,7 +2529,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request->params['paging']['Article']['page'] = 6;
+        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 6);
 
         $result = $this->Paginator->last(2);
         $expected = [
@@ -2527,7 +2553,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastOptions()
     {
-        $this->Paginator->request->params['paging'] = [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 3,
@@ -2538,7 +2564,7 @@ class PaginatorHelperTest extends TestCase
                 'sort' => 'Client.name',
                 'direction' => 'DESC',
             ]
-        ];
+        ]);
 
         $result = $this->Paginator->last();
         $expected = [
@@ -2578,15 +2604,16 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNonDefaultModel()
     {
-        $this->Paginator->request->params['paging']['Article']['page'] = 7;
-        $this->Paginator->request->params['paging']['Client'] = [
-            'page' => 3,
-            'current' => 3,
-            'count' => 13,
-            'prevPage' => false,
-            'nextPage' => true,
-            'pageCount' => 5,
-        ];
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 7)
+            ->withParam('paging.Client', [
+                'page' => 3,
+                'current' => 3,
+                'count' => 13,
+                'prevPage' => false,
+                'nextPage' => true,
+                'pageCount' => 5,
+            ]);
 
         $result = $this->Paginator->last('last', ['model' => 'Article']);
         $this->assertEquals('', $result);
@@ -2650,7 +2677,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounterBigNumbers()
     {
-        $this->Paginator->request = $this->Paginator->withParam('paging', [
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1523,
                 'current' => 1230,

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -158,7 +158,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam');
         $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
 
-        $this->Helper->request->webroot = '/some/dir/';
+        $this->Helper->request = $this->Helper->request->withAttribute('webroot', '/some/dir/');
         $result = $this->Helper->assetTimestamp('/some/dir/' . Configure::read('App.cssBaseUrl') . 'cake.generic.css');
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
     }
@@ -345,7 +345,7 @@ class UrlHelperTest extends TestCase
      */
     public function testWebrootPaths()
     {
-        $this->Helper->request->webroot = '/';
+        $this->Helper->request = $this->Helper->request->withAttribute('webroot', '/');
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/img/cake.power.gif';
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -295,13 +295,13 @@ class JsonViewTest extends TestCase
         $this->assertSame(json_encode($data), $output);
         $this->assertSame('application/json', $View->response->getType());
 
-        $View->request->query = ['callback' => 'jfunc'];
+        $View->request = $View->request->withQueryParams(['callback' => 'jfunc']);
         $output = $View->render(false);
         $expected = 'jfunc(' . json_encode($data) . ')';
         $this->assertSame($expected, $output);
         $this->assertSame('application/javascript', $View->response->getType());
 
-        $View->request->query = ['jsonCallback' => 'jfunc'];
+        $View->request = $View->request->withQueryParams(['jsonCallback' => 'jfunc']);
         $View->viewVars['_jsonp'] = 'jsonCallback';
         $output = $View->render(false);
         $expected = 'jfunc(' . json_encode($data) . ')';

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -743,31 +743,30 @@ class ViewTest extends TestCase
         $View = new TestView();
 
         // Prefix specific layout
-        $View->request->params['prefix'] = 'foo_prefix';
+        $View->request = $View->request->withParam('prefix', 'foo_prefix');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
             'FooPrefix' . DS . 'Layout' . DS . 'default.ctp';
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $View->request->params['prefix'] = 'FooPrefix';
+        $View->request = $View->request->withParam('prefix', 'FooPrefix');
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         // Nested prefix layout
-        $View->request->params['prefix'] = 'foo_prefix/bar_prefix';
+        $View->request = $View->request->withParam('prefix', 'foo_prefix/bar_prefix');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
             'FooPrefix' . DS . 'BarPrefix' . DS . 'Layout' . DS . 'default.ctp';
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $View->request->params['prefix'] = 'foo_prefix/bar_prefix';
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
             'FooPrefix' . DS . 'Layout' . DS . 'nested_prefix_cascade.ctp';
         $result = $View->getLayoutFileName('nested_prefix_cascade');
         $this->assertPathEquals($expected, $result);
 
         // Fallback to app's layout
-        $View->request->params['prefix'] = 'Admin';
+        $View->request = $View->request->withParam('prefix', 'Admin');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
             'Layout' . DS . 'default.ctp';
         $result = $View->getLayoutFileName();
@@ -911,7 +910,7 @@ class ViewTest extends TestCase
      */
     public function testPrefixElement()
     {
-        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->request = $this->View->request->withParam('prefix', 'Admin');
         $result = $this->View->element('prefix_element');
         $this->assertEquals('this is a prefixed test element', $result);
 
@@ -922,11 +921,10 @@ class ViewTest extends TestCase
         $result = $this->View->element('test_plugin_element');
         $this->assertEquals('this is the test set using View::$plugin plugin prefixed element', $result);
 
-        $this->View->request->params['prefix'] = 'FooPrefix/BarPrefix';
+        $this->View->request = $this->View->request->withParam('prefix', 'FooPrefix/BarPrefix');
         $result = $this->View->element('prefix_element');
         $this->assertEquals('this is a nested prefixed test element', $result);
 
-        $this->View->request->params['prefix'] = 'FooPrefix/BarPrefix';
         $result = $this->View->element('prefix_element_in_parent');
         $this->assertEquals('this is a nested prefixed test element in first level element', $result);
     }
@@ -1352,7 +1350,7 @@ class ViewTest extends TestCase
         $this->assertNull($View->render(false, 'ajax2'));
 
         $this->PostsController->helpers = ['Html'];
-        $this->PostsController->request->params['action'] = 'index';
+        $this->PostsController->request = $this->PostsController->request->withParam('action', 'index');
         Configure::write('Cache.check', true);
 
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
@@ -1900,7 +1898,7 @@ TEXT;
      */
     public function testExtendPrefixElement()
     {
-        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->request = $this->View->request->withParam('prefix', 'Admin');
         $this->View->layout = false;
         $content = $this->View->render('extend_element');
         $expected = <<<TEXT
@@ -1955,7 +1953,7 @@ TEXT;
      */
     public function testExtendWithPrefixElementBeforeExtend()
     {
-        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->request = $this->View->request->withParam('prefix', 'Admin');
         $this->View->layout = false;
         $result = $this->View->render('extend_with_element');
         $expected = <<<TEXT

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -340,16 +340,11 @@ class ViewTest extends TestCase
      */
     public function testGetTemplate()
     {
-        $request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
-        $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
-
         $viewOptions = [
             'plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages'
         ];
-        $request->action = 'display';
-        $request->params['pass'] = ['home'];
 
         $ThemeView = new TestView(null, null, null, $viewOptions);
         $ThemeView->theme = 'TestTheme';
@@ -416,16 +411,11 @@ class ViewTest extends TestCase
     public function testPluginGetTemplateAbsoluteFail()
     {
         $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
-        $request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
-        $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
-
         $viewOptions = [
             'plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages'
         ];
-        $request->action = 'display';
-        $request->params['pass'] = ['home'];
 
         $view = new TestView(null, null, null, $viewOptions);
         $expected = TEST_APP . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Template' . DS . 'Pages' . DS . 'index.ctp';

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -88,7 +88,7 @@ class RequestActionController extends AppController
      */
     public function post_pass()
     {
-        return $this->response->withStringBody(json_encode($this->request->data));
+        return $this->response->withStringBody(json_encode($this->request->getData()));
     }
 
     /**
@@ -98,7 +98,7 @@ class RequestActionController extends AppController
      */
     public function query_pass()
     {
-        return $this->response->withStringBody(json_encode($this->request->query));
+        return $this->response->withStringBody(json_encode($this->request->getQueryParams()));
     }
 
     /**
@@ -108,7 +108,7 @@ class RequestActionController extends AppController
      */
     public function cookie_pass()
     {
-        return $this->response->withStringBody(json_encode($this->request->cookies));
+        return $this->response->withStringBody(json_encode($this->request->getCookieParams()));
     }
 
     /**


### PR DESCRIPTION
Having public properties on the request is not something we can have in a PSR7 style request object. I've added deprecation warnings to these properties by using magic methods. This may result in small issues, but we don't have many other tools to deprecate public properties.

Unfortunately it is another very large pull request :cry:. This should be the last one though.

Refs #11385