### PR TITLE
Fix recursive plugin loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
             "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src/",
             "Company\\TestPluginThree\\": "tests/test_app/Plugin/Company/TestPluginThree/src/",
             "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests/",
+            "ParentPlugin\\": "tests/test_app/Plugin/ParentPlugin/src/",
             "PluginJs\\": "tests/test_app/Plugin/PluginJs/src/"
         }
     },

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -409,6 +409,7 @@ class Plugin
     /**
      * Get the shared plugin collection.
      *
+     * @internal
      * @return \Cake\Core\PluginCollection
      */
     public static function getCollection()

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -301,7 +301,10 @@ class PluginTest extends TestCase
     public function testLoadAll()
     {
         Plugin::loadAll();
-        $expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
+        $expected = [
+            'Company', 'ParentPlugin', 'PluginJs', 'TestPlugin',
+            'TestPluginFour', 'TestPluginTwo', 'TestTheme'
+        ];
         $this->assertEquals($expected, Plugin::loaded());
     }
 
@@ -338,7 +341,10 @@ class PluginTest extends TestCase
     {
         $defaults = ['bootstrap' => true, 'ignoreMissing' => true];
         Plugin::loadAll([$defaults]);
-        $expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
+        $expected = [
+            'Company', 'ParentPlugin', 'PluginJs', 'TestPlugin',
+            'TestPluginFour', 'TestPluginTwo', 'TestTheme'
+        ];
         $this->assertEquals($expected, Plugin::loaded());
         $this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
         $this->assertEquals('loaded plugin bootstrap', Configure::read('PluginTest.test_plugin.bootstrap'));
@@ -360,7 +366,10 @@ class PluginTest extends TestCase
         ]);
         Plugin::routes();
 
-        $expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
+        $expected = [
+            'Company', 'ParentPlugin', 'PluginJs', 'TestPlugin',
+            'TestPluginFour', 'TestPluginTwo', 'TestTheme'
+        ];
         $this->assertEquals($expected, Plugin::loaded());
         $this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
         $this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -182,4 +182,33 @@ class BaseApplicationTest extends TestCase
             'Key should not be set, as plugin has already had bootstrap run'
         );
     }
+
+    /**
+     * Test that plugins loaded with addPlugin() can load additional
+     * plugins.
+     *
+     * @return void
+     */
+    public function testPluginBootstrapRecursivePlugins()
+    {
+        $app = $this->getMockForAbstractClass(
+            BaseApplication::class,
+            [$this->path]
+        );
+        $app->addPlugin('ParentPlugin');
+        $app->pluginBootstrap();
+
+        $this->assertTrue(
+            Configure::check('ParentPlugin.bootstrap'),
+            'Plugin bootstrap should be run'
+        );
+        $this->assertTrue(
+            Configure::check('PluginTest.test_plugin.bootstrap'),
+            'Nested plugin should have bootstrap run'
+        );
+        $this->assertTrue(
+            Configure::check('PluginTest.test_plugin_two.bootstrap'),
+            'Nested plugin should have bootstrap run'
+        );
+    }
 }

--- a/tests/test_app/Plugin/ParentPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/ParentPlugin/src/Plugin.php
@@ -1,0 +1,18 @@
+<?php
+namespace ParentPlugin;
+
+use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Core\PluginApplicationInterface;
+use Cake\Core\Plugin as CorePlugin;
+
+class Plugin extends BasePlugin
+{
+    public function bootstrap(PluginApplicationInterface $app)
+    {
+        Configure::write('ParentPlugin.bootstrap', true);
+
+        CorePlugin::load('TestPluginTwo', ['bootstrap' => true]);
+        $app->addPlugin('TestPlugin', ['bootstrap' => true]);
+    }
+}


### PR DESCRIPTION
Plugins can load other plugins. Support this use case by implementing the `Iterator` interface instead of `IteratorAggregate`. Using the basic interface lets us extend the collection as it is being iterated, which `IteratorAggregate` cannot do.

Refs #11787