### PR TITLE
Change to class constant

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -17,6 +17,7 @@ namespace Cake\Datasource;
 use BadMethodCallException;
 use Cake\Collection\Iterator\MapReduce;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Datasource\ResultSetDecorator;
 
 /**
  * Contains the characteristics for an object that is attached to a repository and
@@ -526,6 +527,6 @@ trait QueryTrait
      */
     protected function _decoratorClass()
     {
-        return \Cake\Datasource\ResultSetDecorator::class;
+        return ResultSetDecorator::class;
     }
 }

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -526,6 +526,6 @@ trait QueryTrait
      */
     protected function _decoratorClass()
     {
-        return 'Cake\Datasource\ResultSetDecorator';
+        return \Cake\Datasource\ResultSetDecorator::class;
     }
 }


### PR DESCRIPTION
Saves on potential typos. Introduced in 5.5.0, so allowed by the framework constraint