### PR TITLE
session write & close

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -339,6 +339,19 @@ class Session
     }
 
     /**
+     * Write datas and close the session
+     * @return bool True if session was started
+     */
+    public function close()
+    {
+        if ($this->_started) {
+            return true;
+        }
+
+        return session_write_close();
+    }
+
+    /**
      * Determine if Session has already been started.
      *
      * @return bool True if session has been started.


### PR DESCRIPTION
The php session only allow one process at a time to avoid "session_write" conflict.

The Session::close() allow to write datas and close the session, permit others ajax to run (or multiple loading page)