### PR TITLE
Removing unnecessary return

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -392,8 +392,6 @@ class AuthComponent extends Component
                 $this->_config['ajaxLogin'],
                 $this->RequestHandler->ajaxLayout
             );
-
-            return $response->withStatus(403);
         }
 
         return $response->withStatus(403);


### PR DESCRIPTION
As the natural flow are returning the same response, only the final return statement are necessary.