### PR TITLE
Fix saveOrFail() to include useful messages on output, e.g. CLI/tests.

### DIFF
--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -85,5 +85,4 @@ class PersistenceFailedException extends Exception
     {
         return $this->_entity;
     }
-
 }

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -45,7 +45,35 @@ class PersistenceFailedException extends Exception
     public function __construct(EntityInterface $entity, $message, $code = null, $previous = null)
     {
         $this->_entity = $entity;
+        if (is_array($message)) {
+            $errors = [];
+            foreach ($entity->getErrors() as $field => $error) {
+                $errors[] = $field . ': "' . $this->buildError($error) . '"';
+            }
+            if ($errors) {
+                $message[] = implode(', ', $errors);
+                $this->_messageTemplate = 'Entity %s failure (%s).';
+            }
+        }
         parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @param string|array $error Error message.
+     * @return string
+     */
+    protected function buildError($error)
+    {
+        if (!is_array($error)) {
+            return $error;
+        }
+
+        $errors = [];
+        foreach ($error as $key => $message) {
+            $errors[] = is_int($key) ? $message : $key;
+        }
+
+        return implode(', ', $errors);
     }
 
     /**
@@ -57,4 +85,5 @@ class PersistenceFailedException extends Exception
     {
         return $this->_entity;
     }
+
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6519,6 +6519,28 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that saveOrFail displays useful messages on output, especially in tests for CLI.
+     *
+     * @return void
+     */
+    public function testSaveOrFailErrorDisplay()
+    {
+        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectExceptionMessage('Entity save failure (field: "Some message", multiple: "one, two")');
+        $entity = new Entity([
+            'foo' => 'bar'
+        ]);
+        $entity->setError('field', 'Some message');
+        $entity->setError('multiple', ['one' => 'One', 'two' => 'Two']);
+        $table = TableRegistry::get('users');
+
+        $table->saveOrFail($entity);
+
+        $row = $table->find('all')->where(['foo' => 'bar'])->toArray();
+        $this->assertSame([], $row->toArray());
+    }
+
+    /**
      * Tests that saveOrFail returns the right entity
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6507,15 +6507,13 @@ class TableTest extends TestCase
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure.');
+        
         $entity = new Entity([
             'foo' => 'bar'
         ]);
         $table = TableRegistry::get('users');
 
         $table->saveOrFail($entity);
-
-        $row = $table->find('all')->where(['foo' => 'bar'])->toArray();
-        $this->assertSame([], $row->toArray());
     }
 
     /**
@@ -6527,6 +6525,7 @@ class TableTest extends TestCase
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure (field: "Some message", multiple: "one, two")');
+        
         $entity = new Entity([
             'foo' => 'bar'
         ]);
@@ -6535,9 +6534,6 @@ class TableTest extends TestCase
         $table = TableRegistry::get('users');
 
         $table->saveOrFail($entity);
-
-        $row = $table->find('all')->where(['foo' => 'bar'])->toArray();
-        $this->assertSame([], $row->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6507,7 +6507,7 @@ class TableTest extends TestCase
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure.');
-        
+
         $entity = new Entity([
             'foo' => 'bar'
         ]);
@@ -6525,7 +6525,7 @@ class TableTest extends TestCase
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure (field: "Some message", multiple: "one, two")');
-        
+
         $entity = new Entity([
             'foo' => 'bar'
         ]);


### PR DESCRIPTION
Currently saveOrFail() is pretty unusable.
I so far used my "strict=>true" of Shim plugin which outputted the issue directly for CLI and test usage.
With saveOrFail() you only get:
```
1) App\Test\TestCase\Model\Table\CapabilitiesTableTest::testImport
Cake\ORM\Exception\PersistenceFailedException: Entity save failure.
```

With the provided fix we at least get
```
1) App\Test\TestCase\Model\Table\CapabilitiesTableTest::testImport
Cake\ORM\Exception\PersistenceFailedException: Entity save failure (name: "The provided value is invalid").
```
which really helps and avoids having to add debug() into the whole code everywhere and rerun it :)

For multiple messages it uses the identifier keys if possible to avoid too long messages.