### PR TITLE
Update BaseAuthenticate.php

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -147,12 +147,12 @@ abstract class BaseAuthenticate implements EventListenerInterface
         $config = $this->_config;
         $table = TableRegistry::get($config['userModel']);
 
-        if(empty($config['userIdentificationColumns'])) {
+        if (empty($config['userIdentificationColumns'])) {
             $config['userIdentificationColumns'] = $config['fields']['username'];
         }
-        if(is_array($config['userIdentificationColumns'])) {
+        if (is_array($config['userIdentificationColumns'])) {
             foreach ($config['userIdentificationColumns'] as $userIdentificationColumn) {
-                if(!empty($options['conditions']['OR'])  and is_array($options['conditions']['OR'])) {
+                if (!empty($options['conditions']['OR']) and is_array($options['conditions']['OR'])) {
                     $options['conditions']['OR'] += [$table->aliasField($userIdentificationColumn) => $username];
                 } else {
                     $options['conditions']['OR'] = [$table->aliasField($userIdentificationColumn) => $username];

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -152,7 +152,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
         }
         if (is_array($config['userIdentificationColumns'])) {
             foreach ($config['userIdentificationColumns'] as $userIdentificationColumn) {
-                if (!empty($options['conditions']['OR']) and is_array($options['conditions']['OR'])) {
+                if (!empty($options['conditions']['OR']) && is_array($options['conditions']['OR'])) {
                     $options['conditions']['OR'] += [$table->aliasField($userIdentificationColumn) => $username];
                 } else {
                     $options['conditions']['OR'] = [$table->aliasField($userIdentificationColumn) => $username];

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -147,9 +147,22 @@ abstract class BaseAuthenticate implements EventListenerInterface
         $config = $this->_config;
         $table = TableRegistry::get($config['userModel']);
 
-        $options = [
-            'conditions' => [$table->aliasField($config['fields']['username']) => $username]
-        ];
+        if(empty($config['userIdentificationColumns'])) {
+            $config['userIdentificationColumns'] = $config['fields']['username'];
+        }
+        if(is_array($config['userIdentificationColumns'])) {
+            foreach ($config['userIdentificationColumns'] as $userIdentificationColumn) {
+                if(!empty($options['conditions']['OR'])  and is_array($options['conditions']['OR'])) {
+                    $options['conditions']['OR'] += [$table->aliasField($userIdentificationColumn) => $username];
+                } else {
+                    $options['conditions']['OR'] = [$table->aliasField($userIdentificationColumn) => $username];
+                }
+            }
+        } else {
+            $options = [
+                'conditions' => [$table->aliasField($config['fields']['username']) => $username]
+            ];
+        }
 
         if (!empty($config['scope'])) {
             $options['conditions'] = array_merge($options['conditions'], $config['scope']);
@@ -167,7 +180,6 @@ abstract class BaseAuthenticate implements EventListenerInterface
         if (!isset($options['username'])) {
             $options['username'] = $username;
         }
-
         return $table->find($finder, $options);
     }
 


### PR DESCRIPTION
This change suggested by me solves a need I have. I believe that many have this same need.
If the 'userIdentificationColumns' config exists with one or more values, this change allows the indentification to be performed with one or more columns of the database.
Of course the columns informed in the configuration should count distinct and unique values among them, which is not very difficult to implement. In my case I am authorizing login with username, email and the unique personal document number.

Works fine to me!
