### PR TITLE
Forward port #11581 to 3.x

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -252,7 +252,7 @@ abstract class CacheEngine
 
         $prefix = '';
         if ($this->_groupPrefix) {
-            $prefix = vsprintf($this->_groupPrefix, $this->groups());
+            $prefix = md5(implode('_', $this->groups()));
         }
 
         $key = preg_replace('/[\s]+/', '_', strtolower(trim(str_replace([DIRECTORY_SEPARATOR, '/', '.'], '_', (string)$key))));


### PR DESCRIPTION
Use the md5-sum of group keys instead of the actual group names. This helps mitigate key overflow issues in redis and memcached.

It does change the cache keys used, but those have never been promised to be backwards compatible.