### PR TITLE
2.x Build and Pass with PHP7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 
     - php: 7.2
       env: DB=mysql PHPUNIT=5.7.19
-  allow_failures:
+  exclude:
     - php: 7.2
       env: DB=mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
 
 
 before_script:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]] ; then pear config-set preferred_state snapshot && yes "" | pecl install mcrypt ; fi
   - composer require "phpunit/phpunit=$PHPUNIT"
   - echo "require_once 'vendors/autoload.php';" >> app/Config/bootstrap.php
   - sudo locale-gen de_DE
@@ -62,7 +63,6 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi"
   - chmod -R 777 ./app/tmp
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]] ; then pecl install timezonedb ; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]] ; then pecl install mcrypt ; fi
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require 'cakephp/cakephp-codesniffer:1.*'; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendors/bin/phpcs --config-set installed_paths vendors/cakephp/cakephp-codesniffer; fi"
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,8 @@ matrix:
 
     - php: 7.2
       env: DB=mysql PHPUNIT=5.7.19
-  allow_failures:
-    - php: 7.2
-      env: DB=mysql
 
+  allow_failures:
     - php: 7.2
       env: DB=mysql PHPUNIT=5.7.19
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,9 @@ matrix:
 
     - php: 7.2
       env: DB=mysql PHPUNIT=5.7.19
-
   allow_failures:
     - php: 7.2
-      env: DB=mysql PHPUNIT=5.7.19
+      env: DB=mysql
 
 
 before_script:

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -331,10 +331,10 @@ class ControllerTask extends BakeTask {
 	public function bake($controllerName, $actions = '', $helpers = null, $components = null) {
 		$this->out("\n" . __d('cake_console', 'Baking controller class for %s...', $controllerName), 1, Shell::QUIET);
 
-		if (is_null($helpers)) {
+		if ($helpers === null) {
 			$helpers = array();
 		}
-		if (is_null($components)) {
+		if ($components === null) {
 			$components = array();
 		}
 		$isScaffold = ($actions === 'scaffold') ? true : false;

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -328,7 +328,7 @@ class ControllerTask extends BakeTask {
  * @param array $components Components to use in controller
  * @return string Baked controller
  */
-	public function bake($controllerName, $actions = '', $helpers = null, $components = null) {
+	public function bake($controllerName, $actions = '', $helpers = array(), $components = array()) {
 		$this->out("\n" . __d('cake_console', 'Baking controller class for %s...', $controllerName), 1, Shell::QUIET);
 
 		$isScaffold = ($actions === 'scaffold') ? true : false;

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -328,9 +328,15 @@ class ControllerTask extends BakeTask {
  * @param array $components Components to use in controller
  * @return string Baked controller
  */
-	public function bake($controllerName, $actions = '', $helpers = array(), $components = array()) {
+	public function bake($controllerName, $actions = '', $helpers = null, $components = null) {
 		$this->out("\n" . __d('cake_console', 'Baking controller class for %s...', $controllerName), 1, Shell::QUIET);
 
+		if (is_null($helpers)) {
+			$helpers = array();
+		}
+		if (is_null($components)) {
+			$components = array();
+		}
 		$isScaffold = ($actions === 'scaffold') ? true : false;
 
 		$this->Template->set(array(

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -554,7 +554,7 @@ class Multibyte {
 
 				if (!empty($keys)) {
 					foreach ($keys as $key => $value) {
-						if ($keys[$key]['upper'] == $char && count($keys[$key]['lower'][0]) === 1) {
+						if ($keys[$key]['upper'] == $char && count($keys[$key]['lower']) > 0) {
 							$lowerCase[] = $keys[$key]['lower'][0];
 							$matched = true;
 							break 1;

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -552,6 +552,12 @@ class CakeSession {
 
 		if (!empty($sessionConfig['handler'])) {
 			$sessionConfig['ini']['session.save_handler'] = 'user';
+
+			// In PHP7.2.0+ session.save_handler can't be set to 'user' by the user.
+			// https://github.com/php/php-src/commit/a93a51c3bf4ea1638ce0adc4a899cb93531b9f0d
+			if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+				unset($sessionConfig['ini']['session.save_handler']);
+			}
 		} elseif (!empty($sessionConfig['session.save_path']) && Configure::read('debug')) {
 			if (!is_dir($sessionConfig['session.save_path'])) {
 				mkdir($sessionConfig['session.save_path'], 0775, true);

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -415,6 +415,7 @@ class AuthComponentTest extends CakeTestCase {
 		TestAuthComponent::clearUser();
 		$this->Auth->Session->delete('Auth');
 		$this->Auth->Session->delete('Message.auth');
+		$this->Auth->Session->destroy();
 		unset($this->Controller, $this->Auth);
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -120,11 +120,11 @@ class ControllerPaginateModel extends CakeTestModel {
 /**
  * paginate method
  *
- * @return bool
+ * @return array
  */
 	public function paginate($conditions, $fields, $order, $limit, $page, $recursive, $extra) {
 		$this->extra = $extra;
-		return true;
+		return array(true);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -186,6 +186,7 @@ class SecurityComponentTest extends CakeTestCase {
 	public function tearDown() {
 		parent::tearDown();
 		$this->Controller->Session->delete('_Token');
+		$this->Controller->Session->destroy();
 		unset($this->Controller->Security);
 		unset($this->Controller->Component);
 		unset($this->Controller);

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -17,6 +17,7 @@
  */
 
 App::uses('Router', 'Routing');
+App::uses('CakeSession', 'Model/Datasource');
 App::uses('Controller', 'Controller');
 App::uses('Scaffold', 'Controller');
 App::uses('ScaffoldView', 'View');
@@ -175,6 +176,7 @@ class ScaffoldTest extends CakeTestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
+		CakeSession::destroy();
 		unset($this->Controller);
 	}
 

--- a/lib/Cake/Test/Case/I18n/I18nTest.php
+++ b/lib/Cake/Test/Case/I18n/I18nTest.php
@@ -51,6 +51,7 @@ class I18nTest extends CakeTestCase {
 		parent::tearDown();
 
 		Cache::delete('object_map', '_cake_core_');
+		CakeSession::destroy();
 		App::build();
 		CakePlugin::unload();
 	}

--- a/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
+++ b/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
@@ -64,7 +64,7 @@ class ConnectionManagerTest extends CakeTestCase {
 
 		ConnectionManager::create($name, $config);
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertTrue((bool)(count(array_keys($connections) >= 1)));
+		$this->assertTrue(count(array_keys($connections)) >= 1);
 
 		$source = ConnectionManager::getDataSource('test_get_datasource');
 		$this->assertTrue(is_object($source));
@@ -239,7 +239,7 @@ class ConnectionManagerTest extends CakeTestCase {
 		$name = 'test_created_connection';
 
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertTrue((bool)(count(array_keys($connections) >= 1)));
+		$this->assertTrue(count(array_keys($connections)) >= 1);
 
 		$source = ConnectionManager::getDataSource('test');
 		$this->assertTrue(is_object($source));

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -3367,7 +3367,9 @@ class ModelWriteTest extends BaseModelTest {
 				array(
 					'comment' => 'Article comment',
 					'user_id' => 1
-		)));
+				)
+			)
+		);
 		$Article = new Article();
 		$result = $Article->saveAll($data);
 		$this->assertFalse(empty($result));
@@ -3376,7 +3378,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(2, count($result['Tag']));
 		$this->assertEquals('tag1', $result['Tag'][0]['tag']);
 		$this->assertEquals(1, count($result['Comment']));
-		$this->assertEquals(1, count($result['Comment'][0]['comment']));
+		$this->assertEquals('Article comment', $result['Comment'][0]['comment']);
 	}
 
 /**
@@ -5647,7 +5649,9 @@ class ModelWriteTest extends BaseModelTest {
 				array(
 					'comment' => 'Article comment',
 					'user_id' => 1
-		)));
+				)
+			)
+		);
 		$Article = new Article();
 		$result = $Article->saveAssociated($data);
 		$this->assertFalse(empty($result));
@@ -5656,7 +5660,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(2, count($result['Tag']));
 		$this->assertEquals('tag1', $result['Tag'][0]['tag']);
 		$this->assertEquals(1, count($result['Comment']));
-		$this->assertEquals(1, count($result['Comment'][0]['comment']));
+		$this->assertEquals('Article comment', $result['Comment'][0]['comment']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -87,6 +87,7 @@ class SessionHelperTest extends CakeTestCase {
 	public function tearDown() {
 		$_SESSION = array();
 		unset($this->View, $this->Session);
+		CakeSession::destroy();
 		CakePlugin::unload();
 		parent::tearDown();
 	}


### PR DESCRIPTION
Refs #11346

In this Pull Request, Installed the `mcrypt` extension from pecl in the CI so that we can test it.

- added `pear config-set preferred_state snapshot`. Because pecl's mcrypt package is `snapshot`, is not `stable` https://pecl.php.net/package/mcrypt
- I changed `pecl install` to execute first. Because fails `composer require "phpunit/phpunit=$PHPUNIT"`
- remove cannot run test matrix: PHPUnit 3.7 + PHP7.2