### PR TITLE
refs #10778 add router cache

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -33,11 +33,6 @@ use Zend\Diactoros\Response\RedirectResponse;
 class RoutingMiddleware
 {
     /**
-     * Name of the default cache configuration name used to store routes collection
-     */
-    const DEFAULT_ROUTER_CACHE_CONFIG = '_cake_router_';
-
-    /**
      * Key used to store the route collection in the cache engine
      */
     const ROUTE_COLLECTION_CACHE_KEY = 'routeCollection';
@@ -50,13 +45,23 @@ class RoutingMiddleware
     protected $app;
 
     /**
+     * The cache configuration name to use for route collection caching,
+     * null to disable caching
+     *
+     * @var string
+     */
+    protected $cacheConfig;
+
+    /**
      * Constructor
      *
      * @param \Cake\Http\BaseApplication $app The application instance that routes are defined on.
+     * @param string|null $cacheConfig The cache config name to use or null to disable routes cache
      */
-    public function __construct(BaseApplication $app = null)
+    public function __construct(BaseApplication $app = null, $cacheConfig = null)
     {
         $this->app = $app;
+        $this->cacheConfig = $cacheConfig;
     }
 
     /**
@@ -85,14 +90,10 @@ class RoutingMiddleware
      */
     protected function buildRouteCollection()
     {
-        $isRouterCacheEnabled = Configure::read('Router.cache');
-        if (Cache::enabled() && $isRouterCacheEnabled) {
-            $routesCacheConfig = Configure::read('Router.cacheConfig', static::DEFAULT_ROUTER_CACHE_CONFIG);
-
+        if (Cache::enabled() && $this->cacheConfig !== null) {
             return Cache::remember(static::ROUTE_COLLECTION_CACHE_KEY, function () {
-
                 return $this->prepareRouteCollection();
-            }, $routesCacheConfig);
+            }, $this->cacheConfig);
         }
 
         return $this->prepareRouteCollection();

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Routing\Middleware;
 
-=======
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
@@ -74,10 +73,9 @@ class RoutingMiddleware
         if (!$this->app) {
             return;
         }
+
         $routeCollection = $this->buildRouteCollection();
         Router::setRouteCollection($routeCollection);
-        // Prevent routes from being loaded again
-        Router::$initialized = true;
     }
 
     /**

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -89,9 +89,9 @@ class RoutingMiddleware
     {
         $isRouterCacheEnabled = Configure::read('Router.cache');
         if (Cache::enabled() && $isRouterCacheEnabled) {
-            $routesCacheConfig = Configure::read('Router.cacheConfig', self::DEFAULT_ROUTER_CACHE_CONFIG);
+            $routesCacheConfig = Configure::read('Router.cacheConfig', static::DEFAULT_ROUTER_CACHE_CONFIG);
 
-            return Cache::remember(self::ROUTE_COLLECTION_CACHE_KEY, function () {
+            return Cache::remember(static::ROUTE_COLLECTION_CACHE_KEY, function () {
 
                 return $this->prepareRouteCollection();
             }, $routesCacheConfig);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1157,7 +1157,7 @@ class Router
     public static function setRouteCollection($routeCollection)
     {
         static::$_collection = $routeCollection;
-        Router::$initialized = true;
+        static::$initialized = true;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1151,7 +1151,7 @@ class Router
     /**
      * Set the RouteCollection inside the Router
      *
-     * @param RouteCollection $routeCollection
+     * @param RouteCollection $routeCollection route collection
      * @return void
      */
     public static function setRouteCollection($routeCollection)

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1157,6 +1157,7 @@ class Router
     public static function setRouteCollection($routeCollection)
     {
         static::$_collection = $routeCollection;
+        Router::$initialized = true;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1171,5 +1171,4 @@ class Router
         static::$initialized = true;
         include CONFIG . 'routes.php';
     }
-
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1149,6 +1149,17 @@ class Router
     }
 
     /**
+     * Set the RouteCollection inside the Router
+     *
+     * @param RouteCollection $routeCollection
+     * @return void
+     */
+    public static function setRouteCollection($routeCollection)
+    {
+        static::$_collection = $routeCollection;
+    }
+
+    /**
      * Loads route configuration
      *
      * @deprecated 3.5.0 Routes will be loaded via the Application::routes() hook in 4.0.0
@@ -1159,4 +1170,5 @@ class Router
         static::$initialized = true;
         include CONFIG . 'routes.php';
     }
+
 }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -18,6 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\RouteBuilder;
+use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use TestApp\Application;
@@ -474,7 +475,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = new Response();
         $next = function ($req, $res) {
             $routeCollection = Cache::read('routeCollection', '_cake_router_');
-            $this->assertInstanceOf('\Cake\Routing\RouteCollection', $routeCollection);
+            $this->assertInstanceOf(RouteCollection::class, $routeCollection);
 
             return $res;
         };
@@ -520,11 +521,12 @@ class RoutingMiddlewareTest extends TestCase
      * Test cache name is used
      *
      * @return void
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The "notfound" cache configuration does not exist
      */
     public function testCacheConfigNotFound()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "notfound" cache configuration does not exist');
+
         Configure::write('Router.cache', true);
         Configure::write('Router.cacheConfig', 'notfound');
         Cache::setConfig('_cake_router_', [

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -475,6 +475,7 @@ class RoutingMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             $routeCollection = Cache::read('routeCollection', '_cake_router_');
             $this->assertInstanceOf('\Cake\Routing\RouteCollection', $routeCollection);
+
             return $res;
         };
         $app = new Application(CONFIG);
@@ -504,6 +505,7 @@ class RoutingMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             $routeCollection = Cache::read('routeCollection', '_cake_router_');
             $this->assertFalse($routeCollection);
+
             return $res;
         };
         $app = new Application(CONFIG);


### PR DESCRIPTION
Route collection caching added to RoutingMiddleware.
New configuration keys added 
* `Router.cache` bool, enable cache
* `Router.cacheConfig`  string, define the cache configuration name to be used


