### PR TITLE
Set session save handler when the engine is swapped.

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -221,10 +221,7 @@ class Session
         if (!empty($config['handler']['engine'])) {
             $class = $config['handler']['engine'];
             unset($config['handler']['engine']);
-            $engine = $this->engine($class, $config['handler']);
-            if (!headers_sent()) {
-                session_set_save_handler($engine, false);
-            }
+            $this->engine($class, $config['handler']);
         }
 
         $this->_lifetime = ini_get('session.gc_maxlifetime');
@@ -271,6 +268,9 @@ class Session
             throw new InvalidArgumentException(
                 'The chosen SessionHandler does not implement SessionHandlerInterface, it cannot be used as an engine.'
             );
+        }
+        if (!headers_sent()) {
+            session_set_save_handler($handler, false);
         }
 
         return $this->_engine = $handler;


### PR DESCRIPTION
No tests were changed as there isn't a way to inspect the session save handler state :cry:

Refs #11895 