### PR TITLE
Add to `203` and `204` allowed status code at `Cake\Http\Client\Response::isOk()`

### DIFF
--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -46,6 +46,20 @@ class Message
     const STATUS_ACCEPTED = 202;
 
     /**
+     * HTTP 203 code
+     *
+     * @var int
+     */
+    const STATUS_NON_AUTHORITATIVE_INFORMATION = 203;
+
+    /**
+     * HTTP 204 code
+     *
+     * @var int
+     */
+    const STATUS_NO_CONTENT = 204;
+
+    /**
      * HTTP 301 code
      *
      * @var int

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -236,7 +236,9 @@ class Response extends Message implements ResponseInterface
         $codes = [
             static::STATUS_OK,
             static::STATUS_CREATED,
-            static::STATUS_ACCEPTED
+            static::STATUS_ACCEPTED,
+            static::STATUS_NON_AUTHORITATIVE_INFORMATION,
+            static::STATUS_NO_CONTENT
         ];
 
         return in_array($this->code, $codes);

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -216,6 +216,20 @@ XML;
         $this->assertTrue($response->isOk());
 
         $headers = [
+            'HTTP/1.1 203 Non-Authoritative Information',
+            'Content-Type: text/html'
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isOk());
+
+        $headers = [
+            'HTTP/1.1 204 No Content',
+            'Content-Type: text/html'
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isOk());
+
+        $headers = [
             'HTTP/1.1 301 Moved Permanently',
             'Content-Type: text/html'
         ];


### PR DESCRIPTION
At the moment, `Cake\Http\Client\Response::isOk()` allow to status code between `200` and `202`.
But `Cake\TestSuite\IntegrationTestCase::assertResponseOk()` allow to status code between `200` and `204`.

For example, Status code `204` using to succeed response at `DELETE` method by API call.

#### Call to `http://example.com` with delete method.

- Use `Cake\Http\Client`

```php
// use Cake\Http\Client;
$http = new Client();

// Status code is `204`
$response = $http->delete('http://example.com', $data, $headers);
$body = $response->getBody();
$this->response = $this->response->withStatus($response->getStatusCode());

// `204` is false
if ($response->isOk()) {
    return 'OK';
}
return 'NG';
```

- Use `Cake\TestSuite\IntegrationTestCase`

```php
// TestCase
$this->enableCsrfToken();
$this->delete('http://example.com', $data);
$this->assertResponseOk(); // `204` is OK
```
