### PR TITLE
2.x - Added a test case for the session flash with no params.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -156,10 +156,10 @@ class SessionHelperTest extends CakeTestCase {
  * @return void
  */
     public function testFlashWithNoParams() {
-        $result = $this->Session->flash();
-        $expected = '<div id="flashMessage" class="message">This is a calling</div>';
-        $this->assertEquals($expected, $result);
-        $this->assertFalse($this->Session->check('Message.flash'));
+		$result = $this->Session->flash();
+		$expected = '<div id="flashMessage" class="message">This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash'));
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -151,6 +151,18 @@ class SessionHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Test the flash method works without any params being passed
+ *
+ * @return void
+ */
+    public function testFlashWithNoParams() {
+        $result = $this->Session->flash();
+        $expected = '<div id="flashMessage" class="message">This is a calling</div>';
+        $this->assertEquals($expected, $result);
+        $this->assertFalse($this->Session->check('Message.flash'));
+	}
+
+/**
  * test flash() with the attributes.
  *
  * @return void


### PR DESCRIPTION
In relation to #11658

I've added a test case of calling the SessionHelpers `flash()` method with no params.

Unfortunately, I can't get any of the helpers tests to pass on my machine, but I'm hoping that Travis can with this pull request.

```bash
$ Console/cake test core View/Helper/SessionHelper
// snip
FAILURES!
Tests: 7, Assertions: 7, Failures: 7.
```