### PR TITLE
Batch casting of fields in database results

### DIFF
--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -87,7 +87,6 @@ class FieldTypeConverter
             }
         }
 
-
         // Using batching when there is onl a couple for the type is actually slower,
         // so, let's check for that case here.
         foreach ($batchingResult as $type => $fields) {

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -87,7 +87,7 @@ class FieldTypeConverter
             }
         }
 
-        // Using batching when there is onl a couple for the type is actually slower,
+        // Using batching when there is only a couple for the type is actually slower,
         // so, let's check for that case here.
         foreach ($batchingResult as $type => $fields) {
             if (count($fields) > 2) {

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\Type;
 use Cake\Database\Type\BatchCastingInterface;
 use Cake\Database\Type\OptionalConvertInterface;
 
@@ -40,6 +41,13 @@ class FieldTypeConverter
      */
     protected $batchingTypeMap;
 
+    /**
+     * An array containing all the types registered in the Type system
+     * at the moment this object is created. Used so that the types list
+     * is not fetched on each single row of the results.
+     *
+     * @var array
+     */
     protected $types;
 
     /**
@@ -69,7 +77,15 @@ class FieldTypeConverter
                 continue;
             }
 
-            if ($type instanceof BatchCastingInterface) {
+            // Because of backwards compatibility reasons, we won't allow classes
+            // inheriting Type in userland code to be batchable, even if they implement
+            // the interface. Users can implement the TypeInterface instead to have
+            // access to this feature.
+            $batchingType = $type instanceof BatchCastingInterface &&
+                $type instanceof Type &&
+                strpos(get_class($type), 'Cake\Database\Type') === false;
+
+            if ($batchingType) {
                 $batchingMap[$k] = $type;
                 continue;
             }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2094,7 +2094,6 @@ class Query implements ExpressionInterface, IteratorAggregate
         $driver = $this->getConnection()->getDriver();
 
         if ($this->typeCastEnabled && $typeMap->toArray()) {
-            $driver = $this->_connection->getDriver();
             $statement = new CallbackStatement($statement, $driver, new FieldTypeConverter($typeMap, $driver));
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2035,7 +2035,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Disables the automatic casting of fields to their corresponding type
+     * Disables the automatic casting of fields to their corresponding PHP data type
      *
      * @return $this
      */

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1801,7 +1801,6 @@ class Query implements ExpressionInterface, IteratorAggregate
     {
         if ($overwrite) {
             $this->_resultDecorators = [];
-            $this->_typeCastAttached = false;
         }
 
         if ($callback !== null) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2015,6 +2015,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function setSelectTypeMap(TypeMap $typeMap)
     {
         $this->_selectTypeMap = $typeMap;
+        $this->_dirty();
 
         return $this;
     }

--- a/src/Database/Type/BatchCastingInterface.php
+++ b/src/Database/Type/BatchCastingInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Type;
+
+use Cake\Database\Driver;
+
+/**
+ * Denotes type objects capable of converting many values from their original
+ * database representation to php values.
+ */
+interface BatchCastingInterface
+{
+
+    /**
+     * Returns an array of the values converted to the PHP representation of
+     * this type.
+     *
+     * @param array $values The original array of values containing the fields to be casted
+     * @param array $fields The field keys to cast
+     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver);
+}

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -25,7 +26,7 @@ use PDO;
  *
  * Use to convert bool data between PHP and the database types.
  */
-class BoolType extends Type implements TypeInterface
+class BoolType extends Type implements TypeInterface, BatchCastingInterface
 {
     /**
      * Identifier name for this type.
@@ -82,11 +83,45 @@ class BoolType extends Type implements TypeInterface
         if ($value === null) {
             return null;
         }
-        if (is_string($value) && !is_numeric($value)) {
+        if (!is_numeric($value)) {
             return strtolower($value) === 'true';
         }
 
         return !empty($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver)
+    {
+        foreach ($fields as $field) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+
+            if ($values[$field] === '1') {
+                $values[$field] = true;
+                continue;
+            }
+
+            if ($values[$field] === '0') {
+                $values[$field] = false;
+                continue;
+            }
+
+            $value = $values[$field];
+            if (!is_numeric($value)) {
+                $values[$field] = strtolower($value) === 'true';
+                continue;
+            }
+
+            $values[$field] = !empty($value);
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -80,9 +80,10 @@ class BoolType extends Type implements TypeInterface, BatchCastingInterface
      */
     public function toPHP($value, Driver $driver)
     {
-        if ($value === null) {
-            return null;
+        if ($value === null || $value === true || $value === false) {
+            return $value;
         }
+
         if (!is_numeric($value)) {
             return strtolower($value) === 'true';
         }
@@ -98,7 +99,7 @@ class BoolType extends Type implements TypeInterface, BatchCastingInterface
     public function manyToPHP(array $values, array $fields, Driver $driver)
     {
         foreach ($fields as $field) {
-            if (!isset($values[$field])) {
+            if (!isset($values[$field]) || $values[$field] === true || $values[$field] === false) {
                 continue;
             }
 

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -51,7 +51,6 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
      */
     public static $dateTimeClass = 'Cake\I18n\Time';
 
-
     /**
      * Whether or not we want to override the time of the converted Time objets
      * so the point to the start of the day.

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -52,10 +52,10 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
     public static $dateTimeClass = 'Cake\I18n\Time';
 
     /**
-     * Whether or not we want to override the time of the converted Time objets
-     * so the point to the start of the day.
+     * Whether or not we want to override the time of the converted Time objects
+     * so it points to the start of the day.
      *
-     * This is mainly there to avoid subclasses re-implement the same functionality.
+     * This is primarily to avoid subclasses needing to re-implement the same functionality.
      *
      * @var bool
      */

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -146,7 +146,8 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
             return null;
         }
 
-        $instance = (clone $this->_datetimeInstance)->modify($value);
+        $instance = clone $this->_datetimeInstance;
+        $instance = $instance->modify($value);
 
         if ($this->setToDateStart) {
             $instance = $instance->setTime(0, 0, 0);
@@ -172,7 +173,8 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
                 continue;
             }
 
-            $instance = (clone $this->_datetimeInstance)->modify($values[$field]);
+            $instance = clone $this->_datetimeInstance;
+            $instance = $instance->modify($value);
 
             if ($this->setToDateStart) {
                 $instance = $instance->setTime(0, 0, 0);

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -174,7 +174,7 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
             }
 
             $instance = clone $this->_datetimeInstance;
-            $instance = $instance->modify($value);
+            $instance = $instance->modify($values[$field]);
 
             if ($this->setToDateStart) {
                 $instance = $instance->setTime(0, 0, 0);

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -39,6 +39,14 @@ class DateType extends DateTimeType
     protected $_format = 'Y-m-d';
 
     /**
+     * In this class we want Date objects to  have their time
+     * set to the beginning of the day.
+     *
+     * @var bool
+     */
+    protected $setToDateStart = true;
+
+    /**
      * Change the preferred class name to the FrozenDate implementation.
      *
      * @return $this
@@ -71,23 +79,6 @@ class DateType extends DateTimeType
     public function marshal($value)
     {
         $date = parent::marshal($value);
-        if ($date instanceof DateTime) {
-            $date->setTime(0, 0, 0);
-        }
-
-        return $date;
-    }
-
-    /**
-     * Convert strings into Date instances.
-     *
-     * @param string $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
-     * @return \Cake\I18n\Date|\DateTime
-     */
-    public function toPHP($value, Driver $driver)
-    {
-        $date = parent::toPHP($value, $driver);
         if ($date instanceof DateTime) {
             $date->setTime(0, 0, 0);
         }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -104,7 +104,7 @@ class DecimalType extends Type implements TypeInterface, BatchCastingInterface
             return $value;
         }
 
-        // Using coersion is faster than casting
+        // Using coercion is faster than casting
         // @codingStandardsIgnoreStart
         return (float)+$value;
         // @codingStandardsIgnoreEnd
@@ -122,7 +122,7 @@ class DecimalType extends Type implements TypeInterface, BatchCastingInterface
                 continue;
             }
 
-            // Using coersion is faster than casting
+            // Using coercion is faster than casting
             // @codingStandardsIgnoreStart
             $values[$field] = (float)+$values[$field];
             // @codingStandardsIgnoreEnd

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
 use RuntimeException;
@@ -26,7 +27,7 @@ use RuntimeException;
  *
  * Use to convert decimal data between PHP and the database types.
  */
-class DecimalType extends Type implements TypeInterface
+class DecimalType extends Type implements TypeInterface, BatchCastingInterface
 {
     /**
      * Identifier name for this type.
@@ -90,7 +91,7 @@ class DecimalType extends Type implements TypeInterface
     }
 
     /**
-     * Convert float values to PHP integers
+     * Convert float values to PHP floats
      *
      * @param null|string|resource $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
@@ -100,10 +101,34 @@ class DecimalType extends Type implements TypeInterface
     public function toPHP($value, Driver $driver)
     {
         if ($value === null) {
-            return null;
+            return $value;
         }
 
-        return (float)$value;
+        // Using coersion is faster than casting
+        // @codingStandardsIgnoreStart
+        return (float)+$value;
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver)
+    {
+        foreach ($fields as $field) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+
+            // Using coersion is faster than casting
+            // @codingStandardsIgnoreStart
+            $values[$field] = (float)+$values[$field];
+            // @codingStandardsIgnoreEnd
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -96,7 +96,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
             return null;
         }
 
-        // Using coersion is faster than casting
+        // Using coercion is faster than casting
         // @codingStandardsIgnoreStart
         return (float)+$value;
         // @codingStandardsIgnoreEnd
@@ -114,7 +114,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
                 continue;
             }
 
-            // Using coersion is faster than casting
+            // Using coercion is faster than casting
             // @codingStandardsIgnoreStart
             $values[$field] = (float)+$values[$field];
             // @codingStandardsIgnoreEnd

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -96,10 +96,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
             return null;
         }
 
-        // Using coersion is faster than casting
-        // @codingStandardsIgnoreStart
-        return (float)+$value;
-        // @codingStandardsIgnoreEnd
+        return (float)$value;
     }
 
     /**
@@ -114,10 +111,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
                 continue;
             }
 
-            // Using coersion is faster than casting
-            // @codingStandardsIgnoreStart
-            $values[$field] = (float)+$values[$field];
-            // @codingStandardsIgnoreEnd
+            $values[$field] = (float)$values[$field];
         }
 
         return $values;

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use Cake\Database\Type\BatchCastingInterface;
 use PDO;
 use RuntimeException;
 
@@ -25,7 +26,7 @@ use RuntimeException;
  *
  * Use to convert float/decimal data between PHP and the database types.
  */
-class FloatType extends Type implements TypeInterface
+class FloatType extends Type implements TypeInterface, BatchCastingInterface
 {
     /**
      * Identifier name for this type.
@@ -94,11 +95,32 @@ class FloatType extends Type implements TypeInterface
         if ($value === null) {
             return null;
         }
-        if (is_array($value)) {
-            return 1.0;
+
+        // Using coersion is faster than casting
+        // @codingStandardsIgnoreStart
+        return (float)+$value;
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver)
+    {
+        foreach ($fields as $field) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+
+            // Using coersion is faster than casting
+            // @codingStandardsIgnoreStart
+            $values[$field] = (float)+$values[$field];
+            // @codingStandardsIgnoreEnd
         }
 
-        return (float)$value;
+        return $values;
     }
 
     /**

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -84,7 +84,7 @@ class IntegerType extends Type implements TypeInterface, BatchCastingInterface
             return $value;
         }
 
-        // Using coersion is faster than casting
+        // Using coercion is faster than casting
         // @codingStandardsIgnoreStart
         return (int)+$value;
         // @codingStandardsIgnoreEnd
@@ -101,7 +101,7 @@ class IntegerType extends Type implements TypeInterface, BatchCastingInterface
             if (!isset($values[$field])) {
                 continue;
             }
-            // Using coersion is faster than casting
+            // Using coercion is faster than casting
             // @codingStandardsIgnoreStart
             $values[$field] = (int)+$values[$field];
             // @codingStandardsIgnoreEnd

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -25,7 +26,7 @@ use PDO;
  *
  * Use to convert integer data between PHP and the database types.
  */
-class IntegerType extends Type implements TypeInterface
+class IntegerType extends Type implements TypeInterface, BatchCastingInterface
 {
     /**
      * Identifier name for this type.
@@ -80,10 +81,33 @@ class IntegerType extends Type implements TypeInterface
     public function toPHP($value, Driver $driver)
     {
         if ($value === null) {
-            return null;
+            return $value;
         }
 
-        return (int)$value;
+        // Using coersion is faster than casting
+        // @codingStandardsIgnoreStart
+        return (int)+$value;
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver)
+    {
+        foreach ($fields as $field) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+            // Using coersion is faster than casting
+            // @codingStandardsIgnoreStart
+            $values[$field] = (int)+$values[$field];
+            // @codingStandardsIgnoreEnd
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -25,7 +26,7 @@ use PDO;
  *
  * Use to convert json data between PHP and the database types.
  */
-class JsonType extends Type implements TypeInterface
+class JsonType extends Type implements TypeInterface, BatchCastingInterface
 {
     /**
      * Identifier name for this type.
@@ -76,6 +77,24 @@ class JsonType extends Type implements TypeInterface
     public function toPHP($value, Driver $driver)
     {
         return json_decode($value, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver)
+    {
+        foreach ($fields as $field) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+
+            $values[$field] = json_decode($values[$field], true);
+        }
+
+        return $values;
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4475,7 +4475,7 @@ class QueryTest extends TestCase
             'true' => 'boolean'
         ]);
         $results = $query
-            ->select(['one' => '1', 'two' => '2', 'true' => '1', 'three' => '3.0'])
+            ->select(['one' => '1 * 1', 'two' => '1 * 2', 'true' => '1', 'three' => '1 + 2'])
             ->setSelectTypeMap($typeMap)
             ->execute()
             ->fetchAll('assoc');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4483,6 +4483,29 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test disabling type casting
+     *
+     * @return void
+     */
+    public function testCastResultsDisable()
+    {
+        $query = new Query($this->connection);
+        $typeMap = new TypeMap([
+            'one' => 'integer',
+            'two' => 'integer',
+            'three' => 'integer',
+            'true' => 'boolean'
+        ]);
+        $results = $query
+            ->select(['one' => '1 * 1', 'two' => '1 * 2', 'true' => '1 * 1', 'three' => '1 + 2'])
+            ->setSelectTypeMap($typeMap)
+            ->disableResultsCasting()
+            ->execute()
+            ->fetchAll('assoc');
+        $this->assertSame([['one' => '1', 'two' => '2', 'true' => '1', 'three' => '3']], $results);
+    }
+
+    /**
      * Test that reading an undefined clause does not emit an error.
      *
      * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4528,8 +4528,8 @@ class QueryTest extends TestCase
         // Get results a second time.
         $result = $query->execute()->fetchAll('assoc');
 
-        // Had the type casting being rememberd from the first time,
-        // The valuewould be a truncated float (1.0)
+        // Had the type casting being remembered from the first time,
+        // The value would be a truncated float (1.0)
         $this->assertEquals([['a' => 1.5]], $result);
     }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4461,6 +4461,28 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test automatic results casting
+     *
+     * @return void
+     */
+    public function testCastResults()
+    {
+        $query = new Query($this->connection);
+        $typeMap = new TypeMap([
+            'one' => 'integer',
+            'two' => 'integer',
+            'three' => 'integer',
+            'true' => 'boolean'
+        ]);
+        $results = $query
+            ->select(['one' => '1', 'two' => '2', 'true' => '1', 'three' => '3.0'])
+            ->setSelectTypeMap($typeMap)
+            ->execute()
+            ->fetchAll('assoc');
+        $this->assertSame([['one' => 1, 'two' => 2, 'true' => true, 'three' => 3]], $results);
+    }
+
+    /**
      * Test that reading an undefined clause does not emit an error.
      *
      * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4514,6 +4514,7 @@ class QueryTest extends TestCase
      */
     public function testAllNoDuplicateTypeCasting()
     {
+        $this->skipIf($this->autoQuote, 'Produces bad SQL in postgres with autoQuoting');
         $query = new Query($this->connection);
         $query
             ->select('1.5 AS a')

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4483,7 +4483,7 @@ class QueryTest extends TestCase
             ->limit(1)
             ->execute()
             ->fetchAll('assoc');
-        $this->assertSame([['id' => 1, 'user_id' => 1, 'is_active' => true, 'a' => 1]], $results);
+        $this->assertSame([['id' => 1, 'user_id' => 1, 'is_active' => false, 'a' => 1]], $results);
     }
 
     /**

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -91,18 +91,46 @@ class BoolTypeTest extends TestCase
     public function testToPHP()
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
-        $this->assertTrue($this->type->toPHP(true, $this->driver));
         $this->assertTrue($this->type->toPHP(1, $this->driver));
         $this->assertTrue($this->type->toPHP('1', $this->driver));
         $this->assertTrue($this->type->toPHP('TRUE', $this->driver));
         $this->assertTrue($this->type->toPHP('true', $this->driver));
 
-        $this->assertFalse($this->type->toPHP(false, $this->driver));
         $this->assertFalse($this->type->toPHP(0, $this->driver));
         $this->assertFalse($this->type->toPHP('0', $this->driver));
         $this->assertFalse($this->type->toPHP('FALSE', $this->driver));
         $this->assertFalse($this->type->toPHP('false', $this->driver));
-        $this->assertTrue($this->type->toPHP(['2', '3'], $this->driver));
+    }
+
+    /**
+     * Test converting string booleans to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => 'true',
+            'c' => 'TRUE',
+            'd' => 'false',
+            'e' => 'FALSE',
+            'f' => '0',
+            'g' => '1'
+        ];
+        $expected = [
+            'a' => null,
+            'b' => true,
+            'c' => true,
+            'd' => false,
+            'e' => false,
+            'f' => false,
+            'g' => true,
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -95,11 +95,13 @@ class BoolTypeTest extends TestCase
         $this->assertTrue($this->type->toPHP('1', $this->driver));
         $this->assertTrue($this->type->toPHP('TRUE', $this->driver));
         $this->assertTrue($this->type->toPHP('true', $this->driver));
+        $this->assertTrue($this->type->toPHP(true, $this->driver));
 
         $this->assertFalse($this->type->toPHP(0, $this->driver));
         $this->assertFalse($this->type->toPHP('0', $this->driver));
         $this->assertFalse($this->type->toPHP('FALSE', $this->driver));
         $this->assertFalse($this->type->toPHP('false', $this->driver));
+        $this->assertFalse($this->type->toPHP(false, $this->driver));
     }
 
     /**
@@ -116,7 +118,9 @@ class BoolTypeTest extends TestCase
             'd' => 'false',
             'e' => 'FALSE',
             'f' => '0',
-            'g' => '1'
+            'g' => '1',
+            'h' => true,
+            'i' => false,
         ];
         $expected = [
             'a' => null,
@@ -126,6 +130,8 @@ class BoolTypeTest extends TestCase
             'e' => false,
             'f' => false,
             'g' => true,
+            'h' => true,
+            'i' => false,
         ];
         $this->assertEquals(
             $expected,

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -95,6 +95,29 @@ class DateTimeTypeTest extends TestCase
     }
 
     /**
+     * Test converting string datetimes to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '2001-01-04 12:13:14',
+            'c' => '2001-01-04 12:13:14.12345',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => new Time('2001-01-04 12:13:14'),
+            'c' => new Time('2001-01-04 12:13:14.12345'),
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
+    }
+
+    /**
      * Test datetime parsing when value include milliseconds.
      *
      * Postgres includes milliseconds in timestamp columns,

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -104,12 +104,10 @@ class DateTimeTypeTest extends TestCase
         $values = [
             'a' => null,
             'b' => '2001-01-04 12:13:14',
-            'c' => '2001-01-04 12:13:14.12345',
         ];
         $expected = [
             'a' => null,
             'b' => new Time('2001-01-04 12:13:14'),
-            'c' => new Time('2001-01-04 12:13:14.12345'),
         ];
         $this->assertEquals(
             $expected,

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -64,6 +64,29 @@ class DateTypeTest extends TestCase
     }
 
     /**
+     * Test converting string dates to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '2001-01-04',
+            'c' => '2001-01-04 12:13:14.12345',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => new Date('2001-01-04'),
+            'c' => new Date('2001-01-04'),
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
+    }
+
+    /**
      * Test converting to database format
      *
      * @return void

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -82,17 +82,36 @@ class DecimalTypeTest extends TestCase
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
-        $result = $this->type->toPHP('some data', $this->driver);
-        $this->assertSame(0.0, $result);
-
         $result = $this->type->toPHP('2', $this->driver);
         $this->assertSame(2.0, $result);
 
-        $result = $this->type->toPHP('2 bears', $this->driver);
-        $this->assertSame(2.0, $result);
+        $result = $this->type->toPHP('15.3', $this->driver);
+        $this->assertSame(15.3, $result);
+    }
 
-        $result = $this->type->toPHP(['3', '4'], $this->driver);
-        $this->assertSame(1.0, $result);
+    /**
+     * Test converting string decimals to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '2.3',
+            'c' => '15',
+            'c' => '0.0',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => 2.3,
+            'c' => 15,
+            'c' => 0.0,
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -82,17 +82,36 @@ class FloatTypeTest extends TestCase
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
-        $result = $this->type->toPHP('some data', $this->driver);
-        $this->assertSame(0.0, $result);
-
         $result = $this->type->toPHP('2', $this->driver);
         $this->assertSame(2.0, $result);
 
-        $result = $this->type->toPHP('2 bears', $this->driver);
-        $this->assertSame(2.0, $result);
+        $result = $this->type->toPHP('15.3', $this->driver);
+        $this->assertSame(15.3, $result);
+    }
 
-        $result = $this->type->toPHP(['3', '4'], $this->driver);
-        $this->assertSame(1.0, $result);
+    /**
+     * Test converting string float to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '2.3',
+            'c' => '15',
+            'c' => '0.0',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => 2.3,
+            'c' => 15,
+            'c' => 0.0,
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -54,20 +54,39 @@ class IntegerTypeTest extends TestCase
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
-        $result = $this->type->toPHP('some data', $this->driver);
-        $this->assertSame(0, $result);
-
         $result = $this->type->toPHP('2', $this->driver);
         $this->assertSame(2, $result);
 
-        $result = $this->type->toPHP('2 bears', $this->driver);
+        $result = $this->type->toPHP('2.3', $this->driver);
         $this->assertSame(2, $result);
 
         $result = $this->type->toPHP('-2', $this->driver);
         $this->assertSame(-2, $result);
+    }
 
-        $result = $this->type->toPHP(['3', '4'], $this->driver);
-        $this->assertSame(1, $result);
+    /**
+     * Test converting string float to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '2.3',
+            'c' => '15',
+            'c' => '0.0',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => 2,
+            'c' => 15,
+            'c' => 0,
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -62,6 +62,9 @@ class IntegerTypeTest extends TestCase
 
         $result = $this->type->toPHP('-2', $this->driver);
         $this->assertSame(-2, $result);
+
+        $result = $this->type->toPHP(10, $this->driver);
+        $this->assertSame(10, $result);
     }
 
     /**
@@ -76,12 +79,14 @@ class IntegerTypeTest extends TestCase
             'b' => '2.3',
             'c' => '15',
             'c' => '0.0',
+            'd' => 10
         ];
         $expected = [
             'a' => null,
             'b' => 2,
             'c' => 15,
             'c' => 0,
+            'd' => 10
         ];
         $this->assertEquals(
             $expected,

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -58,6 +58,31 @@ class JsonTypeTest extends TestCase
     }
 
     /**
+     * Test converting json stirngs to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => json_encode([1, 2, 3]),
+            'c' => json_encode('123'),
+            'c' => json_encode(2.3),
+        ];
+        $expected = [
+            'a' => null,
+            'b' => [1, 2, 3],
+            'c' => 123,
+            'c' => 2.3,
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
+    }
+
+    /**
      * Test converting to database format
      *
      * @return void

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -86,6 +86,29 @@ class TimeTypeTest extends TestCase
     }
 
     /**
+     * Test converting string times to PHP values.
+     *
+     * @return void
+     */
+    public function testManyToPHP()
+    {
+        $values = [
+            'a' => null,
+            'b' => '01:30:13',
+            'c' => '12:13:14.12345',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => new Time('01:30:13'),
+            'c' => new Time('12:13:14.12345'),
+        ];
+        $this->assertEquals(
+            $expected,
+            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        );
+    }
+
+    /**
      * Test converting to database format
      *
      * @return void

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -95,12 +95,10 @@ class TimeTypeTest extends TestCase
         $values = [
             'a' => null,
             'b' => '01:30:13',
-            'c' => '12:13:14.12345',
         ];
         $expected = [
             'a' => null,
             'b' => new Time('01:30:13'),
-            'c' => new Time('12:13:14.12345'),
         ];
         $this->assertEquals(
             $expected,

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -246,7 +246,6 @@ class TypeTest extends TestCase
         $this->assertSame(3.14159, $type->toPHP('3.14159', $driver));
         $this->assertSame(3.14159, $type->toPHP(3.14159, $driver));
         $this->assertSame(3.0, $type->toPHP(3, $driver));
-        $this->assertSame(1.0, $type->toPHP(['3', '4'], $driver));
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3548,25 +3548,4 @@ class QueryTest extends TestCase
         ];
         $this->assertSame($expected, $results->first());
     }
-
-    /**
-     * Test that type conversion is only applied once.
-     *
-     * @return void
-     */
-    public function testAllNoDuplicateTypeCasting()
-    {
-        $table = $this->getTableLocator()->get('Comments');
-        $query = $table->find()
-            ->select(['id', 'comment', 'created']);
-
-        // Convert to an array and make the query dirty again.
-        $result = $query->all()->toArray();
-        $query->limit(99);
-
-        // Get results a second time.
-        $result2 = $query->all()->toArray();
-
-        $this->assertEquals(1, $query->__debugInfo()['decorators'], 'Only one typecaster should exist');
-    }
 }


### PR DESCRIPTION
This adds a new `BatchCastingInterface` to type classes. The idea
is that converting fields in a batch is sometimes faster than doing
them one by one.

I also changed the code of some of the casting functions in the type
classes to avoid waste and use faster primitives.

After all these changes are applied, you can expect the process of casting
fields to be around 10 percent faster than before. It is less than I
was expecting, but it is something, at least for wide tables.