### PR TITLE
Fix non interactive to only overwrite with designed force flag enabled.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -879,7 +879,14 @@ class Shell
 
         $this->_io->out();
 
-        if (is_file($path) && empty($this->params['force']) && $this->interactive) {
+        $fileExists = is_file($path);
+        if ($fileExists && empty($this->params['force']) && !$this->interactive) {
+            $this->_io->out('<warning>File exists, skipping</warning>.');
+
+            return false;
+        }
+
+        if ($fileExists && $this->interactive && empty($this->params['force'])) {
             $this->_io->out(sprintf('<warning>File `%s` exists</warning>', $path));
             $key = $this->_io->askChoice('Do you want to overwrite?', ['y', 'n', 'a', 'q'], 'n');
 

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -65,7 +65,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $expected = "/\[.*CORE.*\] cache, help, i18n, orm_cache, plugin, routes, server/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] i18m, integration, sample/";
+        $expected = "/\[.*app.*\] i18m, integration, merge, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();
@@ -86,7 +86,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $expected = "/\[.*CORE.*\] cache, help, orm_cache, plugin, routes, server/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] i18n, integration, sample/";
+        $expected = "/\[.*app.*\] i18n, integration, merge, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -116,7 +116,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = 'TestPlugin.example TestPlugin.sample TestPluginTwo.example unique welcome ' .
-            "cache help i18n orm_cache plugin routes server version i18m integration sample testing_dispatch\n";
+            "cache help i18n orm_cache plugin routes server version i18m integration merge sample test testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 

--- a/tests/test_app/TestApp/Shell/MergeShell.php
+++ b/tests/test_app/TestApp/Shell/MergeShell.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * MergeShell file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.8
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace TestApp\Shell;
+
+use Cake\Console\Shell;
+
+/**
+ * for testing merging vars
+ */
+class MergeShell extends Shell
+{
+    /**
+     * @var array
+     */
+    public $tasks = ['DbConfig', 'Fixture'];
+
+    /**
+     * @var string
+     */
+    public $modelClass = 'Articles';
+}

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * ShellTestShell file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.8
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace TestApp\Shell;
+
+use Cake\Console\Shell;
+
+/**
+ * ShellTestShell class
+ */
+class ShellTestShell extends Shell
+{
+    /**
+     * name property
+     *
+     * @var string
+     */
+    public $name = 'ShellTestShell';
+
+    /**
+     * stopped property
+     *
+     * @var int
+     */
+    public $stopped;
+
+    /**
+     * testMessage property
+     *
+     * @var string
+     */
+    public $testMessage = 'all your base are belong to us';
+
+    /**
+     * stop method
+     *
+     * @param int $status
+     * @return void
+     */
+    protected function _stop($status = Shell::CODE_SUCCESS)
+    {
+        $this->stopped = $status;
+    }
+
+    protected function _secret()
+    {
+    }
+
+    //@codingStandardsIgnoreStart
+    public function doSomething()
+    {
+    }
+
+    protected function noAccess()
+    {
+    }
+
+    public function logSomething()
+    {
+        $this->log($this->testMessage);
+    }
+    //@codingStandardsIgnoreEnd
+}


### PR DESCRIPTION
It seems so far the force flag wasn't used when working with file generation.
Using non-interactive mode in this case, though, can lead to unexpected data loss due to unintentional overwrite.
In my case I had git backup, but this can also go differently.

There is a force flag, we should use it:

   --force, -f            Force overwriting existing files without prompting.

Intuitively, when using non-interactive on shells, one would think it uses the default, which in this case would be "NO, do not overwrite existing file". So this fixes it to what is expected IMO.
I added tests to make sure all combinations of non-interactive and force work as expected.

Note: Also cleaned up two test class files into a standalone file.