### PR TITLE
findThreaded uses the tree's parent_id field as default parentField

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1478,9 +1478,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function findThreaded(Query $query, array $options)
     {
+        $treeBehavior = $this->behaviors()->get('Tree');
         $options += [
             'keyField' => $this->getPrimaryKey(),
-            'parentField' => 'parent_id',
+            'parentField' => $treeBehavior ? $treeBehavior->getConfig('parent') : 'parent_id',
             'nestingKey' => 'children'
         ];
 


### PR DESCRIPTION
Issue #11657

This code changing works for my use case. Maybe we can remove the whole 'parentField' option? I see no use for it any more, as it gets the value from the tree options now. What do you think?

My TableTest rises a lot of errors, i guess that's due to the missing database setup. Is there some documentation how to configure the local database in phpunit.xml?

`<env name="db_dsn" value="mysql://localhost/cake_test?timezone=UTC"/>`

I created a database named "cake_test", mysql server is running and the errors persist.

Thank you,
Mario