### PR TITLE
Fix toDatabase() to work with non-DateTimeImmutable properly

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -18,6 +18,7 @@ use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
@@ -141,6 +142,9 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
         if ($this->dbTimezone !== null
             && $this->dbTimezone->getName() !== $value->getTimezone()->getName()
         ) {
+            if (!$value instanceof DateTimeImmutable) {
+                $value = clone $value;
+            }
             $value = $value->setTimezone($this->dbTimezone);
         }
 

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -146,9 +146,11 @@ class DateTimeTypeTest extends TestCase
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2013-08-12 15:16:17', $result);
 
+        $tz = $date->getTimezone();
         $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->assertEquals($tz, $date->getTimezone());
 
         $this->type->setTimezone(new DateTimeZone('Asia/Kolkata'));
         $result = $this->type->toDatabase($date, $this->driver);


### PR DESCRIPTION
I think it would be better to not change the given DateTime objects. 