### PR TITLE
Fixed Form regression that skipped validation

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -223,6 +223,9 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     public function validate(array $data)
     {
         $validator = $this->getValidator();
+        if (!$validator->count()) {
+            $validator = $this->validator();
+        }
         $this->_errors = $validator->errors($data);
 
         return count($this->_errors) === 0;

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -127,6 +127,11 @@ class FormTest extends TestCase
         $this->assertCount(0, $form->errors());
     }
 
+    /**
+     * tests validate using deprecated validate() method
+     *
+     * @return void
+     */
     public function testValidateDeprected()
     {
         $this->deprecated(function() {

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -129,7 +129,7 @@ class FormTest extends TestCase
 
     public function testValidateDeprected()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $form = new ValidateForm();
             $data = [];
             $this->assertFalse($form->validate($data));

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -19,6 +19,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use TestApp\Form\AppForm;
 use TestApp\Form\FormSchema;
+use TestApp\Form\ValidateForm;
 
 /**
  * Form test case.
@@ -124,6 +125,16 @@ class FormTest extends TestCase
         ];
         $this->assertTrue($form->validate($data));
         $this->assertCount(0, $form->errors());
+    }
+
+    public function testValidateDeprected()
+    {
+        $this->deprecated(function() {
+            $form = new ValidateForm();
+            $data = [];
+            $this->assertFalse($form->validate($data));
+            $this->assertCount(1, $form->errors());
+        });
     }
 
     /**

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -259,13 +259,9 @@ class FormContextTest extends TestCase
         $this->assertEquals([], $context->error('Alias.name'));
         $this->assertEquals([], $context->error('nope.nope'));
 
-        $mock = $this->getMockBuilder('Cake\Validation\Validator')
-            ->setMethods(['errors'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('errors')
-            ->willReturn(['key' => 'should be an array, not a string']);
-        $form->setValidator('default', $mock);
+        $validator = new Validator();
+        $validator->requirePresence('key', true, 'should be an array, not a string');
+        $form->setValidator('default', $validator);
         $form->validate([]);
         $context = new FormContext($this->request, ['entity' => $form]);
         $this->assertEquals(

--- a/tests/test_app/TestApp/Form/ValidateForm.php
+++ b/tests/test_app/TestApp/Form/ValidateForm.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Form;
+
+use Cake\Form\Form;
+
+class ValidateForm extends Form
+{
+
+    public function validator(\Cake\Validation\Validator $validator = null)
+    {
+        return parent::validator($validator)
+            ->requirePresence('title');
+    }
+}


### PR DESCRIPTION
The following was previously valid:

```php
<?php
namespace TestApp\Form;
use Cake\Form\Form;
class ValidateForm extends Form
{
    public function validator(\Cake\Validation\Validator $validator = null)
    {
        return parent::validator($validator)
            ->requirePresence('title');
    }
}
```

In fact, the Form class says in its doc:

> You can also define the validation and schema by chaining method calls off of `$form->schema()` and `$form->validator()`.

The only way I could figure out how to fix this without always throwing a deprecation was to check if the validator built via the event was empty, and replace it with the previously always-called `->validator()` within `validate()`.