### PR TITLE
Only sort paths once.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -384,7 +384,7 @@ class Route
             if ($value === null) {
                 continue;
             }
-            if (is_bool($value)) {
+            if ($value === true || $value === false) {
                 $value = $value ? '1' : '0';
             }
             $name .= $value . $glue;

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -155,7 +155,10 @@ class Route
      */
     public function setExtensions(array $extensions)
     {
-        $this->_extensions = array_map('strtolower', $extensions);
+        $this->_extensions = [];
+        foreach ($extensions as $ext) {
+            $this->_extensions[] = strtolower($ext);
+        }
 
         return $this;
     }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -743,7 +743,9 @@ class RouteBuilder
             }
 
             $route = str_replace('//', '/', $this->_path . $route);
-            $route = $route === '/' ? $route : rtrim($route, '/');
+            if ($route !== '/') {
+                $route = rtrim($route, '/');
+            }
 
             foreach ($this->_params as $param => $val) {
                 if (isset($defaults[$param]) && $param !== 'prefix' && $defaults[$param] !== $val) {
@@ -758,8 +760,7 @@ class RouteBuilder
                     ));
                 }
             }
-            $defaults += $this->_params;
-            $defaults += ['plugin' => null];
+            $defaults += $this->_params + ['plugin' => null];
 
             $route = new $routeClass($route, $defaults, $options);
         }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -121,10 +121,6 @@ class RouteCollection
 
         // Index path prefixes (for parsing)
         $path = $route->staticPath();
-        if (empty($this->_paths[$path])) {
-            $this->_paths[$path] = [];
-            krsort($this->_paths);
-        }
         $this->_paths[$path][] = $route;
 
         $extensions = $route->getExtensions();
@@ -144,7 +140,12 @@ class RouteCollection
     public function parse($url, $method = '')
     {
         $decoded = urldecode($url);
-        foreach (array_keys($this->_paths) as $path) {
+
+        // Sort path segments matching longest paths first.
+        $paths = array_keys($this->_paths);
+        rsort($paths);
+
+        foreach ($paths as $path) {
             if (strpos($decoded, $path) !== 0) {
                 continue;
             }
@@ -189,7 +190,12 @@ class RouteCollection
     {
         $uri = $request->getUri();
         $urlPath = urldecode($uri->getPath());
-        foreach (array_keys($this->_paths) as $path) {
+
+        // Sort path segments matching longest paths first.
+        $paths = array_keys($this->_paths);
+        rsort($paths);
+
+        foreach ($paths as $path) {
             if (strpos($urlPath, $path) !== 0) {
                 continue;
             }


### PR DESCRIPTION
This removes overhead when adding a large number of routes, as the path keys should only be sorted when we're parsing and not on each add.