### PR TITLE
3.6: Always use consistent class usage and inclusion.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -59,10 +59,10 @@ class Type implements TypeInterface
      * @deprecated 3.1 All types will now use a specific class
      */
     protected static $_basicTypes = [
-        'string' => ['callback' => ['\Cake\Database\Type', 'strval']],
-        'text' => ['callback' => ['\Cake\Database\Type', 'strval']],
+        'string' => ['callback' => [Type::class, 'strval']],
+        'text' => ['callback' => [Type::class, 'strval']],
         'boolean' => [
-            'callback' => ['\Cake\Database\Type', 'boolval'],
+            'callback' => [Type::class, 'boolval'],
             'pdo' => PDO::PARAM_BOOL
         ],
     ];

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1430,7 +1430,7 @@ class BelongsToMany extends Association
     {
         if ($name === null) {
             if (empty($this->_junctionTableName)) {
-                $tablesNames = array_map('\Cake\Utility\Inflector::underscore', [
+                $tablesNames = array_map('Cake\Utility\Inflector::underscore', [
                     $this->getSource()->getTable(),
                     $this->getTarget()->getTable()
                 ]);

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -19,7 +19,7 @@ use Cake\ORM\Table;
 /**
  * Registries for Table objects should implement this interface.
  *
- * @method array getConfig()
+ * @method array getConfig($alias)
  * @method $this setConfig($alias, $options = null)
  */
 interface LocatorInterface

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -763,7 +763,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getEntityClass()
     {
         if (!$this->_entityClass) {
-            $default = '\Cake\ORM\Entity';
+            $default = Entity::class;
             $self = get_called_class();
             $parts = explode('\\', $self);
 
@@ -772,7 +772,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
 
             $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
-            $name = implode('\\', array_slice($parts, 0, -1)) . '\Entity\\' . $alias;
+            $name = implode('\\', array_slice($parts, 0, -1)) . '\\Entity\\' . $alias;
             if (!class_exists($name)) {
                 return $this->_entityClass = $default;
             }

--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -22,7 +22,7 @@ if (!empty($plugin)) {
 }
 $prefixNs = '';
 if (!empty($prefix)) {
-    $prefix = array_map('\Cake\Utility\Inflector::camelize', explode('/', $prefix));
+    $prefix = array_map('Cake\Utility\Inflector::camelize', explode('/', $prefix));
     $prefixNs = '\\' . implode('\\', $prefix);
     $prefix = implode(DIRECTORY_SEPARATOR, $prefix) . DIRECTORY_SEPARATOR;
 }

--- a/src/Template/Error/missing_controller.ctp
+++ b/src/Template/Error/missing_controller.ctp
@@ -26,7 +26,7 @@ $originalClass = $class;
 $class = Inflector::camelize($class);
 
 if (!empty($prefix)) {
-    $prefix = array_map('\Cake\Utility\Inflector::camelize', explode('/', $prefix));
+    $prefix = array_map('Cake\Utility\Inflector::camelize', explode('/', $prefix));
     $prefixNs = '\\' . implode('\\', $prefix);
     $prefixPath = implode(DIRECTORY_SEPARATOR, $prefix) . DIRECTORY_SEPARATOR;
 }

--- a/src/Validation/RulesProvider.php
+++ b/src/Validation/RulesProvider.php
@@ -26,7 +26,7 @@ class RulesProvider
     /**
      * The class/object to proxy.
      *
-     * @var mixed
+     * @var string|object
      */
     protected $_class;
 
@@ -40,9 +40,9 @@ class RulesProvider
     /**
      * Constructor, sets the default class to use for calling methods
      *
-     * @param string $class the default class to proxy
+     * @param string|object $class the default class to proxy
      */
-    public function __construct($class = '\Cake\Validation\Validation')
+    public function __construct($class = Validation::class)
     {
         $this->_class = $class;
         $this->_reflection = new ReflectionClass($class);

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -44,7 +44,7 @@ trait ValidatorAwareTrait
      *
      * @var string
      */
-    protected $_validatorClass = '\Cake\Validation\Validator';
+    protected $_validatorClass = Validator::class;
 
     /**
      * A list of validation objects indexed by name

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -14,6 +14,8 @@
 
 namespace Cake\Test\TestCase\Event;
 
+use Cake\Event\Event;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 
@@ -23,7 +25,7 @@ use Cake\TestSuite\TestCase;
 class EventDispatcherTraitTest extends TestCase
 {
     /**
-     * @var EventDispatcherTrait
+     * @var \Cake\Event\EventDispatcherTrait
      */
     public $subject;
 
@@ -36,7 +38,7 @@ class EventDispatcherTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = $this->getObjectForTrait('Cake\Event\EventDispatcherTrait');
+        $this->subject = $this->getObjectForTrait(EventDispatcherTrait::class);
     }
 
     /**
@@ -98,7 +100,7 @@ class EventDispatcherTraitTest extends TestCase
     {
         $event = $this->subject->dispatchEvent('some.event', ['foo' => 'bar']);
 
-        $this->assertInstanceOf('Cake\Event\Event', $event);
+        $this->assertInstanceOf(Event::class, $event);
         $this->assertSame($this->subject, $event->getSubject());
         $this->assertEquals('some.event', $event->getName());
         $this->assertEquals(['foo' => 'bar'], $event->getData());

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1482,7 +1482,7 @@ class TableTest extends TestCase
     public function testEntityClassDefault()
     {
         $table = new Table();
-        $this->assertEquals('\Cake\ORM\Entity', $table->getEntityClass());
+        $this->assertEquals('Cake\ORM\Entity', $table->getEntityClass());
     }
 
     /**
@@ -5992,7 +5992,7 @@ class TableTest extends TestCase
             'registryAlias' => 'Foo.Articles',
             'table' => 'articles',
             'alias' => 'Articles',
-            'entityClass' => '\Cake\ORM\Entity',
+            'entityClass' => 'Cake\ORM\Entity',
             'associations' => [],
             'behaviors' => [],
             'defaultConnection' => 'default',

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -409,7 +409,7 @@ class TestCaseTest extends TestCase
             ->method('save')
             ->will($this->returnValue('mocked'));
         $this->assertEquals('mocked', $Posts->save($entity));
-        $this->assertEquals('\Cake\ORM\Entity', $Posts->getEntityClass());
+        $this->assertEquals('Cake\ORM\Entity', $Posts->getEntityClass());
 
         $Posts = $this->getMockForModel('Posts', ['doSomething']);
         $this->assertInstanceOf('Cake\Database\Connection', $Posts->getConnection());
@@ -450,7 +450,7 @@ class TestCaseTest extends TestCase
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments', ['save']);
 
         $this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $TestPluginComment);
-        $this->assertEquals('\Cake\ORM\Entity', $TestPluginComment->getEntityClass());
+        $this->assertEquals('Cake\ORM\Entity', $TestPluginComment->getEntityClass());
         $TestPluginComment->expects($this->at(0))
             ->method('save')
             ->will($this->returnValue(true));


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/11736

These changes are safer in 3.next.
The main issue is that comparing the string class names requires them to be consistent to what ::class returns, and that is always without a leading slash.
So this makes it consistent and easier to work with. Proper include instead of magic strings also allows discovery and IDE usage detection and refactor.