### PR TITLE
Provide consistent formatting besides the translating+formatting.

### DIFF
--- a/src/I18n/Formatter/FormatterInterface.php
+++ b/src/I18n/Formatter/FormatterInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\I18n\Formatter;
+
+interface FormatterInterface
+{
+    /**
+     * Formats message
+     *
+     * @param string $message
+     * @param string|array $args
+     * @return string
+     */
+    public function format($message, $args);
+}

--- a/src/I18n/Formatter/FormatterInterface.php
+++ b/src/I18n/Formatter/FormatterInterface.php
@@ -19,8 +19,8 @@ interface FormatterInterface
     /**
      * Formats message
      *
-     * @param string $message
-     * @param string|array $args
+     * @param string $message The message content.
+     * @param string|array $args Argument or multiple arguments.
      * @return string
      */
     public function format($message, $args);

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -17,9 +17,11 @@ namespace Cake\I18n;
 use Aura\Intl\FormatterLocator;
 use Aura\Intl\PackageLocator;
 use Cake\Cache\Cache;
+use Cake\I18n\Formatter\FormatterInterface;
 use Cake\I18n\Formatter\IcuFormatter;
 use Cake\I18n\Formatter\SprintfFormatter;
 use Locale;
+use RuntimeException;
 
 /**
  * I18n handles translation of Text and time format strings.
@@ -194,7 +196,7 @@ class I18n
      *
      * @param string $name The domain of the translation messages.
      * @param string|null $locale The locale for the translator.
-     * @return \Aura\Intl\TranslatorInterface The configured translator.
+     * @return \Aura\Intl\TranslatorInterface|\Cake\I18n\Formatter\FormatterInterface The configured translator.
      */
     public static function getTranslator($name = 'default', $locale = null)
     {
@@ -212,6 +214,23 @@ class I18n
         }
 
         return $translator;
+    }
+
+    /**
+     * Formats a message with the same formatter as the translator uses.
+     *
+     * @param string $message The message content.
+     * @param string|array $args Array with arguments or multiple arguments in function.
+     * @return string
+     */
+    public static function format($message, $args)
+    {
+        $translator = static::getTranslator();
+        if (!($translator instanceof FormatterInterface)) {
+            throw new RuntimeException(sprintf('Translater %s does not implement %s', get_class($translator), FormatterInterface::class));
+        }
+
+        return $translator->format($message, $args);
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -220,7 +220,7 @@ class I18n
      * Formats a message with the same formatter as the translator uses.
      *
      * @param string $message The message content.
-     * @param string|array $args Array with arguments or multiple arguments in function.
+     * @param string|array $args Argument or multiple arguments.
      * @return string
      */
     public static function format($message, $args)

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -13,13 +13,14 @@
 namespace Cake\I18n;
 
 use Aura\Intl\Translator as BaseTranslator;
+use Cake\I18n\Formatter\FormatterInterface;
 
 /**
  * Provides missing message behavior for CakePHP internal message formats.
  *
  * @internal
  */
-class Translator extends BaseTranslator
+class Translator extends BaseTranslator implements FormatterInterface
 {
 
     const PLURAL_PREFIX = 'p:';
@@ -84,6 +85,18 @@ class Translator extends BaseTranslator
         }
 
         return $this->formatter->format($this->locale, $message, $tokensValues);
+    }
+
+    /**
+     * Formats a message with the same formatter as the translator uses.
+     *
+     * @param string $message The message content.
+     * @param string|array $args Array with arguments or multiple arguments in function.
+     * @return string
+     */
+    public function format($message, $args)
+    {
+        return $this->formatter->format($this->locale, $message, (array)$args);
     }
 
     /**

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -91,7 +91,7 @@ class Translator extends BaseTranslator implements FormatterInterface
      * Formats a message with the same formatter as the translator uses.
      *
      * @param string $message The message content.
-     * @param string|array $args Array with arguments or multiple arguments in function.
+     * @param string|array $args Argument or multiple arguments.
      * @return string
      */
     public function format($message, $args)


### PR DESCRIPTION
This resolves a painpoint in terms of i18n localization and un-DRY strings.
See https://github.com/cakephp/localized/pull/181#pullrequestreview-80384815
Resolves https://github.com/cakephp/cakephp/issues/11524

Usage:
```php
$message = 'List {0}';
$args = 'Posts';
\Cake\I18n\I18n::getTranslator()->format($message, $args);
```
But a cleaner way would be to use the I18n wrapper directly:
```php
$message = 'List {0} of {1}';
$args = ['Posts', 'today'];
\Cake\I18n\I18n::format($message, $args)
```

So the core FormHelper and other classes can then be fixed from

    $actionName = __d('cake', 'New %s');
    $legend = sprintf($actionName, $modelName);

to

    $actionName = __d('cake', 'New {0}');
    $legend = I18n::format($actionName, $modelName);

and reuse the same strings

A small migration guide can be added to clarify the translations.
I will also add tests if this looks all good.

One could even completely use old %s syntax by translating `New {0}` to `New %s` and configurating i18n properly, so the internal formatting would use the sprintf() one then.