### PR TITLE
Add often-used Entity methods to EntityInterface

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -148,7 +148,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @return bool whether the property was changed or not
      */
     public function dirty($property = null, $isDirty = null);
-    
+
     /**
      * Sets the dirty status of a single property.
      *

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -148,6 +148,24 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @return bool whether the property was changed or not
      */
     public function dirty($property = null, $isDirty = null);
+    
+    /**
+     * Sets the dirty status of a single property.
+     *
+     * @param string $property the field to set or check status for
+     * @param bool $isDirty true means the property was changed, false means
+     * it was not changed
+     * @return $this
+     */
+    public function setDirty($property, $isDirty);
+
+    /**
+     * Checks if the entity is dirty or if a single property of it is dirty.
+     *
+     * @param string $property the field to check the status for
+     * @return bool Whether the property was changed or not
+     */
+    public function isDirty($property = null);
 
     /**
      * Sets the entire entity as clean, which means that it will appear as


### PR DESCRIPTION
This adds `EntityInterface::setDirty` and `EntityInterface::isDirty`, methods which are called in a number of places in the codebase but not defined in the interface.