### PR TITLE
Fix incorrect annotations.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,7 @@ parameters:
         - '#Call to an undefined method object::__toString\(\)#'
         - '#Call to an undefined method object::toArray\(\)#'
         - '#Call to an undefined method object::__debugInfo\(\)#'
+        - '#Method PDO::lastInsertId\(\) invoked with 2 parameters, 0-1 required#'
     earlyTerminatingMethodCalls:
         Cake\Shell\Shell:
             - abort

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -21,7 +21,7 @@ use PDO;
  * Represents a database driver containing all specificities for
  * a database engine including its SQL dialect.
  *
- * @property \Cake\Datasource\ConnectionInterface|null $_connection
+ * @property \PDO|null $_connection
  */
 abstract class Driver
 {

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -26,7 +26,6 @@ namespace Cake\Datasource;
  * @method \Cake\Database\StatementInterface prepare($sql)
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = [])
  * @method string quote($value, $type = null)
- * @method string|int lastInsertId($table = null, $column = null)
  */
 interface ConnectionInterface
 {


### PR DESCRIPTION
@markstory @lorenzo What would be the proper way to avoid having to ignore the `Method PDO::lastInsertId() invoked with 2 parameters, 0-1 required`? It's caused by following line:

https://github.com/cakephp/cakephp/blob/a6c47f15e2dfbb062fcc547d6eecd0a944dc8b17/src/Database/Driver.php#L288