### PR TITLE
Change default return value of ServerRequest::getParam() to false.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -2081,10 +2081,10 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Safely access the values in $this->params.
      *
      * @param string $name The name or dotted path to parameter.
-     * @param mixed $default The default value if `$name` is not set. Default `false`.
+     * @param mixed $default The default value if `$name` is not set. Default `null`.
      * @return mixed
      */
-    public function getParam($name, $default = false)
+    public function getParam($name, $default = null)
     {
         return Hash::get($this->params, $name, $default);
     }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -2536,7 +2536,7 @@ class ServerRequestTest extends TestCase
                 'zero' => '0',
             ]
         ]);
-        $this->assertFalse($request->getParam('not_set'));
+        $this->assertNull($request->getParam('not_set'));
         $this->assertTrue($request->getParam('admin'));
         $this->assertSame(1, $request->getParam('truthy'));
         $this->assertSame('posts', $request->getParam('controller'));
@@ -2560,7 +2560,7 @@ class ServerRequestTest extends TestCase
                     'zero' => '0',
                 ]
             ]);
-            $this->assertFalse($request->param('not_set'));
+            $this->assertNull($request->param('not_set'));
             $this->assertTrue($request->param('admin'));
             $this->assertSame(1, $request->param('truthy'));
             $this->assertSame('posts', $request->param('controller'));
@@ -2683,9 +2683,6 @@ class ServerRequestTest extends TestCase
                 'zero' => '0',
             ]
         ]);
-        $this->deprecated(function () use ($expected, $request, $toRead) {
-            $this->assertSame($expected, $request->param($toRead));
-        });
         $this->assertSame($expected, $request->getParam($toRead));
     }
 
@@ -2704,8 +2701,8 @@ class ServerRequestTest extends TestCase
         ]);
         $this->assertSame('Articles', $request->getParam('controller', 'default'));
         $this->assertSame('default', $request->getParam('null', 'default'));
-        $this->assertNull($request->getParam('unset', null));
-        $this->assertFalse($request->getParam('unset'));
+        $this->assertFalse($request->getParam('unset', false));
+        $this->assertNull($request->getParam('unset'));
     }
 
     /**
@@ -2734,7 +2731,7 @@ class ServerRequestTest extends TestCase
             ],
             [
                 'does_not_exist',
-                false,
+                null,
             ],
             [
                 'admin',
@@ -2768,7 +2765,7 @@ class ServerRequestTest extends TestCase
         );
 
         $request = $request->withParam('Post.null', null);
-        $this->assertFalse($request->getParam('Post.null'), 'default value should be used.');
+        $this->assertNull($request->getParam('Post.null'), 'default value should be used.');
 
         $request = $request->withParam('Post.false', false);
         $this->assertFalse($request->getParam('Post.false'));
@@ -3359,14 +3356,14 @@ XML;
         ]);
         $result = $request->withParam('action', 'view');
         $this->assertNotSame($result, $request, 'New instance should be made');
-        $this->assertFalse($request->getParam('action'), 'No side-effect on original');
+        $this->assertNull($request->getParam('action'), 'No side-effect on original');
         $this->assertSame('view', $result->getParam('action'));
 
         $result = $request->withParam('action', 'index')
             ->withParam('plugin', 'DebugKit')
             ->withParam('prefix', 'Admin');
         $this->assertNotSame($result, $request, 'New instance should be made');
-        $this->assertFalse($request->getParam('action'), 'No side-effect on original');
+        $this->assertNull($request->getParam('action'), 'No side-effect on original');
         $this->assertSame('index', $result->getParam('action'));
         $this->assertSame('DebugKit', $result->getParam('plugin'));
         $this->assertSame('Admin', $result->getParam('prefix'));


### PR DESCRIPTION
Closes #11893.