### PR TITLE
3.next - Allow route placeholders to use {var}

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -323,7 +323,7 @@ class Route
         $parsed = preg_quote($this->template, '#');
 
         if (strpos($route, '{') !== false && strpos($route, '}') !== false) {
-            preg_match_all('/\{([a-z0-9-_]+)\}/i', $route, $namedElements);
+            preg_match_all('/\{([a-z][a-z0-9-_]*)\}/i', $route, $namedElements);
             $this->braceKeys = true;
         } else {
             preg_match_all('/:([a-z0-9-_]+(?<![-_]))/i', $route, $namedElements);

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -322,7 +322,7 @@ class Route
         $names = $routeParams = [];
         $parsed = preg_quote($this->template, '#');
 
-        if (strpos($route, '{') !== false) {
+        if (strpos($route, '{') !== false && strpos($route, '}') !== false) {
             preg_match_all('/\{([a-z0-9-_]+)\}/i', $route, $namedElements);
             $this->braceKeys = true;
         } else {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -191,6 +191,19 @@ class RouteTest extends TestCase
     public function testRouteCompileMixedPlaceholders()
     {
         $route = new Route(
+            '/images/{open/:id',
+            ['controller' => 'Images', 'action' => 'open']
+        );
+        $pattern = $route->compile();
+        $this->assertRegExp($pattern, '/images/{open/9', 'Need both {} to enable brace mode');
+        $result = $route->match([
+            'controller' => 'Images',
+            'action' => 'open',
+            'id' => 123,
+        ]);
+        $this->assertEquals('/images/{open/123', $result);
+
+        $route = new Route(
             '/fighters/{id}/move/{x}/:y',
             ['controller' => 'Fighters', 'action' => 'move'],
             ['id' => '\d+', 'x' => '\d+', 'pass' => ['id', 'x']]

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -122,7 +122,7 @@ class RouteTest extends TestCase
      *
      * @return void
      */
-    public function testRouteBuildingSmallPlaceholders()
+    public function testRouteCompileSmallPlaceholders()
     {
         $route = new Route(
             '/fighters/:id/move/:x/:y',
@@ -140,6 +140,72 @@ class RouteTest extends TestCase
             'y' => 42
         ]);
         $this->assertEquals('/fighters/123/move/8/42', $result);
+    }
+
+    /**
+     * Test route compile with brace format.
+     *
+     * @return void
+     */
+    public function testRouteCompileBraces()
+    {
+        $route = new Route(
+            '/fighters/{id}/move/{x}/{y}',
+            ['controller' => 'Fighters', 'action' => 'move'],
+            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']]
+        );
+        $pattern = $route->compile();
+        $this->assertRegExp($pattern, '/fighters/123/move/8/42');
+
+        $result = $route->match([
+            'controller' => 'Fighters',
+            'action' => 'move',
+            'id' => 123,
+            'x' => 8,
+            'y' => 42
+        ]);
+        $this->assertEquals('/fighters/123/move/8/42', $result);
+
+        $route = new Route(
+            '/images/{id}/{x}x{y}',
+            ['controller' => 'Images', 'action' => 'view']
+        );
+        $pattern = $route->compile();
+        $this->assertRegExp($pattern, '/images/123/640x480');
+
+        $result = $route->match([
+            'controller' => 'Images',
+            'action' => 'view',
+            'id' => 123,
+            'x' => 8,
+            'y' => 42
+        ]);
+        $this->assertEquals('/images/123/8x42', $result);
+    }
+
+    /**
+     * Test route compile with mixed placeholder types brace format.
+     *
+     * @return void
+     */
+    public function testRouteCompileMixedPlaceholders()
+    {
+        $route = new Route(
+            '/fighters/{id}/move/{x}/:y',
+            ['controller' => 'Fighters', 'action' => 'move'],
+            ['id' => '\d+', 'x' => '\d+', 'pass' => ['id', 'x']]
+        );
+        $pattern = $route->compile();
+        $this->assertRegExp($pattern, '/fighters/123/move/8/:y');
+
+        $result = $route->match([
+            'controller' => 'Fighters',
+            'action' => 'move',
+            'id' => 123,
+            'x' => 8,
+            'y' => 9
+        ]);
+        $this->assertEquals('/fighters/123/move/8/:y?y=9', $result);
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -154,8 +154,7 @@ class RouteTest extends TestCase
             ['controller' => 'Fighters', 'action' => 'move'],
             ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']]
         );
-        $pattern = $route->compile();
-        $this->assertRegExp($pattern, '/fighters/123/move/8/42');
+        $this->assertRegExp($route->compile(), '/fighters/123/move/8/42');
 
         $result = $route->match([
             'controller' => 'Fighters',
@@ -170,8 +169,7 @@ class RouteTest extends TestCase
             '/images/{id}/{x}x{y}',
             ['controller' => 'Images', 'action' => 'view']
         );
-        $pattern = $route->compile();
-        $this->assertRegExp($pattern, '/images/123/640x480');
+        $this->assertRegExp($route->compile(), '/images/123/640x480');
 
         $result = $route->match([
             'controller' => 'Images',
@@ -181,6 +179,50 @@ class RouteTest extends TestCase
             'y' => 42
         ]);
         $this->assertEquals('/images/123/8x42', $result);
+    }
+
+    /**
+     * Test route compile with brace format.
+     *
+     * @return void
+     */
+    public function testRouteCompileBracesVariableName()
+    {
+        $route = new Route(
+            '/fighters/{0id}',
+            ['controller' => 'Fighters', 'action' => 'move']
+        );
+        $pattern = $route->compile();
+        $this->assertNotRegExp($route->compile(), '/fighters/123', 'Placeholders must start with letter');
+
+        $route = new Route('/fighters/{Id}', ['controller' => 'Fighters', 'action' => 'move']);
+        $this->assertRegExp($route->compile(), '/fighters/123');
+
+        $route = new Route('/fighters/{i_d}', ['controller' => 'Fighters', 'action' => 'move']);
+        $this->assertRegExp($route->compile(), '/fighters/123');
+
+        $route = new Route('/fighters/{id99}', ['controller' => 'Fighters', 'action' => 'move']);
+        $this->assertRegExp($route->compile(), '/fighters/123');
+    }
+
+    /**
+     * Test route compile with brace format.
+     *
+     * @return void
+     */
+    public function testRouteCompileBracesInvalid()
+    {
+        $route = new Route(
+            '/fighters/{ id }',
+            ['controller' => 'Fighters', 'action' => 'move']
+        );
+        $this->assertNotRegExp($route->compile(), '/fighters/123', 'no spaces in placeholder');
+
+        $route = new Route(
+            '/fighters/{i d}',
+            ['controller' => 'Fighters', 'action' => 'move']
+        );
+        $this->assertNotRegExp($route->compile(), '/fighters/123', 'no spaces in placeholder');
     }
 
     /**


### PR DESCRIPTION
Brace placeholders allow route placeholders to be more easily identified and be placed mid-word with other alphanumeric characters.

While the original issues proposed that this new `{var}` style be the only supported style in the future, I'd like to push that decision off until 5.0 at the earliest. Removing `:var` style placeholders would be a significant impediment to upgrading to 4.0 and I'm not sure that is a good idea given that supporting both styles now is simple. If the `{var}` style proves successful we can deprecate `:var` in 4.x.

Refs #9188
Refs #10689