### PR TITLE
Paginator sort links should go to page 1 when changing order

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -471,7 +471,7 @@ class PaginatorHelper extends Helper
         }
 
         $url = array_merge(
-            ['sort' => $key, 'direction' => $dir],
+            ['sort' => $key, 'direction' => $dir, 'page' => 1],
             $url,
             ['order' => null]
         );

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -840,12 +840,12 @@ class PaginatorHelperTest extends TestCase
     public function urlGenerationResetsToPage1Provider()
     {
         return [
-            'Sorting the field currently sorted asc' => [
+            'Sorting the field currently sorted asc, asc' => [
                 'name',
                 ['sort' => 'name', 'direction' => 'asc'],
                 '<a class="asc" href="/index?sort=name&amp;direction=asc">Name</a>'
             ],
-            'Sorting the field currently sorted desc' => [
+            'Sorting the field currently sorted asc, desc' => [
                 'name',
                 ['sort' => 'name', 'direction' => 'desc'],
                 '<a class="asc" href="/index?sort=name&amp;direction=desc">Name</a>'

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -811,6 +811,59 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Verify that sort links always result in a url that is page 1 (page not
+     * present in the url)
+     *
+     * @param string $field
+     * @param array $options
+     * @param string $expected
+     * @dataProvider urlGenerationResetsToPage1Provider
+     */
+    public function testUrlGenerationResetsToPage1($field, $options, $expected)
+    {
+        $this->Paginator->request = $this->Paginator->request
+            ->withParam('paging.Article.page', 2)
+            ->withParam('paging.Article.sort', 'name')
+            ->withParam('paging.Article.direction', 'asc');
+        $result = $this->Paginator->sort($field, null, ['url' => $options]);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Returns data sets of:
+     *  * the name of the field being sorted on
+     *  * url paramters to pass to paginator sort
+     *  * expected result as a string
+     *
+     * @return array
+     */
+    public function urlGenerationResetsToPage1Provider()
+    {
+        return [
+            'Sorting the field currently sorted asc' => [
+                'name',
+                ['sort' => 'name', 'direction' => 'asc'],
+                '<a class="asc" href="/index?sort=name&amp;direction=asc">Name</a>'
+            ],
+            'Sorting the field currently sorted desc' => [
+                'name',
+                ['sort' => 'name', 'direction' => 'desc'],
+                '<a class="asc" href="/index?sort=name&amp;direction=desc">Name</a>'
+            ],
+            'Sorting other asc' => [
+                'other',
+                ['sort' => 'other', 'direction' => 'asc'],
+                '<a href="/index?sort=other&amp;direction=asc">Other</a>'
+            ],
+            'Sorting other desc' => [
+                'other',
+                ['sort' => 'other', 'direction' => 'desc'],
+                '<a href="/index?sort=other&amp;direction=desc">Other</a>'
+            ]
+        ];
+    }
+
+    /**
      * test URL generation with prefix routes
      *
      * @return void

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -842,7 +842,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('name', null, ['url' => $options]);
         $expected = [
-            'a' => ['href' => '/members/posts/index?page=2&amp;sort=name&amp;direction=asc'],
+            'a' => ['href' => '/members/posts/index?sort=name&amp;direction=asc'],
             'Name',
             '/a'
         ];
@@ -951,7 +951,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('name');
         $expected = [
-            'a' => ['href' => '/posts/index?article%5Bpage%5D=3&amp;article%5Bsort%5D=name&amp;article%5Bdirection%5D=asc'],
+            'a' => ['href' => '/posts/index?article%5Bsort%5D=name&amp;article%5Bdirection%5D=asc'],
             'Name',
             '/a'
         ];


### PR DESCRIPTION
When looking at page n of a  paginated index - the sort links generated by the paginator component keep the page arg, wheras it'd be more logical to always go to page one. On small data sets it won't be noticable/make any difference, on large data sets this behavior is confusing. 

## Example

After following the blog tutorial create a bunch of articles with random titles.

```
truncate articles;

delimiter //
CREATE PROCEDURE createArticles(num INT)
    BEGIN
        SET @i = 0;
        REPEAT
            SET @i = @i + 1;
            INSERT INTO articles (title,body,created) VALUES ('The title', 'This is the article body.', NOW());
        UNTIL @i > num END REPEAT;
    END
    //

delimiter ;
CALL createArticles(1000);
DROP PROCEDURE createArticles;

-- Randomize titles
UPDATE articles set title = CONCAT('RANDOM ', RAND() * 1000);
```

Sort by any column and use page links to arrive at e.g. 

http://cake.local:8765/articles?page=5&sort=title&direction=asc
![screenshot from 2018-03-25 16-21-32](https://user-images.githubusercontent.com/33387/37876136-9998ea8a-3048-11e8-8b86-8da23d2275de.png)

Then use the sort header to sort by a different field - the page parameter is preserved:

http://cake.local:8765/articles?page=5&sort=id&direction=asc
![screenshot from 2018-03-25 16-21-12](https://user-images.githubusercontent.com/33387/37876135-8ea41eb0-3048-11e8-85e7-545f355c67d2.png)

http://cake.local:8765/articles?sort=id&direction=asc
![screenshot from 2018-03-25 16-22-39](https://user-images.githubusercontent.com/33387/37876145-c08e9bf8-3048-11e8-8c07-b34173a989d4.png)

This PR removes the step in the middle.

Why? 

Well, if you're looking at a paginated index and changing the sort order it's most likely because the changed sort allows you to find the records you weren't able to find with the sort order on a different field/direction - it doesn't make any sense to persist the page parameter when changing sort, as the records shown are then effectively random.