### PR TITLE
Clean else

### DIFF
--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -350,9 +350,9 @@ class CounterCacheBehaviorTest extends TestCase
 
                     if (!$original) {
                         return 2;
-                    } else {
-                        return 1;
                     }
+
+                    return 1;
                 }
             ]
         ]);


### PR DESCRIPTION
Small one: I've removed the `else` when we have already returned something :put_litter_in_its_place: