### PR TITLE
Remove combined getter/setter on QueryTrait.

### DIFF
--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -67,7 +67,7 @@ class MapReduce implements IteratorAggregate
      * A callable that will be executed for each intermediate record emitted during
      * the Map phase
      *
-     * @var callable
+     * @var callable|null
      */
     protected $_reducer;
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -341,6 +341,7 @@ trait QueryTrait
                     'Use getMapReducers() instead.'
                 );
             }
+
             return $this->_mapReduce;
         }
         $this->_mapReduce[] = compact('mapper', 'reducer');
@@ -408,6 +409,7 @@ trait QueryTrait
                     'Use getResultFormatters() instead.'
                 );
             }
+
             return $this->_formatters;
         }
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -318,7 +318,7 @@ trait QueryTrait
      * result is attempted to be fetched.
      *
      * If the first argument is set to null, it will return the list of previously
-     * registered map reduce routines.
+     * registered map reduce routines. This is deprecated as of 3.6.0 - use getMapReducers() instead.
      *
      * If the third argument is set to true, it will erase previous map reducers
      * and replace it with the arguments passed.
@@ -335,11 +335,27 @@ trait QueryTrait
             $this->_mapReduce = [];
         }
         if ($mapper === null) {
+            if (!$overwrite) {
+                deprecationWarning(
+                    'Using QueryTrait::mapReduce() as a getter is deprecated. ' .
+                    'Use getMapReducers() instead.'
+                );
+            }
             return $this->_mapReduce;
         }
         $this->_mapReduce[] = compact('mapper', 'reducer');
 
         return $this;
+    }
+
+    /**
+     * Returns the list of previously registered map reduce routines.
+     *
+     * @return array
+     */
+    public function getMapReducers()
+    {
+        return $this->_mapReduce;
     }
 
     /**
@@ -354,7 +370,7 @@ trait QueryTrait
      * after all the `MapReduce` routines for this query have been executed.
      *
      * If the first argument is set to null, it will return the list of previously
-     * registered map reduce routines.
+     * registered format routines. This is deprecated as of 3.6.0 - use getResultFormatters() instead.
      *
      * If the second argument is set to true, it will erase previous formatters
      * and replace them with the passed first argument.
@@ -386,6 +402,12 @@ trait QueryTrait
             $this->_formatters = [];
         }
         if ($formatter === null) {
+            if ($mode !== self::OVERWRITE) {
+                deprecationWarning(
+                    'Using QueryTrait::formatResults() as a getter is deprecated. ' .
+                    'Use getResultFormatters() instead.'
+                );
+            }
             return $this->_formatters;
         }
 
@@ -398,6 +420,16 @@ trait QueryTrait
         $this->_formatters[] = $formatter;
 
         return $this;
+    }
+
+    /**
+     * Returns the list of previously registered format routines.
+     *
+     * @return array
+     */
+    public function getResultFormatters()
+    {
+        return $this->_formatters;
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1216,7 +1216,7 @@ abstract class Association
      */
     protected function _formatAssociationResults($query, $surrogate, $options)
     {
-        $formatters = $surrogate->formatResults();
+        $formatters = $surrogate->getResultFormatters();
 
         if (!$formatters || empty($options['propertyPath'])) {
             return;

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -606,7 +606,7 @@ class CompositeKeyTest extends TestCase
             ['id' => 8, 'name' => 'a', 'site_id' => 2, 'parent_id' => 4],
         ]);
         $query->find('threaded', ['parentField' => ['parent_id', 'site_id']]);
-        $formatter = $query->formatResults()[0];
+        $formatter = $query->getResultFormatters()[0];
 
         $expected = [
             [

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -991,11 +991,11 @@ class QueryTest extends TestCase
         $this->assertSame($query, $query->mapReduce($mapper1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => null]],
-            $query->mapReduce()
+            $query->getMapReducers()
         );
 
         $this->assertEquals($query, $query->mapReduce($mapper2));
-        $result = $query->mapReduce();
+        $result = $query->getMapReducers();
         $this->assertSame(
             [
                 ['mapper' => $mapper1, 'reducer' => null],
@@ -1024,7 +1024,7 @@ class QueryTest extends TestCase
         $this->assertSame($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
-            $query->mapReduce()
+            $query->getMapReducers()
         );
 
         $this->assertSame($query, $query->mapReduce($mapper2, $reducer2));
@@ -1033,7 +1033,7 @@ class QueryTest extends TestCase
                 ['mapper' => $mapper1, 'reducer' => $reducer1],
                 ['mapper' => $mapper2, 'reducer' => $reducer2]
             ],
-            $query->mapReduce()
+            $query->getMapReducers()
         );
     }
 
@@ -1056,13 +1056,13 @@ class QueryTest extends TestCase
         $this->assertEquals($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
-            $query->mapReduce()
+            $query->getMapReducers()
         );
 
         $this->assertEquals($query, $query->mapReduce($mapper2, $reducer2, true));
         $this->assertEquals(
             [['mapper' => $mapper2, 'reducer' => $reducer2]],
-            $query->mapReduce()
+            $query->getMapReducers()
         );
     }
 
@@ -2141,17 +2141,17 @@ class QueryTest extends TestCase
         $table = $this->getTableLocator()->get('authors');
         $query = new Query($this->connection, $table);
         $this->assertSame($query, $query->formatResults($callback1));
-        $this->assertSame([$callback1], $query->formatResults());
+        $this->assertSame([$callback1], $query->getResultFormatters());
         $this->assertSame($query, $query->formatResults($callback2));
-        $this->assertSame([$callback1, $callback2], $query->formatResults());
+        $this->assertSame([$callback1, $callback2], $query->getResultFormatters());
         $query->formatResults($callback2, true);
-        $this->assertSame([$callback2], $query->formatResults());
+        $this->assertSame([$callback2], $query->getResultFormatters());
         $query->formatResults(null, true);
-        $this->assertSame([], $query->formatResults());
+        $this->assertSame([], $query->getResultFormatters());
 
         $query->formatResults($callback1);
         $query->formatResults($callback2, $query::PREPEND);
-        $this->assertSame([$callback2, $callback1], $query->formatResults());
+        $this->assertSame([$callback2, $callback1], $query->getResultFormatters());
     }
 
     /**


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/9978

Makes the API already way more speakable and less error prone.
Cyc. complexity will also dramatically fall with the major upgrade then, as the super complex checks on different flag combinations go away.