### PR TITLE
Allow URL #hash for scoped paginator links

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -553,6 +553,12 @@ class PaginatorHelper extends Helper
         if (!empty($paging['scope'])) {
             $scope = $paging['scope'];
             $currentParams = $this->_config['options']['url'];
+
+            if (isset($url['#'])) {
+                $currentParams['#'] = $url['#'];
+                unset($url['#']);
+            }
+
             // Merge existing query parameters in the scope.
             if (isset($currentParams['?'][$scope]) && is_array($currentParams['?'][$scope])) {
                 $url += $currentParams['?'][$scope];

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -910,6 +910,10 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl(['sort' => 'name']);
         $expected = '/posts/index?article%5Bpage%5D=3&amp;article%5Bsort%5D=name';
         $this->assertEquals($expected, $result);
+
+        $result = $this->Paginator->generateUrl(['#' => 'foo']);
+        $expected = '/posts/index?article%5Bpage%5D=3#foo';
+        $this->assertEquals($expected, $result);
     }
 
     /**


### PR DESCRIPTION
When using multiple paginated tables, it is good idea to jump back to table whose page number I just clicked.

With `$this->Paginator->numbers(['model' => 'Posts', 'url' => ['#' => 'user-posts-table']]);`, 
I'm getting `/users/view/123?posts[page]=2&posts[#]=user-posts-table`,
but I expect `/users/view/123?posts[page]=2#user-posts-table`

