### PR TITLE
Don't display duplicate route errors when a route class is missing.

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -71,9 +71,10 @@ abstract class BaseApplication implements ConsoleApplicationInterface, HttpAppli
     public function routes($routes)
     {
         if (!Router::$initialized) {
-            require $this->configDir . '/routes.php';
             // Prevent routes from being loaded again
             Router::$initialized = true;
+
+            require $this->configDir . '/routes.php';
         }
     }
 

--- a/tests/test_app/invalid_routes/routes.php
+++ b/tests/test_app/invalid_routes/routes.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Test routes file with routes that trigger a missing route class error.
+ * Application requests should have InvalidArgument error rendered.
+ */
+$routes->setRouteClass('DoesNotExist');
+$routes->get('/', ['controller' => 'Pages']);


### PR DESCRIPTION
Previously if an application's routes used a route class that didn't exist, Router::$initialized would not be set, so the error page rendering would re-load the routes, and if the routes defined *before* the missing route class were also named routes, a duplicate route error would be displayed instead of the original error.

By initializing Router we avoid that issue.

Refs #11876