### PR TITLE
Don't break on removing a non-existing rule

### DIFF
--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -594,7 +594,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 		$this->_parseRules();
 		if ($rule === null) {
 			unset($this->_fields[$field]);
-		} else {
+		} elseif (array_key_exists($field, $this->_fields)) {
 			$this->_fields[$field]->removeRule($rule);
 		}
 		return $this;

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -2007,6 +2007,9 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertTrue(isset($Validator['other']));
 		$this->assertFalse(isset($Validator['other']['numeric']));
 		$this->assertTrue(isset($Validator['other']['between']));
+
+		$Validator->remove('other');
+		$Validator->remove('other', 'between');
 	}
 
 /**


### PR DESCRIPTION
Don't fail with an "undefined index" when removing a non-existing rule.
