### PR TITLE
Make view block inst. a bit less internally coupled.

### DIFF
--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -33,7 +33,7 @@ trait EventDispatcherTrait
      *
      * @var string
      */
-    protected $_eventClass = '\Cake\Event\Event';
+    protected $_eventClass = Event::class;
 
     /**
      * Returns the Cake\Event\EventManager manager instance for this object.

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -279,6 +279,13 @@ class View implements EventDispatcherInterface
     protected $_stack = [];
 
     /**
+     * ViewBlock class.
+     *
+     * @var string
+     */
+    protected $_viewBlockClass = ViewBlock::class;
+
+    /**
      * Constant for view file type 'view'
      *
      * @var string
@@ -359,7 +366,7 @@ class View implements EventDispatcherInterface
                 'webroot' => '/'
             ]);
         }
-        $this->Blocks = new ViewBlock();
+        $this->Blocks = new $this->_viewBlockClass();
         $this->initialize();
         $this->loadHelpers();
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -387,8 +387,9 @@ object(Cake\View\View) {
 	[protected] _current => null
 	[protected] _currentType => ''
 	[protected] _stack => []
+	[protected] _viewBlockClass => 'Cake\View\ViewBlock'
 	[protected] _eventManager => object(Cake\Event\EventManager) {}
-	[protected] _eventClass => '\Cake\Event\Event'
+	[protected] _eventClass => 'Cake\Event\Event'
 	[protected] _viewBuilder => null
 }
 TEXT;


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/11691 and explanations around open closed @ https://github.com/cakephp/cakephp/issues/11735#issuecomment-366820612

If we dont use proper DI here (or some factory pattern), at least make it possible to overwrite on extension level without having to copy and paste the whole constructor.

We need to be a bit more careful here inside the framework to not anti-pattern here too much.
This usually will be used against it in terms of "architecture discussions" on various platforms.
Don't need to further fuel those.