### PR TITLE
Throw exception when invalid response status code is used.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -975,11 +975,19 @@ class Response implements ResponseInterface
      * @param int $code The code to set.
      * @param string $reasonPhrase The response reason phrase.
      * @return void
+     * @throws \InvalidArgumentException For invalid status code arguments.
      */
     protected function _setStatus($code, $reasonPhrase = '')
     {
+        if (!isset($this->_statusCodes[$code])) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid status code: %s. Use a valid HTTP status code in range 1xx - 5xx.',
+                $code
+            ));
+        }
+
         $this->_status = $code;
-        if (empty($reasonPhrase) && isset($this->_statusCodes[$code])) {
+        if (empty($reasonPhrase)) {
             $reasonPhrase = $this->_statusCodes[$code];
         }
         $this->_reasonPhrase = $reasonPhrase;

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -2843,7 +2843,7 @@ class ResponseTest extends TestCase
     public function testWithStatusInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this-> expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
+        $this->expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
         $response = new Response();
         $response->withStatus(1001);
     }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -2836,6 +2836,19 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Test invalid status codes
+     *
+     * @return void
+     */
+    public function testWithStatusInvalid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this-> expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
+        $response = new Response();
+        $response->withStatus(1001);
+    }
+
+    /**
      * Test get reason phrase.
      *
      * @return void


### PR DESCRIPTION
Alternative to #11678.