### PR TITLE
Refactoring tests

### DIFF
--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -82,8 +82,8 @@ class XcacheEngineTest extends TestCase
             'probability' => 100,
             'groups' => [],
         ];
-        $this->assertTrue(isset($config['PHP_AUTH_USER']));
-        $this->assertTrue(isset($config['PHP_AUTH_PW']));
+        $this->assertArrayHasKey('PHP_AUTH_USER', $config);
+        $this->assertArrayHasKey('PHP_AUTH_PW', $config);
 
         unset($config['PHP_AUTH_USER'], $config['PHP_AUTH_PW']);
         $this->assertEquals($config, $expecting);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -912,8 +912,8 @@ TEXT;
         $this->assertEquals($spec['epilog'], $parser->getEpilog());
 
         $options = $parser->options();
-        $this->assertTrue(isset($options['name']));
-        $this->assertTrue(isset($options['other']));
+        $this->assertArrayHasKey('name', $options);
+        $this->assertArrayHasKey('other', $options);
 
         $args = $parser->arguments();
         $this->assertCount(2, $args);
@@ -1009,8 +1009,8 @@ TEXT;
         $this->assertEquals($spec['epilog'], $result['epilog']);
 
         $options = $result['options'];
-        $this->assertTrue(isset($options['name']));
-        $this->assertTrue(isset($options['other']));
+        $this->assertArrayHasKey('name', $options);
+        $this->assertArrayHasKey('other', $options);
 
         $this->assertCount(2, $result['arguments']);
         $this->assertCount(1, $result['subcommands']);
@@ -1037,10 +1037,10 @@ TEXT;
         $result = $parser->toArray();
 
         $options = $result['options'];
-        $this->assertTrue(isset($options['quiet']));
-        $this->assertTrue(isset($options['test']));
-        $this->assertTrue(isset($options['file']));
-        $this->assertTrue(isset($options['output']));
+        $this->assertArrayHasKey('quiet', $options);
+        $this->assertArrayHasKey('test', $options);
+        $this->assertArrayHasKey('file', $options);
+        $this->assertArrayHasKey('output', $options);
 
         $this->assertCount(2, $result['arguments']);
         $this->assertCount(6, $result['options']);

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -65,7 +65,7 @@ class IniConfigTest extends TestCase
         $engine = new IniConfig($this->path);
         $config = $engine->read('acl');
 
-        $this->assertTrue(isset($config['admin']));
+        $this->assertArrayHasKey('admin', $config);
         $this->assertTrue(isset($config['paul']['groups']));
         $this->assertEquals('ads', $config['admin']['deny']);
     }
@@ -95,7 +95,7 @@ class IniConfigTest extends TestCase
         $engine = new IniConfig($this->path, 'admin');
         $config = $engine->read('acl');
 
-        $this->assertTrue(isset($config['groups']));
+        $this->assertArrayHasKey('groups', $config);
         $this->assertEquals('administrators', $config['groups']);
     }
 

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -140,7 +140,7 @@ class JsonConfigTest extends TestCase
         Plugin::load('TestPlugin');
         $engine = new JsonConfig($this->path);
         $result = $engine->read('TestPlugin.load');
-        $this->assertTrue(isset($result['plugin_load']));
+        $this->assertArrayHasKey('plugin_load', $result);
 
         Plugin::unload();
     }

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -126,7 +126,7 @@ class PhpConfigTest extends TestCase
         Plugin::load('TestPlugin');
         $engine = new PhpConfig($this->path);
         $result = $engine->read('TestPlugin.load');
-        $this->assertTrue(isset($result['plugin_load']));
+        $this->assertArrayHasKey('plugin_load', $result);
 
         Plugin::unload();
     }

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -112,8 +112,8 @@ class ConfigureTest extends TestCase
 
         $result = Configure::read();
         $this->assertInternalType('array', $result);
-        $this->assertTrue(isset($result['debug']));
-        $this->assertTrue(isset($result['level1']));
+        $this->assertArrayHasKey('debug', $result);
+        $this->assertArrayHasKey('level1', $result);
 
         $result = Configure::read('something_I_just_made_up_now');
         $this->assertNull($result, 'Missing key should return null.');

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -122,7 +122,7 @@ class TypeTest extends TestCase
     {
         $map = Type::map();
         $this->assertNotEmpty($map);
-        $this->assertFalse(isset($map['foo']));
+        $this->assertArrayNotHasKey('foo', $map);
 
         $fooType = FooType::class;
         Type::map('foo', $fooType);

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1181,12 +1181,12 @@ class ServerRequestTest extends TestCase
             $this->assertEquals('speedy-slug', $request->slug);
             $this->assertEquals('speedy-slug', $request['slug']);
 
-            $this->assertTrue(isset($request['action']));
-            $this->assertFalse(isset($request['wrong-param']));
+            $this->assertArrayHasKey('action', $request);
+            $this->assertArrayNotHasKey('wrong-param', $request);
 
-            $this->assertTrue(isset($request['plugin']));
+            $this->assertArrayHasKey('plugin', $request);
             unset($request['plugin']);
-            $this->assertFalse(isset($request['plugin']));
+            $this->assertArrayNotHasKey('plugin', $request);
             $this->assertNull($request['plugin']);
             $this->assertNull($request->plugin);
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -527,12 +527,12 @@ class TimeTest extends TestCase
         $this->assertTrue(isset($return['America']['America/Argentina/Buenos_Aires']));
         $this->assertEquals('Argentina/Buenos_Aires', $return['America']['America/Argentina/Buenos_Aires']);
         $this->assertTrue(isset($return['UTC']['UTC']));
-        $this->assertFalse(isset($return['Cuba']));
-        $this->assertFalse(isset($return['US']));
+        $this->assertArrayNotHasKey('Cuba', $return);
+        $this->assertArrayNotHasKey('US', $return);
 
         $return = $class::listTimezones('#^Asia/#');
         $this->assertTrue(isset($return['Asia']['Asia/Bangkok']));
-        $this->assertFalse(isset($return['Pacific']));
+        $this->assertArrayNotHasKey('Pacific', $return);
 
         $return = $class::listTimezones(null, null, ['abbr' => true]);
         $this->assertTrue(isset($return['Asia']['Asia/Jakarta']));
@@ -548,16 +548,16 @@ class TimeTest extends TestCase
         $this->assertEquals('Regina (CST)', $return['America']['America/Regina']);
 
         $return = $class::listTimezones('#^(America|Pacific)/#', null, false);
-        $this->assertTrue(isset($return['America/Argentina/Buenos_Aires']));
-        $this->assertTrue(isset($return['Pacific/Tahiti']));
+        $this->assertArrayHasKey('America/Argentina/Buenos_Aires', $return);
+        $this->assertArrayHasKey('Pacific/Tahiti', $return);
 
         $return = $class::listTimezones(\DateTimeZone::ASIA);
         $this->assertTrue(isset($return['Asia']['Asia/Bangkok']));
-        $this->assertFalse(isset($return['Pacific']));
+        $this->assertArrayNotHasKey('Pacific', $return);
 
         $return = $class::listTimezones(\DateTimeZone::PER_COUNTRY, 'US', false);
-        $this->assertTrue(isset($return['Pacific/Honolulu']));
-        $this->assertFalse(isset($return['Asia/Bangkok']));
+        $this->assertArrayHasKey('Pacific/Honolulu', $return);
+        $this->assertArrayNotHasKey('Asia/Bangkok', $return);
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -549,11 +549,11 @@ class EmailTest extends TestCase
     {
         $this->Email->setMessageId(true);
         $result = $this->Email->getHeaders();
-        $this->assertTrue(isset($result['Message-ID']));
+        $this->assertArrayHasKey('Message-ID', $result);
 
         $this->Email->setMessageId(false);
         $result = $this->Email->getHeaders();
-        $this->assertFalse(isset($result['Message-ID']));
+        $this->assertArrayNotHasKey('Message-ID', $result);
 
         $result = $this->Email->setMessageId('<my-email@localhost>');
         $this->assertSame($this->Email, $result);
@@ -574,7 +574,7 @@ class EmailTest extends TestCase
         $this->assertSame(4, $this->Email->getPriority());
 
         $result = $this->Email->getHeaders();
-        $this->assertTrue(isset($result['X-Priority']));
+        $this->assertArrayHasKey('X-Priority', $result);
     }
 
     /**
@@ -1162,15 +1162,15 @@ class EmailTest extends TestCase
         $expected = "Here is my body, with multi lines.\r\nThis is the second line.\r\n\r\nAnd the last.\r\n\r\n";
 
         $this->assertEquals($expected, $result['message']);
-        $this->assertTrue((bool)strpos($result['headers'], 'Date: '));
-        $this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
-        $this->assertTrue((bool)strpos($result['headers'], 'To: '));
+        $this->assertContains('Date: ', $result['headers']);
+        $this->assertContains('Message-ID: ', $result['headers']);
+        $this->assertContains('To: ', $result['headers']);
 
         $result = $this->Email->send('Other body');
         $expected = "Other body\r\n\r\n";
         $this->assertSame($expected, $result['message']);
-        $this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
-        $this->assertTrue((bool)strpos($result['headers'], 'To: '));
+        $this->assertContains('Message-ID: ', $result['headers']);
+        $this->assertContains('To: ', $result['headers']);
 
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1758,7 +1758,7 @@ class EmailTest extends TestCase
         $result = $this->Email->send();
 
         $expected = mb_convert_encoding('ここにあなたの設定した値が入ります: 日本語の差し込み123', 'ISO-2022-JP');
-        $this->assertTrue((bool)strpos($result['message'], $expected));
+        $this->assertContains($expected, $result['message']);
     }
 
     /**
@@ -1785,7 +1785,7 @@ class EmailTest extends TestCase
         $result = $this->Email->send();
         $dateTime = new \DateTime;
         $dateTime->setTimestamp($timestamp);
-        $this->assertTrue((bool)strpos($result['message'], 'Right now: ' . $dateTime->format($dateTime::ATOM)));
+        $this->assertContains('Right now: ' . $dateTime->format($dateTime::ATOM), $result['message']);
 
         $result = $this->Email->getHelpers();
         $this->assertEquals(['Time'], $result);
@@ -2184,8 +2184,8 @@ class EmailTest extends TestCase
 
         $result = $this->Email->send('This is the message');
 
-        $this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
-        $this->assertTrue((bool)strpos($result['headers'], 'To: '));
+        $this->assertContains('Message-ID: ', $result['headers']);
+        $this->assertContains('To: ', $result['headers']);
     }
 
     /**
@@ -2241,8 +2241,8 @@ class EmailTest extends TestCase
 
         $result = $this->Email->send('This is the message');
 
-        $this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
-        $this->assertTrue((bool)strpos($result['headers'], 'To: '));
+        $this->assertContains('Message-ID: ', $result['headers']);
+        $this->assertContains('To: ', $result['headers']);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -588,10 +588,10 @@ class EntityTest extends TestCase
     public function testIssetArrayAccess()
     {
         $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
-        $this->assertTrue(isset($entity['id']));
-        $this->assertTrue(isset($entity['name']));
-        $this->assertFalse(isset($entity['foo']));
-        $this->assertFalse(isset($entity['thing']));
+        $this->assertArrayHasKey('id', $entity);
+        $this->assertArrayHasKey('name', $entity);
+        $this->assertArrayNotHasKey('foo', $entity);
+        $this->assertArrayNotHasKey('thing', $entity);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3553,7 +3553,7 @@ class TableTest extends TestCase
 
         $validator = $table->getValidator('Behavior');
         $set = $validator->field('name');
-        $this->assertTrue(isset($set['behaviorRule']));
+        $this->assertArrayHasKey('behaviorRule', $set);
     }
 
     /**
@@ -5932,7 +5932,7 @@ class TableTest extends TestCase
 
         $callbackExecuted = false;
         $firstArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) use (&$callbackExecuted) {
-            $this->assertTrue($article instanceof EntityInterface);
+            $this->assertInstanceOf(EntityInterface::class, $article);
             $article->body = 'New body';
             $callbackExecuted = true;
         });

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -156,10 +156,10 @@ class RouteTest extends TestCase
         );
 
         $result = $route->parse('/posts/index', 'GET');
-        $this->assertFalse(isset($result['_ext']));
+        $this->assertArrayNotHasKey('_ext', $result);
 
         $result = $route->parse('/posts/index.pdf', 'GET');
-        $this->assertFalse(isset($result['_ext']));
+        $this->assertArrayNotHasKey('_ext', $result);
 
         $result = $route->setExtensions(['pdf', 'json', 'xml', 'xml.gz'])->parse('/posts/index.pdf', 'GET');
         $this->assertEquals('pdf', $result['_ext']);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1817,7 +1817,7 @@ class RouterTest extends TestCase
         $this->assertEquals('rss', $result['_ext']);
 
         $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
-        $this->assertFalse(isset($result['_ext']));
+        $this->assertArrayNotHasKey('_ext', $result);
 
         Router::extensions(['xml']);
     }

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -73,7 +73,7 @@ class XmlTest extends TestCase
     {
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml);
-        $this->assertTrue($obj instanceof \SimpleXMLElement);
+        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
         $this->assertEquals('tag', (string)$obj->getName());
         $this->assertEquals('value', (string)$obj);
 
@@ -81,7 +81,7 @@ class XmlTest extends TestCase
         $this->assertEquals($obj, Xml::build($xml));
 
         $obj = Xml::build($xml, ['return' => 'domdocument']);
-        $this->assertTrue($obj instanceof \DOMDocument);
+        $this->assertInstanceOf(\DOMDocument::class, $obj);
         $this->assertEquals('tag', $obj->firstChild->nodeName);
         $this->assertEquals('value', $obj->firstChild->nodeValue);
 
@@ -270,7 +270,7 @@ class XmlTest extends TestCase
             ]
         ];
         $obj = Xml::fromArray($xml, 'attributes');
-        $this->assertTrue($obj instanceof \SimpleXMLElement);
+        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
         $this->assertEquals('tags', $obj->getName());
         $this->assertEquals(2, count($obj));
         $xmlText = <<<XML
@@ -283,7 +283,7 @@ XML;
         $this->assertXmlStringEqualsXmlString($xmlText, $obj->asXML());
 
         $obj = Xml::fromArray($xml);
-        $this->assertTrue($obj instanceof \SimpleXMLElement);
+        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
         $this->assertEquals('tags', $obj->getName());
         $this->assertEquals(2, count($obj));
         $xmlText = <<<XML

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -94,10 +94,10 @@ class ValidationSetTest extends TestCase
             ->add('numeric', ['rule' => 'numeric'])
             ->add('other', ['rule' => 'email']);
 
-        $this->assertTrue(isset($set['notBlank']));
-        $this->assertTrue(isset($set['numeric']));
-        $this->assertTrue(isset($set['other']));
-        $this->assertFalse(isset($set['fail']));
+        $this->assertArrayHasKey('notBlank', $set);
+        $this->assertArrayHasKey('numeric', $set);
+        $this->assertArrayHasKey('other', $set);
+        $this->assertArrayNotHasKey('fail', $set);
     }
 
     /**
@@ -110,7 +110,7 @@ class ValidationSetTest extends TestCase
         $set = (new ValidationSet)
             ->add('notBlank', ['rule' => 'notBlank']);
 
-        $this->assertFalse(isset($set['other']));
+        $this->assertArrayNotHasKey('other', $set);
         $set['other'] = ['rule' => 'email'];
         $rule = $set['other'];
         $this->assertInstanceOf('Cake\Validation\ValidationRule', $rule);
@@ -130,13 +130,13 @@ class ValidationSetTest extends TestCase
             ->add('other', ['rule' => 'email']);
 
         unset($set['notBlank']);
-        $this->assertFalse(isset($set['notBlank']));
+        $this->assertArrayNotHasKey('notBlank', $set);
 
         unset($set['numeric']);
-        $this->assertFalse(isset($set['numeric']));
+        $this->assertArrayNotHasKey('numeric', $set);
 
         unset($set['other']);
-        $this->assertFalse(isset($set['other']));
+        $this->assertArrayNotHasKey('other', $set);
     }
 
     /**
@@ -197,17 +197,17 @@ class ValidationSetTest extends TestCase
             ->add('numeric', ['rule' => 'numeric'])
             ->add('other', ['rule' => 'email']);
 
-        $this->assertTrue(isset($set['notBlank']));
+        $this->assertArrayHasKey('notBlank', $set);
         $set->remove('notBlank');
-        $this->assertFalse(isset($set['notBlank']));
+        $this->assertArrayNotHasKey('notBlank', $set);
 
-        $this->assertTrue(isset($set['numeric']));
+        $this->assertArrayHasKey('numeric', $set);
         $set->remove('numeric');
-        $this->assertFalse(isset($set['numeric']));
+        $this->assertArrayNotHasKey('numeric', $set);
 
-        $this->assertTrue(isset($set['other']));
+        $this->assertArrayHasKey('other', $set);
         $set->remove('other');
-        $this->assertFalse(isset($set['other']));
+        $this->assertArrayNotHasKey('other', $set);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1118,9 +1118,9 @@ class ValidatorTest extends TestCase
         $validator
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
-        $this->assertTrue(isset($validator['email']));
-        $this->assertTrue(isset($validator['title']));
-        $this->assertFalse(isset($validator['foo']));
+        $this->assertArrayHasKey('email', $validator);
+        $this->assertArrayHasKey('title', $validator);
+        $this->assertArrayNotHasKey('foo', $validator);
     }
 
     /**
@@ -1151,9 +1151,9 @@ class ValidatorTest extends TestCase
         $validator
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
-        $this->assertTrue(isset($validator['title']));
+        $this->assertArrayHasKey('title', $validator);
         unset($validator['title']);
-        $this->assertFalse(isset($validator['title']));
+        $this->assertArrayNotHasKey('title', $validator);
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -338,7 +338,7 @@ class CellTest extends TestCase
     {
         $cell = $this->View->cell('Articles', [], ['limit' => 10, 'nope' => 'nope']);
         $this->assertEquals(10, $cell->limit);
-        $this->assertFalse(property_exists('nope', $cell), 'Not a valid option');
+        $this->assertObjectNotHasAttribute('nope', $cell, 'Not a valid option');
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7359,7 +7359,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->postButton('Send', '/', ['data' => ['extra' => 'value']]);
-        $this->assertNotFalse(strpos($result, '<input type="hidden" name="extra" value="value"'));
+        $this->assertContains('<input type="hidden" name="extra" value="value"', $result);
     }
 
     /**


### PR DESCRIPTION
Continuing to improve tests, like #11480 and #11498, this time I've used:
- `assertArrayHasKey` and `assertArrayHasKey` instead of `isset` function;
- `assertContains` instead of `strpos` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertObjectNotHasAttribute` instead of `property_exists` function;