### PR TITLE
Fix dispatched event info display in debug.

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -576,10 +576,14 @@ class EventManager
             $properties['_listeners'][$key] = $listenerCount . ' listener(s)';
         }
         if ($this->_eventList) {
-            foreach ($this->_eventList as $event) {
+            for ($i = 0; $i < count($this->_eventList); $i++) {
+                $event = $this->_eventList[$i];
                 $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . get_class($event->getSubject());
             }
+        } else {
+            $properties['_dispatchedEvents'] = null;
         }
+        unset($properties['_eventList']);
 
         return $properties;
     }

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -576,7 +576,8 @@ class EventManager
             $properties['_listeners'][$key] = $listenerCount . ' listener(s)';
         }
         if ($this->_eventList) {
-            for ($i = 0; $i < count($this->_eventList); $i++) {
+            $count = count($this->_eventList);
+            for ($i = 0; $i < $count; $i++) {
                 $event = $this->_eventList[$i];
                 $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . get_class($event->getSubject());
             }

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -819,7 +819,7 @@ class EventManagerTest extends TestCase
         );
 
         $eventManager->setEventList(new EventList());
-        $eventManager->addEventToList(new Event('Foo'));
+        $eventManager->addEventToList(new Event('Foo', $this));
         $this->assertSame(
             [
                 '_listeners' => [],
@@ -827,7 +827,7 @@ class EventManagerTest extends TestCase
                 '_trackEvents' => true,
                 '_generalManager' => '(object) EventManager',
                 '_dispatchedEvents' => [
-                    'Foo with subject Cake\Event\EventManager'
+                    'Foo with subject Cake\Test\TestCase\Event\EventManagerTest'
                 ],
             ],
             $eventManager->__debugInfo()

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -811,12 +811,29 @@ class EventManagerTest extends TestCase
             [
                 '_listeners' => [],
                 '_isGlobal' => false,
-                '_eventList' => null,
                 '_trackEvents' => false,
                 '_generalManager' => '(object) EventManager',
+                '_dispatchedEvents' => null,
             ],
             $eventManager->__debugInfo()
         );
+
+        $eventManager->setEventList(new EventList());
+        $eventManager->addEventToList(new Event('Foo'));
+        $this->assertSame(
+            [
+                '_listeners' => [],
+                '_isGlobal' => false,
+                '_trackEvents' => true,
+                '_generalManager' => '(object) EventManager',
+                '_dispatchedEvents' => [
+                    'Foo with subject Cake\Event\EventManager'
+                ],
+            ],
+            $eventManager->__debugInfo()
+        );
+
+        $eventManager->unsetEventList();
 
         $func = function () {
         };
@@ -828,9 +845,9 @@ class EventManagerTest extends TestCase
                     'foo' => '1 listener(s)',
                 ],
                 '_isGlobal' => false,
-                '_eventList' => null,
                 '_trackEvents' => false,
                 '_generalManager' => '(object) EventManager',
+                '_dispatchedEvents' => null,
             ],
             $eventManager->__debugInfo()
         );
@@ -843,9 +860,9 @@ class EventManagerTest extends TestCase
                     'foo' => '0 listener(s)',
                 ],
                 '_isGlobal' => false,
-                '_eventList' => null,
                 '_trackEvents' => false,
                 '_generalManager' => '(object) EventManager',
+                '_dispatchedEvents' => null,
             ],
             $eventManager->__debugInfo()
         );
@@ -867,9 +884,9 @@ class EventManagerTest extends TestCase
                     'baz' => '1 listener(s)',
                 ],
                 '_isGlobal' => false,
-                '_eventList' => null,
                 '_trackEvents' => false,
                 '_generalManager' => '(object) EventManager',
+                '_dispatchedEvents' => null,
             ],
             $eventManager->__debugInfo()
         );


### PR DESCRIPTION
"foreach" can't be used for event list since it's not traversable.