### PR TITLE
Deprecate passing extra sort expressions by associative array

### DIFF
--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -66,6 +66,14 @@ class OrderByExpression extends QueryExpression
      */
     protected function _addConditions(array $orders, array $types)
     {
+        foreach ($orders as $key => $val) {
+            if (is_string($key) && is_string($val) && !in_array(strtoupper($val), ['ASC', 'DESC'], true)) {
+                deprecationWarning(
+                    'Passing extra sort expressions by associative array is deprecated. ' .
+                    'Use QueryExpression or numeric array instead.'
+                );
+            }
+        }
         $this->_conditions = array_merge($this->_conditions, $orders);
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1788,6 +1788,29 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that order() works with an associative array which contains extra values.
+     *
+     * @return void
+     */
+    public function testSelectOrderByAssociativeArrayContainingExtraExpressions()
+    {
+        $this->deprecated(function () {
+            $this->loadFixtures('Articles');
+            $query = new Query($this->connection);
+            $query->select(['id'])
+                ->from('articles')
+                ->order([
+                    'id' => 'desc -- Comment',
+                ]);
+            $result = $query->execute();
+            $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $result->closeCursor();
+        });
+    }
+
+    /**
      * Test orderAsc() and its input types.
      *
      * @return void


### PR DESCRIPTION
Alternative to #11157.