### PR TITLE
fix Controller 3.6 deprecated message from class attribute to method

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -346,7 +346,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
-            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s instead.', $name, $method));
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
 
             return $this->{$method}();
         }


### PR DESCRIPTION
Just makes the deprecated message a little bit more explicit.