### PR TITLE
3.next - plugin command cleanup

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -138,17 +138,12 @@ class CommandRunner implements EventDispatcherInterface
             'help' => HelpCommand::class,
         ]);
         $commands = $this->app->console($commands);
+        $this->checkCollection($commands, 'console');
+
         if ($this->app instanceof PluginApplicationInterface) {
             $commands = $this->app->pluginConsole($commands);
         }
-
-        if (!($commands instanceof CommandCollection)) {
-            $type = getTypeName($commands);
-            throw new RuntimeException(
-                "The application's `console` method did not return a CommandCollection." .
-                " Got '{$type}' instead."
-            );
-        }
+        $this->checkCollection($commands, 'pluginConsole');
         $this->dispatchEvent('Console.buildCommands', ['commands' => $commands]);
 
         if (empty($argv)) {
@@ -193,6 +188,26 @@ class CommandRunner implements EventDispatcherInterface
         $this->app->bootstrap();
         if ($this->app instanceof PluginApplicationInterface) {
             $this->app->pluginBootstrap();
+        }
+    }
+
+    /**
+     * Check the created CommandCollection
+     *
+     * @param mixed $commands The CommandCollection to check, could be anything though.
+     * @param string $method The method that was used.
+     * @return void
+     * @throws \RuntimeException
+     * @deprecated 3.6.0 This method should be replaced with return types in 4.x
+     */
+    protected function checkCollection($commands, $method)
+    {
+        if (!($commands instanceof CommandCollection)) {
+            $type = getTypeName($commands);
+            throw new RuntimeException(
+                "The application's `{$method}` method did not return a CommandCollection." .
+                " Got '{$type}' instead."
+            );
         }
     }
 

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -246,7 +246,7 @@ class BasePlugin implements PluginInterface
      */
     public function console($commands)
     {
-        return $commands;
+        return $commands->addMany($commands->discoverPlugin($this->getName()));
     }
 
     /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -126,6 +126,7 @@ class Plugin
             'autoload' => false,
             'bootstrap' => false,
             'routes' => false,
+            'console' => true,
             'classBase' => 'src',
             'ignoreMissing' => false,
             'name' => $plugin

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -245,7 +245,8 @@ class CommandCollectionTest extends TestCase
      */
     public function testDiscoverPluginUnknown()
     {
-        $this->assertSame([], $collection = new CommandCollection());
+        $collection = new CommandCollection();
+        $this->assertSame([], $collection->discoverPlugin('Nope'));
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -133,6 +133,24 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test that the console hook not returning a command collection
+     * raises an error.
+     *
+     * @return void
+     */
+    public function testRunPluginConsoleHookFailure()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The application\'s `pluginConsole` method did not return a CommandCollection.');
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->setMethods(['pluginConsole', 'middleware', 'bootstrap'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+        $runner = new CommandRunner($app);
+        $runner->run(['cake', '-h']);
+    }
+
+    /**
      * Test that running with empty argv fails
      *
      * @return void

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -81,11 +81,25 @@ class BasePluginTest extends TestCase
         $this->assertSame($middleware, $plugin->middleware($middleware));
     }
 
-    public function testConsole()
+    public function testConsoleNoop()
     {
         $plugin = new BasePlugin();
         $commands = new CommandCollection();
         $this->assertSame($commands, $plugin->console($commands));
+    }
+
+    public function testConsoleFind()
+    {
+        $plugin = new TestPlugin();
+        Plugin::getCollection()->add($plugin);
+
+        $result = $plugin->console(new CommandCollection());
+
+        $this->assertTrue($result->has('widget'), 'Should have plugin command added');
+        $this->assertTrue($result->has('test_plugin.widget'), 'Should have long plugin name');
+
+        $this->assertTrue($result->has('example'), 'Should have plugin shell added');
+        $this->assertTrue($result->has('test_plugin.example'), 'Should have long plugin name');
     }
 
     public function testBootstrap()


### PR DESCRIPTION
Move plugin command discovery into plugin classes. When console commands were added there were no plugin classes. Now that plugin classes exist they can handle discovery of their plugin's commands/shells.  This will allow plugin authors to have more control on the commands their plugin exposes.

Refs #11137
Refs cakephp/docs#5652