### PR TITLE
@codingStandards syntax is deprecated

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -242,9 +242,9 @@ class FileEngine extends CacheEngine
         $path = $this->_File->getRealPath();
         $this->_File = null;
 
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         return @unlink($path);
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**
@@ -331,9 +331,9 @@ class FileEngine extends CacheEngine
                 $filePath = $file->getRealPath();
                 $file = null;
 
-                //@codingStandardsIgnoreStart
+                // phpcs:disable
                 @unlink($filePath);
-                //@codingStandardsIgnoreEnd
+                // phpcs:enable
             }
         }
     }
@@ -423,9 +423,9 @@ class FileEngine extends CacheEngine
         $path = $dir->getPathname();
         $success = true;
         if (!is_dir($path)) {
-            //@codingStandardsIgnoreStart
+            // phpcs:disable
             $success = @mkdir($path, 0775, true);
-            //@codingStandardsIgnoreEnd
+            // phpcs:enable
         }
 
         $isWritableDir = ($dir->isDir() && $dir->isWritable());
@@ -484,9 +484,9 @@ class FileEngine extends CacheEngine
             if ($object->isFile() && $containsGroup && $hasPrefix) {
                 $path = $object->getPathname();
                 $object = null;
-                //@codingStandardsIgnoreStart
+                // phpcs:disable
                 @unlink($path);
-                //@codingStandardsIgnoreEnd
+                // phpcs:enable
             }
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -727,7 +727,7 @@ trait CollectionTrait
      * @return \Traversable
      * @deprecated
      */
-    // @codingStandardsIgnoreLine
+    // phpcs:ignore
     public function _unwrap()
     {
         return $this->unwrap();

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -82,7 +82,7 @@ trait SqlserverDialectTrait
      *
      * @return int
      */
-    // @codingStandardsIgnoreLine
+    // phpcs:ignore
     public function _version()
     {
         $this->connect();

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -68,9 +68,9 @@ class Sqlite extends Driver
         $this->_connect($dsn, $config);
 
         if (!$databaseExists && $config['database'] != ':memory:') {
-            //@codingStandardsIgnoreStart
+            // phpcs:disable
             @chmod($config['database'], $config['mask']);
-            //@codingStandardsIgnoreEnd
+            // phpcs:enable
         }
 
         if (!empty($config['init'])) {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -435,7 +435,7 @@ class QueryExpression implements ExpressionInterface, Countable
         return $this->add(new BetweenExpression($field, $from, $to, $type));
     }
 
-// @codingStandardsIgnoreStart
+// phpcs:disable
     /**
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
@@ -471,7 +471,7 @@ class QueryExpression implements ExpressionInterface, Countable
 
         return new static($conditions, $this->getTypeMap()->setTypes($types), 'OR');
     }
-// @codingStandardsIgnoreEnd
+// phpcs:enable
 
     /**
      * Adds a new set of conditions to this level of the tree and negates

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -458,9 +458,9 @@ class Folder
         }
 
         if ($recursive === false && is_dir($path)) {
-            //@codingStandardsIgnoreStart
+            // phpcs:disable
             if (@chmod($path, intval($mode, 8))) {
-                //@codingStandardsIgnoreEnd
+                // phpcs:enable
                 $this->_messages[] = sprintf('%s changed to %s', $path, $mode);
 
                 return true;
@@ -483,9 +483,9 @@ class Folder
                         continue;
                     }
 
-                    //@codingStandardsIgnoreStart
+                    // phpcs:disable
                     if (@chmod($fullpath, intval($mode, 8))) {
-                        //@codingStandardsIgnoreEnd
+                        // phpcs:enable
                         $this->_messages[] = sprintf('%s changed to %s', $fullpath, $mode);
                     } else {
                         $this->_errors[] = sprintf('%s NOT changed to %s', $fullpath, $mode);
@@ -713,17 +713,17 @@ class Folder
             foreach ($iterator as $item) {
                 $filePath = $item->getPathname();
                 if ($item->isFile() || $item->isLink()) {
-                    //@codingStandardsIgnoreStart
+                    // phpcs:disable
                     if (@unlink($filePath)) {
-                        //@codingStandardsIgnoreEnd
+                        // phpcs:enable
                         $this->_messages[] = sprintf('%s removed', $filePath);
                     } else {
                         $this->_errors[] = sprintf('%s NOT removed', $filePath);
                     }
                 } elseif ($item->isDir() && !$item->isDot()) {
-                    //@codingStandardsIgnoreStart
+                    // phpcs:disable
                     if (@rmdir($filePath)) {
-                        //@codingStandardsIgnoreEnd
+                        // phpcs:enable
                         $this->_messages[] = sprintf('%s removed', $filePath);
                     } else {
                         $this->_errors[] = sprintf('%s NOT removed', $filePath);
@@ -734,9 +734,9 @@ class Folder
             }
 
             $path = rtrim($path, DIRECTORY_SEPARATOR);
-            //@codingStandardsIgnoreStart
+            // phpcs:disable
             if (@rmdir($path)) {
-                //@codingStandardsIgnoreEnd
+                // phpcs:enable
                 $this->_messages[] = sprintf('%s removed', $path);
             } else {
                 $this->_errors[] = sprintf('%s NOT removed', $path);
@@ -803,9 +803,9 @@ class Folder
         }
 
         $exceptions = array_merge(['.', '..', '.svn'], $options['skip']);
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         if ($handle = @opendir($fromDir)) {
-            //@codingStandardsIgnoreEnd
+            // phpcs:enable
             while (($item = readdir($handle)) !== false) {
                 $to = Folder::addPathElement($toDir, $item);
                 if (($options['scheme'] != Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions)) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2539,9 +2539,9 @@ class Response implements ResponseInterface
      */
     protected function _clearBuffer()
     {
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         return @ob_end_clean();
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**
@@ -2552,12 +2552,12 @@ class Response implements ResponseInterface
      */
     protected function _flushBuffer()
     {
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         @flush();
         if (ob_get_level()) {
             @ob_flush();
         }
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -72,12 +72,12 @@ class MailTransport extends AbstractTransport
      */
     protected function _mail($to, $subject, $message, $headers, $params = null)
     {
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         if (!@mail($to, $subject, $message, $headers, $params)) {
             $error = error_get_last();
             $msg = 'Could not send email: ' . (isset($error['message']) ? $error['message'] : 'unknown');
             throw new SocketException($msg);
         }
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 }

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -89,7 +89,7 @@ class Socket
      * @var array
      */
     protected $_encryptMethods = [
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         // @deprecated Will be removed in 4.0.0
         'sslv2_client' => STREAM_CRYPTO_METHOD_SSLv2_CLIENT,
         // @deprecated Will be removed in 4.0.0
@@ -108,7 +108,7 @@ class Socket
         'tlsv10_server' => STREAM_CRYPTO_METHOD_TLSv1_0_SERVER,
         'tlsv11_server' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER,
         'tlsv12_server' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     ];
 
     /**
@@ -458,14 +458,14 @@ class Socket
         // See https://github.com/php/php-src/commit/10bc5fd4c4c8e1dd57bd911b086e9872a56300a0
         if (version_compare(PHP_VERSION, '5.6.7', '>=')) {
             if ($method == STREAM_CRYPTO_METHOD_TLS_CLIENT) {
-                // @codingStandardsIgnoreStart
+                // phpcs:disable
                 $method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
-                // @codingStandardsIgnoreEnd
+                // phpcs:enable
             }
             if ($method == STREAM_CRYPTO_METHOD_TLS_SERVER) {
-                // @codingStandardsIgnoreStart
+                // phpcs:disable
                 $method |= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER | STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
-                // @codingStandardsIgnoreEnd
+                // phpcs:enable
             }
         }
 

--- a/src/Shell/Task/AssetsTask.php
+++ b/src/Shell/Task/AssetsTask.php
@@ -217,7 +217,7 @@ class AssetsTask extends Shell
         }
 
         if (is_link($dest)) {
-            // @codingStandardsIgnoreLine
+            // phpcs:ignore
             if (@unlink($dest)) {
                 $this->out('Unlinked ' . $dest);
 
@@ -250,9 +250,9 @@ class AssetsTask extends Shell
     protected function _createDirectory($dir)
     {
         $old = umask(0);
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $result = @mkdir($dir, 0755, true);
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
         umask($old);
 
         if ($result) {
@@ -275,9 +275,9 @@ class AssetsTask extends Shell
      */
     protected function _createSymlink($target, $link)
     {
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $result = @symlink($target, $link);
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
 
         if ($result) {
             $this->out('Created symlink ' . $link);

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -567,7 +567,7 @@ abstract class TestCase extends BaseTestCase
         return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
 
-// @codingStandardsIgnoreStart
+// phpcs:disable
 
     /**
      * Compatibility function to test if a value is between an acceptable range.
@@ -632,7 +632,7 @@ abstract class TestCase extends BaseTestCase
         return $condition;
     }
 
-// @codingStandardsIgnoreEnd
+// phpcs:enable
 
     /**
      * Mock a model, maintain fixtures and table association

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -35,9 +35,9 @@ class MemcachedEngineTest extends TestCase
         parent::setUp();
         $this->skipIf(!class_exists('Memcached'), 'Memcached is not installed or configured properly.');
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $socket = @fsockopen('127.0.0.1', 11211, $errno, $errstr, 1);
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->skipIf(!$socket, 'Memcached is not running.');
         fclose($socket);
 
@@ -374,11 +374,11 @@ class MemcachedEngineTest extends TestCase
 
         foreach ($servers as $server) {
             list($host, $port) = explode(':', $server);
-            //@codingStandardsIgnoreStart
+            // phpcs:disable
             if (!$Memcached->addServer($host, $port)) {
                 $available = false;
             }
-            //@codingStandardsIgnoreEnd
+            // phpcs:enable
         }
 
         $this->skipIf(!$available, 'Need memcached servers at ' . implode(', ', $servers) . ' to run this test.');

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -35,9 +35,9 @@ class RedisEngineTest extends TestCase
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
         $this->skipIf(version_compare(PHP_VERSION, '7.2.0dev', '>='), 'Redis is misbehaving in PHP7.2');
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $socket = @fsockopen('127.0.0.1', 6379, $errno, $errstr, 1);
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->skipIf(!$socket, 'Redis is not running.');
         fclose($socket);
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -134,7 +134,7 @@ class TestController extends ControllerTestAppController
         return 'I am from the controller.';
     }
 
-    //@codingStandardsIgnoreStart
+    // phpcs:disable
     protected function protected_m()
     {
     }
@@ -146,7 +146,7 @@ class TestController extends ControllerTestAppController
     public function _hidden()
     {
     }
-    //@codingStandardsIgnoreEnd
+    // phpcs:enable
 
     public function admin_add()
     {
@@ -1059,9 +1059,9 @@ class ControllerTest extends TestCase
         $controller = new TestController(new ServerRequest(), new Response());
         $theme = $controller->theme;
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         $this->assertEquals($theme, @$controller->createView()->theme);
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -173,9 +173,9 @@ class ErrorHandlerTest extends TestCase
         $this->_restoreError = true;
 
         ob_start();
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         @include 'invalid.file';
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $result = ob_get_clean();
         $this->assertEmpty($result);
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4863,7 +4863,7 @@ class FormHelperTest extends TestCase
         ]);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option B']);
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             ['input' => [
                 'type' => 'hidden',
@@ -4889,7 +4889,7 @@ class FormHelperTest extends TestCase
                 'option B',
             '/label',
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
     }
 
@@ -8202,7 +8202,7 @@ class FormHelperTest extends TestCase
         $article = new Article(['comments' => [$comment]]);
         $this->Form->create([$article]);
         $result = $this->Form->control('0.comments.1.comment');
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             'div' => ['class' => 'input textarea'],
                 'label' => ['for' => '0-comments-1-comment'],
@@ -8216,11 +8216,11 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->control('0.comments.0.comment');
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             'div' => ['class' => 'input textarea'],
                 'label' => ['for' => '0-comments-0-comment'],
@@ -8235,12 +8235,12 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
 
         $comment->errors('comment', ['Not valid']);
         $result = $this->Form->control('0.comments.0.comment');
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             'div' => ['class' => 'input textarea error'],
                 'label' => ['for' => '0-comments-0-comment'],
@@ -8259,14 +8259,14 @@ class FormHelperTest extends TestCase
                 '/div',
             '/div'
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
 
         TableRegistry::get('Comments')
             ->validator('default')
             ->allowEmpty('comment', false);
         $result = $this->Form->control('0.comments.1.comment');
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             'div' => ['class' => 'input textarea required'],
                 'label' => ['for' => '0-comments-1-comment'],
@@ -8281,7 +8281,7 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -148,7 +148,7 @@ class RssHelperTest extends TestCase
         ];
         $content = 'content-here';
         $result = $this->Rss->channel($attrib, $elements, $content);
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             '<channel',
                 '<title', 'Title of RSS Feed', '/title',
@@ -169,7 +169,7 @@ class RssHelperTest extends TestCase
             'content-here',
             '/channel',
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
     }
 
@@ -194,7 +194,7 @@ class RssHelperTest extends TestCase
         ];
         $content = 'content-here';
         $result = $this->Rss->channel($attrib, $elements, $content);
-        //@codingStandardsIgnoreStart
+        // phpcs:disable
         $expected = [
             '<channel',
                 '<title', 'Title of RSS Feed', '/title',
@@ -214,7 +214,7 @@ class RssHelperTest extends TestCase
             'content-here',
             '/channel',
         ];
-        //@codingStandardsIgnoreEnd
+        // phpcs:enable
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,13 +49,13 @@ define('APP', TEST_APP . 'TestApp' . DS);
 define('WWW_ROOT', TEST_APP . 'webroot' . DS);
 define('CONFIG', TEST_APP . 'config' . DS);
 
-//@codingStandardsIgnoreStart
+// phpcs:disable
 @mkdir(LOGS);
 @mkdir(SESSIONS);
 @mkdir(CACHE);
 @mkdir(CACHE . 'views');
 @mkdir(CACHE . 'models');
-//@codingStandardsIgnoreEnd
+// phpcs:enable
 
 require_once CORE_PATH . 'config/bootstrap.php';
 

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -60,7 +60,7 @@ class ShellTestShell extends Shell
     {
     }
 
-    //@codingStandardsIgnoreStart
+    // phpcs:disable
     public function doSomething()
     {
     }
@@ -73,5 +73,5 @@ class ShellTestShell extends Shell
     {
         $this->log($this->testMessage);
     }
-    //@codingStandardsIgnoreEnd
+    // phpcs:enable
 }


### PR DESCRIPTION
I fixed it because it is deprecated.

`@codingStandardsIgnoreStart` → `phpcs:disable`
`@codingStandardsIgnoreEnd` → `phpcs:enable`
`@codingStandardsIgnoreLine` → `phpcs:ignore`

## Docment

https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file
> Note: Before PHP_CodeSniffer version 3.2.0, use // @codingStandardsIgnoreStart instead of // phpcs:disable, and use // @codingStandardsIgnoreEnd instead of // phpcs:enable. The @codingStandards syntax is deprecated and will be removed in PHP_CodeSniffer version 4.0.