### PR TITLE
Fast opt-in check for deprecations of CakePHP

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -288,6 +288,9 @@ if (!function_exists('deprecationWarning')) {
         if (!(error_reporting() & E_USER_DEPRECATED)) {
             return;
         }
+        if (!defined('CAKEPHP_DEPRECATIONS') || !CAKEPHP_DEPRECATIONS) {
+            return;
+        }
 
         $trace = debug_backtrace();
         if (isset($trace[$stackFrame])) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,6 +49,9 @@ define('APP', TEST_APP . 'TestApp' . DS);
 define('WWW_ROOT', TEST_APP . 'webroot' . DS);
 define('CONFIG', TEST_APP . 'config' . DS);
 
+// enable cakephp deprecation warnings in tests
+define('CAKEPHP_DEPRECATIONS', true);
+
 //@codingStandardsIgnoreStart
 @mkdir(LOGS);
 @mkdir(SESSIONS);


### PR DESCRIPTION
I would like to discuss a very fast way of opt-in checking the deprecation warnings of CakePHP.

### Current status quo
It will throw them until you globally turn of E_USER_DEPRECATED.
Which itself will also turn of all other (either own or from specific vendors) ones.

This itself means in reality:
- Most users will just turn this off forever, especially with the plugin ecosystem not always being super quick with each minor released and having deprecations in them you cannot get rid off.
- This is not helpful, as it only is a pain without any much gain. I am afraid this will reduce the currently nicely working plugin ecosystem and might *scare off* some of the newbies and people freshly checking out the code (you get immediate errors everywhere with a lot of plugins).
- The time around 3.next landing, this is especially painful, as some plugins are not yet upgraded, others you need to know to use "3.next" branch etc. Very confusing, especially if you want to help checking if the next minor framework version is BC and will work fine with your app.

### Proposal
Use this tool as opt-in and use it deliberately to help upgrading parts of the system when there is time and resources. Do not mix this with other deprecation warnings of other parts of the vendor or app namespace, and force those to also hide away.

This means:
- Plugins can stay BC and supporting at least one more version (e.g. 3.5 and 3.6 instead of just 3.6), easing the pain for this ecosystem. Most could work with more than just the latest.
- No one is forced to always upgrade immediately. There is neither business value or any other value other than being "4.x ready" - which you wouldnt need to spend immediate resources on.
- You dont scare off people with something that shouldnt scare off anyone. This is and should be a optional thing to do. Most do not quite know how to turn off the global deprecations either.

We can enable the constant by default in cakephp/app bootstrap and document how to activate it for existing projects.

### Alternative
We could also opt-out by default - but this would mean all plugins then would also have to add this constant in their testing suite if they want to stay compatible with a previous framework version.

### Why const
I used a const as this is a good "application only" way of introducing a flag which also has probably the quickest speed (over Configure etc). We sure don't want much performance issues around this issue.

For test suites, the define statement can have a getenv() part to read from config here.

--- 

I am bringing this up specifically to discuss the pros and cons here of the current opt-out which will soon land in stable master.