### PR TITLE
[2.x]In getMockForModel, place useDbConfig test_xxx

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -445,7 +445,8 @@ class CakeTestCaseTest extends CakeTestCase {
 		), App::RESET);
 		CakePlugin::load('TestPlugin');
 		ConnectionManager::create('test_secondary', array(
-			'datasource' => 'Database/TestLocalDriver'
+			'datasource' => 'Database/TestLocalDriver',
+			'prefix' => ''
 		));
 		$post = $this->getMockForModel('SecondaryPost', array('save'));
 		$this->assertEquals('test_secondary', $post->useDbConfig);

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -866,7 +866,8 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 		$availableDs = array_keys(ConnectionManager::enumConnectionObjects());
 
 		if ($mock->useDbConfig !== 'test' && in_array('test_' . $mock->useDbConfig, $availableDs)) {
-			$mock->setDataSource('test_' . $mock->useDbConfig);
+			$mock->useDbConfig = 'test_' . $mock->useDbConfig;
+			$mock->setDataSource($mock->useDbConfig);
 		} else {
 			$mock->useDbConfig = 'test';
 			$mock->setDataSource('test');


### PR DESCRIPTION
Mock secondary datasource by getMockForModel does not connect test_xxx database. 
That's why modify test and CakeTestCake.getMockForModel.
Ref issue #11810 
