### PR TITLE
Allow `false` prefix to be used in options().

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -536,7 +536,7 @@ class PaginatorHelper extends Helper
         }
 
         $url = array_filter($url, function ($value) {
-            return ($value || is_numeric($value));
+            return ($value || is_numeric($value) || $value === false);
         });
         $url = array_merge($url, $options);
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -638,7 +638,6 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortAdminLinks()
     {
-        Configure::write('Routing.prefixes', ['admin']);
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
         Router::setRequestInfo([
@@ -760,7 +759,6 @@ class PaginatorHelperTest extends TestCase
      */
     public function testGenerateUrlWithPrefixes()
     {
-        Configure::write('Routing.prefixes', ['members']);
         Router::reload();
         Router::connect('/members/:controller/:action/*', ['prefix' => 'members']);
         Router::connect('/:controller/:action/*');
@@ -815,6 +813,49 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl($options);
         $expected = '/posts/index?page=2&amp;sort=Article.name&amp;direction=desc';
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * test URL generation can leave prefix routes
+     *
+     * @return void
+     */
+    public function testGenerateUrlWithPrefixesLeavePrefix()
+    {
+        Router::reload();
+        Router::connect('/members/:controller/:action/*', ['prefix' => 'members']);
+        Router::connect('/:controller/:action/*');
+
+        $request = new ServerRequest([
+            'params' => [
+                'prefix' => 'members',
+                'controller' => 'posts',
+                'action' => 'index',
+                'plugin' => null,
+                'paging' => [
+                    'Articles' => ['page' => 2, 'prevPage' => true]
+                ]
+            ],
+            'webroot' => '/'
+        ]);
+        Router::setRequestInfo($request);
+        $this->Paginator->request = $request;
+
+        $result = $this->Paginator->generateUrl();
+        $expected = '/members/posts/index?page=2';
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Paginator->generateUrl(['prefix' => 'members']);
+        $expected = '/members/posts/index?page=2';
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Paginator->generateUrl(['prefix' => false]);
+        $expected = '/posts/index?page=2';
+        $this->assertEquals($expected, $result);
+
+        $this->Paginator->options(['url' => ['prefix' => false]]);
+        $result = $this->Paginator->generateUrl();
+        $this->assertEquals($expected, $result, 'Setting prefix in options should work too.');
     }
 
     /**


### PR DESCRIPTION
Allow prefixes to be disabled via options('url').

Fixes #11515