### PR TITLE
Don't hard fail on missing columns.

### DIFF
--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -198,6 +198,10 @@ class TimestampBehavior extends Behavior
         $ts = $this->timestamp(null, $refreshTimestamp);
 
         $columnType = $this->getTable()->getSchema()->getColumnType($field);
+        if (!$columnType) {
+            return;
+        }
+
         /** @var \Cake\Database\Type\DateTimeType $type */
         $type = Type::build($columnType);
         $class = $type->getDateTimeClassName();

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -196,6 +196,28 @@ class TimestampBehaviorTest extends TestCase
     }
 
     /**
+     * test that timestamp creation doesn't fail on missing columns
+     *
+     * @return void
+     */
+    public function testModifiedMissingColumn()
+    {
+        $table = $this->getTable();
+        $table->getSchema()->removeColumn('created')->removeColumn('modified');
+        $this->Behavior = new TimestampBehavior($table);
+        $ts = new \DateTime('2000-01-01');
+        $this->Behavior->timestamp($ts);
+
+        $event = new Event('Model.beforeSave');
+        $entity = new Entity(['name' => 'Foo']);
+
+        $return = $this->Behavior->handleEvent($event, $entity);
+        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->assertNull($entity->created);
+        $this->assertNull($entity->modified);
+    }
+
+    /**
      * testUseImmutable
      *
      * @return void


### PR DESCRIPTION
If timestamp behavior is attached to a table that doesn't have the required columns, it should not hard fail in this way. This failure mode can be percieved as a compatibility break as it happens deep into runtime, and not during configuration/attach time.

Refs #11800