### PR TITLE
feat: allow modifying the Form schema class

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -35,6 +35,12 @@ use Cake\Validation\Validator;
  */
 class Form
 {
+    /**
+     * Schema class.
+     *
+     * @var string
+     */
+    protected $_schemaClass = '\Cake\Form\Schema';
 
     /**
      * The schema used by this form.
@@ -70,7 +76,7 @@ class Form
     public function schema(Schema $schema = null)
     {
         if ($schema === null && empty($this->_schema)) {
-            $schema = $this->_buildSchema(new Schema());
+            $schema = $this->_buildSchema(new $this->_schemaClass);
         }
         if ($schema) {
             $this->_schema = $schema;

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Form;
 
+use Cake\Form\Schema;
 use Cake\Validation\Validator;
 
 /**
@@ -40,7 +41,7 @@ class Form
      *
      * @var string
      */
-    protected $_schemaClass = '\Cake\Form\Schema';
+    protected $_schemaClass = Schema::class;
 
     /**
      * The schema used by this form.

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -16,6 +16,8 @@ namespace Cake\Test\TestCase\Form;
 
 use Cake\Form\Form;
 use Cake\TestSuite\TestCase;
+use TestApp\Form\AppForm;
+use TestApp\Form\FormSchema;
 
 /**
  * Form test case.
@@ -39,6 +41,9 @@ class FormTest extends TestCase
         $schema = $this->getMockBuilder('Cake\Form\Schema')->getMock();
         $this->assertSame($schema, $form->schema($schema));
         $this->assertSame($schema, $form->schema());
+
+        $form = new AppForm();
+        $this->assertInstanceOf(FormSchema::class, $form->schema());
     }
 
     /**

--- a/tests/test_app/TestApp/Form/AppForm.php
+++ b/tests/test_app/TestApp/Form/AppForm.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.13
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Form;
+
+use Cake\Form\Form;
+
+class AppForm extends Form
+{
+    protected $_schemaClass = FormSchema::class;
+}

--- a/tests/test_app/TestApp/Form/FormSchema.php
+++ b/tests/test_app/TestApp/Form/FormSchema.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.13
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Form;
+
+use Cake\Form\Schema;
+
+/**
+ * Contains the schema information for Form instances.
+ */
+class FormSchema extends Schema
+{
+}


### PR DESCRIPTION
I was working on a CMS and found it annoying to override the Schema class in use for a given form. This change allows the Form::__construct() to override `$this->_schemaClass`, making it easier to swap out the schema class in use.

The alternative is the following hack:

```
protected function _buildSchema(Schema $schema)
{
    if (count($schema->fields()) === 0) {
        $schema = new AnotherSchemaClass;
    }
}
```