### PR TITLE
Adds the possibility of using innerJoin after contain

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Database;
 
 use Cake\Database\Expression\OrderByExpression;
@@ -41,6 +42,13 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @var \Cake\Database\Connection
      */
     protected $_connection;
+
+    /**
+     * Enable smart ordering of JOIN.
+     *
+     * @var bool
+     */
+    protected $_smartJoin = false;
 
     /**
      * Type of this query (select, insert, update, delete).
@@ -1927,6 +1935,31 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Toggle smart join.
+     *
+     * If set to true, enables smart sorting in query compilation.
+     *
+     * @param bool $enable Use a boolean to set the smart join mode.
+     * @return $this
+     */
+    public function enableSmartJoin($enable = true)
+    {
+        $this->_smartJoin = (bool)$enable;
+
+        return $this;
+    }
+
+    /**
+     * Returns the current hydration mode.
+     *
+     * @return bool
+     */
+    public function isSmartJoin()
+    {
+        return $this->_smartJoin;
+    }
+
+    /**
      * Enable/Disable buffered results.
      *
      * When enabled the results returned by this Query will be
@@ -1965,6 +1998,7 @@ class Query implements ExpressionInterface, IteratorAggregate
 
         return $this;
     }
+
     /**
      * Gets the TypeMap class where the types for each of the fields in the
      * select clause are stored.

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Database;
 
 use Cake\Database\Expression\QueryExpression;
@@ -223,6 +224,9 @@ class QueryCompiler
      */
     protected function _buildJoinPart($parts, $query, $generator)
     {
+        if ($query->isSmartJoin())
+            return $this->_buildJoinPartSmartly($parts, $query, $generator);
+
         $joins = '';
         foreach ($parts as $join) {
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
@@ -248,6 +252,70 @@ class QueryCompiler
         }
 
         return $joins;
+    }
+
+    /**
+     *
+     * @param array $parts list of joins to be transformed to string
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @return string
+     */
+    protected function _buildJoinPartSmartly($parts, $query, $generator)
+    {
+        $alias = [];
+        $joins = [];
+        $order = [];
+        foreach (array_reverse($parts) as $join) {
+            $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
+            if ($join['table'] instanceof ExpressionInterface) {
+                $join['table'] = $join['table']->sql($generator);
+            }
+
+            if ($subquery) {
+                $join['table'] = '(' . $join['table'] . ')';
+            }
+
+            $part = sprintf(' %s JOIN %s %s', $join['type'], $join['table'], $join['alias']);
+
+            $condition = '';
+            if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
+                $condition = $join['conditions']->sql($generator);
+            }
+
+            $ordered = false;
+            if (preg_match_all('/(^|\s)([\w\d]+)\s*\.|`([^`]+)`\s*\./', $condition, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $identified = end($match);
+                    if (isset($alias[$identified]) && $p = array_search($alias[$identified], $order) !== false) {
+                        $order = array_merge(array_slice($order, 0, $p + 1), [$join['alias']], array_slice($order, $p + 1));
+                        $ordered = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!$ordered)
+                array_unshift($order, $join['alias']);
+
+            if (strlen($condition)) {
+                $part .= " ON {$condition}";
+            } else {
+                $part .= ' ON 1 = 1';
+            }
+
+            $joins[$join['alias']] = $part;
+
+            $alias[trim($join['alias'], '`')] = $join['alias'];
+            $alias[trim($join['table'], '`')] = $join['alias'];
+        }
+
+        $part = '';
+        foreach ($order as $alias) {
+            $part .= $joins[$alias];
+        }
+
+        return $part;
     }
 
     /**

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -225,7 +225,6 @@ class QueryCompiler
     protected function _buildJoinPart($parts, $query, $generator)
     {
         if ($query->isSmartJoin()) {
-
             return $this->_buildJoinPartSmartly($parts, $query, $generator);
         }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -224,8 +224,10 @@ class QueryCompiler
      */
     protected function _buildJoinPart($parts, $query, $generator)
     {
-        if ($query->isSmartJoin())
+        if ($query->isSmartJoin()) {
+
             return $this->_buildJoinPartSmartly($parts, $query, $generator);
+        }
 
         $joins = '';
         foreach ($parts as $join) {
@@ -295,8 +297,9 @@ class QueryCompiler
                 }
             }
 
-            if (!$ordered)
+            if (!$ordered) {
                 array_unshift($order, $join['alias']);
+            }
 
             if (strlen($condition)) {
                 $part .= " ON {$condition}";

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -460,7 +460,7 @@ class EagerLoader
      *
      * @param \Cake\ORM\Table $repository The table containing the associations to be
      * attached
-     * @return array
+     * @return \Cake\ORM\EagerLoadable[]
      */
     public function attachableAssociations(Table $repository)
     {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\ORM;
 
 use ArrayObject;
@@ -42,16 +43,16 @@ use RuntimeException;
  * @method \Cake\Collection\CollectionInterface extract($field) Extracts a single column from each row
  * @method mixed max($field, $type = SORT_NUMERIC) Returns the maximum value for a single column in all the results.
  * @method mixed min($field, $type = SORT_NUMERIC) Returns the minimum value for a single column in all the results.
- * @method \Cake\Collection\CollectionInterface groupBy(string|callable $field) In-memory group all results by the value of a column.
- * @method \Cake\Collection\CollectionInterface indexBy(string|callable $field) Returns the results indexed by the value of a column.
- * @method int countBy(string|callable $field) Returns the number of unique values for a column
- * @method float sumOf(string|callable $field) Returns the sum of all values for a single column
+ * @method \Cake\Collection\CollectionInterface groupBy(string | callable $field) In-memory group all results by the value of a column.
+ * @method \Cake\Collection\CollectionInterface indexBy(string | callable $field) Returns the results indexed by the value of a column.
+ * @method int countBy(string | callable $field) Returns the number of unique values for a column
+ * @method float sumOf(string | callable $field) Returns the sum of all values for a single column
  * @method \Cake\Collection\CollectionInterface shuffle() In-memory randomize the order the results are returned
  * @method \Cake\Collection\CollectionInterface sample($size = 10) In-memory shuffle the results and return a subset of them.
  * @method \Cake\Collection\CollectionInterface take($size = 1, $from = 0) In-memory limit and offset for the query results.
  * @method \Cake\Collection\CollectionInterface skip(int $howMany) Skips some rows from the start of the query result.
  * @method mixed last() Return the last row of the query result
- * @method \Cake\Collection\CollectionInterface append(array|\Traversable $items) Appends more rows to the result of the query.
+ * @method \Cake\Collection\CollectionInterface append(array | \Traversable $items) Appends more rows to the result of the query.
  * @method \Cake\Collection\CollectionInterface combine($k, $v, $g = null) Returns the values of the column $v index by column $k,
  *   and grouped by $g.
  * @method \Cake\Collection\CollectionInterface nest($k, $p, $n = 'children') Creates a tree structure by nesting the values of column $p into that
@@ -59,7 +60,7 @@ use RuntimeException;
  * @method array toArray() Returns a key-value array with the results of this query.
  * @method array toList() Returns a numerically indexed array with the results of this query.
  * @method \Cake\Collection\CollectionInterface stopWhen(callable $c) Returns each row until the callable returns true.
- * @method \Cake\Collection\CollectionInterface zip(array|\Traversable $c) Returns the first result of both the query and $c in an array,
+ * @method \Cake\Collection\CollectionInterface zip(array | \Traversable $c) Returns the first result of both the query and $c in an array,
  *   then the second results and so on.
  * @method \Cake\Collection\CollectionInterface zipWith($collections, callable $callable) Returns each of the results out of calling $c
  *   with the first rows of the query and each of the items, then the second rows and so on.
@@ -1068,6 +1069,32 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
+     * Intelligently sorts the join according to the conditions.
+     *
+     * @return void
+     */
+    protected function _smartOrderingJoin()
+    {
+        if (count($this->_parts['join']) < 2)
+            return;
+
+        $keys = array_keys($this->_parts['join']);
+        $names = [];
+
+        for ($i = count($keys) - 1; $i >= 0; $i--) {
+            if (!is_numeric($keys[$i]))
+                $names[$keys[$i]] = $keys[$i];
+
+            $join = &$this->_parts['join'][$keys[$i]];
+
+            $names[$join['table']] = $keys[$i];
+
+            //$join['conditions'];
+
+        }
+    }
+
+    /**
      * Inspects if there are any set fields for selecting, otherwise adds all
      * the fields for the default table.
      *
@@ -1215,15 +1242,15 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $eagerLoader = $this->getEagerLoader();
 
         return parent::__debugInfo() + [
-            'hydrate' => $this->_hydrate,
-            'buffered' => $this->_useBufferedResults,
-            'formatters' => count($this->_formatters),
-            'mapReducers' => count($this->_mapReduce),
-            'contain' => $eagerLoader ? $eagerLoader->contain() : [],
-            'matching' => $eagerLoader ? $eagerLoader->getMatching() : [],
-            'extraOptions' => $this->_options,
-            'repository' => $this->_repository
-        ];
+                'hydrate' => $this->_hydrate,
+                'buffered' => $this->_useBufferedResults,
+                'formatters' => count($this->_formatters),
+                'mapReducers' => count($this->_mapReduce),
+                'contain' => $eagerLoader ? $eagerLoader->contain() : [],
+                'matching' => $eagerLoader ? $eagerLoader->getMatching() : [],
+                'extraOptions' => $this->_options,
+                'repository' => $this->_repository
+            ];
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1059,20 +1059,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             return;
         }
 
-        $joins = $this->_parts['join'];
-        $this->_parts['join'] = [];
-
         if (empty($this->_parts['from'])) {
             $this->from([$this->_repository->getAlias() => $this->_repository->table()]);
         }
         $this->_addDefaultFields();
         $this->getEagerLoader()->attachAssociations($this, $this->_repository, !$this->_hasFields);
         $this->_addDefaultSelectTypes();
-
-        $i = count($this->_parts['join']);
-        foreach ($joins as $a => $j) {
-            $this->_parts['join'][is_string($a) ? $a : $i++] = $j;
-        }
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1059,12 +1059,20 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             return;
         }
 
+        $joins = $this->_parts['join'];
+        $this->_parts['join'] = [];
+
         if (empty($this->_parts['from'])) {
             $this->from([$this->_repository->getAlias() => $this->_repository->table()]);
         }
         $this->_addDefaultFields();
         $this->getEagerLoader()->attachAssociations($this, $this->_repository, !$this->_hasFields);
         $this->_addDefaultSelectTypes();
+
+        $i = count($this->_parts['join']);
+        foreach ($joins as $a => $j) {
+            $this->_parts['join'][is_string($a) ? $a : $i++] = $j;
+        }
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1069,32 +1069,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
-     * Intelligently sorts the join according to the conditions.
-     *
-     * @return void
-     */
-    protected function _smartOrderingJoin()
-    {
-        if (count($this->_parts['join']) < 2)
-            return;
-
-        $keys = array_keys($this->_parts['join']);
-        $names = [];
-
-        for ($i = count($keys) - 1; $i >= 0; $i--) {
-            if (!is_numeric($keys[$i]))
-                $names[$keys[$i]] = $keys[$i];
-
-            $join = &$this->_parts['join'][$keys[$i]];
-
-            $names[$join['table']] = $keys[$i];
-
-            //$join['conditions'];
-
-        }
-    }
-
-    /**
      * Inspects if there are any set fields for selecting, otherwise adds all
      * the fields for the default table.
      *

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -729,9 +729,7 @@ class Inflector
         $result = static::_cache(__FUNCTION__, $string);
 
         if ($result === false) {
-            $camelized = static::camelize(static::underscore($string));
-            $replace = strtolower(substr($camelized, 0, 1));
-            $result = $replace . substr($camelized, 1);
+            $result = lcfirst(static::camelize(static::underscore($string)));
             static::_cache(__FUNCTION__, $string, $result);
         }
 


### PR DESCRIPTION
Example of use:

$Users->find()->contain(['Contacts'])->innerJoin(['CT' => 'contact_types'], ['CT.id = Contacts.contact_type_id']);