### PR TITLE
Fix duplicate plugin bootstrapping.

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -34,13 +34,6 @@ class BasePlugin implements PluginInterface
     protected $bootstrapEnabled = true;
 
     /**
-     * Are events enabled.
-     *
-     * @var bool
-     */
-    protected $eventsEnabled = true;
-
-    /**
      * Load routes or not
      *
      * @var bool

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -173,7 +173,10 @@ class Plugin
             );
         }
 
-        if ($config['bootstrap'] === true) {
+        // Defer the bootstrap process if an Application class exists.
+        // Immediate plugin bootstrapping is deprecated and will be removed in 4.x
+        $appClass = Configure::read('App.namespace') . '\\' . 'Application';
+        if ($config['bootstrap'] === true && !class_exists($appClass)) {
             static::bootstrap($plugin);
         }
     }

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -111,6 +111,7 @@ class PluginTest extends TestCase
     /**
      * Tests loading a plugin and its bootstrap file
      *
+     * @deprecated Immediate plugin bootstrap should be removed in 4.x
      * @return void
      */
     public function testLoadSingleWithBootstrap()
@@ -122,6 +123,20 @@ class PluginTest extends TestCase
         Plugin::load('Company/TestPluginThree', ['bootstrap' => true]);
         $this->assertTrue(Plugin::loaded('Company/TestPluginThree'));
         $this->assertEquals('loaded plugin three bootstrap', Configure::read('PluginTest.test_plugin_three.bootstrap'));
+    }
+
+    /**
+     * Tests loading a plugin defers bootstrap when an application exists
+     *
+     * @return void
+     */
+    public function testLoadSingleDeferBootstrap()
+    {
+        static::setAppNamespace('TestApp');
+
+        Plugin::load('TestPlugin', ['bootstrap' => true]);
+        $this->assertTrue(Plugin::loaded('TestPlugin'));
+        $this->assertNull(Configure::read('PluginTest.test_plugin.bootstrap'), 'Normally this value would be loaded');
     }
 
     /**


### PR DESCRIPTION
Use the presence of an application class to defer plugin bootstrapping. Defering this logic pushes it into the pluginBootstrap() application hook.

The hook method has one caveat that plugins will need to conditionally define constants and functions as plugins can now be bootstrapped multiple times in a single testsuite run.

Refs #11783