### PR TITLE
Pass required attribute into generated datetime options.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2434,6 +2434,9 @@ class FormHelper extends Helper
             if (isset($options['empty'][$type])) {
                 $options[$type]['empty'] = $options['empty'][$type];
             }
+            if (isset($options['required']) && is_array($options[$type])) {
+                $options[$type]['required'] = $options['required'];
+            }
         }
 
         $hasYear = is_array($options['year']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6987,6 +6987,23 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * test control() datetime & required attributes
+     *
+     * @return void
+     */
+    public function testControlDatetimeRequired()
+    {
+        $result = $this->Form->control('birthday', [
+            'type' => 'date',
+            'required' => true
+        ]);
+        $this->assertContains(
+            '<select name="birthday[year]" required="required"',
+            $result
+        );
+    }
+
+    /**
      * testYearAutoExpandRange method
      *
      * @return void


### PR DESCRIPTION
The required option was not copied onto the attributes for each select element. This resulted in them not having the required attribute.

Refs #11699
