### PR TITLE
Allow changing timezone when generating datetime string for db.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -111,7 +111,7 @@ class DateTimeType extends Type implements TypeInterface
     /**
      * Convert DateTime instance into strings.
      *
-     * @param string|int|\DateTime $value The value to convert.
+     * @param string|int|\DateTime|\DateTimeImmutable $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
@@ -128,8 +128,9 @@ class DateTimeType extends Type implements TypeInterface
         $format = (array)$this->_format;
 
         if ($this->dbTimezone !== null
-            && $this->dbTimezone !== $value->getTimezone()->getName()) {
-            $value->setTimezone(new DateTimeZone($this->dbTimezone));
+            && $this->dbTimezone !== $value->getTimezone()->getName()
+        ) {
+            $value = $value->setTimezone(new DateTimeZone($this->dbTimezone));
         }
 
         return $value->format(array_shift($format));

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -18,6 +18,7 @@ use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use DateTimeInterface;
+use DateTimeZone;
 use Exception;
 use PDO;
 use RuntimeException;
@@ -91,6 +92,13 @@ class DateTimeType extends Type implements TypeInterface
     protected $_className;
 
     /**
+     * Timezone string.
+     *
+     * @var string|null
+     */
+    protected $dbTimezone;
+
+    /**
      * {@inheritDoc}
      */
     public function __construct($name = null)
@@ -119,7 +127,29 @@ class DateTimeType extends Type implements TypeInterface
 
         $format = (array)$this->_format;
 
+        if ($this->dbTimezone !== null
+            && $this->dbTimezone !== $value->getTimezone()->getName()) {
+            $value->setTimezone(new DateTimeZone($this->dbTimezone));
+        }
+
         return $value->format(array_shift($format));
+    }
+
+    /**
+     * Set database timezone.
+     *
+     * Specified timezone will be set for DateTime objects before generating
+     * datetime string for saving to database. If `null` no timezone conversion
+     * will be done.
+     *
+     * @param string|null $timezone Database timezone.
+     * @return $this
+     */
+    public function setTimezone($timezone)
+    {
+        $this->dbTimezone = $timezone;
+
+        return $this;
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -92,9 +92,9 @@ class DateTimeType extends Type implements TypeInterface
     protected $_className;
 
     /**
-     * Timezone string.
+     * Timezone instance.
      *
-     * @var string|null
+     * @var \DateTimeZone|null
      */
     protected $dbTimezone;
 
@@ -128,9 +128,9 @@ class DateTimeType extends Type implements TypeInterface
         $format = (array)$this->_format;
 
         if ($this->dbTimezone !== null
-            && $this->dbTimezone !== $value->getTimezone()->getName()
+            && $this->dbTimezone->getName() !== $value->getTimezone()->getName()
         ) {
-            $value = $value->setTimezone(new DateTimeZone($this->dbTimezone));
+            $value = $value->setTimezone($this->dbTimezone);
         }
 
         return $value->format(array_shift($format));
@@ -143,11 +143,14 @@ class DateTimeType extends Type implements TypeInterface
      * datetime string for saving to database. If `null` no timezone conversion
      * will be done.
      *
-     * @param string|null $timezone Database timezone.
+     * @param string|\DateTimeZone|null $timezone Database timezone.
      * @return $this
      */
     public function setTimezone($timezone)
     {
+        if (is_string($timezone)) {
+            $timezone = new DateTimeZone($timezone);
+        }
         $this->dbTimezone = $timezone;
 
         return $this;

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -124,6 +124,11 @@ class DateTimeTypeTest extends TestCase
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2013-08-12 15:16:17', $result);
 
+        $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
+        $result = $this->type->toDatabase($date, $this->driver);
+        $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->type->setTimezone(null);
+
         $date = 1401906995;
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2014-06-04 18:36:35', $result);

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -129,6 +129,15 @@ class DateTimeTypeTest extends TestCase
         $this->assertEquals('2013-08-12 20:46:17', $result);
         $this->type->setTimezone(null);
 
+        $date = new FrozenTime('2013-08-12 15:16:17');
+        $result = $this->type->toDatabase($date, $this->driver);
+        $this->assertEquals('2013-08-12 15:16:17', $result);
+
+        $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
+        $result = $this->type->toDatabase($date, $this->driver);
+        $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->type->setTimezone(null);
+
         $date = 1401906995;
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2014-06-04 18:36:35', $result);

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -18,6 +18,7 @@ use Cake\Database\Type\DateTimeType;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
+use DateTimeZone;
 
 /**
  * Test for the DateTime type.
@@ -125,6 +126,10 @@ class DateTimeTypeTest extends TestCase
         $this->assertEquals('2013-08-12 15:16:17', $result);
 
         $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
+        $result = $this->type->toDatabase($date, $this->driver);
+        $this->assertEquals('2013-08-12 20:46:17', $result);
+
+        $this->type->setTimezone(new DateTimeZone('Asia/Kolkata'));
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2013-08-12 20:46:17', $result);
         $this->type->setTimezone(null);


### PR DESCRIPTION
Refs #11712.

This change won't do anything unless a timezone is explicitly set, so it won't cause any backwards compatibility issues or unexpected changes to the datetime values.