### PR TITLE
Add whereIn() and whereNotIn() and allow to behave as intuitively expected

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -906,7 +906,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $options Options
      * @return $this
      */
-    public function whereIn($field, array $values, array $options = [])
+    public function whereInArray($field, array $values, array $options = [])
     {
         $options += [
             'types' => [],
@@ -933,7 +933,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $options Options
      * @return $this
      */
-    public function whereNotIn($field, array $values, array $options = [])
+    public function whereNotInArray($field, array $values, array $options = [])
     {
         $options += [
             'types' => [],
@@ -941,7 +941,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         ];
 
         if ($options['allowEmpty'] && !$values) {
-            return $this->where('1=1');
+            return $this->where([$field . ' IS NOT' => null]);
         }
 
         return $this->where([$field . ' NOT IN' => $values], $options['types']);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -893,16 +893,18 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Adds an IN condition or set of conditions to be used in the WHERE clause for this
      * query.
      *
-     * This method does allow empty inputs in contrast to where().
+     * This method does allow empty inputs in contrast to where() if you set
+     * $allowEmpty to true.
      * Be careful about using it without proper sanity checks.
      *
      * @param string $field Field
      * @param array $values Array of values
+     * @param bool $allowEmpty Allow empty array
      * @return $this
      */
-    public function whereIn($field, array $values)
+    public function whereIn($field, array $values, $allowEmpty = false)
     {
-        if (!$values) {
+        if ($allowEmpty && !$values) {
             return $this->where('1=0');
         }
 
@@ -913,16 +915,18 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Adds a NOT IN condition or set of conditions to be used in the WHERE clause for this
      * query.
      *
-     * This method does allow empty inputs in contrast to where().
+     * This method does allow empty inputs in contrast to where() if you set
+     * $allowEmpty to true.
      * Be careful about using it without proper sanity checks.
      *
      * @param string $field Field
      * @param array $values Array of values
+     * @param bool $allowEmpty Allow empty array
      * @return $this
      */
-    public function whereNotIn($field, array $values)
+    public function whereNotIn($field, array $values, $allowEmpty = false)
     {
-        if (!$values) {
+        if ($allowEmpty && !$values) {
             return $this->where('1=1');
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -890,6 +890,46 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Adds an IN condition or set of conditions to be used in the WHERE clause for this
+     * query.
+     *
+     * This method does allow empty inputs in contrast to where().
+     * Be careful about using it without proper sanity checks.
+     *
+     * @param string $field Field
+     * @param array $values Array of values
+     * @return $this
+     */
+    public function whereIn($field, array $values)
+    {
+        if (!$values) {
+            return $this->where('1=0');
+        }
+
+        return $this->where([$field . ' IN' => $values]);
+    }
+
+    /**
+     * Adds a NOT IN condition or set of conditions to be used in the WHERE clause for this
+     * query.
+     *
+     * This method does allow empty inputs in contrast to where().
+     * Be careful about using it without proper sanity checks.
+     *
+     * @param string $field Field
+     * @param array $values Array of values
+     * @return $this
+     */
+    public function whereNotIn($field, array $values)
+    {
+        if (!$values) {
+            return $this->where('1=1');
+        }
+
+        return $this->where([$field . ' NOT IN' => $values]);
+    }
+
+    /**
      * Connects any previously defined set of conditions to the provided list
      * using the AND operator. This function accepts the conditions list in the same
      * format as the method `where` does, hence you can use arrays, expression objects

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -894,21 +894,30 @@ class Query implements ExpressionInterface, IteratorAggregate
      * query.
      *
      * This method does allow empty inputs in contrast to where() if you set
-     * $allowEmpty to true.
+     * 'allowEmpty' to true.
      * Be careful about using it without proper sanity checks.
+     *
+     * Options:
+     * - `types` - Associative array of type names used to bind values to query
+     * - `allowEmpty` - Allow empty array.
      *
      * @param string $field Field
      * @param array $values Array of values
-     * @param bool $allowEmpty Allow empty array
+     * @param array $options Options
      * @return $this
      */
-    public function whereIn($field, array $values, $allowEmpty = false)
+    public function whereIn($field, array $values, array $options = [])
     {
-        if ($allowEmpty && !$values) {
+        $options += [
+            'types' => [],
+            'allowEmpty' => false,
+        ];
+
+        if ($options['allowEmpty'] && !$values) {
             return $this->where('1=0');
         }
 
-        return $this->where([$field . ' IN' => $values]);
+        return $this->where([$field . ' IN' => $values], $options['types']);
     }
 
     /**
@@ -916,21 +925,26 @@ class Query implements ExpressionInterface, IteratorAggregate
      * query.
      *
      * This method does allow empty inputs in contrast to where() if you set
-     * $allowEmpty to true.
+     * 'allowEmpty' to true.
      * Be careful about using it without proper sanity checks.
      *
      * @param string $field Field
      * @param array $values Array of values
-     * @param bool $allowEmpty Allow empty array
+     * @param array $options Options
      * @return $this
      */
-    public function whereNotIn($field, array $values, $allowEmpty = false)
+    public function whereNotIn($field, array $values, array $options = [])
     {
-        if ($allowEmpty && !$values) {
+        $options += [
+            'types' => [],
+            'allowEmpty' => false,
+        ];
+
+        if ($options['allowEmpty'] && !$values) {
             return $this->where('1=1');
         }
 
-        return $this->where([$field . ' NOT IN' => $values]);
+        return $this->where([$field . ' NOT IN' => $values], $options['types']);
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -906,7 +906,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $options Options
      * @return $this
      */
-    public function whereInArray($field, array $values, array $options = [])
+    public function whereInList($field, array $values, array $options = [])
     {
         $options += [
             'types' => [],
@@ -933,7 +933,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $options Options
      * @return $this
      */
-    public function whereNotInArray($field, array $values, array $options = [])
+    public function whereNotInList($field, array $values, array $options = [])
     {
         $options += [
             'types' => [],

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1749,7 +1749,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereIn('id', [], true)
+            ->whereIn('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 
@@ -1799,7 +1799,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotIn('id', [], true)
+            ->whereNotIn('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1714,17 +1714,17 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests whereIn() and its input types.
+     * Tests whereInArray() and its input types.
      *
      * @return void
      */
-    public function testWhereIn()
+    public function testWhereInArray()
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereIn('id', [2, 3])
+            ->whereInArray('id', [2, 3])
             ->execute();
         $sql = $query->sql();
 
@@ -1739,17 +1739,17 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests whereIn() and empty array input.
+     * Tests whereInArray() and empty array input.
      *
      * @return void
      */
-    public function testWhereInEmpty()
+    public function testWhereInArrayEmpty()
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereIn('id', [], ['allowEmpty' => true])
+            ->whereInArray('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 
@@ -1764,17 +1764,17 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests whereNotIn() and its input types.
+     * Tests whereNotInArray() and its input types.
      *
      * @return void
      */
-    public function testWhereNotIn()
+    public function testWhereNotInArray()
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotIn('id', [1, 3])
+            ->whereNotInArray('id', [1, 3])
             ->execute();
         $sql = $query->sql();
 
@@ -1789,17 +1789,17 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests whereNotIn() and empty array input.
+     * Tests whereNotInArray() and empty array input.
      *
      * @return void
      */
-    public function testWhereNotInEmpty()
+    public function testWhereNotInArrayEmpty()
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotIn('id', [], ['allowEmpty' => true])
+            ->whereNotInArray('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 
@@ -1807,7 +1807,7 @@ class QueryTest extends TestCase
         $this->assertEquals(['id' => '1'], $result->fetch('assoc'));
 
         $this->assertQuotedQuery(
-            'SELECT <id> FROM <articles> WHERE 1=1',
+            'SELECT <id> FROM <articles> WHERE \(<id>\) IS NOT NULL',
             $sql,
             !$this->autoQuote
         );

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1749,7 +1749,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereIn('id', [])
+            ->whereIn('id', [], true)
             ->execute();
         $sql = $query->sql();
 
@@ -1799,7 +1799,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotIn('id', [])
+            ->whereNotIn('id', [], true)
             ->execute();
         $sql = $query->sql();
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -36,6 +36,16 @@ class QueryTest extends TestCase
     const AUTHOR_COUNT = 4;
     const COMMENT_COUNT = 6;
 
+    /**
+     * @var \Cake\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var bool
+     */
+    protected $autoQuote;
+
     public function setUp()
     {
         parent::setUp();
@@ -1701,6 +1711,106 @@ class QueryTest extends TestCase
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
         $this->assertEquals(['id' => 2], $result->fetch('assoc'));
         $result->closeCursor();
+    }
+
+    /**
+     * Tests whereIn() and its input types.
+     *
+     * @return void
+     */
+    public function testWhereIn()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->whereIn('id', [2, 3])
+            ->execute();
+        $sql = $query->sql();
+
+        $result = $query->execute();
+        $this->assertEquals(['id' => '2'], $result->fetch('assoc'));
+
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> WHERE <id> in \\(:c0,:c1\\)',
+            $sql,
+            !$this->autoQuote
+        );
+    }
+
+    /**
+     * Tests whereIn() and empty array input.
+     *
+     * @return void
+     */
+    public function testWhereInEmpty()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->whereIn('id', [])
+            ->execute();
+        $sql = $query->sql();
+
+        $result = $query->execute();
+        $this->assertFalse($result->fetch('assoc'));
+
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> WHERE 1=0',
+            $sql,
+            !$this->autoQuote
+        );
+    }
+
+    /**
+     * Tests whereNotIn() and its input types.
+     *
+     * @return void
+     */
+    public function testWhereNotIn()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->whereNotIn('id', [1, 3])
+            ->execute();
+        $sql = $query->sql();
+
+        $result = $query->execute();
+        $this->assertEquals(['id' => '2'], $result->fetch('assoc'));
+
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> WHERE <id> not in \\(:c0,:c1\\)',
+            $sql,
+            !$this->autoQuote
+        );
+    }
+
+    /**
+     * Tests whereNotIn() and empty array input.
+     *
+     * @return void
+     */
+    public function testWhereNotInEmpty()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->whereNotIn('id', [])
+            ->execute();
+        $sql = $query->sql();
+
+        $result = $query->execute();
+        $this->assertEquals(['id' => '1'], $result->fetch('assoc'));
+
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> WHERE 1=1',
+            $sql,
+            !$this->autoQuote
+        );
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1724,7 +1724,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereInArray('id', [2, 3])
+            ->whereInList('id', [2, 3])
             ->execute();
         $sql = $query->sql();
 
@@ -1749,7 +1749,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereInArray('id', [], ['allowEmpty' => true])
+            ->whereInList('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 
@@ -1774,7 +1774,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotInArray('id', [1, 3])
+            ->whereNotInList('id', [1, 3])
             ->execute();
         $sql = $query->sql();
 
@@ -1799,7 +1799,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereNotInArray('id', [], ['allowEmpty' => true])
+            ->whereNotInList('id', [], ['allowEmpty' => true])
             ->execute();
         $sql = $query->sql();
 


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/11745

Two important things:

a) Adds standalone wrapper to not have to add the cumbersome IN / NOT IN (since 3.x) strings into the field key when there "could" be an array.

b) Adds support for the intuitive behavior of empty result for empty array (instead of the hard and problematic exception) - and all results for empty array on NOT.

Protecting the developer from himself here is not helpful. Often times these exceptions are not happening until somewhere someday it does happen - and then it is a big deal. Which it shouldn't have been.
Additionally, it is better to not force the developer to add additional logic all over the place, including controllers - as I have seen and experienced it myself. If (!empty) then add on top, otherwise not. Makes the whole RAD thing a bit less RAD and CRUD.

With these wrappers a dev has the choice at least to some extend.