### PR TITLE
Fix namespace displayed for nested prefix.

### DIFF
--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -22,9 +22,9 @@ if (!empty($plugin)) {
 }
 $prefixNs = '';
 if (!empty($prefix)) {
-    $prefix = Inflector::camelize($prefix);
-    $prefixNs = '\\' . $prefix;
-    $prefix .= DIRECTORY_SEPARATOR;
+    $prefix = array_map('\Cake\Utility\Inflector::camelize', explode('/', $prefix));
+    $prefixNs = '\\' . implode('\\', $prefix);
+    $prefix = implode(DIRECTORY_SEPARATOR, $prefix) . DIRECTORY_SEPARATOR;
 }
 
 // Controller MissingAction support


### PR DESCRIPTION
For e.g. it now correctly shows

```php
namespace App\Controller\Api\V2;
```
instead of

```php
namespace App\Controller\Api/v2;
```
