### PR TITLE
Add more field value comparison validation rules

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -300,48 +300,66 @@ class Validation
         $operator = str_replace([' ', "\t", "\n", "\r", "\0", "\x0B"], '', strtolower($operator));
         switch ($operator) {
             case 'isgreater':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_GREATER instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_GREATER instead.
+                // no break
             case static::COMPARE_GREATER:
                 if ($check1 > $check2) {
                     return true;
                 }
                 break;
             case 'isless':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_LESS instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_LESS instead.
+                // no break
             case static::COMPARE_LESS:
                 if ($check1 < $check2) {
                     return true;
                 }
                 break;
             case 'greaterorequal':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_GREATER_OR_EQUAL instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER_OR_EQUAL'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_GREATER_OR_EQUAL instead.
+                // no break
             case static::COMPARE_GREATER_OR_EQUAL:
                 if ($check1 >= $check2) {
                     return true;
                 }
                 break;
             case 'lessorequal':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_LESS_OR_EQUAL instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS_OR_EQUAL'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_LESS_OR_EQUAL instead.
+                // no break
             case static::COMPARE_LESS_OR_EQUAL:
                 if ($check1 <= $check2) {
                     return true;
                 }
                 break;
             case 'equalto':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_EQUAL instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_EQUAL'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_EQUAL instead.
+                // no break
             case static::COMPARE_EQUAL:
                 if ($check1 == $check2) {
                     return true;
                 }
                 break;
             case 'notequal':
+                /**
+                 * @deprecated 3.6.0 Use Validation::COMPARE_NOT_EQUAL instead.
+                 */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_NOT_EQUAL'));
-                // @deprecated 3.6.0 Use Validation::COMPARE_NOT_EQUAL instead.
+                // no break
             case static::COMPARE_NOT_EQUAL:
                 if ($check1 != $check2) {
                     return true;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -295,51 +295,57 @@ class Validation
             return false;
         }
 
+        $message = 'Operator `%s` is deprecated, use constant `Validation::%s` instead.';
+
         $operator = str_replace([' ', "\t", "\n", "\r", "\0", "\x0B"], '', strtolower($operator));
         switch ($operator) {
             case 'isgreater':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER'));
             case static::COMPARE_GREATER:
                 if ($check1 > $check2) {
                     return true;
                 }
                 break;
             case 'isless':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS'));
             case static::COMPARE_LESS:
                 if ($check1 < $check2) {
                     return true;
                 }
                 break;
             case 'greaterorequal':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER_OR_EQUAL'));
             case static::COMPARE_GREATER_OR_EQUAL:
                 if ($check1 >= $check2) {
                     return true;
                 }
                 break;
             case 'lessorequal':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS_OR_EQUAL'));
             case static::COMPARE_LESS_OR_EQUAL:
                 if ($check1 <= $check2) {
                     return true;
                 }
                 break;
             case 'equalto':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_EQUAL'));
             case static::COMPARE_EQUAL:
                 if ($check1 == $check2) {
                     return true;
                 }
                 break;
             case 'notequal':
+                deprecationWarning(sprintf($message, $operator, 'COMPARE_NOT_EQUAL'));
             case static::COMPARE_NOT_EQUAL:
                 if ($check1 != $check2) {
                     return true;
                 }
                 break;
-            case 'sameas':
             case static::COMPARE_SAME:
                 if ($check1 === $check2) {
                     return true;
                 }
                 break;
-            case 'notsameas':
             case static::COMPARE_NOT_SAME:
                 if ($check1 !== $check2) {
                     return true;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -33,64 +33,46 @@ class Validation
 
     /**
      * Default locale
-     *
-     * @var string
      */
     const DEFAULT_LOCALE = 'en_US';
 
     /**
      * Same as operator.
-     *
-     * @var string
      */
-    const COMPARE_SAME_AS = '===';
+    const COMPARE_SAME = '===';
 
     /**
      * Not same as comparison operator.
-     *
-     * @var string
      */
-    const COMPARE_NOT_SAME_AS = '!==';
+    const COMPARE_NOT_SAME = '!==';
 
     /**
      * Equal to comparison operator.
-     *
-     * @var string
      */
-    const COMPARE_EQUAL_TO = '==';
+    const COMPARE_EQUAL = '==';
 
     /**
      * Not equal to comparison operator.
-     *
-     * @var string
      */
-    const COMPARE_NOT_EQUAL_TO = '!=';
+    const COMPARE_NOT_EQUAL = '!=';
 
     /**
      * Greater than comparison operator.
-     *
-     * @var string
      */
-    const COMPARE_GREATER_THAN = '>';
+    const COMPARE_GREATER = '>';
 
     /**
      * Greater than or equal to comparison operator.
-     *
-     * @var string
      */
     const COMPARE_GREATER_OR_EQUAL = '>=';
 
     /**
      * Less than comparison operator.
-     *
-     * @var string
      */
-    const COMPARE_LESS_THAN = '<';
+    const COMPARE_LESS = '<';
 
     /**
      * Less than or equal to comparison operator.
-     *
-     * @var string
      */
     const COMPARE_LESS_OR_EQUAL = '<=';
 
@@ -316,13 +298,13 @@ class Validation
         $operator = str_replace([' ', "\t", "\n", "\r", "\0", "\x0B"], '', strtolower($operator));
         switch ($operator) {
             case 'isgreater':
-            case static::COMPARE_GREATER_THAN:
+            case static::COMPARE_GREATER:
                 if ($check1 > $check2) {
                     return true;
                 }
                 break;
             case 'isless':
-            case static::COMPARE_LESS_THAN:
+            case static::COMPARE_LESS:
                 if ($check1 < $check2) {
                     return true;
                 }
@@ -340,25 +322,25 @@ class Validation
                 }
                 break;
             case 'equalto':
-            case static::COMPARE_EQUAL_TO:
+            case static::COMPARE_EQUAL:
                 if ($check1 == $check2) {
                     return true;
                 }
                 break;
             case 'notequal':
-            case static::COMPARE_NOT_EQUAL_TO:
+            case static::COMPARE_NOT_EQUAL:
                 if ($check1 != $check2) {
                     return true;
                 }
                 break;
             case 'sameas':
-            case static::COMPARE_SAME_AS:
+            case static::COMPARE_SAME:
                 if ($check1 === $check2) {
                     return true;
                 }
                 break;
             case 'notsameas':
-            case static::COMPARE_NOT_SAME_AS:
+            case static::COMPARE_NOT_SAME:
                 if ($check1 !== $check2) {
                     return true;
                 }
@@ -382,7 +364,7 @@ class Validation
      */
     public static function compareWith($check, $field, $context)
     {
-        return self::compareFields($check, $field, static::COMPARE_SAME_AS, $context);
+        return self::compareFields($check, $field, static::COMPARE_SAME, $context);
     }
 
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -314,7 +314,7 @@ class Validation
      */
     public static function compareWith($check, $field, $context)
     {
-        return self::compareFields($check, $field, true, $context);
+        return self::compareFields($check, $field, 'equalto', $context);
     }
 
     /**
@@ -324,20 +324,18 @@ class Validation
      *
      * @param mixed $check The value to find in $field.
      * @param string $field The field to check $check against. This field must be present in $context.
-     * @param bool $result The expected result of field comparison.
+     * @param string $operator Comparison operator.
      * @param array $context The validation context.
      * @return bool
      * @since 3.6.0
      */
-    public static function compareFields($check, $field, $result, $context)
+    public static function compareFields($check, $field, $operator, $context)
     {
         if (!isset($context['data'][$field])) {
             return false;
         }
 
-        $comparison = $context['data'][$field] === $check;
-
-        return $comparison === $result;
+        return static::comparison($check, $operator, $context['data'][$field]);
     }
 
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -295,6 +295,18 @@ class Validation
                     return true;
                 }
                 break;
+            case 'sameas':
+            case '===':
+                if ($check1 === $check2) {
+                    return true;
+                }
+                break;
+            case 'notsameas':
+            case '!==':
+                if ($check1 !== $check2) {
+                    return true;
+                }
+                break;
             default:
                 static::$errors[] = 'You must define the $operator parameter for Validation::comparison()';
         }
@@ -314,7 +326,7 @@ class Validation
      */
     public static function compareWith($check, $field, $context)
     {
-        return self::compareFields($check, $field, 'equalto', $context);
+        return self::compareFields($check, $field, '===', $context);
     }
 
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -300,7 +300,7 @@ class Validation
         $operator = str_replace([' ', "\t", "\n", "\r", "\0", "\x0B"], '', strtolower($operator));
         switch ($operator) {
             case 'isgreater':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_GREATER instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER'));
@@ -311,7 +311,7 @@ class Validation
                 }
                 break;
             case 'isless':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_LESS instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS'));
@@ -322,7 +322,7 @@ class Validation
                 }
                 break;
             case 'greaterorequal':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_GREATER_OR_EQUAL instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER_OR_EQUAL'));
@@ -333,7 +333,7 @@ class Validation
                 }
                 break;
             case 'lessorequal':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_LESS_OR_EQUAL instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS_OR_EQUAL'));
@@ -344,7 +344,7 @@ class Validation
                 }
                 break;
             case 'equalto':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_EQUAL instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_EQUAL'));
@@ -355,7 +355,7 @@ class Validation
                 }
                 break;
             case 'notequal':
-                /**
+                /*
                  * @deprecated 3.6.0 Use Validation::COMPARE_NOT_EQUAL instead.
                  */
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_NOT_EQUAL'));

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -301,6 +301,7 @@ class Validation
         switch ($operator) {
             case 'isgreater':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_GREATER instead.
             case static::COMPARE_GREATER:
                 if ($check1 > $check2) {
                     return true;
@@ -308,6 +309,7 @@ class Validation
                 break;
             case 'isless':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_LESS instead.
             case static::COMPARE_LESS:
                 if ($check1 < $check2) {
                     return true;
@@ -315,6 +317,7 @@ class Validation
                 break;
             case 'greaterorequal':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_GREATER_OR_EQUAL'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_GREATER_OR_EQUAL instead.
             case static::COMPARE_GREATER_OR_EQUAL:
                 if ($check1 >= $check2) {
                     return true;
@@ -322,6 +325,7 @@ class Validation
                 break;
             case 'lessorequal':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_LESS_OR_EQUAL'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_LESS_OR_EQUAL instead.
             case static::COMPARE_LESS_OR_EQUAL:
                 if ($check1 <= $check2) {
                     return true;
@@ -329,6 +333,7 @@ class Validation
                 break;
             case 'equalto':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_EQUAL'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_EQUAL instead.
             case static::COMPARE_EQUAL:
                 if ($check1 == $check2) {
                     return true;
@@ -336,6 +341,7 @@ class Validation
                 break;
             case 'notequal':
                 deprecationWarning(sprintf($message, $operator, 'COMPARE_NOT_EQUAL'));
+                // @deprecated 3.6.0 Use Validation::COMPARE_NOT_EQUAL instead.
             case static::COMPARE_NOT_EQUAL:
                 if ($check1 != $check2) {
                     return true;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -39,6 +39,62 @@ class Validation
     const DEFAULT_LOCALE = 'en_US';
 
     /**
+     * Same as operator.
+     *
+     * @var string
+     */
+    const COMPARE_SAME_AS = '===';
+
+    /**
+     * Not same as comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_NOT_SAME_AS = '!==';
+
+    /**
+     * Equal to comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_EQUAL_TO = '==';
+
+    /**
+     * Not equal to comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_NOT_EQUAL_TO = '!=';
+
+    /**
+     * Greater than comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_GREATER_THAN = '>';
+
+    /**
+     * Greater than or equal to comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_GREATER_THAN_OR_EQUAL_TO = '>=';
+
+    /**
+     * Less than comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_LESS_THAN = '<';
+
+    /**
+     * Less than or equal to comparison operator.
+     *
+     * @var string
+     */
+    const COMPARE_LESS_THAN_OR_EQUAL_TO = '<=';
+
+    /**
      * Some complex patterns needed in multiple places
      *
      * @var array
@@ -260,49 +316,49 @@ class Validation
         $operator = str_replace([' ', "\t", "\n", "\r", "\0", "\x0B"], '', strtolower($operator));
         switch ($operator) {
             case 'isgreater':
-            case '>':
+            case static::COMPARE_GREATER_THAN:
                 if ($check1 > $check2) {
                     return true;
                 }
                 break;
             case 'isless':
-            case '<':
+            case static::COMPARE_LESS_THAN:
                 if ($check1 < $check2) {
                     return true;
                 }
                 break;
             case 'greaterorequal':
-            case '>=':
+            case static::COMPARE_GREATER_THAN_OR_EQUAL_TO:
                 if ($check1 >= $check2) {
                     return true;
                 }
                 break;
             case 'lessorequal':
-            case '<=':
+            case static::COMPARE_LESS_THAN_OR_EQUAL_TO:
                 if ($check1 <= $check2) {
                     return true;
                 }
                 break;
             case 'equalto':
-            case '==':
+            case static::COMPARE_EQUAL_TO:
                 if ($check1 == $check2) {
                     return true;
                 }
                 break;
             case 'notequal':
-            case '!=':
+            case static::COMPARE_NOT_EQUAL_TO:
                 if ($check1 != $check2) {
                     return true;
                 }
                 break;
             case 'sameas':
-            case '===':
+            case static::COMPARE_SAME_AS:
                 if ($check1 === $check2) {
                     return true;
                 }
                 break;
             case 'notsameas':
-            case '!==':
+            case static::COMPARE_NOT_SAME_AS:
                 if ($check1 !== $check2) {
                     return true;
                 }
@@ -326,7 +382,7 @@ class Validation
      */
     public static function compareWith($check, $field, $context)
     {
-        return self::compareFields($check, $field, '===', $context);
+        return self::compareFields($check, $field, static::COMPARE_SAME_AS, $context);
     }
 
     /**
@@ -1226,10 +1282,10 @@ class Validation
         if ($options['optional'] && $error === UPLOAD_ERR_NO_FILE) {
             return true;
         }
-        if (isset($options['minSize']) && !static::fileSize($file, '>=', $options['minSize'])) {
+        if (isset($options['minSize']) && !static::fileSize($file, static::COMPARE_GREATER_THAN_OR_EQUAL_TO, $options['minSize'])) {
             return false;
         }
-        if (isset($options['maxSize']) && !static::fileSize($file, '<=', $options['maxSize'])) {
+        if (isset($options['maxSize']) && !static::fileSize($file, static::COMPARE_LESS_THAN_OR_EQUAL_TO, $options['maxSize'])) {
             return false;
         }
         if (isset($options['types']) && !static::mimeType($file, $options['types'])) {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -78,7 +78,7 @@ class Validation
      *
      * @var string
      */
-    const COMPARE_GREATER_THAN_OR_EQUAL_TO = '>=';
+    const COMPARE_GREATER_OR_EQUAL = '>=';
 
     /**
      * Less than comparison operator.
@@ -92,7 +92,7 @@ class Validation
      *
      * @var string
      */
-    const COMPARE_LESS_THAN_OR_EQUAL_TO = '<=';
+    const COMPARE_LESS_OR_EQUAL = '<=';
 
     /**
      * Some complex patterns needed in multiple places
@@ -328,13 +328,13 @@ class Validation
                 }
                 break;
             case 'greaterorequal':
-            case static::COMPARE_GREATER_THAN_OR_EQUAL_TO:
+            case static::COMPARE_GREATER_OR_EQUAL:
                 if ($check1 >= $check2) {
                     return true;
                 }
                 break;
             case 'lessorequal':
-            case static::COMPARE_LESS_THAN_OR_EQUAL_TO:
+            case static::COMPARE_LESS_OR_EQUAL:
                 if ($check1 <= $check2) {
                     return true;
                 }
@@ -1282,10 +1282,10 @@ class Validation
         if ($options['optional'] && $error === UPLOAD_ERR_NO_FILE) {
             return true;
         }
-        if (isset($options['minSize']) && !static::fileSize($file, static::COMPARE_GREATER_THAN_OR_EQUAL_TO, $options['minSize'])) {
+        if (isset($options['minSize']) && !static::fileSize($file, static::COMPARE_GREATER_OR_EQUAL, $options['minSize'])) {
             return false;
         }
-        if (isset($options['maxSize']) && !static::fileSize($file, static::COMPARE_LESS_THAN_OR_EQUAL_TO, $options['maxSize'])) {
+        if (isset($options['maxSize']) && !static::fileSize($file, static::COMPARE_LESS_OR_EQUAL, $options['maxSize'])) {
             return false;
         }
         if (isset($options['types']) && !static::mimeType($file, $options['types'])) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -970,8 +970,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * If both fields have the exact same value the rule will pass.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -990,8 +990,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare that two fields have different values.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1011,8 +1011,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is equal to another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1032,8 +1032,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is not equal to another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1053,8 +1053,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is greater than another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1074,8 +1074,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is greater than or equal to another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1095,8 +1095,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is less than another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
@@ -1116,8 +1116,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Add a rule to compare one field is less than or equal to another.
      *
-     * @param mixed $field The field you want to apply the rule to.
-     * @param mixed $secondField The field you want to compare against.
+     * @param string $field The field you want to apply the rule to.
+     * @param string $secondField The field you want to compare against.
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1009,6 +1009,48 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Add a rule to compare one field is equal to another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     * @since 3.6.0
+     */
+    public function equalToField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'equalToField', $extra + [
+            'rule' => ['compareFields', $secondField, '==']
+        ]);
+    }
+
+    /**
+     * Add a rule to compare one field is not equal to another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     * @since 3.6.0
+     */
+    public function notEqualToField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'notEqualToField', $extra + [
+            'rule' => ['compareFields', $secondField, '!=']
+        ]);
+    }
+
+    /**
      * Add a rule to compare one field is greater than another.
      *
      * @param mixed $field The field you want to apply the rule to.
@@ -1018,6 +1060,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareFields()
      * @return $this
+     * @since 3.6.0
      */
     public function greaterThanField($field, $secondField, $message = null, $when = null)
     {
@@ -1038,6 +1081,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareFields()
      * @return $this
+     * @since 3.6.0
      */
     public function greaterThanOrEqualToField($field, $secondField, $message = null, $when = null)
     {
@@ -1058,6 +1102,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareFields()
      * @return $this
+     * @since 3.6.0
      */
     public function lessThanField($field, $secondField, $message = null, $when = null)
     {
@@ -1078,6 +1123,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareFields()
      * @return $this
+     * @since 3.6.0
      */
     public function lessThanOrEqualToField($field, $secondField, $message = null, $when = null)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -881,7 +881,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqual', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO, $value]
+            'rule' => ['comparison', Validation::COMPARE_GREATER_OR_EQUAL, $value]
         ]);
     }
 
@@ -921,7 +921,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqual', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_LESS_THAN_OR_EQUAL_TO, $value]
+            'rule' => ['comparison', Validation::COMPARE_LESS_OR_EQUAL, $value]
         ]);
     }
 
@@ -1088,7 +1088,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER_OR_EQUAL]
         ]);
     }
 
@@ -1130,7 +1130,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS_THAN_OR_EQUAL_TO]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS_OR_EQUAL]
         ]);
     }
 
@@ -1853,7 +1853,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                     $value = $value['_ids'];
                 }
 
-                return Validation::numElements($value, Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO, $count);
+                return Validation::numElements($value, Validation::COMPARE_GREATER_OR_EQUAL, $count);
             }
         ]);
     }
@@ -1880,7 +1880,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                     $value = $value['_ids'];
                 }
 
-                return Validation::numElements($value, Validation::COMPARE_LESS_THAN_OR_EQUAL_TO, $count);
+                return Validation::numElements($value, Validation::COMPARE_LESS_OR_EQUAL, $count);
             }
         ]);
     }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -861,7 +861,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThan', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_GREATER_THAN, $value]
+            'rule' => ['comparison', Validation::COMPARE_GREATER, $value]
         ]);
     }
 
@@ -901,7 +901,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThan', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_LESS_THAN, $value]
+            'rule' => ['comparison', Validation::COMPARE_LESS, $value]
         ]);
     }
 
@@ -941,7 +941,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equals', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_EQUAL_TO, $value]
+            'rule' => ['comparison', Validation::COMPARE_EQUAL, $value]
         ]);
     }
 
@@ -961,7 +961,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEquals', $extra + [
-            'rule' => ['comparison', Validation::COMPARE_NOT_EQUAL_TO, $value]
+            'rule' => ['comparison', Validation::COMPARE_NOT_EQUAL, $value]
         ]);
     }
 
@@ -983,7 +983,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_SAME_AS]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_SAME]
         ]);
     }
 
@@ -1004,7 +1004,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notSameAs', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_SAME_AS]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_SAME]
         ]);
     }
 
@@ -1025,7 +1025,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equalToField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_EQUAL_TO]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_EQUAL]
         ]);
     }
 
@@ -1046,7 +1046,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_EQUAL_TO]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_EQUAL]
         ]);
     }
 
@@ -1067,7 +1067,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER_THAN]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER]
         ]);
     }
 
@@ -1109,7 +1109,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanField', $extra + [
-            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS_THAN]
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS]
         ]);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -983,7 +983,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
-            'rule' => ['compareFields', $secondField, 'equalto']
+            'rule' => ['compareFields', $secondField, '===']
         ]);
     }
 
@@ -1004,7 +1004,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notSameAs', $extra + [
-            'rule' => ['compareFields', $secondField, 'notequal']
+            'rule' => ['compareFields', $secondField, '!==']
         ]);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -983,7 +983,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
-            'rule' => ['compareFields', $secondField, true]
+            'rule' => ['compareFields', $secondField, 'equalto']
         ]);
     }
 
@@ -1004,7 +1004,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notSameAs', $extra + [
-            'rule' => ['compareFields', $secondField, false]
+            'rule' => ['compareFields', $secondField, 'notequal']
         ]);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1009,6 +1009,86 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Add a rule to compare one field is greater than another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     */
+    public function greaterThanField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'greaterThanField', $extra + [
+            'rule' => ['compareFields', $secondField, '>']
+        ]);
+    }
+
+    /**
+     * Add a rule to compare one field is greater than or equal to another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     */
+    public function greaterThanOrEqualToField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'greaterThanOrEqualToField', $extra + [
+            'rule' => ['compareFields', $secondField, '>=']
+        ]);
+    }
+
+    /**
+     * Add a rule to compare one field is less than another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     */
+    public function lessThanField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'lessThanField', $extra + [
+            'rule' => ['compareFields', $secondField, '<']
+        ]);
+    }
+
+    /**
+     * Add a rule to compare one field is less than or equal to another.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     */
+    public function lessThanOrEqualToField($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'lessThanOrEqualToField', $extra + [
+            'rule' => ['compareFields', $secondField, '<=']
+        ]);
+    }
+
+    /**
      * Add a rule to check if a field contains non alpha numeric characters.
      *
      * @param string $field The field you want to apply the rule to.

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -861,7 +861,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThan', $extra + [
-            'rule' => ['comparison', '>', $value]
+            'rule' => ['comparison', Validation::COMPARE_GREATER_THAN, $value]
         ]);
     }
 
@@ -881,7 +881,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqual', $extra + [
-            'rule' => ['comparison', '>=', $value]
+            'rule' => ['comparison', Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO, $value]
         ]);
     }
 
@@ -901,7 +901,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThan', $extra + [
-            'rule' => ['comparison', '<', $value]
+            'rule' => ['comparison', Validation::COMPARE_LESS_THAN, $value]
         ]);
     }
 
@@ -921,7 +921,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqual', $extra + [
-            'rule' => ['comparison', '<=', $value]
+            'rule' => ['comparison', Validation::COMPARE_LESS_THAN_OR_EQUAL_TO, $value]
         ]);
     }
 
@@ -941,7 +941,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equals', $extra + [
-            'rule' => ['comparison', '==', $value]
+            'rule' => ['comparison', Validation::COMPARE_EQUAL_TO, $value]
         ]);
     }
 
@@ -961,7 +961,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEquals', $extra + [
-            'rule' => ['comparison', '!=', $value]
+            'rule' => ['comparison', Validation::COMPARE_NOT_EQUAL_TO, $value]
         ]);
     }
 
@@ -983,7 +983,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
-            'rule' => ['compareFields', $secondField, '===']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_SAME_AS]
         ]);
     }
 
@@ -1004,7 +1004,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notSameAs', $extra + [
-            'rule' => ['compareFields', $secondField, '!==']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_SAME_AS]
         ]);
     }
 
@@ -1025,7 +1025,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equalToField', $extra + [
-            'rule' => ['compareFields', $secondField, '==']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_EQUAL_TO]
         ]);
     }
 
@@ -1046,7 +1046,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, '!=']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_NOT_EQUAL_TO]
         ]);
     }
 
@@ -1067,7 +1067,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanField', $extra + [
-            'rule' => ['compareFields', $secondField, '>']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER_THAN]
         ]);
     }
 
@@ -1088,7 +1088,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, '>=']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO]
         ]);
     }
 
@@ -1109,7 +1109,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanField', $extra + [
-            'rule' => ['compareFields', $secondField, '<']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS_THAN]
         ]);
     }
 
@@ -1130,7 +1130,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqualToField', $extra + [
-            'rule' => ['compareFields', $secondField, '<=']
+            'rule' => ['compareFields', $secondField, Validation::COMPARE_LESS_THAN_OR_EQUAL_TO]
         ]);
     }
 
@@ -1853,7 +1853,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                     $value = $value['_ids'];
                 }
 
-                return Validation::numElements($value, '>=', $count);
+                return Validation::numElements($value, Validation::COMPARE_GREATER_THAN_OR_EQUAL_TO, $count);
             }
         ]);
     }
@@ -1880,7 +1880,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                     $value = $value['_ids'];
                 }
 
-                return Validation::numElements($value, '<=', $count);
+                return Validation::numElements($value, Validation::COMPARE_LESS_THAN_OR_EQUAL_TO, $count);
             }
         ]);
     }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -841,45 +841,43 @@ class ValidationTest extends TestCase
     public function testComparison()
     {
         $this->assertFalse(Validation::comparison(7, null, 6));
-        $this->assertTrue(Validation::comparison(7, 'is greater', 6));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER, 6));
-        $this->assertTrue(Validation::comparison(6, 'is less', 7));
         $this->assertTrue(Validation::comparison(6, Validation::COMPARE_LESS, 7));
-        $this->assertTrue(Validation::comparison(7, 'greater or equal', 7));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER_OR_EQUAL, 7));
-        $this->assertTrue(Validation::comparison(7, 'greater or equal', 6));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER_OR_EQUAL, 6));
-        $this->assertTrue(Validation::comparison(6, 'less or equal', 7));
         $this->assertTrue(Validation::comparison(6, Validation::COMPARE_LESS_OR_EQUAL, 7));
-        $this->assertTrue(Validation::comparison(7, 'equal to', 7));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_EQUAL, 7));
-        $this->assertTrue(Validation::comparison(7, 'not equal', 6));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_NOT_EQUAL, 6));
-        $this->assertTrue(Validation::comparison(7, 'same as', 7));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_SAME, 7));
-        $this->assertTrue(Validation::comparison(7, 'not same as', '7'));
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_NOT_SAME, '7'));
-        $this->assertFalse(Validation::comparison(6, 'is greater', 7));
         $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER, 7));
-        $this->assertFalse(Validation::comparison(7, 'is less', 6));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_LESS, 6));
-        $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
         $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER_OR_EQUAL, 7));
-        $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
         $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER_OR_EQUAL, 7));
-        $this->assertFalse(Validation::comparison(7, 'less or equal', 6));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_LESS_OR_EQUAL, 6));
-        $this->assertFalse(Validation::comparison(7, 'equal to', 6));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_EQUAL, 6));
-        $this->assertFalse(Validation::comparison(7, 'not equal', 7));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_NOT_EQUAL, 7));
-        $this->assertFalse(Validation::comparison(7, 'same as', '7'));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_SAME, '7'));
-        $this->assertFalse(Validation::comparison(7, 'not same as', 7));
         $this->assertFalse(Validation::comparison(7, Validation::COMPARE_NOT_SAME, 7));
-
         $this->assertTrue(Validation::comparison('6.5', Validation::COMPARE_NOT_EQUAL, 6));
         $this->assertTrue(Validation::comparison('6.5', Validation::COMPARE_LESS, 7));
+
+        $this->deprecated(function () {
+            $this->assertTrue(Validation::comparison(7, 'is greater', 6));
+            $this->assertTrue(Validation::comparison(6, 'is less', 7));
+            $this->assertTrue(Validation::comparison(7, 'greater or equal', 7));
+            $this->assertTrue(Validation::comparison(7, 'greater or equal', 6));
+            $this->assertTrue(Validation::comparison(6, 'less or equal', 7));
+            $this->assertTrue(Validation::comparison(7, 'equal to', 7));
+            $this->assertTrue(Validation::comparison(7, 'not equal', 6));
+            $this->assertFalse(Validation::comparison(6, 'is greater', 7));
+            $this->assertFalse(Validation::comparison(7, 'is less', 6));
+            $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
+            $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
+            $this->assertFalse(Validation::comparison(7, 'less or equal', 6));
+            $this->assertFalse(Validation::comparison(7, 'equal to', 6));
+            $this->assertFalse(Validation::comparison(7, 'not equal', 7));
+        });
     }
 
     /**
@@ -2602,13 +2600,13 @@ class ValidationTest extends TestCase
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_LESS, 1024));
-        $this->assertTrue(Validation::fileSize(['tmp_name' => $image], 'isless', 1024));
+        $this->assertTrue(Validation::fileSize(['tmp_name' => $image], Validation::COMPARE_LESS, 1024));
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_LESS, '1KB'));
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_GREATER_OR_EQUAL, 200));
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_EQUAL, 201));
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_EQUAL, '201B'));
 
-        $this->assertFalse(Validation::fileSize($image, 'isgreater', 1024));
+        $this->assertFalse(Validation::fileSize($image, Validation::COMPARE_GREATER, 1024));
         $this->assertFalse(Validation::fileSize(['tmp_name' => $image], Validation::COMPARE_GREATER, '1KB'));
     }
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2761,17 +2761,17 @@ class ValidationTest extends TestCase
                 'other' => 'a value'
             ]
         ];
-        $this->assertTrue(Validation::compareFields('a value', 'other', 'equalto', $context));
+        $this->assertTrue(Validation::compareFields('a value', 'other', Validation::COMPARE_EQUAL, $context));
 
         $context = [
             'data' => [
                 'other' => 'different'
             ]
         ];
-        $this->assertFalse(Validation::compareFields('a value', 'other', 'equalto', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', Validation::COMPARE_EQUAL, $context));
 
         $context = [];
-        $this->assertFalse(Validation::compareFields('a value', 'other', 'equalto', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', Validation::COMPARE_EQUAL, $context));
     }
 
     /**
@@ -2786,17 +2786,17 @@ class ValidationTest extends TestCase
                 'other' => 'different'
             ]
         ];
-        $this->assertTrue(Validation::compareFields('a value', 'other', 'notequal', $context));
+        $this->assertTrue(Validation::compareFields('a value', 'other', Validation::COMPARE_NOT_EQUAL, $context));
 
         $context = [
             'data' => [
                 'other' => 'a value'
             ]
         ];
-        $this->assertFalse(Validation::compareFields('a value', 'other', 'notequal', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', Validation::COMPARE_NOT_EQUAL, $context));
 
         $context = [];
-        $this->assertFalse(Validation::compareFields('a value', 'other', 'notequal', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', Validation::COMPARE_NOT_EQUAL, $context));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2742,53 +2742,53 @@ class ValidationTest extends TestCase
     }
 
     /**
-     * Test the compareFields method with true result.
+     * Test the compareFields method with eual result.
      *
      * @return void
      */
-    public function testCompareFieldsTrue()
+    public function testCompareFieldsEqualTo()
     {
         $context = [
             'data' => [
                 'other' => 'a value'
             ]
         ];
-        $this->assertTrue(Validation::compareFields('a value', 'other', true, $context));
+        $this->assertTrue(Validation::compareFields('a value', 'other', 'equalto', $context));
 
         $context = [
             'data' => [
                 'other' => 'different'
             ]
         ];
-        $this->assertFalse(Validation::compareFields('a value', 'other', true, $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', 'equalto', $context));
 
         $context = [];
-        $this->assertFalse(Validation::compareFields('a value', 'other', true, $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', 'equalto', $context));
     }
 
     /**
-     * Test the compareFields method with false result.
+     * Test the compareFields method with not equal result.
      *
      * @return void
      */
-    public function testCompareFieldsFalse()
+    public function testCompareFieldsNotEqual()
     {
         $context = [
             'data' => [
                 'other' => 'different'
             ]
         ];
-        $this->assertTrue(Validation::compareFields('a value', 'other', false, $context));
+        $this->assertTrue(Validation::compareFields('a value', 'other', 'notequal', $context));
 
         $context = [
             'data' => [
                 'other' => 'a value'
             ]
         ];
-        $this->assertFalse(Validation::compareFields('a value', 'other', false, $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', 'notequal', $context));
 
         $context = [];
-        $this->assertFalse(Validation::compareFields('a value', 'other', false, $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', 'notequal', $context));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -855,6 +855,10 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::comparison(7, '==', 7));
         $this->assertTrue(Validation::comparison(7, 'not equal', 6));
         $this->assertTrue(Validation::comparison(7, '!=', 6));
+        $this->assertTrue(Validation::comparison(7, 'same as', 7));
+        $this->assertTrue(Validation::comparison(7, '===', 7));
+        $this->assertTrue(Validation::comparison(7, 'not same as', '7'));
+        $this->assertTrue(Validation::comparison(7, '!==', '7'));
         $this->assertFalse(Validation::comparison(6, 'is greater', 7));
         $this->assertFalse(Validation::comparison(6, '>', 7));
         $this->assertFalse(Validation::comparison(7, 'is less', 6));
@@ -869,6 +873,10 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::comparison(7, '==', 6));
         $this->assertFalse(Validation::comparison(7, 'not equal', 7));
         $this->assertFalse(Validation::comparison(7, '!=', 7));
+        $this->assertFalse(Validation::comparison(7, 'same as', '7'));
+        $this->assertFalse(Validation::comparison(7, '===', '7'));
+        $this->assertFalse(Validation::comparison(7, 'not same as', 7));
+        $this->assertFalse(Validation::comparison(7, '!==', 7));
 
         $this->assertTrue(Validation::comparison('6.5', '!=', 6));
         $this->assertTrue(Validation::comparison('6.5', '<', 7));

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2750,7 +2750,7 @@ class ValidationTest extends TestCase
     }
 
     /**
-     * Test the compareFields method with eual result.
+     * Test the compareFields method with equal result.
      *
      * @return void
      */

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -842,44 +842,44 @@ class ValidationTest extends TestCase
     {
         $this->assertFalse(Validation::comparison(7, null, 6));
         $this->assertTrue(Validation::comparison(7, 'is greater', 6));
-        $this->assertTrue(Validation::comparison(7, '>', 6));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER, 6));
         $this->assertTrue(Validation::comparison(6, 'is less', 7));
-        $this->assertTrue(Validation::comparison(6, '<', 7));
+        $this->assertTrue(Validation::comparison(6, Validation::COMPARE_LESS, 7));
         $this->assertTrue(Validation::comparison(7, 'greater or equal', 7));
-        $this->assertTrue(Validation::comparison(7, '>=', 7));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER_OR_EQUAL, 7));
         $this->assertTrue(Validation::comparison(7, 'greater or equal', 6));
-        $this->assertTrue(Validation::comparison(7, '>=', 6));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER_OR_EQUAL, 6));
         $this->assertTrue(Validation::comparison(6, 'less or equal', 7));
-        $this->assertTrue(Validation::comparison(6, '<=', 7));
+        $this->assertTrue(Validation::comparison(6, Validation::COMPARE_LESS_OR_EQUAL, 7));
         $this->assertTrue(Validation::comparison(7, 'equal to', 7));
-        $this->assertTrue(Validation::comparison(7, '==', 7));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_EQUAL, 7));
         $this->assertTrue(Validation::comparison(7, 'not equal', 6));
-        $this->assertTrue(Validation::comparison(7, '!=', 6));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_NOT_EQUAL, 6));
         $this->assertTrue(Validation::comparison(7, 'same as', 7));
-        $this->assertTrue(Validation::comparison(7, '===', 7));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_SAME, 7));
         $this->assertTrue(Validation::comparison(7, 'not same as', '7'));
-        $this->assertTrue(Validation::comparison(7, '!==', '7'));
+        $this->assertTrue(Validation::comparison(7, Validation::COMPARE_NOT_SAME, '7'));
         $this->assertFalse(Validation::comparison(6, 'is greater', 7));
-        $this->assertFalse(Validation::comparison(6, '>', 7));
+        $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER, 7));
         $this->assertFalse(Validation::comparison(7, 'is less', 6));
-        $this->assertFalse(Validation::comparison(7, '<', 6));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_LESS, 6));
         $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
-        $this->assertFalse(Validation::comparison(6, '>=', 7));
+        $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER_OR_EQUAL, 7));
         $this->assertFalse(Validation::comparison(6, 'greater or equal', 7));
-        $this->assertFalse(Validation::comparison(6, '>=', 7));
+        $this->assertFalse(Validation::comparison(6, Validation::COMPARE_GREATER_OR_EQUAL, 7));
         $this->assertFalse(Validation::comparison(7, 'less or equal', 6));
-        $this->assertFalse(Validation::comparison(7, '<=', 6));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_LESS_OR_EQUAL, 6));
         $this->assertFalse(Validation::comparison(7, 'equal to', 6));
-        $this->assertFalse(Validation::comparison(7, '==', 6));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_EQUAL, 6));
         $this->assertFalse(Validation::comparison(7, 'not equal', 7));
-        $this->assertFalse(Validation::comparison(7, '!=', 7));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_NOT_EQUAL, 7));
         $this->assertFalse(Validation::comparison(7, 'same as', '7'));
-        $this->assertFalse(Validation::comparison(7, '===', '7'));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_SAME, '7'));
         $this->assertFalse(Validation::comparison(7, 'not same as', 7));
-        $this->assertFalse(Validation::comparison(7, '!==', 7));
+        $this->assertFalse(Validation::comparison(7, Validation::COMPARE_NOT_SAME, 7));
 
-        $this->assertTrue(Validation::comparison('6.5', '!=', 6));
-        $this->assertTrue(Validation::comparison('6.5', '<', 7));
+        $this->assertTrue(Validation::comparison('6.5', Validation::COMPARE_NOT_EQUAL, 6));
+        $this->assertTrue(Validation::comparison('6.5', Validation::COMPARE_LESS, 7));
     }
 
     /**
@@ -889,14 +889,14 @@ class ValidationTest extends TestCase
      */
     public function testComparisonTypeChecks()
     {
-        $this->assertFalse(Validation::comparison('\x028', '>=', 1), 'hexish encoding fails');
-        $this->assertFalse(Validation::comparison('0b010', '>=', 1), 'binary string data fails');
-        $this->assertFalse(Validation::comparison('0x01', '>=', 1), 'hex string data fails');
-        $this->assertFalse(Validation::comparison('0x1', '>=', 1), 'hex string data fails');
+        $this->assertFalse(Validation::comparison('\x028', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'hexish encoding fails');
+        $this->assertFalse(Validation::comparison('0b010', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'binary string data fails');
+        $this->assertFalse(Validation::comparison('0x01', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'hex string data fails');
+        $this->assertFalse(Validation::comparison('0x1', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'hex string data fails');
 
-        $this->assertFalse(Validation::comparison('\x028', '>=', 1.5), 'hexish encoding fails');
-        $this->assertFalse(Validation::comparison('0b010', '>=', 1.5), 'binary string data fails');
-        $this->assertFalse(Validation::comparison('0x02', '>=', 1.5), 'hex string data fails');
+        $this->assertFalse(Validation::comparison('\x028', Validation::COMPARE_GREATER_OR_EQUAL, 1.5), 'hexish encoding fails');
+        $this->assertFalse(Validation::comparison('0b010', Validation::COMPARE_GREATER_OR_EQUAL, 1.5), 'binary string data fails');
+        $this->assertFalse(Validation::comparison('0x02', Validation::COMPARE_GREATER_OR_EQUAL, 1.5), 'hex string data fails');
     }
 
     /**
@@ -2601,15 +2601,15 @@ class ValidationTest extends TestCase
     public function testFileSize()
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
-        $this->assertTrue(Validation::fileSize($image, '<', 1024));
+        $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_LESS, 1024));
         $this->assertTrue(Validation::fileSize(['tmp_name' => $image], 'isless', 1024));
-        $this->assertTrue(Validation::fileSize($image, '<', '1KB'));
-        $this->assertTrue(Validation::fileSize($image, '>=', 200));
-        $this->assertTrue(Validation::fileSize($image, '==', 201));
-        $this->assertTrue(Validation::fileSize($image, '==', '201B'));
+        $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_LESS, '1KB'));
+        $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_GREATER_OR_EQUAL, 200));
+        $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_EQUAL, 201));
+        $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_EQUAL, '201B'));
 
         $this->assertFalse(Validation::fileSize($image, 'isgreater', 1024));
-        $this->assertFalse(Validation::fileSize(['tmp_name' => $image], '>', '1KB'));
+        $this->assertFalse(Validation::fileSize(['tmp_name' => $image], Validation::COMPARE_GREATER, '1KB'));
     }
 
     /**
@@ -2622,10 +2622,10 @@ class ValidationTest extends TestCase
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $file = new UploadedFile($image, 1000, UPLOAD_ERR_OK, 'cake.power.gif', 'image/gif');
 
-        $this->assertTrue(Validation::fileSize($file, '==', 201));
-        $this->assertTrue(Validation::fileSize($file, '<', 1024));
-        $this->assertFalse(Validation::fileSize($file, '>', 202));
-        $this->assertFalse(Validation::fileSize($file, '>', 1000));
+        $this->assertTrue(Validation::fileSize($file, Validation::COMPARE_EQUAL, 201));
+        $this->assertTrue(Validation::fileSize($file, Validation::COMPARE_LESS, 1024));
+        $this->assertFalse(Validation::fileSize($file, Validation::COMPARE_GREATER, 202));
+        $this->assertFalse(Validation::fileSize($file, Validation::COMPARE_GREATER, 1000));
     }
 
     /**
@@ -3044,19 +3044,19 @@ class ValidationTest extends TestCase
     public function testNumElements()
     {
         $array = ['cake', 'php'];
-        $this->assertTrue(Validation::numElements($array, '==', 2));
-        $this->assertFalse(Validation::numElements($array, '>', 3));
-        $this->assertFalse(Validation::numElements($array, '<', 1));
+        $this->assertTrue(Validation::numElements($array, Validation::COMPARE_EQUAL, 2));
+        $this->assertFalse(Validation::numElements($array, Validation::COMPARE_GREATER, 3));
+        $this->assertFalse(Validation::numElements($array, Validation::COMPARE_LESS, 1));
 
         $callable = function () {
             return '';
         };
 
-        $this->assertFalse(Validation::numElements(null, '==', 0));
-        $this->assertFalse(Validation::numElements(new stdClass(), '==', 0));
-        $this->assertFalse(Validation::numElements($callable, '==', 0));
-        $this->assertFalse(Validation::numElements(false, '==', 0));
-        $this->assertFalse(Validation::numElements(true, '==', 0));
+        $this->assertFalse(Validation::numElements(null, Validation::COMPARE_EQUAL, 0));
+        $this->assertFalse(Validation::numElements(new stdClass(), Validation::COMPARE_EQUAL, 0));
+        $this->assertFalse(Validation::numElements($callable, Validation::COMPARE_EQUAL, 0));
+        $this->assertFalse(Validation::numElements(false, Validation::COMPARE_EQUAL, 0));
+        $this->assertFalse(Validation::numElements(true, Validation::COMPARE_EQUAL, 0));
     }
 
     /**
@@ -3083,38 +3083,38 @@ class ValidationTest extends TestCase
         ];
 
         $this->assertTrue(Validation::imageSize($upload, [
-            'width' => ['>', 100],
-            'height' => ['>', 100],
+            'width' => [Validation::COMPARE_GREATER, 100],
+            'height' => [Validation::COMPARE_GREATER, 100],
         ]));
 
         $this->assertFalse(Validation::imageSize($upload, [
-            'width' => ['>', 100],
-            'height' => ['<', 100],
+            'width' => [Validation::COMPARE_GREATER, 100],
+            'height' => [Validation::COMPARE_LESS, 100],
         ]));
 
         $this->assertFalse(Validation::imageSize($upload, [
-            'width' => ['==', 100],
-            'height' => ['==', 300],
+            'width' => [Validation::COMPARE_EQUAL, 100],
+            'height' => [Validation::COMPARE_EQUAL, 300],
         ]));
 
         $this->assertTrue(Validation::imageSize($upload, [
-            'width' => ['>=', 300],
-            'height' => ['>=', 300],
+            'width' => [Validation::COMPARE_GREATER_OR_EQUAL, 300],
+            'height' => [Validation::COMPARE_GREATER_OR_EQUAL, 300],
         ]));
 
         $this->assertTrue(Validation::imageSize($upload, [
-            'width' => ['<=', 300],
-            'height' => ['<=', 300],
+            'width' => [Validation::COMPARE_LESS_OR_EQUAL, 300],
+            'height' => [Validation::COMPARE_LESS_OR_EQUAL, 300],
         ]));
 
         $this->assertTrue(Validation::imageSize($upload, [
-            'width' => ['<=', 300],
-            'height' => ['>=', 300],
+            'width' => [Validation::COMPARE_LESS_OR_EQUAL, 300],
+            'height' => [Validation::COMPARE_GREATER_OR_EQUAL, 300],
         ]));
 
         $this->assertFalse(Validation::imageSize($upload, [
-            'width' => ['<=', 299],
-            'height' => ['>=', 300],
+            'width' => [Validation::COMPARE_LESS_OR_EQUAL, 299],
+            'height' => [Validation::COMPARE_GREATER_OR_EQUAL, 300],
         ]));
     }
 
@@ -3130,13 +3130,13 @@ class ValidationTest extends TestCase
             'tmp_name' => $image
         ];
 
-        $this->assertTrue(Validation::imageHeight($upload, '>', 100));
-        $this->assertTrue(Validation::imageHeight($upload, '<', 2000));
-        $this->assertTrue(Validation::imageHeight($upload, '==', 300));
+        $this->assertTrue(Validation::imageHeight($upload, Validation::COMPARE_GREATER, 100));
+        $this->assertTrue(Validation::imageHeight($upload, Validation::COMPARE_LESS, 2000));
+        $this->assertTrue(Validation::imageHeight($upload, Validation::COMPARE_EQUAL, 300));
 
-        $this->assertFalse(Validation::imageHeight($upload, '<', 100));
-        $this->assertFalse(Validation::imageHeight($upload, '>', 2000));
-        $this->assertFalse(Validation::imageHeight($upload, '==', 3000));
+        $this->assertFalse(Validation::imageHeight($upload, Validation::COMPARE_LESS, 100));
+        $this->assertFalse(Validation::imageHeight($upload, Validation::COMPARE_GREATER, 2000));
+        $this->assertFalse(Validation::imageHeight($upload, Validation::COMPARE_EQUAL, 3000));
     }
 
     /**
@@ -3151,13 +3151,13 @@ class ValidationTest extends TestCase
             'tmp_name' => $image
         ];
 
-        $this->assertTrue(Validation::imageWidth($upload, '>', 100));
-        $this->assertTrue(Validation::imageWidth($upload, '<', 2000));
-        $this->assertTrue(Validation::imageWidth($upload, '==', 300));
+        $this->assertTrue(Validation::imageWidth($upload, Validation::COMPARE_GREATER, 100));
+        $this->assertTrue(Validation::imageWidth($upload, Validation::COMPARE_LESS, 2000));
+        $this->assertTrue(Validation::imageWidth($upload, Validation::COMPARE_EQUAL, 300));
 
-        $this->assertFalse(Validation::imageWidth($upload, '<', 100));
-        $this->assertFalse(Validation::imageWidth($upload, '>', 2000));
-        $this->assertFalse(Validation::imageWidth($upload, '==', 3000));
+        $this->assertFalse(Validation::imageWidth($upload, Validation::COMPARE_LESS, 100));
+        $this->assertFalse(Validation::imageWidth($upload, Validation::COMPARE_GREATER, 2000));
+        $this->assertFalse(Validation::imageWidth($upload, Validation::COMPARE_EQUAL, 3000));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
+use Cake\Validation\Validation;
 use Cake\Validation\ValidationSet;
 use Cake\Validation\Validator;
 
@@ -1352,7 +1353,7 @@ class ValidatorTest extends TestCase
     public function testGreaterThan()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'greaterThan', 5, ['>', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'greaterThan', 5, [Validation::COMPARE_GREATER, 5], 'comparison');
         $this->assertNotEmpty($validator->errors(['username' => 2]));
     }
 
@@ -1364,7 +1365,7 @@ class ValidatorTest extends TestCase
     public function testGreaterThanOrEqual()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, ['>=', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, [Validation::COMPARE_GREATER_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->errors(['username' => 2]));
     }
 
@@ -1376,7 +1377,7 @@ class ValidatorTest extends TestCase
     public function testLessThan()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'lessThan', 5, ['<', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'lessThan', 5, [Validation::COMPARE_LESS, 5], 'comparison');
         $this->assertNotEmpty($validator->errors(['username' => 5]));
     }
 
@@ -1388,7 +1389,7 @@ class ValidatorTest extends TestCase
     public function testLessThanOrEqual()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, ['<=', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, [Validation::COMPARE_LESS_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->errors(['username' => 6]));
     }
 
@@ -1400,7 +1401,7 @@ class ValidatorTest extends TestCase
     public function testEquals()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'equals', 5, ['==', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'equals', 5, [Validation::COMPARE_EQUAL, 5], 'comparison');
         $this->assertEmpty($validator->errors(['username' => 5]));
         $this->assertNotEmpty($validator->errors(['username' => 6]));
     }
@@ -1413,7 +1414,7 @@ class ValidatorTest extends TestCase
     public function testNotEquals()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'notEquals', 5, ['!=', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'notEquals', 5, [Validation::COMPARE_NOT_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->errors(['username' => 5]));
     }
 
@@ -1425,7 +1426,7 @@ class ValidatorTest extends TestCase
     public function testSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', '==='], 'compareFields');
+        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', Validation::COMPARE_SAME], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
         $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => '1']));
     }
@@ -1438,7 +1439,7 @@ class ValidatorTest extends TestCase
     public function testNotSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', '!=='], 'compareFields');
+        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', Validation::COMPARE_NOT_SAME], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 
@@ -1450,7 +1451,7 @@ class ValidatorTest extends TestCase
     public function testEqualToField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', '=='], 'compareFields');
+        $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', Validation::COMPARE_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'bar']));
     }
@@ -1463,7 +1464,7 @@ class ValidatorTest extends TestCase
     public function testNotEqualToField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', '!='], 'compareFields');
+        $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', Validation::COMPARE_NOT_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 
@@ -1475,7 +1476,7 @@ class ValidatorTest extends TestCase
     public function testGreaterThanField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', '>'], 'compareFields');
+        $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', Validation::COMPARE_GREATER], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
     }
@@ -1488,7 +1489,7 @@ class ValidatorTest extends TestCase
     public function testGreaterThanOrEqualToField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', '>='], 'compareFields');
+        $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', Validation::COMPARE_GREATER_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
     }
 
@@ -1500,7 +1501,7 @@ class ValidatorTest extends TestCase
     public function testLessThanField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', '<'], 'compareFields');
+        $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', Validation::COMPARE_LESS], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
     }
@@ -1513,7 +1514,7 @@ class ValidatorTest extends TestCase
     public function testLessThanOrEqualToField()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', '<='], 'compareFields');
+        $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', Validation::COMPARE_LESS_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1442,6 +1442,56 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the greaterThanField proxy method
+     *
+     * @return void
+     */
+    public function testGreaterThanField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', '>'], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
+        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
+    }
+
+    /**
+     * Tests the greaterThanOrEqualToField proxy method
+     *
+     * @return void
+     */
+    public function testGreaterThanOrEqualToField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', '>='], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
+    }
+
+    /**
+     * Tests the lessThanField proxy method
+     *
+     * @return void
+     */
+    public function testLessThanField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', '<'], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
+        $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
+    }
+
+    /**
+     * Tests the lessThanOrEqualToField proxy method
+     *
+     * @return void
+     */
+    public function testLessThanOrEqualToField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', '<='], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
+    }
+
+    /**
      * Tests the containsNonAlphaNumeric proxy method
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1427,6 +1427,7 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', '==='], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
+        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => '1']));
     }
 
     /**
@@ -1438,6 +1439,31 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', '!=='], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
+    }
+
+    /**
+     * Tests the equalToField proxy method
+     *
+     * @return void
+     */
+    public function testEqualToField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', '=='], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 'foo']));
+        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'bar']));
+    }
+
+    /**
+     * Tests the notEqualToField proxy method
+     *
+     * @return void
+     */
+    public function testNotEqualToField()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', '!='], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1425,7 +1425,7 @@ class ValidatorTest extends TestCase
     public function testSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', 'equalto'], 'compareFields');
+        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', '==='], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
     }
 
@@ -1437,7 +1437,7 @@ class ValidatorTest extends TestCase
     public function testNotSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', 'notequal'], 'compareFields');
+        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', '!=='], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1425,7 +1425,7 @@ class ValidatorTest extends TestCase
     public function testSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', true], 'compareFields');
+        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', 'equalto'], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
     }
 
@@ -1437,7 +1437,7 @@ class ValidatorTest extends TestCase
     public function testNotSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', false], 'compareFields');
+        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', 'notequal'], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 


### PR DESCRIPTION
Added a number of validation rules that compare one field value to another field value.
Useful in date range checks etc.

- `equalToField` - weak type equality comparison
- `notEqualToField` - weak type non-equality comparison
- `greaterThanField`
- `greaterThanOrEqualToField`
- `lessThanField`
- `lessThanOrEqualToField`

Behind the scenes `Validation::compareFields()` now leverages `comparison` method for value checks.
I also added strict type comparisons to `Validation::comparison()`.