### PR TITLE
Patch issue #11415

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -609,19 +609,6 @@ class Route
         unset($context['params']);
         $hostOptions = array_intersect_key($url, $context);
 
-        // Check for properties that will cause an
-        // absolute url. Copy the other properties over.
-        if (isset($hostOptions['_scheme']) ||
-            isset($hostOptions['_port']) ||
-            isset($hostOptions['_host'])
-        ) {
-            $hostOptions += $context;
-
-            if ($hostOptions['_port'] == $context['_port']) {
-                unset($hostOptions['_port']);
-            }
-        }
-
         // Apply the _host option if possible
         if (isset($this->options['_host'])) {
             if (!isset($hostOptions['_host']) && strpos($this->options['_host'], '*') === false) {
@@ -634,6 +621,19 @@ class Route
             // The host did not match the route preferences
             if (!$this->hostMatches($hostOptions['_host'])) {
                 return false;
+            }
+        }
+
+        // Check for properties that will cause an
+        // absolute url. Copy the other properties over.
+        if (isset($hostOptions['_scheme']) ||
+            isset($hostOptions['_port']) ||
+            isset($hostOptions['_host'])
+        ) {
+            $hostOptions += $context;
+
+            if (getservbyname($hostOptions['_scheme'], 'tcp') === $hostOptions['_port']) {
+                unset($hostOptions['_port']);
             }
         }
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -564,12 +564,14 @@ class RouteTest extends TestCase
             ['controller' => 'posts', 'action' => 'index', '_host' => 'example.com'],
             $context
         );
+        // Http has port 80 as default, do not include it in the url
         $this->assertEquals('http://example.com/posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'posts', 'action' => 'index', '_scheme' => 'webcal'],
             $context
         );
+        // Webcal is not on port 80 by default, include it in url
         $this->assertEquals('webcal://foo.com:80/posts/index', $result);
 
         $result = $route->match(
@@ -614,6 +616,7 @@ class RouteTest extends TestCase
             ],
             $context
         );
+        // Https scheme is not on port 8080 by default, include the port
         $this->assertEquals('https://example.com:8080/dir/posts/index', $result);
     }
 
@@ -690,6 +693,7 @@ class RouteTest extends TestCase
             '_host' => 'foo.example.com',
             '_port' => 8080
         ]);
+        // When the port and scheme in the context are not present in the original url, they should be added
         $this->assertSame('https://foo.example.com:8080/fallback', $result);
     }
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -570,7 +570,7 @@ class RouteTest extends TestCase
             ['controller' => 'posts', 'action' => 'index', '_scheme' => 'webcal'],
             $context
         );
-        $this->assertEquals('webcal://foo.com/posts/index', $result);
+        $this->assertEquals('webcal://foo.com:80/posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'posts', 'action' => 'index', '_port' => '8080'],
@@ -584,6 +584,25 @@ class RouteTest extends TestCase
         );
         $this->assertEquals('/dir/posts/index', $result);
 
+        $result = $route->match(
+            [
+                'controller' => 'posts',
+                'action' => 'index',
+                '_port' => '8080',
+                '_host' => 'example.com',
+                '_scheme' => 'https',
+                '_base' => '/dir'
+            ],
+            $context
+        );
+        $this->assertEquals('https://example.com:8080/dir/posts/index', $result);
+
+        $context = [
+            '_host' => 'foo.com',
+            '_scheme' => 'http',
+            '_port' => 8080,
+            '_base' => ''
+        ];
         $result = $route->match(
             [
                 'controller' => 'posts',
@@ -662,6 +681,16 @@ class RouteTest extends TestCase
             '_host' => 'foo.example.com'
         ]);
         $this->assertSame('http://foo.example.com/fallback', $result);
+
+        $result = $route->match([
+            'controller' => 'Articles',
+            'action' => 'index',
+        ], [
+            '_scheme' => 'https',
+            '_host' => 'foo.example.com',
+            '_port' => 8080
+        ]);
+        $this->assertSame('https://foo.example.com:8080/fallback', $result);
     }
 
     /**


### PR DESCRIPTION
Fixes issue #11415 

Two things have been changed:
- When route is matched based on `_host`, `_port` and `_scheme` are copied from context as well, when they are not defined.
- Port is only omitted when it is the default port for the service (`_scheme`), not when it matches the context.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
