### PR TITLE
Adding whereNotNull() and whereNull() to the Query object

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -882,7 +882,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Convenience method that adds a NOT NULL condition to the query
+     * Adds a NOT NULL or IS NULL expression to the query
      *
      * @param array $fields A list of fields that should be not null
      * @param bool $isNull Toggles between NOT NULL and NULL checks
@@ -894,9 +894,9 @@ class Query implements ExpressionInterface, IteratorAggregate
             $this->where(function ($exp) use ($condition, $isNull) {
                 if ($isNull) {
                     return $exp->isNull($condition);
-                } else {
-                    return $exp->isNotNull($condition);
                 }
+
+                return $exp->isNotNull($condition);
             });
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -882,47 +882,45 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Adds a NOT NULL or IS NULL expression to the query
-     *
-     * @param array $fields A list of fields that should be not null
-     * @param bool $isNull Toggles between NOT NULL and NULL checks
-     * @return $this
-     */
-    protected function whereNullOrNotNull($fields, $isNull = true)
-    {
-        foreach ($fields as $condition) {
-            $this->where(function ($exp) use ($condition, $isNull) {
-                if ($isNull) {
-                    return $exp->isNull($condition);
-                }
-
-                return $exp->isNotNull($condition);
-            });
-        }
-
-        return $this;
-    }
-
-    /**
      * Convenience method that adds a NOT NULL condition to the query
      *
-     * @param array $fields A list of fields that should be not null
+     * @param array|string|\Cake\Database\ExpressionInterface $fields A single field or expressions or a list of them that should be not null
      * @return $this
      */
     public function whereNotNull($fields)
     {
-        return $this->whereNullOrNotNull($fields, false);
+        if (!is_array($fields)) {
+            $fields = [$fields];
+        }
+
+        $exp = $this->newExpr();
+
+        foreach ($fields as $field) {
+            $exp->isNotNull($field);
+        }
+
+        return $this->where($exp);
     }
 
     /**
      * Convenience method that adds a IS NULL condition to the query
      *
-     * @param array $fields A list of fields that should be not null
+     * @param array|string|\Cake\Database\ExpressionInterface $fields A single field or expressions or a list of them that should be null
      * @return $this
      */
     public function whereNull($fields)
     {
-        return $this->whereNullOrNotNull($fields, true);
+        if (!is_array($fields)) {
+            $fields = [$fields];
+        }
+
+        $exp = $this->newExpr();
+
+        foreach ($fields as $field) {
+           $exp->isNull($field);
+        }
+
+        return $this->where($exp);
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -882,6 +882,50 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Convenience method that adds a NOT NULL condition to the query
+     *
+     * @param array $fields A list of fields that should be not null
+     * @param bool $isNull Toggles between NOT NULL and NULL checks
+     * @return $this
+     */
+    protected function whereNullOrNotNull($fields, $isNull = true)
+    {
+        foreach ($fields as $condition) {
+            $this->where(function ($exp) use ($condition, $isNull) {
+                if ($isNull) {
+                    return $exp->isNull($condition);
+                } else {
+                    return $exp->isNotNull($condition);
+                }
+            });
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convenience method that adds a NOT NULL condition to the query
+     *
+     * @param array $fields A list of fields that should be not null
+     * @return $this
+     */
+    public function whereNotNull($fields)
+    {
+        return $this->whereNullOrNotNull($fields, false);
+    }
+
+    /**
+     * Convenience method that adds a IS NULL condition to the query
+     *
+     * @param array $fields A list of fields that should be not null
+     * @return $this
+     */
+    public function whereNull($fields)
+    {
+        return $this->whereNullOrNotNull($fields, true);
+    }
+
+    /**
      * Adds an IN condition or set of conditions to be used in the WHERE clause for this
      * query.
      *

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -917,7 +917,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         $exp = $this->newExpr();
 
         foreach ($fields as $field) {
-           $exp->isNull($field);
+            $exp->isNull($field);
         }
 
         return $this->where($exp);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -774,6 +774,15 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(5, $result);
         $result->closeCursor();
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('menu_link_trees')
+            ->whereNull('parent_id')
+            ->execute();
+        $this->assertCount(5, $result);
+        $result->closeCursor();
     }
 
     /**
@@ -799,6 +808,15 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('menu_link_trees')
             ->whereNotNull($this->connection->newQuery()->select('parent_id'))
+            ->execute();
+        $this->assertCount(13, $result);
+        $result->closeCursor();
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('menu_link_trees')
+            ->whereNotNull('parent_id')
             ->execute();
         $this->assertCount(13, $result);
         $result->closeCursor();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -765,6 +765,15 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(5, $result);
         $result->closeCursor();
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('menu_link_trees')
+            ->whereNull($this->connection->newQuery()->select('parent_id'))
+            ->execute();
+        $this->assertCount(5, $result);
+        $result->closeCursor();
     }
 
     /**
@@ -781,6 +790,15 @@ class QueryTest extends TestCase
             ->select(['id', 'parent_id'])
             ->from('menu_link_trees')
             ->whereNotNull(['parent_id'])
+            ->execute();
+        $this->assertCount(13, $result);
+        $result->closeCursor();
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('menu_link_trees')
+            ->whereNotNull($this->connection->newQuery()->select('parent_id'))
             ->execute();
         $this->assertCount(13, $result);
         $result->closeCursor();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -28,7 +28,13 @@ use Cake\TestSuite\TestCase;
 class QueryTest extends TestCase
 {
 
-    public $fixtures = ['core.articles', 'core.authors', 'core.comments', 'core.profiles'];
+    public $fixtures = [
+        'core.articles',
+        'core.authors',
+        'core.comments',
+        'core.profiles',
+        'core.menu_link_trees'
+    ];
 
     public $autoFixtures = false;
 
@@ -739,6 +745,44 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(1, $result);
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $result->closeCursor();
+    }
+
+    /**
+     * Tests Query::whereNull()
+     *
+     * @return void
+     */
+    public function testSelectWhereNull()
+    {
+        $this->loadFixtures('MenuLinkTrees');
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id', 'parent_id'])
+            ->from('menu_link_trees')
+            ->whereNull(['parent_id'])
+            ->execute();
+        $this->assertCount(5, $result);
+        $result->closeCursor();
+    }
+
+    /**
+     * Tests Query::whereNotNull()
+     *
+     * @return void
+     */
+    public function testSelectWhereNotNull()
+    {
+        $this->loadFixtures('MenuLinkTrees');
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id', 'parent_id'])
+            ->from('menu_link_trees')
+            ->whereNotNull(['parent_id'])
+            ->execute();
+        $this->assertCount(13, $result);
         $result->closeCursor();
     }
 


### PR DESCRIPTION
Convenience methods for NOT NULL and IS NULL expressions.

Honestly I needed to lookup the expression way of doing this almost every time I needed it because I couldn't remember it. 😆 The convenience methods are pretty self explaining and easy to discover if you're using an IDE.

```php
$this->find()
    ->whereNotNull(['parent_id'])
    ->all();
```

```php
$this->find()
    ->whereNull(['parent_id'])
    ->all();
```

This is also pretty much in line with the recent additions of `inList()`.