### PR TITLE
Add enum column type support to schema functions

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -624,10 +624,16 @@ class CakeSchema extends CakeObject {
 			if ($Obj->primaryKey === $name && !$hasPrimaryAlready && !isset($value['key'])) {
 				$value['key'] = 'primary';
 			}
-			if (!isset($db->columns[$value['type']])) {
+			$isEnum = (strpos($value['type'], 'enum') !== false);
+			if (!isset($db->columns[$value['type']]) && !$isEnum) {
 				trigger_error(__d('cake_dev', 'Schema generation error: invalid column type %s for %s.%s does not exist in DBO', $value['type'], $Obj->name, $name), E_USER_NOTICE);
 				continue;
 			} else {
+				if ($isEnum) {
+					$length = trim(str_replace(')', '', str_replace('enum(', '', $value['type'])));
+					$value['type'] = 'enum';
+					$value['length'] = $length;
+				}
 				$defaultCol = $db->columns[$value['type']];
 				if (isset($defaultCol['limit']) && $defaultCol['limit'] == $value['length']) {
 					unset($value['length']);

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -131,7 +131,8 @@ class Mysql extends DboSource {
 		'time' => array('name' => 'time', 'format' => 'H:i:s', 'formatter' => 'date'),
 		'date' => array('name' => 'date', 'format' => 'Y-m-d', 'formatter' => 'date'),
 		'binary' => array('name' => 'blob'),
-		'boolean' => array('name' => 'tinyint', 'limit' => '1')
+		'boolean' => array('name' => 'tinyint', 'limit' => '1'),
+		'enum' => array('name' => 'enum', 'limit' => '512')
 	);
 
 /**


### PR DESCRIPTION
The command "Console/cake schema generate/create" does not work with Enum type fields by default. You will always get NOTICE's while doing so, and won't be able to restore them.

Based on: https://github.com/matheuscmpm/cakephp-schema-enum