### PR TITLE
ConsoleOptionParser addSubcommand Sorting - Issue #11838

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -576,7 +576,7 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
-     * @param boolean $sort
+     * @param boolean $sort Optional sorting of the subcommand
      * @return $this
      */
     public function addSubcommand($name, array $options = [], $sort = true)

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -121,6 +121,13 @@ class ConsoleOptionParser
     protected $_subcommands = [];
 
     /**
+     * Subcommand sorting option
+     *
+     * @var bool
+     */
+    protected $_subcommandSort = true;
+
+    /**
      * Command name.
      *
      * @var string
@@ -408,6 +415,32 @@ class ConsoleOptionParser
     }
 
     /**
+     * Gets the subcommandSort Property
+     *
+     * @return bool
+     */
+    public function getSubcommandSort()
+    {
+        return $this->_subcommandSort;
+    }
+
+    /**
+     * Sets the subcommandSort property.
+     *
+     * @param bool $sort Whether or not the ConsoleOptionParser should sort subcommands
+     *
+     * @return $this
+     */
+    public function setSubcommandSort($sort)
+    {
+        if ($sort !== true) {
+            $this->_subcommandSort = false;
+        }
+
+        return $this;
+    }
+
+    /**
      * Add an option to the option parser. Options allow you to define optional or required
      * parameters for your console application. Options are defined by the parameters they use.
      *
@@ -576,10 +609,9 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
-     * @param boolean $sort Optional sorting of the subcommand
      * @return $this
      */
-    public function addSubcommand($name, array $options = [], $sort = true)
+    public function addSubcommand($name, array $options = [])
     {
         if ($name instanceof ConsoleInputSubcommand) {
             $command = $name;
@@ -596,7 +628,7 @@ class ConsoleOptionParser
             $command = new ConsoleInputSubcommand($options);
         }
         $this->_subcommands[$name] = $command;
-        if ($sort) {
+        if ($this->_subcommandSort) {
             asort($this->_subcommands);
         }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -414,12 +414,12 @@ class ConsoleOptionParser
         return $this->getEpilog();
     }
 
-  /**
-   * Enables sorting of subcommands
-   *
-   * @param bool $value Whether or not to sort subcommands
-   * @return $this
-   */
+    /**
+     * Enables sorting of subcommands
+     *
+     * @param bool $value Whether or not to sort subcommands
+     * @return $this
+     */
     public function enableSubcommandSort($value = true)
     {
         $this->_subcommandSort = (bool)$value;

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -576,7 +576,7 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
-     * @param boolean $sort Optional sorting of the subcommand
+     * @param bool $sort Optional sorting of the subcommand
      * @return $this
      */
     public function addSubcommand($name, array $options = [], $sort = true)

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -576,9 +576,10 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
+     * @param boolean $sort
      * @return $this
      */
-    public function addSubcommand($name, array $options = [])
+    public function addSubcommand($name, array $options = [], $sort = true)
     {
         if ($name instanceof ConsoleInputSubcommand) {
             $command = $name;
@@ -595,7 +596,9 @@ class ConsoleOptionParser
             $command = new ConsoleInputSubcommand($options);
         }
         $this->_subcommands[$name] = $command;
-        asort($this->_subcommands);
+        if ($sort) {
+            asort($this->_subcommands);
+        }
 
         return $this;
     }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -414,30 +414,27 @@ class ConsoleOptionParser
         return $this->getEpilog();
     }
 
-    /**
-     * Gets the subcommandSort Property
-     *
-     * @return bool
-     */
-    public function getSubcommandSort()
+  /**
+   * Enables sorting of subcommands
+   *
+   * @param bool $value Whether or not to sort subcommands
+   * @return $this
+   */
+    public function enableSubcommandSort($value = true)
     {
-        return $this->_subcommandSort;
+        $this->_subcommandSort = (bool)$value;
+
+        return $this;
     }
 
     /**
-     * Sets the subcommandSort property.
+     * Checks whether or not sorting is enabled for subcommands.
      *
-     * @param bool $sort Whether or not the ConsoleOptionParser should sort subcommands
-     *
-     * @return $this
+     * @return bool
      */
-    public function setSubcommandSort($sort)
+    public function isSubcommandSortEnabled()
     {
-        if ($sort !== true) {
-            $this->_subcommandSort = false;
-        }
-
-        return $this;
+        return $this->_subcommandSort;
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -576,7 +576,7 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
-     * @param boolean $sort
+     * @param bool $sort
      * @return $this
      */
     public function addSubcommand($name, array $options = [], $sort = true)

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -652,6 +652,20 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test addSubcommand without sorting applied.
+     */
+    public function testAddSubcommandSort()
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addSubcommand(new ConsoleInputSubcommand('betaTest'), [], false);
+        $parser->addSubcommand(new ConsoleInputSubcommand('alphaTest'), [], false);
+        $result = $parser->subcommands();
+        $this->assertCount(2, $result);
+        $firstResult = key($result);
+        $this->assertEquals('betaTest', $firstResult);
+    }
+
+    /**
      * test removeSubcommand with an object.
      *
      * @return void

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -657,9 +657,9 @@ class ConsoleOptionParserTest extends TestCase
     public function testAddSubcommandSort()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $this->assertEquals(true, $parser->getSubcommandSort());
-        $parser->setSubcommandSort(false);
-        $this->assertEquals(false, $parser->getSubcommandSort());
+        $this->assertEquals(true, $parser->isSubcommandSortEnabled());
+        $parser->enableSubcommandSort(false);
+        $this->assertEquals(false, $parser->isSubcommandSortEnabled());
         $parser->addSubcommand(new ConsoleInputSubcommand('betaTest'), []);
         $parser->addSubcommand(new ConsoleInputSubcommand('alphaTest'), []);
         $result = $parser->subcommands();

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -657,8 +657,11 @@ class ConsoleOptionParserTest extends TestCase
     public function testAddSubcommandSort()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $parser->addSubcommand(new ConsoleInputSubcommand('betaTest'), [], false);
-        $parser->addSubcommand(new ConsoleInputSubcommand('alphaTest'), [], false);
+        $this->assertEquals(true, $parser->getSubcommandSort());
+        $parser->setSubcommandSort(false);
+        $this->assertEquals(false, $parser->getSubcommandSort());
+        $parser->addSubcommand(new ConsoleInputSubcommand('betaTest'), []);
+        $parser->addSubcommand(new ConsoleInputSubcommand('alphaTest'), []);
         $result = $parser->subcommands();
         $this->assertCount(2, $result);
         $firstResult = key($result);


### PR DESCRIPTION
Issue #11838
Implemented an optional sort parameter to \Cake\Console\ConsoleOptionParser::addSubcommand
Added unit test for the new parameter.


