### PR TITLE
2.x - Change PHPUnit version as requested by test shell

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"ext-mcrypt": "*"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "<6.0.0",
+		"phpunit/phpunit": "^3.7",
 		"cakephp/cakephp-codesniffer": "^1.0.0"
 	},
 	"config": {


### PR DESCRIPTION
I'm trying to run the SessionHelper tests and I can't. The closest I have got is the following.

![Test shell requesting php unit 3.7](https://i.imgur.com/gmQHqnj.png)

So I changed the `composer.json` to use PHP Unit 3.7 and then the test shell works.

Apologies for the misleading folder name, this is on the 2.x branch 😄 