### PR TITLE
Fix incorrect tag for EntityInterface::getSource()

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -36,7 +36,7 @@ use JsonSerializable;
  * @method $this setAccess($property, $set)
  * @method bool isAccessible($property)
  * @method $this setSource($source)
- * @method array getSource()
+ * @method string getSource()
  * @method array extractOriginal(array $properties)
  * @method array extractOriginalChanged(array $properties)
  *


### PR DESCRIPTION
Fix mismatch between EntityInterface and implements in EntityTrait.

With [phan](https://github.com/phan/phan), static analyzer reports error.

```php
Inflector::singularize($entity->getSource());
```
then
```
PhanTypeMismatchArgument Argument 1 (word) is array but \Cake\Utility\Inflector::singularize() takes string defined at vendor/cakephp/cakephp/src/Utility/Inflector.php:546
```
  
  