### PR TITLE
Consolidate placeholders to new syntax. Eases 4.x migration.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1046,13 +1046,13 @@ class FormHelper extends Helper
         }
 
         if ($legend === true) {
-            $actionName = __d('cake', 'New %s');
             $isCreate = $context->isCreate();
-            if (!$isCreate) {
-                $actionName = __d('cake', 'Edit %s');
-            }
             $modelName = Inflector::humanize(Inflector::singularize($this->request->getParam('controller')));
-            $legend = sprintf($actionName, $modelName);
+            if (!$isCreate) {
+                $legend = __d('cake', 'Edit {0}', $modelName);
+            } else {
+                $legend = __d('cake', 'New {0}', $modelName);
+            }
         }
 
         if ($fieldset !== false) {


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/11540
Resolves https://github.com/cakephp/cakephp/issues/11524

Docs: https://github.com/cakephp/docs/pull/5478

Consolidating translation strings.

This eases migration for 4.0 as this can be cleaned up in 3.6 with migration guide.
Also less confusion for those upgrading from 2.x and str-replacing all placeholders to discover that some do not function as expected.