### PR TITLE
Raise minimum for chronos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=5.6.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "^1.0.0",
+        "cakephp/chronos": "^1.0.1",
         "aura/intl": "^3.0.0",
         "psr/log": "^1.0.0",
         "zendframework/zend-diactoros": "^1.4.0"


### PR DESCRIPTION
This is needed for "prefer lowest" to work when using php7.1+:
https://travis-ci.org/dereuromark/cakephp-menu/jobs/356116778

For me this is a reasonable constraint here.