### PR TITLE
Possibilty to override the 'Asset.timestamp' value in Configure when generating assetUrls

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -71,7 +71,7 @@ class UrlHelper extends Helper
      *   `fullBase` Return full URL with domain name
      *   `pathPrefix` Path prefix for relative URLs
      *   `plugin` False value will prevent parsing path as a plugin
-     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *   `timestamp` Overrides the value of `Asset.timestamp` in Configure.
      *        Set to false to skip timestamp generation.
      *        Set to true to apply timestamps when debug is true. Set to 'force' to always
      *        enable timestamping regardless of debug value.
@@ -96,7 +96,7 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
-     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *   `timestamp` Overrides the value of `Asset.timestamp` in Configure.
      *        Set to false to skip timestamp generation.
      *        Set to true to apply timestamps when debug is true. Set to 'force' to always
      *        enable timestamping regardless of debug value.
@@ -122,7 +122,7 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
-     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *   `timestamp` Overrides the value of `Asset.timestamp` in Configure.
      *        Set to false to skip timestamp generation.
      *        Set to true to apply timestamps when debug is true. Set to 'force' to always
      *        enable timestamping regardless of debug value.
@@ -148,7 +148,7 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
-     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *   `timestamp` Overrides the value of `Asset.timestamp` in Configure.
      *        Set to false to skip timestamp generation.
      *        Set to true to apply timestamps when debug is true. Set to 'force' to always
      *        enable timestamping regardless of debug value.
@@ -181,11 +181,11 @@ class UrlHelper extends Helper
             $path = Inflector::underscore($plugin) . '/' . $path;
         }
 
-        $optionAssetTimestamp = null;
-        if (array_key_exists('assetTimestamp', $options)) {
-            $optionAssetTimestamp = $options['assetTimestamp'];
+        $optionTimestamp = null;
+        if (array_key_exists('timestamp', $options)) {
+            $optionTimestamp = $options['timestamp'];
         }
-        $webPath = $this->assetTimestamp($this->webroot($path), $optionAssetTimestamp);
+        $webPath = $this->assetTimestamp($this->webroot($path), $optionTimestamp);
 
         $path = $this->_encodeUrl($webPath);
 

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -218,15 +218,15 @@ class UrlHelper extends Helper
      * a timestamp will be added.
      *
      * @param string $path The file path to timestamp, the path must be inside WWW_ROOT
-     * @param bool|string $stamp If set will overrule the value of `Asset.timestamp` in Configure.
+     * @param bool|string $timestamp If set will overrule the value of `Asset.timestamp` in Configure.
      * @return string Path with a timestamp added, or not.
      */
-    public function assetTimestamp($path, $stamp = null)
+    public function assetTimestamp($path, $timestamp = null)
     {
-        if (is_null($stamp)) {
-            $stamp = Configure::read('Asset.timestamp');
+        if (is_null($timestamp)) {
+            $timestamp = Configure::read('Asset.timestamp');
         }
-        $timestampEnabled = $stamp === 'force' || ($stamp === true && Configure::read('debug'));
+        $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));
         if ($timestampEnabled && strpos($path, '?') === false) {
             $filepath = preg_replace(
                 '/^' . preg_quote($this->request->getAttribute('webroot'), '/') . '/',

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -71,6 +71,10 @@ class UrlHelper extends Helper
      *   `fullBase` Return full URL with domain name
      *   `pathPrefix` Path prefix for relative URLs
      *   `plugin` False value will prevent parsing path as a plugin
+     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *        Set to false to skip timestamp generation.
+     *        Set to true to apply timestamps when debug is true. Set to 'force' to always
+     *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
     public function image($path, array $options = [])
@@ -92,6 +96,10 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
+     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *        Set to false to skip timestamp generation.
+     *        Set to true to apply timestamps when debug is true. Set to 'force' to always
+     *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
     public function css($path, array $options = [])
@@ -114,6 +122,10 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
+     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *        Set to false to skip timestamp generation.
+     *        Set to true to apply timestamps when debug is true. Set to 'force' to always
+     *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
     public function script($path, array $options = [])
@@ -136,6 +148,10 @@ class UrlHelper extends Helper
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
+     *   `assetTimestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *        Set to false to skip timestamp generation.
+     *        Set to true to apply timestamps when debug is true. Set to 'force' to always
+     *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
     public function assetUrl($path, array $options = [])
@@ -164,7 +180,14 @@ class UrlHelper extends Helper
         if (isset($plugin)) {
             $path = Inflector::underscore($plugin) . '/' . $path;
         }
-        $path = $this->_encodeUrl($this->assetTimestamp($this->webroot($path)));
+
+        $optionAssetTimestamp = null;
+        if (array_key_exists('assetTimestamp', $options)) {
+            $optionAssetTimestamp = $options['assetTimestamp'];
+        }
+        $webPath = $this->assetTimestamp($this->webroot($path), $optionAssetTimestamp);
+
+        $path = $this->_encodeUrl($webPath);
 
         if (!empty($options['fullBase'])) {
             $path = rtrim(Router::fullBaseUrl(), '/') . '/' . ltrim($path, '/');
@@ -195,11 +218,14 @@ class UrlHelper extends Helper
      * a timestamp will be added.
      *
      * @param string $path The file path to timestamp, the path must be inside WWW_ROOT
+     * @param bool|string $stamp If set will overrule the value of `Asset.timestamp` in Configure.
      * @return string Path with a timestamp added, or not.
      */
-    public function assetTimestamp($path)
+    public function assetTimestamp($path, $stamp = null)
     {
-        $stamp = Configure::read('Asset.timestamp');
+        if (is_null($stamp)) {
+            $stamp = Configure::read('Asset.timestamp');
+        }
         $timestampEnabled = $stamp === 'force' || ($stamp === true && Configure::read('debug'));
         if ($timestampEnabled && strpos($path, '?') === false) {
             $filepath = preg_replace(

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -223,7 +223,7 @@ class UrlHelper extends Helper
      */
     public function assetTimestamp($path, $timestamp = null)
     {
-        if (is_null($timestamp)) {
+        if ($timestamp === null) {
             $timestamp = Configure::read('Asset.timestamp');
         }
         $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -314,6 +314,20 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test script and Asset.timestamp = force
+     *
+     * @return void
+     */
+    public function testScriptTimestampForce()
+    {
+        $this->Helper->webroot = '';
+        Configure::write('Asset.timestamp', 'force');
+
+        $result = $this->Helper->script('script.js');
+        $this->assertRegExp('/' . preg_quote(Configure::read('App.jsBaseUrl') . 'script.js?', '/') . '[0-9]+/', $result);
+    }
+
+    /**
      * test image()
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -394,6 +394,20 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test image with timestamp option overriding `Asset.timestamp` in Configure
+     *
+     * @return void
+     */
+    public function testCssTimestampConfigureOverride()
+    {
+        Configure::write('Asset.timestamp', 'force');
+        $timestamp = false;
+
+        $result = $this->Helper->css('cake.generic', ['timestamp' => $timestamp]);
+        $this->assertEquals('css/cake.generic.css', $result);
+    }
+
+    /**
      * Test generating paths with webroot().
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -343,6 +343,19 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test image with `Asset.timestamp` = force
+     *
+     * @return void
+     */
+    public function testImageTimestampForce()
+    {
+        Configure::write('Asset.timestamp', 'force');
+
+        $result = $this->Helper->image('cake.icon.png');
+        $this->assertRegExp('/' . preg_quote('img/cake.icon.png?', '/') . '[0-9]+/', $result);
+    }
+
+    /**
      * test css
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -338,7 +338,7 @@ class UrlHelperTest extends TestCase
         $timestamp = false;
 
         $result = $this->Helper->script('script.js', ['timestamp' => $timestamp]);
-        $this->assertEquals(Configure::read('App.jsBaseUrl').'script.js', $result);
+        $this->assertEquals(Configure::read('App.jsBaseUrl') . 'script.js', $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -254,6 +254,11 @@ class UrlHelperTest extends TestCase
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
     }
 
+    /**
+     * Test assetTimestamp with timestamp option overriding `Asset.timestamp` in Configure.
+     *
+     * @return void
+     */
     public function testAssetTimestampConfigureOverride()
     {
         $this->Helper->webroot = '';

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -328,6 +328,20 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test script with timestamp option overriding `Asset.timestamp` in Configure
+     *
+     * @return void
+     */
+    public function testScriptTimestampConfigureOverride()
+    {
+        Configure::write('Asset.timestamp', 'force');
+        $timestamp = false;
+
+        $result = $this->Helper->script('script.js', ['timestamp' => $timestamp]);
+        $this->assertEquals(Configure::read('App.jsBaseUrl').'script.js', $result);
+    }
+
+    /**
      * test image()
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -356,6 +356,20 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test image with timestamp option overriding `Asset.timestamp` in Configure
+     *
+     * @return void
+     */
+    public function testImageTimestampConfigureOverride()
+    {
+        Configure::write('Asset.timestamp', 'force');
+        $timestamp = false;
+
+        $result = $this->Helper->image('cake.icon.png', ['timestamp' => $timestamp]);
+        $this->assertEquals('img/cake.icon.png', $result);
+    }
+
+    /**
      * test css
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -381,6 +381,19 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Test css with `Asset.timestamp` = force
+     *
+     * @return void
+     */
+    public function testCssTimestampForce()
+    {
+        Configure::write('Asset.timestamp', 'force');
+
+        $result = $this->Helper->css('cake.generic');
+        $this->assertRegExp('/' . preg_quote('css/cake.generic.css?', '/') . '[0-9]+/', $result);
+    }
+
+    /**
      * Test generating paths with webroot().
      *
      * @return void

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -254,6 +254,16 @@ class UrlHelperTest extends TestCase
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
     }
 
+    public function testAssetTimestampConfigureOverride()
+    {
+        $this->Helper->webroot = '';
+        Configure::write('Asset.timestamp', 'force');
+        $timestamp = false;
+
+        $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $timestamp);
+        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+    }
+
     /**
      * test assetTimestamp with plugins and themes
      *


### PR DESCRIPTION
See issue #11520 