### PR TITLE
Allow disabling cache fallback logic

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -178,6 +178,10 @@ class Cache
                 return;
             }
 
+            if ($config['fallback'] === false) {
+                throw $e;
+            }
+
             if ($config['fallback'] === $name) {
                 throw new InvalidArgumentException(sprintf('"%s" cache configuration cannot fallback to itself.', $name), null, $e);
             }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -97,6 +97,27 @@ class CacheTest extends TestCase
     }
 
     /**
+     * tests you can disable Cache::engine() fallback
+     *
+     * @return void
+     */
+    public function testCacheEngineFallbackDisabled()
+    {
+        $this->expectException(Error::class);
+
+        $filename = tempnam(TMP, 'tmp_');
+
+        Cache::setConfig('tests', [
+            'engine' => 'File',
+            'path' => $filename,
+            'prefix' => 'test_',
+            'fallback' => false
+        ]);
+
+        $engine = Cache::engine('tests');
+    }
+
+    /**
      * tests handling misconfiguration of fallback
      *
      * @return void


### PR DESCRIPTION
The fallback logic is pretty handy, but I have found it to be a problem in more complex caching scenarios and need to disable it, which isn't directly possible. The tldr as to why _I_ would want to disable the fallback logic, is because it interferes with my own; I'm also uneasy with the idea that this creates the scenario where you can write to a cache engine, think it succeeded (if code is lazy, and not checking return values) but in fact be writing to /dev/null.

If disabled, cache exceptions do not silently convert the cache engine to a null (or different, configured) cache engine - instead the exception bubbles up for client code to deal with.

Related https://github.com/cakephp/cakephp/pull/10726