### PR TITLE
Improve getBehavior() nullable check

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -931,7 +931,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function getBehavior($name)
     {
-        if ($this->hasBehavior($name) === false) {
+        $behavior = $this->_behaviors->get($name);
+        if ($behavior === null) {
             throw new InvalidArgumentException(sprintf(
                 'The %s behavior is not defined on %s.',
                 $name,
@@ -939,7 +940,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ));
         }
 
-        return $this->_behaviors->get($name);
+        return $behavior;
     }
 
     /**


### PR DESCRIPTION
Implements the intended improvement of https://github.com/cakephp/cakephp/pull/11635
The get() call itself might in a future version then be strict and we can simply remove the nullable comparison here, no need to fetch data twice.