### PR TITLE
SecurityComponent regression

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -337,7 +337,10 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         if (strlen($config['url'])) {
             $uri = $uri->withPath('/' . $config['url']);
         }
-        if (strlen($querystr)) {
+        if (strlen($querystr) || isset($config['query'])) {
+            if (!strlen($querystr)) {
+                $querystr = http_build_query($config['query']);
+            }
             $uri = $uri->withQuery($querystr);
         }
 
@@ -2324,9 +2327,10 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * application relative path without base directory, and the query string
      * defined in the SERVER environment.
      *
+     * @param bool $base Include the base path, set to false to trim the base path off.
      * @return string
      */
-    public function getRequestTarget()
+    public function getRequestTarget($base = false)
     {
         if ($this->requestTarget !== null) {
             return $this->requestTarget;
@@ -2334,11 +2338,15 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
 
         $target = $this->uri->getPath();
         if ($this->uri->getQuery()) {
-            $target .= '?' . $this->uri->getQuery();
+            $target .= '?' . urldecode($this->uri->getQuery());
         }
 
         if (empty($target)) {
             $target = '/';
+        }
+
+        if ($base) {
+            $target = $this->getAttribute('base') . $target;
         }
 
         return $target;

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -2882,6 +2882,33 @@ class ServerRequestTest extends TestCase
     }
 
     /**
+     * tests here() is compatible with the new getRequestTarget()
+     *
+     * @return void
+     */
+    public function testHereMatchesGetRequestTarget()
+    {
+        $this->deprecated(function () {
+            Configure::write('App.base', '/base_path');
+            $request = new ServerRequest([
+                'query' => [
+                    'q' => 'arg'
+                ],
+                'url' => '/posts/add/1/value',
+                'base' => '/base_path'
+            ]);
+
+            $this->assertSame($request->here(), $request->getRequestTarget(true));
+
+            $request = new ServerRequest([
+                'url' => '/posts/add/1/value?q=arg',
+            ]);
+
+            $this->assertSame($request->here(false), $request->getRequestTarget());
+        });
+    }
+
+    /**
      * Test the input() method.
      *
      * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -1094,4 +1094,33 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->disableErrorHandlerMiddleware();
         $this->get('/foo');
     }
+
+    /**
+     * tests getting a secure action while passing a query string
+     *
+     * @return void
+     * @dataProvider methodsProvider
+     */
+    public function testSecureWithQueryString($method)
+    {
+        $this->enableSecurityToken();
+        $this->{$method}('/posts/securePost/?ids[]=1&ids[]=2');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * data provider for HTTP methods
+     *
+     * @return array
+     */
+    public function methodsProvider()
+    {
+        return [
+            'GET' => ['get'],
+            'POST' => ['post'],
+            'PATCH' => ['patch'],
+            'PUT' => ['put'],
+            'DELETE' => ['delete'],
+        ];
+    }
 }


### PR DESCRIPTION
This fixes a regression in the SecurityComponent which previously used `$request->here()` as the URL to validate the token with, but now uses `$request->getRequestTarget()`. 

There are a couple of issues as I see it:

1. `here()` didn't encode the query string, while `UriInterface` dictates "The value returned MUST be percent-encoded"
2. `getRequestTarget()` doesn't prepend the base, where `here()` does it by default. I'm not too keen on the inverse `$base` flag, but applying the base by default caused a lot of tests to fail. Should I make the signatures the same and fix the tests?
3. The URI created by ServerInterface didn't seem to add query args that were passed in the config array, it just added query args if they were in the URL string

I'm not sure about the new `$base` flag. I'm wondering if `getRequestTarget()` should remain the same (never include base) and just prepend the base where necessary, or if it's better to have a more compatible replacement for `here()`.
