### PR TITLE
Fix gc as per interface definition and expectation/documentation.

### DIFF
--- a/src/Network/Session/CacheSession.php
+++ b/src/Network/Session/CacheSession.php
@@ -123,7 +123,7 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Helper function called on gc for cache sessions.
      *
-     * @param string $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
+     * @param int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return bool Always true.
      */
     public function gc($maxlifetime)

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -170,12 +170,12 @@ class DatabaseSession implements SessionHandlerInterface
     /**
      * Helper function called on gc for database sessions.
      *
-     * @param string $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
+     * @param int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return bool True on success, false on failure.
      */
     public function gc($maxlifetime)
     {
-        $this->_table->deleteAll(['expires <' => time()]);
+        $this->_table->deleteAll(['expires <' => time() - $maxlifetime]);
 
         return true;
     }


### PR DESCRIPTION
The PHP session handler states
```php
	 * @param int $maxlifetime <p>
	 * Sessions that have not updated for
	 * the last maxlifetime seconds will be removed.
	 * </p>
	 * @return bool <p>
	 * The return value (usually TRUE on success, FALSE on failure).
	 * Note this value is returned internally to PHP for processing.
	 * </p>
	 * @since 5.4.0
	 */
	public function gc($maxlifetime);
```

And Cache class already uses
```php
Cache::gc($this->_options['config'], time() - $maxlifetime);
```

Must have been an oversight in upgrading to 3.x.
