### PR TITLE
3.next - Allow console helpers to live in the command namespace.

### DIFF
--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -46,6 +46,9 @@ class HelperRegistry extends ObjectRegistry
     /**
      * Resolve a helper classname.
      *
+     * Will prefer helpers defined in Command\Helper over those
+     * defined in Shell\Helper.
+     *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
      * @param string $class Partial classname to resolve.
@@ -53,6 +56,11 @@ class HelperRegistry extends ObjectRegistry
      */
     protected function _resolveClassName($class)
     {
+        $name = App::className($class, 'Command/Helper', 'Helper');
+        if ($name) {
+            return $name;
+        }
+
         return App::className($class, 'Shell/Helper', 'Helper');
     }
 

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -16,6 +16,9 @@ namespace Cake\Test\TestCase\Console;
 use Cake\Console\HelperRegistry;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use TestApp\Command\Helper\CommandHelper;
+use TestApp\Shell\Helper\SimpleHelper;
+use TestPlugin\Shell\Helper\ExampleHelper;
 
 /**
  * HelperRegistryTest
@@ -58,11 +61,26 @@ class HelperRegistryTest extends TestCase
     public function testLoad()
     {
         $result = $this->helpers->load('Simple');
-        $this->assertInstanceOf('TestApp\Shell\Helper\SimpleHelper', $result);
-        $this->assertInstanceOf('TestApp\Shell\Helper\SimpleHelper', $this->helpers->Simple);
+        $this->assertInstanceOf(SimpleHelper::class, $result);
+        $this->assertInstanceOf(SimpleHelper::class, $this->helpers->Simple);
 
         $result = $this->helpers->loaded();
         $this->assertEquals(['Simple'], $result, 'loaded() results are wrong.');
+    }
+
+    /**
+     * test loading helpers.
+     *
+     * @return void
+     */
+    public function testLoadCommandNamespace()
+    {
+        $result = $this->helpers->load('Command');
+        $this->assertInstanceOf(CommandHelper::class, $result);
+        $this->assertInstanceOf(CommandHelper::class, $this->helpers->Command);
+
+        $result = $this->helpers->loaded();
+        $this->assertEquals(['Command'], $result, 'loaded() results are wrong.');
     }
 
     /**
@@ -97,15 +115,15 @@ class HelperRegistryTest extends TestCase
         Plugin::load('TestPlugin');
 
         $result = $this->helpers->load('SimpleAliased', ['className' => 'Simple']);
-        $this->assertInstanceOf('TestApp\Shell\Helper\SimpleHelper', $result);
-        $this->assertInstanceOf('TestApp\Shell\Helper\SimpleHelper', $this->helpers->SimpleAliased);
+        $this->assertInstanceOf(SimpleHelper::class, $result);
+        $this->assertInstanceOf(SimpleHelper::class, $this->helpers->SimpleAliased);
 
         $result = $this->helpers->loaded();
         $this->assertEquals(['SimpleAliased'], $result, 'loaded() results are wrong.');
 
         $result = $this->helpers->load('SomeHelper', ['className' => 'TestPlugin.Example']);
-        $this->assertInstanceOf('TestPlugin\Shell\Helper\ExampleHelper', $result);
-        $this->assertInstanceOf('TestPlugin\Shell\Helper\ExampleHelper', $this->helpers->SomeHelper);
+        $this->assertInstanceOf(ExampleHelper::class, $result);
+        $this->assertInstanceOf(ExampleHelper::class, $this->helpers->SomeHelper);
 
         $result = $this->helpers->loaded();
         $this->assertEquals(['SimpleAliased', 'SomeHelper'], $result, 'loaded() results are wrong.');

--- a/tests/test_app/TestApp/Command/Helper/CommandHelper.php
+++ b/tests/test_app/TestApp/Command/Helper/CommandHelper.php
@@ -1,0 +1,12 @@
+<?php
+namespace TestApp\Command\Helper;
+
+use Cake\Console\Helper;
+
+class CommandHelper extends Helper
+{
+    public function output($args)
+    {
+        $this->_io->out('I am helping ' . implode(' ', $args));
+    }
+}


### PR DESCRIPTION
It will be weird if helpers used in command classes live under the shell namespace. This allows helpers to be found in either namespace.

Refs #11137