### PR TITLE
Fixed regression in IntegrationTestCase

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -22,6 +22,7 @@ if (class_exists('PHPUnit_Runner_Version', false) && !interface_exists('PHPUnit\
 
 use Cake\Core\Configure;
 use Cake\Database\Exception as DatabaseException;
+use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\Routing\Router;
 use Cake\TestSuite\Stub\TestExceptionRenderer;
@@ -658,14 +659,19 @@ abstract class IntegrationTestCase extends TestCase
      */
     protected function _url($url)
     {
-        $url = Router::url($url);
+        // re-create URL in ServerRequest's context so
+        // query strings are encoded as expected
+        $request = new ServerRequest(['url' => Router::url($url)]);
+        $url = $request->getRequestTarget();
+
         $query = '';
 
+        $path = parse_url($url, PHP_URL_PATH);
         if (strpos($url, '?') !== false) {
-            list($url, $query) = explode('?', $url, 2);
+            $query = parse_url($url, PHP_URL_QUERY);
         }
 
-        return [$url, $query];
+        return [$path, $query];
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -1094,4 +1094,33 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->disableErrorHandlerMiddleware();
         $this->get('/foo');
     }
+
+    /**
+     * tests getting a secure action while passing a query string
+     *
+     * @return void
+     * @dataProvider methodsProvider
+     */
+    public function testSecureWithQueryString($method)
+    {
+        $this->enableSecurityToken();
+        $this->{$method}('/posts/securePost/?ids[]=1&ids[]=2');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * data provider for HTTP methods
+     *
+     * @return array
+     */
+    public function methodsProvider()
+    {
+        return [
+            'GET' => ['get'],
+            'POST' => ['post'],
+            'PATCH' => ['patch'],
+            'PUT' => ['put'],
+            'DELETE' => ['delete'],
+        ];
+    }
 }


### PR DESCRIPTION
This PR re-builds the URL that the user passes in IntegrationTestCase tests as a ServerRequest, then extracts the url via `->getRequestTarget`. This reliably creates the query string so that url the security tokens use match the one expected in SecurityComponent.

I had originally thought this was an issue with the SecurityComponent, but since the FormHelper generates the URL for the token the same way SecurityComponent expects it (with encoded query string args), it should be fine.