### PR TITLE
Fix PHP7 error handler compatibility.

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -191,10 +191,13 @@ class ErrorHandlerMiddleware
             return;
         }
 
-        $skipLog = $this->getConfig('skipLog');
-        if ($skipLog) {
-            foreach ((array)$skipLog as $class) {
-                if ($exception instanceof $class) {
+        $unwrapped = $exception instanceof PHP7ErrorException ?
+            $exception->getError() :
+            $exception;
+
+        if ($this->getConfig('skipLog')) {
+            foreach ((array)$this->getConfig('skipLog') as $class) {
+                if ($unwrapped instanceof $class) {
                     return;
                 }
             }

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -19,7 +19,9 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Error\ExceptionRenderer;
+use Cake\Error\PHP7ErrorException;
 use Cake\Log\Log;
+use Error;
 use Exception;
 use Throwable;
 
@@ -153,6 +155,11 @@ class ErrorHandlerMiddleware
     {
         if (!$this->exceptionRenderer) {
             $this->exceptionRenderer = $this->getConfig('exceptionRenderer') ?: ExceptionRenderer::class;
+        }
+
+        // For PHP5 backwards compatibility
+        if ($exception instanceof Error) {
+            $exception = new PHP7ErrorException($exception);
         }
 
         if (is_string($this->exceptionRenderer)) {

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -191,15 +191,9 @@ class ErrorHandlerMiddleware
             return;
         }
 
-        $unwrapped = $exception instanceof PHP7ErrorException ?
-            $exception->getError() :
-            $exception;
-
-        if ($this->getConfig('skipLog')) {
-            foreach ((array)$this->getConfig('skipLog') as $class) {
-                if ($unwrapped instanceof $class) {
-                    return;
-                }
+        foreach ((array)$this->getConfig('skipLog') as $class) {
+            if ($exception instanceof $class) {
+                return;
             }
         }
 

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -147,6 +147,24 @@ class ErrorHandlerMiddlewareTest extends TestCase
     }
 
     /**
+     * Test handling PHP 7's Error instance.
+     *
+     * @return void
+     */
+    public function testHandlePHP7Error()
+    {
+        $this->skipIf(version_compare(PHP_VERSION, '7.0.0', '<'), 'Error class only exists since PHP 7.');
+
+        $middleware = new ErrorHandlerMiddleware();
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+        $error = new Error();
+
+        $result = $middleware->handleException($error, $request, $response);
+        $this->assertInstanceOf(Response::class, $result);
+    }
+
+    /**
      * Test rendering an error page logs errors
      *
      * @return void

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -19,6 +19,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use Error;
 use LogicException;
 use Psr\Log\LoggerInterface;
 


### PR DESCRIPTION
Possible solution of https://github.com/cakephp/cakephp/issues/11514
We convert it back to the PHP5 exception where needed as the constructor for ExceptionRenderer exceptions Exception which is not compatible with PHP7.
Removing the typehint here can only be done in a non-patch version as the eco system could implement them still as such.