### PR TITLE
Remove @method from Shell

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -31,8 +31,6 @@ use ReflectionMethod;
  * Base class for command-line utilities for automating programmer chores.
  *
  * Is the equivalent of Cake\Controller\Controller on the command line.
- *
- * @method int|bool|null main(...$args)
  */
 class Shell
 {


### PR DESCRIPTION
`@method` is for the 'magic' method.
So in IDE(PhpStorm) an error will result if a method exists.

http://docs.phpdoc.org/references/phpdoc/tags/method.html
> The @method allows a class to know which ‘magic’ methods are callable.

## error

php bin/cake.php bake shell test
![1](https://user-images.githubusercontent.com/28671296/35722057-20f6f96a-0838-11e8-85a5-39e41f11f3ea.png)

---
## Example

![2](https://user-images.githubusercontent.com/28671296/35722067-2d5f5648-0838-11e8-8e40-66ffb33918b9.png)
![3](https://user-images.githubusercontent.com/28671296/35722070-2f1d5bce-0838-11e8-8596-b4f531621d91.png)
