### PR TITLE
Hash matches strict compare numeric value

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -267,6 +267,8 @@ class Hash
                 $prop = $prop ? '1' : '0';
             } elseif ($isBool) {
                 $prop = $prop ? 'true' : 'false';
+            } elseif (is_numeric($prop)) {
+                $prop = (string)$prop;
             }
 
             // Pattern matches and other operators.
@@ -274,8 +276,8 @@ class Hash
                 if (!preg_match($val, $prop)) {
                     return false;
                 }
-            } elseif (($op === '=' && $prop != $val) ||
-                ($op === '!=' && $prop == $val) ||
+            } elseif (($op === '=' && $prop !== $val) ||
+                ($op === '!=' && $prop === $val) ||
                 ($op === '>' && $prop <= $val) ||
                 ($op === '<' && $prop >= $val) ||
                 ($op === '>=' && $prop < $val) ||

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1422,6 +1422,26 @@ class HashTest extends TestCase
     }
 
     /**
+     * Test extracting value-zero contained data based on attributes with string
+     *
+     * @return void
+     */
+    public function testExtractAttributeStringWithDataContainsZero()
+    {
+        $data = [
+            ['value' => '0'],
+            ['value' => 0],
+            ['value' => 'string-value'],
+        ];
+
+        $expected = [
+            ['value' => 'string-value'],
+        ];
+        $result = Hash::extract($data, '{n}[value=string-value]');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Test that uneven keys are handled correctly.
      *
      * @return void


### PR DESCRIPTION
## What I did

```php
$john = Hash::extract([
    ['value' => 0],
    ['value' => 'John']
], '{n}[value=John]');
return current($john);
```

## What happened
get the value as bellow.
```php
$john = ['value' => 0];
```
## What I expected to happen
like this.

```php
$john = ['value' => 'John'];
```

---
I think it's better that `Hash::_matches()`  handles `'0'` and `(string)some-value` as another value, when non numeric character token are given.
To regard some string values as '0' is counterintuitive for me ;(