### PR TITLE
Fix Hash::_matches() with object implements toString

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -276,8 +276,8 @@ class Hash
                 if (!preg_match($val, $prop)) {
                     return false;
                 }
-            } elseif (($op === '=' && $prop !== $val) ||
-                ($op === '!=' && $prop === $val) ||
+            } elseif (($op === '=' && $prop != $val) ||
+                ($op === '!=' && $prop == $val) ||
                 ($op === '>' && $prop <= $val) ||
                 ($op === '<' && $prop >= $val) ||
                 ($op === '>=' && $prop < $val) ||

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1422,23 +1422,33 @@ class HashTest extends TestCase
     }
 
     /**
-     * Test extracting value-zero contained data based on attributes with string
+     * Test extracting attributes with string
      *
      * @return void
      */
-    public function testExtractAttributeStringWithDataContainsZero()
+    public function testExtractAttributeString()
     {
         $data = [
-            ['value' => '0'],
             ['value' => 0],
+            ['value' => 3],
             ['value' => 'string-value'],
+            ['value' => new Time('2010-01-05 01:23:45')],
         ];
 
-        $expected = [
-            ['value' => 'string-value'],
-        ];
+        // check _matches does not work as `0 == 'string-value'`
+        $expected = [$data[2]];
         $result = Hash::extract($data, '{n}[value=string-value]');
         $this->assertSame($expected, $result);
+
+        // check _matches work with object implements __toString()
+        $expected = [$data[3]];
+        $result = Hash::extract($data, sprintf('{n}[value=%s]', $data[3]['value']));
+        $this->assertSame($expected, $result);
+
+        // check _matches does not work as `3 == '3 people'`
+        $unexpected = $data[1];
+        $result = Hash::extract($data, '{n}[value=3people]');
+        $this->assertNotContains($unexpected, $result);
     }
 
     /**


### PR DESCRIPTION
I requested #11690 to Hash::extract work with string attr correctly, but it has problem about `__toString` object comparison.

@chinpei215 told me about the problem in Slack CakePHP workspace#Japanese.

Like this.
```php
use \Cake\I18n\Time;

// Time::setToStringFormat('yyyy-MM-dd');
Hash::extract([
    ['time' => new Time('2016-02-06'), ],
    ['time' => new Time('2016-02-07'), ],
    ['time' => new Time('2016-02-08'), ],
], '{n}[time=2016-02-07]')
```

At master:HEAD,  $result is `[ ['time' =>  new Time('2016-02-07')]]`;
But  in #11690, Hash::_matches check value type, so `Time` object will not match `string`.

Then, I would like to remove checking value type.

And I refactored test case for string-attr.

* Object::toString()
* to cast string contains numeric into int.