### PR TITLE
Fixed TimestampBehavior failing when type isn't DateTimeType

### DIFF
--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -204,6 +204,13 @@ class TimestampBehavior extends Behavior
 
         /** @var \Cake\Database\Type\DateTimeType $type */
         $type = Type::build($columnType);
+
+        if (!$type instanceof Type\DateTimeType) {
+            $entity->set($field, (string)$ts);
+
+            return;
+        }
+
         $class = $type->getDateTimeClassName();
 
         $entity->set($field, new $class($ts));

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -206,6 +206,7 @@ class TimestampBehavior extends Behavior
         $type = Type::build($columnType);
 
         if (!$type instanceof Type\DateTimeType) {
+            deprecationWarning('TimestampBehavior support for column types other than DateTimeType will be removed in 4.0.');
             $entity->set($field, (string)$ts);
 
             return;

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Error\Deprecated;
 
 /**
  * Behavior test case
@@ -226,15 +227,7 @@ class TimestampBehaviorTest extends TestCase
     public function testUseImmutable()
     {
         $table = $this->getTable();
-        $this->Behavior = new TimestampBehavior($table, [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'modified' => 'always',
-                    'timestamp_str' => 'always',
-                ]
-            ],
-        ]);
+        $this->Behavior = new TimestampBehavior($table);
         $entity = new Entity();
         $event = new Event('Model.beforeSave');
 
@@ -247,8 +240,29 @@ class TimestampBehaviorTest extends TestCase
         $entity->clean();
         $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
+    }
 
-        $entity->clean();
+    /**
+     * tests using non-DateTimeType throws deprecation warning
+     *
+     * @return void
+     */
+    public function testNonDateTimeTypeDeprecated()
+    {
+        $this->expectException(Deprecated::class);
+        $this->expectExceptionMessage('TimestampBehavior support for column types other than DateTimeType will be removed in 4.0.');
+
+        $table = $this->getTable();
+        $this->Behavior = new TimestampBehavior($table, [
+            'events' => [
+                'Model.beforeSave' => [
+                    'timestamp_str' => 'always',
+                ]
+            ],
+        ]);
+
+        $entity = new Entity();
+        $event = new Event('Model.beforeSave');
         $this->Behavior->handleEvent($event, $entity);
         $this->assertInternalType('string', $entity->timestamp_str);
     }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -226,7 +226,15 @@ class TimestampBehaviorTest extends TestCase
     public function testUseImmutable()
     {
         $table = $this->getTable();
-        $this->Behavior = new TimestampBehavior($table);
+        $this->Behavior = new TimestampBehavior($table, [
+            'events' => [
+                'Model.beforeSave' => [
+                    'created' => 'new',
+                    'modified' => 'always',
+                    'timestamp_str' => 'always',
+                ]
+            ],
+        ]);
         $entity = new Entity();
         $event = new Event('Model.beforeSave');
 
@@ -239,6 +247,10 @@ class TimestampBehaviorTest extends TestCase
         $entity->clean();
         $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
+
+        $entity->clean();
+        $this->Behavior->handleEvent($event, $entity);
+        $this->assertInternalType('string', $entity->timestamp_str);
     }
 
     /**
@@ -457,6 +469,7 @@ class TimestampBehaviorTest extends TestCase
             'created' => ['type' => 'datetime'],
             'modified' => ['type' => 'timestamp'],
             'date_specialed' => ['type' => 'datetime'],
+            'timestamp_str' => ['type' => 'string'],
         ];
         $table = new Table(['schema' => $schema]);
 


### PR DESCRIPTION
I was testing out 3.next and a bunch of my tests failed. I looked into it and it turned out I had an oddly stray `created VARCHAR(45)` column made it into one my the tables, which was apparently supported as the table has a bunch of timestamp string in it :D This caused an undefined method error as  `getDateTimeClassName` doesn't exist on StringType.

This re-adds the string type compatibility. I'm off to fix my DB in the meantime...
