### PR TITLE
Backported few Table class methods

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -807,6 +807,46 @@ class Model extends CakeObject implements CakeEventListener {
 	}
 
 /**
+ * Setup multiple associations.
+ *
+ * It takes an array containing set of table names indexed by association type
+ * as argument:
+ *
+ * ```
+ * $this->Post->addAssociations([
+ *   'belongsTo' => [
+ *     'User' => ['className' => 'Users']
+ *   ],
+ *   'hasMany' => ['Comment'],
+ *   'belongsToMany' => ['Tag']
+ * ]);
+ * ```
+ *
+ * Each association type accepts multiple associations where the keys
+ * are the aliases, and the values are association config data. If numeric
+ * keys are used the values will be treated as association aliases.
+ *
+ * @param array $params Set of associations to bind (indexed by association type).
+ * @return $this
+ * @see Model::belongsTo()
+ * @see Model::hasOne()
+ * @see Model::hasMany()
+ * @see Model::belongsToMany()
+ */
+	public function addAssociations(array $params) {
+		foreach ($params as $assocType => $tables) {
+			foreach ($tables as $associated => $options) {
+				if (is_numeric($associated)) {
+					$associated = $options;
+					$options = [];
+				}
+				$this->{$assocType}($associated, $options);
+			}
+		}
+		return $this;
+	}
+
+/**
  * Creates a permament BelongsTo association between this model and a target
  * model.
  *

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -827,7 +827,7 @@ class Model extends CakeObject implements CakeEventListener {
  * @return void
  * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#belongsto
  */
-	public function belongsTo($associated, array $options = []) {
+	public function belongsTo($associated, array $options = array()) {
 		$params = array(
 			'belongsTo' => array(
 				$associated => $options,
@@ -855,7 +855,7 @@ class Model extends CakeObject implements CakeEventListener {
  * @return void
  * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasone
  */
-	public function hasOne($associated, array $options = []) {
+	public function hasOne($associated, array $options = array()) {
 		$params = array(
 			'hasOne' => array(
 				$associated => $options,
@@ -886,7 +886,7 @@ class Model extends CakeObject implements CakeEventListener {
  * @return void
  * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasmany
  */
-	public function hasMany($associated, array $options = []) {
+	public function hasMany($associated, array $options = array()) {
 		$params = array(
 			'hasMany' => array(
 				$associated => $options,
@@ -920,7 +920,7 @@ class Model extends CakeObject implements CakeEventListener {
  * @return void
  * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasandbelongstomany-habtm
  */
-	public function belongsToMany($associated, array $options = []) {
+	public function belongsToMany($associated, array $options = array()) {
 		$params = array(
 			'hasAndBelongsToMany' => array(
 				$associated => $options,

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -837,6 +837,99 @@ class Model extends CakeObject implements CakeEventListener {
 	}
 
 /**
+ * Creates a new HasOne association between this model and a target
+ * model. A "has one" association is a 1-1 relationship.
+ *
+ * The options array accept the following keys:
+ *
+ * - className
+ * - foreignKey
+ * - conditions
+ * - fields
+ * - order
+ * - dependent
+ *
+ * @param string $associated the alias for the target model. This is used to
+ * uniquely identify the association.
+ * @param array $options list of options to configure the association definition.
+ * @return void
+ * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasone
+ */
+	public function hasOne($associated, array $options = []) {
+		$params = array(
+			'hasOne' => array(
+				$associated => $options,
+			),
+		);
+		$this->bindModel($params, false);
+	}
+
+/**
+ * Creates a new HasMany association between this model and a target
+ * model. A "has many" association is a 1-N relationship.
+ *
+ * The options array accept the following keys:
+ *
+ * - className
+ * - foreignKey
+ * - conditions
+ * - order
+ * - limit
+ * - offset
+ * - dependent
+ * - exclusive
+ * - finderQuery
+ *
+ * @param string $associated the alias for the target model. This is used to
+ * uniquely identify the association.
+ * @param array $options list of options to configure the association definition.
+ * @return void
+ * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasmany
+ */
+	public function hasMany($associated, array $options = []) {
+		$params = array(
+			'hasMany' => array(
+				$associated => $options,
+			),
+		);
+		$this->bindModel($params, false);
+	}
+
+/**
+ * Creates a new HasAndBelongsToMany association between this model and a target
+ * model. A "has and belongs to many" association is a M-N relationship.
+ *
+ * The options array accept the following keys:
+ *
+ * - className
+ * - joinTable
+ * - with
+ * - foreignKey
+ * - associationForeignKey
+ * - unique
+ * - conditions
+ * - fields
+ * - order
+ * - limit
+ * - offset
+ * - finderQuery
+ *
+ * @param string $associated the alias for the target model. This is used to
+ * uniquely identify the association.
+ * @param array $options list of options to configure the association definition.
+ * @return void
+ * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#hasandbelongstomany-habtm
+ */
+	public function belongsToMany($associated, array $options = []) {
+		$params = array(
+			'hasAndBelongsToMany' => array(
+				$associated => $options,
+			),
+		);
+		$this->bindModel($params, false);
+	}
+
+/**
  * Returns a list of all events that will fire in the model during it's lifecycle.
  * You can override this function to add your own listener callbacks
  *

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -838,7 +838,7 @@ class Model extends CakeObject implements CakeEventListener {
 			foreach ($tables as $associated => $options) {
 				if (is_numeric($associated)) {
 					$associated = $options;
-					$options = [];
+					$options = array();
 				}
 				$this->{$assocType}($associated, $options);
 			}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -779,6 +779,61 @@ class Model extends CakeObject implements CakeEventListener {
 
 		$this->_createLinks();
 		$this->Behaviors->init($this->alias, $this->actsAs);
+		$this->initialize(array(
+			'table' => $this->table,
+			'alias' => $this->alias,
+			'schema' => $this->schemaName,
+		));
+	}
+
+/**
+ * Initialize a table instance. Called after the constructor.
+ *
+ * You can use this method to define associations, attach behaviors
+ * define validation and do any other initialization logic you need.
+ *
+ * ```
+ *  public function initialize(array $config)
+ *  {
+ *      $this->belongsTo('User');
+ *      $this->belongsToMany('Tagging.Tag');
+ *  }
+ * ```
+ *
+ * @param array $config Configuration options passed to the constructor.
+ * @return void
+ */
+	public function initialize(array $config) {
+	}
+
+/**
+ * Creates a permament BelongsTo association between this model and a target
+ * model.
+ *
+ * The options array accept the following keys:
+ *
+ * - className
+ * - foreignKey
+ * - conditions
+ * - type
+ * - fields
+ * - order
+ * - counterCache
+ * - counterScope
+ *
+ * @param string $associated The alias for the target model. This is used to
+ * uniquely identify the association.
+ * @param array $options List of options to configure the association definition.
+ * @return void
+ * @link https://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#belongsto
+ */
+	public function belongsTo($associated, array $options = []) {
+		$params = array(
+			'belongsTo' => array(
+				$associated => $options,
+			),
+		);
+		$this->bindModel($params, false);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -65,7 +65,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testInitialize() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->find('count');
 		$this->assertEquals(7, $result);
@@ -82,7 +82,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidLeft() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
 
@@ -109,7 +109,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidRight() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
 
@@ -136,7 +136,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
 
@@ -161,7 +161,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectNoneExistentParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
 		$this->Tree->updateAll(array($parentField => 999999), array('id' => $result[$modelClass]['id']));
@@ -312,7 +312,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRecoverFromMissingParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
 		$this->Tree->updateAll(array($parentField => 999999), array('id' => $result[$modelClass]['id']));
@@ -335,7 +335,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidParents() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->updateAll(array($parentField => null));
 
@@ -357,7 +357,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidLftsRghts() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->updateAll(array($leftField => 0, $rightField => 0));
 
@@ -378,7 +378,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectEqualLftsRghts() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 3);
+		$this->Tree->init(1, 3);
 
 		$result = $this->Tree->findByName('1.1');
 		$this->Tree->updateAll(array($rightField => $result[$modelClass][$leftField]), array('id' => $result[$modelClass]['id']));
@@ -405,7 +405,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddOrphan() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->create();
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
@@ -425,7 +425,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddMiddle() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
 		$initialCount = $this->Tree->find('count');
@@ -456,7 +456,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddWithPreSpecifiedId() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array(
 			'fields' => array('id'),
@@ -486,7 +486,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$initialCount = $this->Tree->find('count');
@@ -511,7 +511,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddNotIndexedByModel() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'testAddNotIndexed', $parentField => null));
@@ -531,7 +531,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMovePromote() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -557,7 +557,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGetLevel() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$result = $this->Tree->getLevel(5);
@@ -577,7 +577,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveWithWhitelist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -604,7 +604,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testInsertWithWhitelist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->whitelist = array('name', $parentField);
 		$this->Tree->create();
@@ -623,7 +623,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveBefore() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.1')));
@@ -651,7 +651,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveAfter() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2')));
@@ -679,7 +679,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDemoteInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -711,7 +711,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$initialCount = $this->Tree->find('count');
@@ -735,7 +735,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveSelfInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$initialCount = $this->Tree->find('count');
@@ -760,7 +760,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpSuccess() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.2')));
 		$this->Tree->moveUp($data[$modelClass]['id']);
@@ -781,7 +781,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpFail() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.1')));
 
@@ -803,7 +803,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUp2() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 10);
+		$this->Tree->init(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
 		$this->Tree->moveUp($data[$modelClass]['id'], 2);
@@ -833,7 +833,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpFirst() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 10);
+		$this->Tree->init(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
 		$this->Tree->moveUp($data[$modelClass]['id'], true);
@@ -863,7 +863,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownSuccess() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
 		$this->Tree->moveDown($data[$modelClass]['id']);
@@ -884,7 +884,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownFail() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2')));
 		$this->Tree->moveDown($data[$modelClass]['id']);
@@ -905,7 +905,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownLast() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 10);
+		$this->Tree->init(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
 		$this->Tree->moveDown($data[$modelClass]['id'], true);
@@ -935,7 +935,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDown2() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 10);
+		$this->Tree->init(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
 		$this->Tree->moveDown($data[$modelClass]['id'], 2);
@@ -965,7 +965,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testSaveNoMove() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 10);
+		$this->Tree->init(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -995,7 +995,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveToRootAndMoveUp() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(1, 1);
+		$this->Tree->init(1, 1);
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
 		$this->Tree->id = $data[$modelClass]['id'];
 		$this->Tree->save(array($parentField => null));
@@ -1019,7 +1019,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDelete() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$initialCount = $this->Tree->find('count');
 		$result = $this->Tree->findByName('1.1.1');
@@ -1054,7 +1054,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDeleteDoesNotExist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->delete(99999);
 	}
 
@@ -1066,7 +1066,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemove() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$initialCount = $this->Tree->find('count');
 		$result = $this->Tree->findByName('1.1');
 
@@ -1098,7 +1098,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveLastTopParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$initialCount = $this->Tree->find('count');
 		$initialTopNodes = $this->Tree->childCount(false);
@@ -1131,7 +1131,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$initialCount = $this->Tree->find('count');
 
 		$result = $this->Tree->findByName('1.1.1');
@@ -1165,7 +1165,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveAndDelete() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$initialCount = $this->Tree->find('count');
 		$result = $this->Tree->findByName('1.1');
@@ -1199,7 +1199,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveAndDeleteNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$initialCount = $this->Tree->find('count');
 
 		$result = $this->Tree->findByName('1.1.1');
@@ -1231,7 +1231,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -1261,7 +1261,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testCountChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -1286,7 +1286,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGetParentNode() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2.2')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -1304,7 +1304,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGetPath() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2.2')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -1326,7 +1326,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree = new $modelClass();
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -1356,7 +1356,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testReorderTree() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(3, 3);
+		$this->Tree->init(3, 3);
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
@@ -1387,7 +1387,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testReorderBigTreeWithQueryCaching() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 10);
+		$this->Tree->init(2, 10);
 
 		$original = $this->Tree->cacheQueries;
 		$this->Tree->cacheQueries = true;
@@ -1406,7 +1406,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree = new $modelClass();
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->generateTreeList();
 		$expected = array(1 => '1. Root', 2 => '_1.1', 3 => '__1.1.1', 4 => '__1.1.2', 5 => '_1.2', 6 => '__1.2.1', 7 => '__1.2.2');
@@ -1421,7 +1421,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGenerateTreeListFormatting() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->generateTreeList(
 			null,
@@ -1441,7 +1441,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testFormatTreeList() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$options = array('order' => array('lft' => 'asc'));
 		$records = $this->Tree->find('all', $options);
@@ -1464,7 +1464,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testArraySyntax() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
-		$this->Tree->initialize(3, 3);
+		$this->Tree->init(3, 3);
 		$this->assertSame($this->Tree->childCount(2), $this->Tree->childCount(array('id' => 2)));
 		$this->assertSame($this->Tree->getParentNode(2), $this->Tree->getParentNode(array('id' => 2)));
 		$this->assertSame($this->Tree->getPath(4), $this->Tree->getPath(array('id' => 4)));
@@ -1556,7 +1556,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->Behaviors->attach('Tree', array('level' => 'level'));
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->findByName('1. Root');
 		$this->assertEquals(0, $result[$modelClass][$level]);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -64,7 +64,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 	public function testStringScope() {
 		$this->Tree = new FlagTree();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 3);
+		$this->Tree->init(2, 3);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -101,7 +101,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 	public function testArrayScope() {
 		$this->Tree = new FlagTree();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 3);
+		$this->Tree->init(2, 3);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -315,7 +315,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->TreeTwo = new NumberTreeTwo();
 		$this->TreeTwo->order = null;
@@ -373,7 +373,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 3);
+		$this->Tree->init(2, 3);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -412,7 +412,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 3);
+		$this->Tree->init(2, 3);
 
 		$this->Tree->Behaviors->load('Tree', array('scope' => 'FlagTree.flag = 1'));
 		$this->Tree->Behaviors->disable('Tree');
@@ -472,7 +472,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -503,7 +503,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -533,7 +533,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);
@@ -562,7 +562,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(1, 3);
+		$this->Tree->init(1, 3);
 
 		$this->Tree->id = 1;
 		$this->Tree->saveField('flag', 1);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -66,7 +66,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array(
 			'fields' => array('id'),
@@ -98,7 +98,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -125,7 +125,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$this->Tree->id = null;
 
 		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -153,7 +153,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$initialCount = $this->Tree->find('count');
 
 		$result = $this->Tree->findByName('1.1.1');
@@ -188,7 +188,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 		$initialCount = $this->Tree->find('count');
 
 		$result = $this->Tree->findByName('1.1.1');
@@ -221,7 +221,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -250,7 +250,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->order = null;
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
@@ -289,7 +289,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$this->Tree->order = null;
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
-		$this->Tree->initialize(2, 2);
+		$this->Tree->init(2, 2);
 
 		$result = $this->Tree->generateTreeList();
 		$expected = array('1. Root', '_1.1', '__1.1.1', '__1.1.2', '_1.2', '__1.2.1', '__1.2.2');

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -4859,6 +4859,34 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * testBelongsTo method
+ *
+ * @return void
+ */
+	public function testBelongsTo() {
+		$expected = array(
+			'className' => 'FeatureSet',
+			'foreignKey' => false,
+			'conditions' => array(
+				'Feature.name' => 'DeviceType.name',
+			),
+			'fields' => '',
+			'order' => '',
+			'counterCache' => '',
+		);
+		$DeviceType = new DeviceType();
+		$options = array(
+			'className' => 'FeatureSet',
+			'foreignKey' => false,
+			'conditions' => array(
+				'Feature.name' => 'DeviceType.name',
+			),
+		);
+		$DeviceType->belongsTo('FeatureSet', $options);
+		$this->assertEquals($expected, $DeviceType->belongsTo['FeatureSet']);
+	}
+
+/**
  * testBindMultipleTimes method
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -4985,6 +4985,67 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * testAddAssociations method
+ *
+ * @return void
+ */
+	public function testAddAssociations() {
+		$this->loadFixtures('Article', 'Tag', 'User');
+		$options = array(
+			'belongsTo' => array(
+				'Users' => array(
+					'className' => 'User',
+					'foreignKey' => 'user_id',
+					'conditions' => array(
+						'user_id >' => 10,
+					),
+				),
+			),
+			'belongsToMany' => array(
+				'Tags' => array(
+					'className' => 'Tag',
+					'conditions' => array(
+						'article_id >' => 15,
+					),
+				),
+			),
+		);
+		$Article = new Article();
+		$Article->addAssociations($options);
+
+		$expectedBelongsTo = array(
+			'className' => 'User',
+			'foreignKey' => 'user_id',
+			'conditions' => array(
+				'user_id >' => 10,
+			),
+			'fields' => '',
+			'order' => '',
+			'counterCache' => '',
+		);
+		$this->assertEquals($expectedBelongsTo, $Article->belongsTo['Users']);
+
+		$expectedHabtm = array(
+			'className' => 'Tag',
+			'foreignKey' => 'article_id',
+			'conditions' => array(
+				'article_id >' => 15,
+			),
+			'fields' => '',
+			'order' => '',
+			'limit' => '',
+			'offset' => '',
+			'finderQuery' => '',
+			'joinTable' => 'articles_tags',
+			'with' => 'ArticlesTag',
+			'dynamicWith' => true,
+			'associationForeignKey' => 'tag_id',
+			'unique' => true,
+		);
+		$this->assertEquals($expectedHabtm, $Article->hasAndBelongsToMany['Tags']);
+	}
+
+/**
  * testBindMultipleTimes method
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -4864,6 +4864,7 @@ class ModelReadTest extends BaseModelTest {
  * @return void
  */
 	public function testBelongsTo() {
+		$this->loadFixtures('DeviceType', 'FeatureSet');
 		$expected = array(
 			'className' => 'FeatureSet',
 			'foreignKey' => false,
@@ -4884,6 +4885,103 @@ class ModelReadTest extends BaseModelTest {
 		);
 		$DeviceType->belongsTo('FeatureSet', $options);
 		$this->assertEquals($expected, $DeviceType->belongsTo['FeatureSet']);
+	}
+
+/**
+ * testHasOne method
+ *
+ * @return void
+ */
+	public function testHasOne() {
+		$this->loadFixtures('DeviceType', 'FeatureSet');
+		$expected = array(
+			'className' => 'DeviceType',
+			'foreignKey' => false,
+			'conditions' => array(
+				'Feature.name' => 'DeviceType.name',
+			),
+			'fields' => '',
+			'order' => '',
+			'dependent' => '',
+		);
+		$FeatureSet = new FeatureSet();
+		$options = array(
+			'className' => 'DeviceType',
+			'foreignKey' => false,
+			'conditions' => array(
+				'Feature.name' => 'DeviceType.name',
+			),
+		);
+		$FeatureSet->hasOne('DeviceType', $options);
+		$this->assertEquals($expected, $FeatureSet->hasOne['DeviceType']);
+	}
+
+/**
+ * testHasMany method
+ *
+ * @return void
+ */
+	public function testHasMany() {
+		$this->loadFixtures('DeviceType', 'FeatureSet');
+		$expected = array(
+			'className' => 'FeatureSet',
+			'foreignKey' => 'device_type_id',
+			'conditions' => array(
+				'active' => true,
+			),
+			'fields' => '',
+			'order' => '',
+			'dependent' => '',
+			'limit' => '',
+			'offset' => '',
+			'exclusive' => '',
+			'finderQuery' => '',
+			'counterQuery' => '',
+		);
+		$DeviceType = new DeviceType();
+		$options = array(
+			'className' => 'FeatureSet',
+			'conditions' => array(
+				'active' => true,
+			),
+		);
+		$DeviceType->hasMany('NewFeatureSet', $options);
+		$this->assertEquals($expected, $DeviceType->hasMany['NewFeatureSet']);
+	}
+
+/**
+ * testHasMany method
+ *
+ * @return void
+ */
+	public function testBelongsToMany() {
+		$this->loadFixtures('Article', 'Tag');
+		$expected = array(
+			'className' => 'Tag',
+			'foreignKey' => 'article_id',
+			'conditions' => array(
+				'article_id >' => 15,
+			),
+			'fields' => '',
+			'order' => '',
+			'limit' => '',
+			'offset' => '',
+			'finderQuery' => '',
+			'joinTable' => 'articles_tags',
+			'with' => 'ArticlesTag',
+			'dynamicWith' => true,
+			'associationForeignKey' => 'tag_id',
+			'unique' => true,
+		);
+		$Article = new Article();
+		$options = array(
+			'className' => 'Tag',
+			'conditions' => array(
+				'article_id >' => 15,
+			),
+		);
+		$Article->belongsToMany('Tags', $options);
+		$this->assertEquals($expected, $Article->hasAndBelongsToMany['Tags']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -2613,12 +2613,12 @@ class NumberTree extends CakeTestModel {
  * @param bool $hierarchal
  * @return void
  */
-	public function initialize($levelLimit = 3, $childLimit = 3, $currentLevel = null, $parentId = null, $prefix = '1', $hierarchal = true) {
+	public function init($levelLimit = 3, $childLimit = 3, $currentLevel = null, $parentId = null, $prefix = '1', $hierarchal = true) {
 		if (!$parentId) {
 			$db = ConnectionManager::getDataSource($this->useDbConfig);
 			$db->truncate($this->table);
 			$this->save(array($this->name => array('name' => '1. Root')));
-			$this->initialize($levelLimit, $childLimit, 1, $this->id, '1', $hierarchal);
+			$this->init($levelLimit, $childLimit, 1, $this->id, '1', $hierarchal);
 			$this->create(array());
 		}
 
@@ -2639,7 +2639,7 @@ class NumberTree extends CakeTestModel {
 				}
 			}
 			$this->save($data);
-			$this->initialize($levelLimit, $childLimit, $currentLevel + 1, $this->id, $name, $hierarchal);
+			$this->init($levelLimit, $childLimit, $currentLevel + 1, $this->id, $name, $hierarchal);
 		}
 	}
 


### PR DESCRIPTION
Partially backported initialize(), belongsTo(), hasOne(), hasMany() and belongsToMany(), addAssociations() methods from Table to Model.