### PR TITLE
show _name parameter in request if set

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -479,6 +479,11 @@ class Route
             $route['_ext'] = $ext;
         }
 
+        // pass the name if set
+        if (isset($this->options['_name'])) {
+            $route['_name'] = $this->options['_name'];
+        }
+
         // restructure 'pass' key route params
         if (isset($this->options['pass'])) {
             $j = count($this->options['pass']);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -746,7 +746,8 @@ class Router
             $params['requested'],
             $params['return'],
             $params['_Token'],
-            $params['_matchedRoute']
+            $params['_matchedRoute'],
+            $params['_name']
         );
         $params = array_merge($params, $pass);
         if (!empty($url)) {

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -361,7 +361,7 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
-        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
+        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
         $request = new ServerRequest(['url' => '/b/']);
         $result = $this->collection->parseRequest($request);
@@ -384,7 +384,6 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
-            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
 
@@ -397,7 +396,6 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
-            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
 

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -78,6 +78,65 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
+
+        $result = $this->collection->parse('/b/');
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'pass' => [],
+            'plugin' => null,
+            'key' => 'value',
+            '_matchedRoute' => '/b',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->collection->parse('/b/the-thing?one=two');
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'id' => 'the-thing',
+            'pass' => [],
+            'plugin' => null,
+            'key' => 'value',
+            '?' => ['one' => 'two'],
+            '_matchedRoute' => '/b/:id',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->collection->parse('/b/media/search');
+        $expected = [
+            'key' => 'value',
+            'pass' => [],
+            'plugin' => null,
+            'controller' => 'Media',
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->collection->parse('/b/media/search/thing');
+        $expected = [
+            'key' => 'value',
+            'pass' => ['thing'],
+            'plugin' => null,
+            'controller' => 'Media',
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test parsing routes with and without _name.
+     *
+     * @return void
+     */
+    public function testParseWithNameParameter()
+    {
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->connect('/', ['controller' => 'Articles']);
+        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
         $result = $this->collection->parse('/b/');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -78,7 +78,7 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
-        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
+        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
         $result = $this->collection->parse('/b/');
         $expected = [
@@ -112,6 +112,7 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
+            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
 
@@ -123,6 +124,7 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
+            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
     }
@@ -300,7 +302,7 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
-        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
+        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
         $request = new ServerRequest(['url' => '/b/']);
         $result = $this->collection->parseRequest($request);
@@ -323,6 +325,7 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
+            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
 
@@ -335,6 +338,7 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Media',
             'action' => 'search',
             '_matchedRoute' => '/b/media/search/*',
+            '_name' => 'media_search'
         ];
         $this->assertEquals($expected, $result);
 

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -117,7 +117,7 @@ class RoutesShellTest extends ConsoleIntegrationTestCase
         $this->assertOutputContainsRow([
             'testName',
             '/tests/index',
-            '{"action":"index","pass":[],"controller":"Tests","plugin":null}'
+            '{"action":"index","pass":[],"controller":"Tests","plugin":null,"_name":"testName"}'
         ]);
     }
 


### PR DESCRIPTION
Hi,
I made this pull request for these issues: #11595  and #10950,

With this addition the _name parameter is also visible in the request object.

In my use case we use the _name to identify a route, and if we have seo stuff in the db we can easily retrieve it by using _name.

For me having the full Route object attached to the request isn't necessary, but if you think this would be a better solution let me know and i will try to make a pull request for it