### PR TITLE
using JSON_UNESCAPED_UNICODE with json_encode()

### DIFF
--- a/src/Database/README.md
+++ b/src/Database/README.md
@@ -55,7 +55,7 @@ directly in the options array:
 use Cake\Database\Connection;
 
 $connection = new Connection([
-	'driver' => 'Cake\Database\Driver\Sqlite'
+	'driver' => 'Cake\Database\Driver\Sqlite',
 	'database' => '/path/to/file.db'
 ]);
 ```

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1292,7 +1292,7 @@ trait EntityTrait
      */
     public function __toString()
     {
-        return json_encode($this, JSON_PRETTY_PRINT);
+        return json_encode($this, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
It is useful for debug

```
{
    "id": 1,
    "word": "\u30c6\u30b9\u30c81",
    "created": "2018-03-29T01:41:58",
    "modified": "2018-03-29T01:41:58"
}
```

↓

```
{
    "id": 1,
    "word": "テスト1",
    "created": "2018-03-29T01:41:58",
    "modified": "2018-03-29T01:41:58"
}
```