### PR TITLE
Remove bad plugin load magic

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -495,9 +495,6 @@ class Shell
             $this->params = array_merge($this->params, $extra);
         }
         $this->_setOutputLevel();
-        if (!empty($this->params['plugin']) && !Plugin::loaded($this->params['plugin'])) {
-            Plugin::load($this->params['plugin']);
-        }
         $this->command = $command;
         if (!empty($this->params['help'])) {
             return $this->_displayHelp($command);

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -17,7 +17,6 @@ namespace Cake\Console;
 use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\App;
-use Cake\Core\Plugin;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Filesystem\File;
 use Cake\Log\LogTrait;


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/11533
Follows the plugin enhancements of https://github.com/cakephp/cakephp/pull/11564 

Makes it more explicit and less bad magic to load and use plugins.

This shouldn't even be needed anymore, as the bootstrapping process loads all wanted plugins anyway.
We should not allow hidden lazy load of plugins - especially not if that compromises the config to be used for anything else (e.g. generating sth for a plugin without loading it, as the upgrade tool does).

Any downsides of this? Does it suffice to have this outlined in the 3.6 migration guide?