### PR TITLE
Fixed default adapter

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -159,10 +159,14 @@ class Client
      */
     public function __construct($config = [])
     {
+        if (!isset($config['adapter'])) {
+            $adapter = $this->_defaultConfig['adapter'];
+        } else {
+            $adapter = $config['adapter'];
+        }
+        $this->setConfig('adapter', $adapter);
         $this->setConfig($config);
 
-        $adapter = $this->_config['adapter'];
-        $this->setConfig('adapter', null);
         if (is_string($adapter)) {
             $adapter = new $adapter();
         }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -59,6 +59,12 @@ class ClientTest extends TestCase
         }
     }
 
+    public function testConstructWithEmptyOptions()
+    {
+        $http = new Client();
+        $this->assertEquals(\Cake\Http\Client\Adapter\Stream::class, $http->getConfig('adapter'));
+    }
+
     /**
      * Data provider for buildUrl() tests
      *


### PR DESCRIPTION
This bug prevented the client being instantiated with empty options.

```php
$client = new Client();
// Undefined index: adapter
```