### PR TITLE
Enable automatic PHPCS fixing from stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,13 @@
+---
 linters:
   phpcs:
     standard: CakePHP
     extensions: 'php,ctp'
+    fixer: true
+
 branches:
     ignore: ['2.x', '2.next']
+
+fixers:
+  enable: true
+  workflow: commit


### PR DESCRIPTION
This will instruct stickler - when possible - to push a commit to pull requests automatically fixing some PHPCS errors. This should help cut down on the amount of work we and contributors have to do.
