### PR TITLE
Defect 11686

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -278,7 +278,11 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
                 $objectName = $i;
             }
             list(, $name) = pluginSplit($objectName);
-            $normal[$name] = ['class' => $objectName, 'config' => $config];
+            if (isset($config['class'])) {
+                $normal[$name] = $config;
+            } else {
+                $normal[$name] = ['class' => $objectName, 'config' => $config];
+            }
         }
 
         return $normal;

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -351,4 +351,81 @@ class HelperRegistryTest extends TestCase
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);
     }
+
+    /**
+     * Test ObjectRegistry normalizeArray
+     *
+     * @return void
+     */
+    public function testArrayIsNormalized()
+    {
+        $config = [
+            'SomeHelper' => [
+                'value' => 1,
+                'value2' => 2
+            ],
+            'Plugin.SomeOtherHelper' => [
+                'value' => 1,
+                'value2' => 2
+            ]
+        ];
+        $result = $this->Helpers->normalizeArray($config);
+        $expected = [
+            'SomeHelper' => [
+                'class' => 'SomeHelper',
+                'config' => [
+                    'value' => 1,
+                    'value2' => 2
+                ]
+            ],
+            'SomeOtherHelper' => [
+                'class' => 'Plugin.SomeOtherHelper',
+                'config' => [
+                    'value' => 1,
+                    'value2' => 2
+                ]
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that calling normalizeArray multiple times does
+     * not nest the configuration.
+     *
+     * @return void
+     */
+    public function testArrayIsNormalizedAfterMultipleCalls()
+    {
+        $config = [
+            'SomeHelper' => [
+                'value' => 1,
+                'value2' => 2
+            ],
+            'Plugin.SomeOtherHelper' => [
+                'value' => 1,
+                'value2' => 2
+            ]
+        ];
+
+        $result1 = $this->Helpers->normalizeArray($config);
+        $result2 = $this->Helpers->normalizeArray($result1);
+        $expected = [
+            'SomeHelper' => [
+                'class' => 'SomeHelper',
+                'config' => [
+                    'value' => 1,
+                    'value2' => 2
+                ]
+            ],
+            'SomeOtherHelper' => [
+                'class' => 'Plugin.SomeOtherHelper',
+                'config' => [
+                    'value' => 1,
+                    'value2' => 2
+                ]
+            ],
+        ];
+        $this->assertEquals($expected, $result2);
+    }
 }


### PR DESCRIPTION
ObjectRegistry::normalizedArray normalizes the array the first time. When passing an array already normalized it continues trying to normalize producing a nested effect. This should resolve the issue.