### PR TITLE
Fix cache as dependency for ORM

### DIFF
--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "php": ">=5.6.0",
+        "cakephp/cache": "^3.0.0",
         "cakephp/core": "^3.0.0",
         "cakephp/datasource": "^3.0.0"
     },
     "suggest": {
-        "cakephp/log": "Require this if you want to use the built-in query logger",
-        "cakephp/cache": "Require this if you decide to use the schema caching feature"
+        "cakephp/log": "Require this if you want to use the built-in query logger"
     },
     "autoload": {
         "psr-4": {

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -25,6 +25,7 @@
     },
     "require": {
         "php": ">=5.6.0",
+        "cakephp/cache": "^3.0.0",
         "cakephp/core": "^3.0.0"
     },
     "suggest": {

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cache": "^3.0.0",
         "cakephp/core": "^3.0.0"
     },
     "suggest": {
-        "cakephp/utility": "Require this if you decide to use EntityTrait",
-        "cakephp/collection": "Require this if you decide to use ResultSetInterface"
+        "cakephp/utility": "If you decide to use EntityTrait.",
+        "cakephp/collection": "If you decide to use ResultSetInterface.",
+        "cakephp/cache": "If you decide to use Query caching."
     },
     "autoload": {
         "psr-4": {

--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -115,6 +115,22 @@ $article = $articles->get(2);
 $articles->delete($article);
 ```
 
+## Meta Data Cache
+
+It is recommended to enable meta data cache for production systems to avoid performance issues.
+For e.g. file system strategy your bootstrap file could look like this:
+```php
+use Cake\Cache\Engine\FileEngine;
+
+$cacheConfig = [
+   'className' => FileEngine::class,
+   'duration' => '+1 year',
+   'serialize' => true,
+   'prefix'    => 'orm_',
+],
+Cache::setConfig('_cake_model_', $cacheConfig);
+```
+
 ## Additional Documentation
 
 Consult [the CakePHP ORM documentation](https://book.cakephp.org/3.0/en/orm.html)

--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -32,7 +32,8 @@ ConnectionManager::setConfig('default', [
 	'database' => 'test',
 	'username' => 'root',
 	'password' => 'secret',
-	'cacheMetadata' => false // If set to `true` you need to install the optional "cakephp/cache" package.
+	'cacheMetadata' => true,
+	'quoteIdentifiers' => false,
 ]);
 ```
 


### PR DESCRIPTION
Resolves https://github.com/sergeyklay/php-orm-benchmark/pull/6
By default cache must be enabled on production systems, otherwise it will completely kill the ORM performance.
Thus this should be a require dependency.
We should use good production defaults here - and the exception should really be avoided:

    Error: Class 'Cake\Cache\Cache' not found ...
  
  A few files more don't hurt, but the benefit of a good default is crucial, especially for those first time working with this ORM and might otherwise miss it somewhere hidden in docs.