### PR TITLE
Fixed the multiple option when it is set false on belongsToMany selects

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1288,7 +1288,7 @@ class FormHelper extends Helper
 
         if ($allowOverride && substr($fieldName, -5) === '._ids') {
             $options['type'] = 'select';
-            if (!isset($options['multiple']) || $options['multiple']) {
+            if ( (!isset($options['multiple']) || ($options['multiple'] && $options['multiple'] != 'checkbox')) ) {
                 $options['multiple'] = true;
             }
         }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1288,7 +1288,7 @@ class FormHelper extends Helper
 
         if ($allowOverride && substr($fieldName, -5) === '._ids') {
             $options['type'] = 'select';
-            if (empty($options['multiple'])) {
+            if (!isset($options['multiple']) || $options['multiple']) {
                 $options['multiple'] = true;
             }
         }


### PR DESCRIPTION
I faced this problem when I tried to set `'multiple' = false` in a select field which sets a belongs to many relationship (my field calls `stores._ids`). So I fixed how these especific option is built on FormHelper class.