### PR TITLE
Add basic timezone support for form datetime input.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -243,7 +243,8 @@ class DateTimeType extends Type implements TypeInterface
      *
      * @return bool
      */
-    protected function _isEmpty($value) {
+    protected function _isEmpty($value)
+    {
         unset($value['timezone']);
 
         return implode('', $value) === '';

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database\Type;
 
+use Cake\Core\Configure;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
@@ -181,7 +182,7 @@ class DateTimeType extends Type implements TypeInterface
             return $value;
         }
 
-        if (is_array($value) && implode('', $value) === '') {
+        if (is_array($value) && $this->_isEmpty($value)) {
             return null;
         }
         $value += ['hour' => 0, 'minute' => 0, 'second' => 0];
@@ -206,9 +207,17 @@ class DateTimeType extends Type implements TypeInterface
             $value['minute'],
             $value['second']
         );
-        $tz = isset($value['timezone']) ? $value['timezone'] : null;
+        $tz = isset($value['timezone']) ? $value['timezone'] : Configure::read('App.defaultOutputTimezone');
 
-        return new $class($format, $tz);
+        /* @var \Cake\I18n\Time $time */
+        $time = new $class($format, $tz);
+
+        $internalTimezone = date_default_timezone_get();
+        if ($tz && $tz !== $internalTimezone) {
+            $time = $time->timezone($internalTimezone);
+        }
+
+        return $time;
     }
 
     /**
@@ -225,6 +234,19 @@ class DateTimeType extends Type implements TypeInterface
         }
 
         return false;
+    }
+
+    /**
+     * Returns true if the array can be considered an empty date time value.
+     *
+     * @param array $value Date time array.
+     *
+     * @return bool
+     */
+    protected function _isEmpty($value) {
+        unset($value['timezone']);
+
+        return implode('', $value) === '';
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -109,7 +109,7 @@ class FormHelper extends Helper
             // Wrapper container for checkboxes.
             'checkboxWrapper' => '<div class="checkbox">{{label}}</div>',
             // Widget ordering for date/time/datetime pickers.
-            'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
+            'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}{{timezone}}',
             // Error message wrapper elements.
             'error' => '<div class="error-message">{{content}}</div>',
             // Container for error items.

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -524,7 +524,7 @@ class DateTimeWidget implements WidgetInterface
     /**
      * Generates a meridian select
      *
-     * @param array $options The options to generate a meridian select with.
+     * @param array $options The options to generate a meridian select.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
@@ -541,9 +541,9 @@ class DateTimeWidget implements WidgetInterface
     }
 
     /**
-     * Generates a meridian select
+     * Generates a timezone select
      *
-     * @param array $options The options to generate a meridian select with.
+     * @param array $options The options to generate a timezone select.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -164,6 +164,14 @@ class DateTimeWidget implements WidgetInterface
             $templateOptions[$select] = $this->{$method}($data[$select], $context);
             unset($data[$select]);
         }
+
+        if (!empty($selected['timezone'])) {
+            $data['timezone']['name'] = $data['name'] . '[timezone]';
+            $data['timezone']['val'] = $selected['timezone'];
+
+            $templateOptions['timezone'] = $this->_timezoneHidden($data['timezone'], $context);
+        }
+
         unset($data['name'], $data['empty'], $data['disabled'], $data['val']);
         $templateOptions['attrs'] = $this->_templates->formatAttributes($data);
 
@@ -541,23 +549,27 @@ class DateTimeWidget implements WidgetInterface
     }
 
     /**
-     * Generates a timezone select
+     * Generates a hidden input for timezone.
      *
-     * @param array $options The options to generate a timezone select.
+     * @param array $options The options to generate a hidden input for timezone.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
-    protected function _timezoneSelect($options, $context)
+    protected function _timezoneHidden($options, $context)
     {
         $options += [
             'name' => '',
             'val' => null,
-            'style' => ['display: none'],
-            'options' => [$options['val'] => $options['val']],
-            'templateVars' => [],
         ];
 
-        return $this->_select->render($options, $context);
+        return $this->_templates->format('input', [
+            'name' => $options['name'],
+            'type' => 'hidden',
+            'attrs' => $this->_templates->formatAttributes(
+                $options,
+                ['name', 'type']
+            ),
+        ]);
     }
 
     /**
@@ -654,6 +666,13 @@ class DateTimeWidget implements WidgetInterface
             }
 
             $fields[] = $data['name'] . '[' . $select . ']';
+        }
+
+        if (Configure::read('App.defaultOutputTimezone')
+            && $data[$select] !== false
+            && $data[$select] !== null
+        ) {
+            $fields[] = $data['name'] . '[timezone]';
         }
 
         return $fields;

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -267,7 +267,7 @@ class DateTimeWidget implements WidgetInterface
 
                 $date = new DateTime('now', $timezone);
             } else {
-                /* @var \DateTime $value */
+                /* @var \Cake\Chronos\ChronosInterface $value */
                 $date = clone $value;
                 if ($timezone) {
                     $date = $date->timezone($timezone);

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -94,7 +94,7 @@ class DateTimeWidget implements WidgetInterface
      * - `second` - Set to true to enable the seconds input. Defaults to false.
      * - `meridian` - Set to true to enable the meridian input. Defaults to false.
      *   The meridian will be enabled automatically if you choose a 12 hour format.
-     * - `timezone` - A hidden field for timezone handling when working with UTC internally.
+     * - `timezone` - A hidden field for timezone handling when working with a specific timezone internally.
      *
      * The `year` option accepts the `start` and `end` options. These let you control
      * the year range that is generated. It defaults to +-5 years from today.

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -231,7 +231,7 @@ class DateTimeWidget implements WidgetInterface
             } elseif (is_bool($value)) {
                 $date = new DateTime('now', $timezone);
             } elseif (is_int($value) || is_numeric($value)) {
-                $date = new DateTime('@' . $value, $timezone);
+                $date = new DateTime('@' . $value);
             } elseif (is_array($value)) {
                 $dateArray = [
                     'year' => '', 'month' => '', 'day' => '',


### PR DESCRIPTION
Basic stab at https://github.com/cakephp/cakephp/issues/10877

Currently all forms are broken if you follow recommended UTC for DB and localized forms (e.g. UTC+1 Berlin time).
The time in forms is always behind upon transformation to output, and when you save it, it becomes even more behind as it converts it wrong a 2nd time.
Using a defaultOutputTimezone config (and optionally even a timezone dropdown maybe) you can have localized forms and keep the expected timezoned datetime.

If there is only one timezone (output), one can just use config here:
```php
	'App' => [
		'defaultLocale' => env('APP_DEFAULT_LOCALE', 'de_DE'),
		'defaultOutputTimezone' => env('APP_DEFAULT_OUTPUT_TIMEZONE', 'Europe/Berlin'),
```

I kindly ask for help to finalize this for 3.6.