### PR TITLE
Use a stricter get+has pattern for associations on tables.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -354,14 +354,14 @@ class BelongsToMany extends Association
         $junctionAlias = $junction->getAlias();
         $sAlias = $source->getAlias();
 
-        if (!$target->getAssociation($junctionAlias)) {
+        if (!$target->hasAssociation($junctionAlias)) {
             $target->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getTargetForeignKey(),
                 'strategy' => $this->_strategy,
             ]);
         }
-        if (!$target->getAssociation($sAlias)) {
+        if (!$target->hasAssociation($sAlias)) {
             $target->belongsToMany($sAlias, [
                 'sourceTable' => $target,
                 'targetTable' => $source,
@@ -391,7 +391,7 @@ class BelongsToMany extends Association
     protected function _generateSourceAssociations($junction, $source)
     {
         $junctionAlias = $junction->getAlias();
-        if (!$source->getAssociation($junctionAlias)) {
+        if (!$source->hasAssociation($junctionAlias)) {
             $source->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getForeignKey(),
@@ -421,13 +421,13 @@ class BelongsToMany extends Association
         $tAlias = $target->getAlias();
         $sAlias = $source->getAlias();
 
-        if (!$junction->getAssociation($tAlias)) {
+        if (!$junction->hasAssociation($tAlias)) {
             $junction->belongsTo($tAlias, [
                 'foreignKey' => $this->getTargetForeignKey(),
                 'targetTable' => $target
             ]);
         }
-        if (!$junction->getAssociation($sAlias)) {
+        if (!$junction->hasAssociation($sAlias)) {
             $junction->belongsTo($sAlias, [
                 'foreignKey' => $this->getForeignKey(),
                 'targetTable' => $source

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -88,10 +88,9 @@ class Marshaller
                 $key = $nested;
                 $nested = [];
             }
-            $assoc = $this->_table->getAssociation($key);
             // If the key is not a special field like _ids or _joinData
             // it is a missing association that we should error on.
-            if (!$assoc) {
+            if (!$this->_table->hasAssociation($key)) {
                 if (substr($key, 0, 1) !== '_') {
                     throw new \InvalidArgumentException(sprintf(
                         'Cannot marshal data for "%s" association. It is not associated with "%s".',
@@ -101,6 +100,8 @@ class Marshaller
                 }
                 continue;
             }
+            $assoc = $this->_table->getAssociation($key);
+
             if (isset($options['forceNew'])) {
                 $nested['forceNew'] = $options['forceNew'];
             }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -437,10 +437,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected function _addAssociationsToTypeMap($table, $typeMap, $associations)
     {
         foreach ($associations as $name => $nested) {
-            $association = $table->getAssociation($name);
-            if (!$association) {
+            if (!$table->hasAssociation($name)) {
                 continue;
             }
+            $association = $table->getAssociation($name);
             $target = $association->getTarget();
             $primary = (array)$target->getPrimaryKey();
             if (empty($primary) || $typeMap->type($target->aliasField($primary[0])) === null) {

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -80,8 +80,7 @@ class ExistsIn
     public function __invoke(EntityInterface $entity, array $options)
     {
         if (is_string($this->_repository)) {
-            $repository = $options['repository']->getAssociation($this->_repository);
-            if (!$repository) {
+            if (!$options['repository']->hasAssociation($this->_repository)) {
                 throw new RuntimeException(sprintf(
                     "ExistsIn rule for '%s' is invalid. '%s' is not associated with '%s'.",
                     implode(', ', $this->_fields),
@@ -89,6 +88,7 @@ class ExistsIn
                     get_class($options['repository'])
                 ));
             }
+            $repository = $options['repository']->getAssociation($this->_repository);
             $this->_repository = $repository;
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -968,7 +968,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $association = $this->findAssociation($name);
         if (!$association) {
-            throw new InvalidArgumentException('Association does not exist: ' . $name);
+            throw new InvalidArgumentException("The {$name} association is not defined on {$this->getAlias()}.");
         }
 
         return $association;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -934,7 +934,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns an association object configured for the specified alias if any
+     * Returns an association object configured for the specified alias if any.
      *
      * @deprecated 3.6.0 Use getAssociation() instead.
      * @param string $name the alias used for the association.
@@ -942,9 +942,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function association($name)
     {
-        deprecationWarning('Use Table::getAssociation() instead.');
+        deprecationWarning('Use Table::getAssociation() and Table::hasAssocation() instead.');
 
-        return $this->getAssociation($name);
+        return $this->findAssociation($name);
     }
 
     /**
@@ -956,10 +956,54 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * $users = $this->getAssociation('Articles.Comments.Users');
      * ```
      *
-     * @param string $name the alias used for the association.
-     * @return \Cake\ORM\Association|null Either the association or null.
+     * Note that this method requires the association to be present or otherwise
+     * throws an exception.
+     * If you are not sure, use hasAssociation() before calling this method.
+     *
+     * @param string $name The alias used for the association.
+     * @return \Cake\ORM\Association The association.
+     * @throws \InvalidArgumentException
      */
     public function getAssociation($name)
+    {
+        $association = $this->findAssociation($name);
+        if (!$association) {
+            throw new InvalidArgumentException('Association does not exist: ' . $name);
+        }
+
+        return $association;
+    }
+
+    /**
+     * Checks whether a specific association exists on this Table instance.
+     *
+     * The name argument also supports dot syntax to access deeper associations.
+     *
+     * ```
+     * $hasUsers = $this->hasAssociation('Articles.Comments.Users');
+     * ```
+     *
+     * @param string $name The alias used for the association.
+     * @return bool
+     */
+    public function hasAssociation($name)
+    {
+        return $this->findAssociation($name) !== null;
+    }
+
+    /**
+     * Returns an association object configured for the specified alias if any.
+     *
+     * The name argument also supports dot syntax to access deeper associations.
+     *
+     * ```
+     * $users = $this->getAssociation('Articles.Comments.Users');
+     * ```
+     *
+     * @param string $name The alias used for the association.
+     * @return \Cake\ORM\Association|null Either the association or null.
+     */
+    protected function findAssociation($name)
     {
         if (strpos($name, '.') === false) {
             return $this->_associations->get($name);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -936,7 +936,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns an association object configured for the specified alias if any.
      *
-     * @deprecated 3.6.0 Use getAssociation() instead.
+     * @deprecated 3.6.0 Use getAssociation() and Table::hasAssocation() instead.
      * @param string $name the alias used for the association.
      * @return \Cake\ORM\Association|null Either the association or null.
      */
@@ -948,7 +948,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns an association object configured for the specified alias if any.
+     * Returns an association object configured for the specified alias.
      *
      * The name argument also supports dot syntax to access deeper associations.
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -39,6 +39,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use InvalidArgumentException;
 
 /**
  * Used to test correct class is instantiated when using TableRegistry::get();
@@ -641,6 +642,18 @@ class TableTest extends TestCase
             $groups->getAssociation('GroupsMembers')->getAssociation('Members')->getAssociation('Groups'),
             $association
         );
+    }
+
+    /**
+     * Tests that the getAssociation() method throws an exception on non-existent ones.
+     *
+     * @return void
+     */
+    public function testGetAssociationNonExistent()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        TableRegistry::get('Groups')->getAssociation('FooBar');
     }
 
     /**


### PR DESCRIPTION
association() in 3.6 has been deprecated in favor of a new getAssociation().
But similar to other get/has/find pattern uses in Core, I suggest that we apply a bit stricter get syntax here too. 
I consider that cleaner code, as the flow of chaining can expect the object to be directly present - or otherwise get a meaningful exception instead of a bad fatal error.
Whoever needs, can use a "has..." check beforehand to ensure the object existence in optional cases.

This relates to https://github.com/cakephp/cakephp/pull/11635 and hasBehavior() vs getBehavior() etc.

I kept the find method protected, as get+has should usually suffice for the public API.
I will add tests once this stricter approach is approved.
I consider this reasonably BC since the method gets cleanly deprecated via migration guide and we can point out the stricter behavior there - as well as in code doc block.
