### PR TITLE
Ensure given type exists as array key.

### DIFF
--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -90,6 +90,10 @@ class CommandTask extends Shell
      */
     protected function _appendShells($type, $shells, $shellList, $skip)
     {
+        if (!isset($shellList[$type])) {
+            $shellList[$type] = [];
+        }
+
         foreach ($shells as $shell) {
             $name = Inflector::underscore(preg_replace('/(Shell|Command)$/', '', $shell));
             if (!in_array($name, $skip, true)) {


### PR DESCRIPTION
This fixes the numerous `sort() expects parameter 1 to be array, null given` seen here https://travis-ci.org/cakephp/bake/jobs/334680609.