### PR TITLE
Timestamp behavior follow datetimetype set immutable

### DIFF
--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -14,11 +14,11 @@
  */
 namespace Cake\ORM\Behavior;
 
+use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
-use Cake\I18n\Time;
 use Cake\ORM\Behavior;
-use DateTime;
+use DateTimeInterface;
 use UnexpectedValueException;
 
 class TimestampBehavior extends Behavior
@@ -57,7 +57,7 @@ class TimestampBehavior extends Behavior
     /**
      * Current timestamp
      *
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $_ts;
 
@@ -130,19 +130,22 @@ class TimestampBehavior extends Behavior
      * If an explicit date time is passed, the config option `refreshTimestamp` is
      * automatically set to false.
      *
-     * @param \DateTime|null $ts Timestamp
+     * @param \DateTimeInterface|null $ts Timestamp
      * @param bool $refreshTimestamp If true timestamp is refreshed.
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
-    public function timestamp(DateTime $ts = null, $refreshTimestamp = false)
+    public function timestamp(DateTimeInterface $ts = null, $refreshTimestamp = false)
     {
+        $class = Type::build('datetime')
+            ->getDateTimeClassName();
+
         if ($ts) {
             if ($this->_config['refreshTimestamp']) {
                 $this->_config['refreshTimestamp'] = false;
             }
-            $this->_ts = new Time($ts);
+            $this->_ts = new $class($ts);
         } elseif ($this->_ts === null || $refreshTimestamp) {
-            $this->_ts = new Time();
+            $this->_ts = new $class();
         }
 
         return $this->_ts;

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -136,8 +136,9 @@ class TimestampBehavior extends Behavior
      */
     public function timestamp(DateTimeInterface $ts = null, $refreshTimestamp = false)
     {
-        $class = Type::build('datetime')
-            ->getDateTimeClassName();
+        /** @var \Cake\Database\Type\DateTimeType $type */
+        $type = Type::build('datetime');
+        $class = $type->getDateTimeClassName();
 
         if ($ts) {
             if ($this->_config['refreshTimestamp']) {

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ORM\Behavior;
 
+use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\I18n\Time;
@@ -193,6 +194,14 @@ class TimestampBehavior extends Behavior
         if ($entity->isDirty($field)) {
             return;
         }
-        $entity->set($field, $this->timestamp(null, $refreshTimestamp));
+
+        $ts = $this->timestamp(null, $refreshTimestamp);
+
+        $columnType = $this->getTable()->getSchema()->getColumnType($field);
+        /** @var \Cake\Database\Type\DateTimeType $type */
+        $type = Type::build($columnType);
+        $class = $type->getDateTimeClassName();
+
+        $entity->set($field, new $class($ts));
     }
 }

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -14,11 +14,11 @@
  */
 namespace Cake\ORM\Behavior;
 
-use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\I18n\Time;
 use Cake\ORM\Behavior;
-use DateTimeInterface;
+use DateTime;
 use UnexpectedValueException;
 
 class TimestampBehavior extends Behavior
@@ -57,7 +57,7 @@ class TimestampBehavior extends Behavior
     /**
      * Current timestamp
      *
-     * @var \DateTimeInterface
+     * @var \DateTime
      */
     protected $_ts;
 
@@ -130,23 +130,19 @@ class TimestampBehavior extends Behavior
      * If an explicit date time is passed, the config option `refreshTimestamp` is
      * automatically set to false.
      *
-     * @param \DateTimeInterface|null $ts Timestamp
+     * @param \DateTime|null $ts Timestamp
      * @param bool $refreshTimestamp If true timestamp is refreshed.
-     * @return \DateTimeInterface
+     * @return \DateTime
      */
-    public function timestamp(DateTimeInterface $ts = null, $refreshTimestamp = false)
+    public function timestamp(DateTime $ts = null, $refreshTimestamp = false)
     {
-        /** @var \Cake\Database\Type\DateTimeType $type */
-        $type = Type::build('datetime');
-        $class = $type->getDateTimeClassName();
-
         if ($ts) {
             if ($this->_config['refreshTimestamp']) {
                 $this->_config['refreshTimestamp'] = false;
             }
-            $this->_ts = new $class($ts);
+            $this->_ts = new Time($ts);
         } elseif ($this->_ts === null || $refreshTimestamp) {
-            $this->_ts = new $class();
+            $this->_ts = new Time();
         }
 
         return $this->_ts;

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use Cake\Database\Type;
 use Cake\Event\Event;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior\TimestampBehavior;
@@ -193,6 +194,30 @@ class TimestampBehaviorTest extends TestCase
         $this->assertTrue($return, 'Handle Event is expected to always return true');
         $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
         $this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is expected to be updated');
+    }
+
+    /**
+     * testUseImmutable
+     *
+     * @return void
+     * @triggers Model.beforeSave
+     */
+    public function testUseImmutable()
+    {
+        $table = $this->getTable();
+        $this->Behavior = new TimestampBehavior($table);
+        $entity = new Entity();
+        $event = new Event('Model.beforeSave');
+
+        Type::build('timestamp')->useImmutable();
+        $entity->clean();
+        $this->Behavior->handleEvent($event, $entity);
+        $this->assertInstanceOf('Cake\I18n\FrozenTime', $entity->modified);
+
+        Type::build('timestamp')->useMutable();
+        $entity->clean();
+        $this->Behavior->handleEvent($event, $entity);
+        $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -306,8 +306,10 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new TimestampBehavior($table);
+        /** @var \Cake\Database\Type\DateTimeType $type */
+        $type = Type::build('datetime');
 
-        Type::build('datetime')->useImmutable();
+        $type->useImmutable();
         $return = $behavior->timestamp(null, true);
         $this->assertInstanceOf(
             FrozenTime::class,
@@ -315,7 +317,7 @@ class TimestampBehaviorTest extends TestCase
             'Should return a immutable datetime object'
         );
 
-        Type::build('datetime')->useMutable();
+        $type->useMutable();
         $return = $behavior->timestamp(null, true);
         $this->assertInstanceOf(
             Time::class,

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -14,9 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
-use Cake\Database\Type;
 use Cake\Event\Event;
-use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
@@ -294,35 +292,6 @@ class TimestampBehaviorTest extends TestCase
             $ts->format('c'),
             $return->format('c'),
             'Should return the same value as initially set'
-        );
-    }
-
-    /**
-     * testGetTimestampFollowingDatetimeClassSetting
-     *
-     * @return void
-     */
-    public function testGetTimestampFollowingDatetimeClassSetting()
-    {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
-        $behavior = new TimestampBehavior($table);
-        /** @var \Cake\Database\Type\DateTimeType $type */
-        $type = Type::build('datetime');
-
-        $type->useImmutable();
-        $return = $behavior->timestamp(null, true);
-        $this->assertInstanceOf(
-            FrozenTime::class,
-            $return,
-            'Should return a immutable datetime object'
-        );
-
-        $type->useMutable();
-        $return = $behavior->timestamp(null, true);
-        $this->assertInstanceOf(
-            Time::class,
-            $return,
-            'Should return a mutable datetime object'
         );
     }
 

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -18,6 +18,7 @@ use Cake\Event\Event;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -88,7 +89,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedAbsent()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -110,7 +111,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedPresent()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -132,7 +133,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedNotNew()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -154,7 +155,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testModifiedAbsent()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -177,7 +178,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testModifiedPresent()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -204,7 +205,7 @@ class TimestampBehaviorTest extends TestCase
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid');
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $settings = ['events' => ['Model.beforeSave' => ['created' => 'fat fingers']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
 
@@ -220,7 +221,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testGetTimestamp()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
 
         $return = $behavior->timestamp();
@@ -241,7 +242,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testGetTimestampPersists()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
 
         $initialValue = $behavior->timestamp();
@@ -261,7 +262,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testGetTimestampRefreshes()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
 
         $initialValue = $behavior->timestamp();
@@ -281,7 +282,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testSetTimestampExplicit()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
 
         $ts = new \DateTime();
@@ -302,7 +303,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouch()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -325,7 +326,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouchNoop()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $config = [
             'events' => [
                 'Model.beforeSave' => [
@@ -352,7 +353,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouchCustomEvent()
     {
-        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table = $this->getTable();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
         $ts = new \DateTime('2000-01-01');
@@ -397,5 +398,22 @@ class TimestampBehaviorTest extends TestCase
         $now = Time::now();
         $this->assertEquals($now->toDateTimeString(), $row->created->toDateTimeString());
         $this->assertEquals($now->toDateTimeString(), $row->updated->toDateTimeString());
+    }
+
+    /**
+     * Helper method to get Table instance with created/modified column
+     *
+     * @return \Cake\ORM\Table
+     */
+    protected function getTable()
+    {
+        $schema = [
+            'created' => ['type' => 'datetime'],
+            'modified' => ['type' => 'timestamp'],
+            'date_specialed' => ['type' => 'datetime'],
+        ];
+        $table = new Table(['schema' => $schema]);
+
+        return $table;
     }
 }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use Cake\Database\Type;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
@@ -292,6 +294,33 @@ class TimestampBehaviorTest extends TestCase
             $ts->format('c'),
             $return->format('c'),
             'Should return the same value as initially set'
+        );
+    }
+
+    /**
+     * testGetTimestampFollowingDatetimeClassSetting
+     *
+     * @return void
+     */
+    public function testGetTimestampFollowingDatetimeClassSetting()
+    {
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $behavior = new TimestampBehavior($table);
+
+        Type::build('datetime')->useImmutable();
+        $return = $behavior->timestamp(null, true);
+        $this->assertInstanceOf(
+            FrozenTime::class,
+            $return,
+            'Should return a immutable datetime object'
+        );
+
+        Type::build('datetime')->useMutable();
+        $return = $behavior->timestamp(null, true);
+        $this->assertInstanceOf(
+            Time::class,
+            $return,
+            'Should return a mutable datetime object'
         );
     }
 


### PR DESCRIPTION
TimestampBehavior hard construct `Cake\I18n\Time` instance. ([here](https://github.com/cakephp/cakephp/blob/f0e61d9b665249eef415e9749e8506e82e53fdc7/src/ORM/Behavior/TimestampBehavior.php#L143))
So, when new entity instance got by Table->save `created(or modified) property` is `Time` (new Time).
But with `useImmutable`,  the entity got by Table->get `created property` is `FrozenTime` (DateTimeType->toPHP()).

The same properties of same entity should be same type wherever they come from.

-------
### What you did
```php
$Table = TableRegistry::get('Users');
$entity = $Table->newEntity(['name' => 'my name']);
$saved = $Table->save($entity);
$read = $Table->get($entity->id);

echo get_class($saved->created); // Cake\I18n\Time
echo get_class($read->created); //  Cake\I18n\FrozenTime
```

### What you expected to happen
```diff
-- echo get_class($saved); // Cake\I18n\Time
++ echo get_class($saved); // Cake\I18n\FrozenTime
echo get_class($read); //  Cake\I18n\FrozenTime
```