### PR TITLE
Fix path in FileTest

### DIFF
--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -66,7 +66,7 @@ class FileTest extends TestCase
      */
     public function testBasic()
     {
-        $file = CORE_PATH . DS . 'LICENSE.txt';
+        $file = CORE_PATH . 'LICENSE.txt';
 
         $this->File = new File($file, false);
 


### PR DESCRIPTION
CORE_PATH already ends with a DS (define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS))