### PR TITLE
Fix issue #11582

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -617,6 +617,12 @@ class Router
             return $output;
         }
         if (is_array($url)) {
+            if (isset($url['_ssl'])) {
+                if (!isset($url['_full'])) {
+                    $url['_scheme'] = ($url['_ssl'] === true) ? 'https' : 'http';
+                }
+                unset($url['_ssl']);
+            }
             if (isset($url['_full']) && $url['_full'] === true) {
                 $full = true;
                 unset($url['_full']);
@@ -624,10 +630,6 @@ class Router
             if (isset($url['#'])) {
                 $frag = '#' . $url['#'];
                 unset($url['#']);
-            }
-            if (isset($url['_ssl'])) {
-                $url['_scheme'] = ($url['_ssl'] === true) ? 'https' : 'http';
-                unset($url['_ssl']);
             }
 
             $url = static::_applyUrlFilters($url);
@@ -677,6 +679,11 @@ class Router
             if ($full) {
                 $output = static::fullBaseUrl() . $output;
             }
+        }
+
+        $protocolError = preg_match('#^[a-z][a-z0-9+\-.]*\:///#i', $output);
+        if ($protocolError === 1) {
+            $output = str_replace(':///', '://', $output);
         }
 
         return $output . $frag;


### PR DESCRIPTION
In `url()` method, looks for `isset($url['_ssl'])` first, so that `_ssl` changes are only made if `$url['_full']` is not met. Then, looks for the string `:///` and replaces it with `://`. Has been tested with all combinations of `$url['_ssl']`, `$url['_full']`, and whether or not `App.fullBaseUrl` has been set.