### PR TITLE
[2.x]Fix can't mock aliased component on ControllerTestCase

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -281,8 +281,7 @@ class ControllerTestCaseTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testGenerateWithMockedAliasedComponent()
-	{
+	public function testGenerateWithMockedAliasedComponent() {
 		$Posts = $this->Case->generate('Posts', array(
 			'components' => array(
 				'AliasedEmail' => array('send')
@@ -301,8 +300,7 @@ class ControllerTestCaseTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testGenerateWithMockedAliasedPluginComponent()
-	{
+	public function testGenerateWithMockedAliasedPluginComponent() {
 		$Posts = $this->Case->generate('Posts', array(
 			'components' => array(
 				'AliasedPluginEmail' => array('send')

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -79,6 +79,12 @@ if (!class_exists('PostsController')) {
 		public $components = array(
 			'RequestHandler',
 			'Email',
+			'AliasedEmail' => array(
+				'className' => 'Email',
+			),
+			'AliasedPluginEmail' => array(
+				'className' => 'TestPlugin.TestPluginEmail',
+			),
 			'Auth'
 		);
 	}
@@ -268,6 +274,46 @@ class ControllerTestCaseTest extends CakeTestCase {
 			->will($this->returnValue(false));
 		$this->assertTrue($Tests->TestPluginComment->save(array()));
 		$this->assertFalse($Tests->TestPluginComment->save(array()));
+	}
+
+/**
+ * Tests ControllerTestCase::generate() using aliased component
+ *
+ * @return void
+ */
+	public function testGenerateWithMockedAliasedComponent()
+	{
+		$Posts = $this->Case->generate('Posts', array(
+			'components' => array(
+				'AliasedEmail' => array('send')
+			)
+		));
+		$Posts->AliasedEmail->expects($this->once())
+			->method('send')
+			->will($this->returnValue(true));
+
+		$this->assertInstanceOf('EmailComponent', $Posts->AliasedEmail);
+		$this->assertTrue($Posts->AliasedEmail->send());
+	}
+
+/**
+ * Tests ControllerTestCase::generate() using aliased plugin component
+ *
+ * @return void
+ */
+	public function testGenerateWithMockedAliasedPluginComponent()
+	{
+		$Posts = $this->Case->generate('Posts', array(
+			'components' => array(
+				'AliasedPluginEmail' => array('send')
+			)
+		));
+		$Posts->AliasedPluginEmail->expects($this->once())
+			->method('send')
+			->will($this->returnValue(true));
+
+		$this->assertInstanceOf('TestPluginEmailComponent', $Posts->AliasedPluginEmail);
+		$this->assertTrue($Posts->AliasedPluginEmail->send());
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginEmailComponent.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginEmailComponent.php
@@ -1,0 +1,10 @@
+<?php
+App::uses('EmailComponent', 'Controller/Component');
+
+/**
+ * TestPluginEmailComponent
+ *
+ * @package       Cake.Test.TestApp.Plugin.TestPlugin.Controller.Component
+ */
+class TestPluginEmailComponent extends EmailComponent {
+}

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -388,7 +388,15 @@ abstract class ControllerTestCase extends CakeTestCase {
 			if ($methods === true) {
 				$methods = array();
 			}
+			$config = isset($controllerObj->components[$component]) ? $controllerObj->components[$component] : array();
+			if (isset($config['className'])) {
+				$alias = $component;
+				$component = $config['className'];
+			}
 			list($plugin, $name) = pluginSplit($component, true);
+			if (!isset($alias)) {
+				$alias = $name;
+			}
 			$componentClass = $name . 'Component';
 			App::uses($componentClass, $plugin . 'Controller/Component');
 			if (!class_exists($componentClass)) {
@@ -396,11 +404,11 @@ abstract class ControllerTestCase extends CakeTestCase {
 					'class' => $componentClass
 				));
 			}
-			$config = isset($controllerObj->components[$component]) ? $controllerObj->components[$component] : array();
 			/** @var Component|PHPUnit_Framework_MockObject_MockObject $componentObj */
 			$componentObj = $this->getMock($componentClass, $methods, array($controllerObj->Components, $config));
-			$controllerObj->Components->set($name, $componentObj);
-			$controllerObj->Components->enable($name);
+			$controllerObj->Components->set($alias, $componentObj);
+			$controllerObj->Components->enable($alias);
+			unset($alias);
 		}
 
 		$controllerObj->constructClasses();


### PR DESCRIPTION
* CakePHP Version: 2.10.6
* Platform and Target: PHP 5.6.31

In the `ControllerTestCase::generate()` method, cannot mock components defined by aliases as follows.

```php
<?php
class PostsController extends AppController {
    public $components = array(
        'Auth' => array(
            'className' => 'CustomizedAuth'
        )
    );

    // other code
}
```

In this case, the `AuthComponent` is mocked, not the `CustomizedAuthComponent`.

To fix the problem, I imported the code to load the component from [`ComponentCollection::load()`](https://github.com/cakephp/cakephp/blob/2.x/lib/Cake/Controller/ComponentCollection.php#L97-L104)