### PR TITLE
[2.x] Make mcrypt optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
 		"source": "https://github.com/cakephp/cakephp"
 	},
 	"require": {
-		"php": ">=5.3.0",
-		"ext-mcrypt": "*"
+		"php": ">=5.3.0"
+	},
+	"suggest": {
+		"ext-openssl": "You need to install ext-openssl or ext-mcrypt to use AES-256 encryption",
+		"ext-mcrypt": "You need to install ext-openssl or ext-mcrypt to use AES-256 encryption"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "<6.0.0",

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -36,7 +36,7 @@ class SecurityTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Security::engine(null);
+		Configure::delete('Security.useOpenSsl');
 	}
 
 /**
@@ -46,26 +46,7 @@ class SecurityTest extends CakeTestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Security::engine(null);
-	}
-
-/**
- * Tests that Security::engine() works
- *
- * @return void
- */
-	public function testEngine() {
-		if (extension_loaded('mcrypt')) {
-			$this->assertEquals('mcrypt', Security::engine());
-		}
-
-		$this->assertContains(Security::engine(), array('mcrypt', 'openssl'));
-
-		Security::engine('mcrypt');
-		$this->assertEquals('mcrypt', Security::engine());
-
-		Security::engine('openssl');
-		$this->assertEquals('openssl', Security::engine());
+		Configure::delete('Security.useOpenSsl');
 	}
 
 /**
@@ -385,24 +366,24 @@ class SecurityTest extends CakeTestCase {
  */
 	public function testEncryptDecryptCompatibility($txt) {
 		$this->skipIf(!extension_loaded('mcrypt'), 'This test requires mcrypt to be installed');
-		$this->skipIf(!extension_loaded('openssl'), 'This test requires oepnssl to be installed');
-		$this->skipIf(version_compare(PHP_VERSION, '5.3.3', '<'), 'This test requires PHP 5.3.3 or grater');
+		$this->skipIf(!extension_loaded('openssl'), 'This test requires openssl to be installed');
+		$this->skipIf(version_compare(PHP_VERSION, '5.3.3', '<'), 'This test requires PHP 5.3.3 or greater');
 
 		$key = '12345678901234567890123456789012';
 
-		Security::engine('mcrypt');
+		Configure::write('Security.useOpenSsl', false);
 		$mcrypt = Security::encrypt($txt, $key);
 
-		Security::engine('openssl');
+		Configure::write('Security.useOpenSsl', true);
 		$openssl = Security::encrypt($txt, $key);
 
 		$this->assertEquals(strlen($mcrypt), strlen($openssl));
 
-		Security::engine('mcrypt');
+		Configure::write('Security.useOpenSsl', false);
 		$this->assertEquals($txt, Security::decrypt($mcrypt, $key));
 		$this->assertEquals($txt, Security::decrypt($openssl, $key));
 
-		Security::engine('openssl');
+		Configure::write('Security.useOpenSsl', true);
 		$this->assertEquals($txt, Security::decrypt($mcrypt, $key));
 		$this->assertEquals($txt, Security::decrypt($openssl, $key));
 	}

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -192,7 +192,7 @@ class Security {
 			return openssl_random_pseudo_bytes($length);
 		}
 		if (function_exists('mcrypt_create_iv')) {
-			return mcrypt_create_iv($length);
+			return mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
 		}
 		trigger_error(
 			'You do not have a safe source of random data available. ' .

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -191,9 +191,12 @@ class Security {
 		if (function_exists('openssl_random_pseudo_bytes')) {
 			return openssl_random_pseudo_bytes($length);
 		}
+		if (function_exists('mcrypt_create_iv')) {
+			return mcrypt_create_iv($length);
+		}
 		trigger_error(
 			'You do not have a safe source of random data available. ' .
-			'Install either the openssl extension, or paragonie/random_compat. ' .
+			'Install either the openssl extension, the mcrypt extension, or paragonie/random_compat. ' .
 			'Falling back to an insecure random source.',
 			E_USER_WARNING
 		);

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -26,13 +26,6 @@ App::uses('CakeText', 'Utility');
 class Security {
 
 /**
- * The encryption engine
- *
- * @var string
- */
-	protected static $_engine = null;
-
-/**
  * Default hash method
  *
  * @var string
@@ -359,7 +352,7 @@ class Security {
 		// Generate the encryption and hmac key.
 		$key = substr(hash('sha256', $key . $hmacSalt), 0, 32);
 
-		if (static::engine() === 'openssl') {
+		if (Configure::read('Security.useOpenSsl')) {
 			$method = 'AES-256-CBC';
 			$ivSize = openssl_cipher_iv_length($method);
 			$iv = openssl_random_pseudo_bytes($ivSize);
@@ -426,7 +419,7 @@ class Security {
 			return false;
 		}
 
-		if (static::engine() === 'openssl') {
+		if (Configure::read('Security.useOpenSsl')) {
 			$method = 'AES-256-CBC';
 			$ivSize = openssl_cipher_iv_length($method);
 			$iv = substr($cipher, 0, $ivSize);
@@ -444,24 +437,6 @@ class Security {
 		}
 
 		return rtrim($plain, "\0");
-	}
-
-/**
- * Set or get the encryption engine
- *
- * @param string $engine The encryption engine to use
- * @return string
- */
-	public static function engine($engine = null) {
-		if (func_num_args() > 0) {
-			static::$_engine = $engine;
-		} elseif (static::$_engine === null) {
-			static::$_engine = 'mcrypt';
-			if (!extension_loaded('mcrypt') && extension_loaded('openssl') && version_compare(PHP_VERSION, '5.3.3', '>=')) {
-				static::$_engine = 'openssl';
-			}
-		}
-		return static::$_engine;
 	}
 
 }


### PR DESCRIPTION
Now Security::encrypt() and Security::decrypt() work with openssl if the mcrypt extension is unavailable. Note that Security::rijndael() doesn't work with openssl.

And, I have changed Security::randomBytes() to fallback to mcrypt_create_iv() if the openssl extension is unavailable.

Relates to #11346