### PR TITLE
Fix invalid SQL generation from leftJoinWith() & auto-fields

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1143,7 +1143,8 @@ abstract class Association
         }
 
         if ($autoFields === true) {
-            $fields = array_merge((array)$fields, $target->getSchema()->columns());
+            $fields = array_filter((array)$fields);
+            $fields = array_merge($fields, $target->getSchema()->columns());
         }
 
         if ($fields) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3318,6 +3318,25 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Tests that leftJoinWith() can be used with autofields()
+     *
+     * @return void
+     */
+    public function testLeftJoinWithAutoFields()
+    {
+        $table = TableRegistry::get('articles');
+        $table->belongsTo('authors');
+
+        $results = $table
+            ->find()
+            ->leftJoinWith('authors', function ($q) {
+                return $q->enableAutoFields(true);
+            })
+            ->all();
+        $this->assertCount(3, $results);
+    }
+
+    /**
      * Tests innerJoinWith()
      *
      * @return void


### PR DESCRIPTION
When no fields are selected, and auto-fields is enabled, `$fields` gets set to false which ends up as '' in SQL causing invalid field lists.

Refs #11663
