### PR TITLE
PHPUnit 7 compatibility

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -17,7 +17,8 @@ namespace Cake\TestSuite\Fixture;
 loadPHPUnitAliases();
 
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 
@@ -25,9 +26,10 @@ use PHPUnit\Framework\TestSuite;
  * Test listener used to inject a fixture manager in all tests that
  * are composed inside a Test Suite
  */
-class FixtureInjector extends BaseTestListener
+class FixtureInjector implements TestListener
 {
 
+    use TestListenerDefaultImplementation;
     /**
      * The instance of the fixture manager to use
      *
@@ -63,7 +65,7 @@ class FixtureInjector extends BaseTestListener
      * @param \PHPUnit\Framework\TestSuite $suite The test suite
      * @return void
      */
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
         if (empty($this->_first)) {
             $this->_first = $suite;
@@ -77,7 +79,7 @@ class FixtureInjector extends BaseTestListener
      * @param \PHPUnit\Framework\TestSuite $suite The test suite
      * @return void
      */
-    public function endTestSuite(TestSuite $suite)
+    public function endTestSuite(TestSuite $suite): void
     {
         if ($this->_first === $suite) {
             $this->_fixtureManager->shutDown();
@@ -90,7 +92,7 @@ class FixtureInjector extends BaseTestListener
      * @param \PHPUnit\Framework\Test $test The test case
      * @return void
      */
-    public function startTest(Test $test)
+    public function startTest(Test $test): void
     {
         $test->fixtureManager = $this->_fixtureManager;
         if ($test instanceof TestCase) {
@@ -106,7 +108,7 @@ class FixtureInjector extends BaseTestListener
      * @param float $time current time
      * @return void
      */
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, $time): void
     {
         if ($test instanceof TestCase) {
             $this->_fixtureManager->unload($test);

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -17,9 +17,9 @@ namespace Cake\TestSuite\Fixture;
 loadPHPUnitAliases();
 
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
-use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 
 /**


### PR DESCRIPTION
According to ChangeLog https://github.com/sebastianbergmann/phpunit/blob/7.0/ChangeLog-7.0.md

- The PHPUnit\Framework\BaseTestListener class has been removed (deprecated in PHPUnit 6.4)
- Scalar Type Declarations and Return Type Declarations are now used where possible (as a result, the API of PHPUnit\Framework\TestListener, for instance, has changed)