### PR TITLE
Fixing issue with how the check is done for determining if templatePa…

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1249,7 +1249,7 @@ class View implements EventDispatcherInterface
         if (strlen($this->subDir)) {
             $subDir = $this->subDir . DIRECTORY_SEPARATOR;
             // Check if templatePath already terminates with subDir
-            if (strrpos($templatePath, $subDir) == strlen($templatePath) - strlen($subDir)) {
+            if ($templatePath != $subDir && substr($templatePath, -(strlen($subDir))) == $subDir) {
                 $subDir = '';
             }
         }


### PR DESCRIPTION
…th already terminates with subDir

The problem the with current check:
`strrpos($templatePath, $subDir) == strlen($templatePath) - strlen($subDir)`
Lets say your have a templatePath that is equal to `Jobs` for example and you have a subDir equal to say `xlsx` both have a `strlen` of `4`, `strrpos` returns false and 4-4 = 0 therefore `false == 0` is `true` which is incorrect.  
