### PR TITLE
Deprecate serving files by relative paths.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -16,6 +16,7 @@ namespace Cake\Http;
 
 use Cake\Core\Configure;
 use Cake\Filesystem\File;
+use Cake\Filesystem\Folder;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Cookie\CookieInterface;
@@ -2587,8 +2588,17 @@ class Response implements ResponseInterface
             throw new NotFoundException(__d('cake', 'The requested file contains `..` and will not be read.'));
         }
         if (!is_file($path)) {
-            deprecationWarning('Using non-absolute paths with Response::file() and withFile() is deprecated.');
+            deprecationWarning(
+                'Automatic prefixing of paths with `APP` by `Response::file()` and `withFile()` is deprecated. ' .
+                'Use absolute paths instead.'
+            );
             $path = APP . $path;
+        }
+        if (!Folder::isAbsolute($path)) {
+            deprecationWarning(
+                'Serving files via `file()` or `withFile()` using relative paths is deprecated.' .
+                'Use an absolute path instead.'
+            );
         }
 
         $file = new File($path);


### PR DESCRIPTION
Relative paths assume that cwd is 'safe'. Instead we should require people to be more explicit in their paths.

Refs #11921
Refs #11926
