### PR TITLE
AuthComponent should only compare paths.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -439,8 +439,8 @@ class AuthComponent extends Component
      */
     protected function _isLoginAction(Controller $controller)
     {
-        $url = $controller->request->getRequestTarget();
-        $url = Router::normalize($url);
+        $uri = $controller->request->getUri();
+        $url = Router::normalize($uri->getPath());
         $loginAction = Router::normalize($this->_config['loginAction']);
 
         return $loginAction === $url;

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -831,6 +831,36 @@ class AuthComponentTest extends TestCase
     }
 
     /**
+     * testNoLoginRedirectForAuthenticatedUser method
+     *
+     * @return void
+     * @triggers Controller.startup $this->Controller
+     */
+    public function testStartupLoginActionIgnoreQueryString()
+    {
+        $request = new ServerRequest([
+            'params' => [
+                'plugin' => null,
+                'controller' => 'auth_test',
+                'action' => 'login'
+            ],
+            'query' => ['redirect' => '/admin/articles'],
+            'url' => '/auth_test/login?redirect=%2Fadmin%2Farticles',
+            'session' => $this->Auth->session
+        ]);
+        $this->Controller->request = $request;
+
+        $this->Auth->session->clear();
+        $this->Auth->setConfig('authenticate', ['Form']);
+        $this->Auth->setConfig('authorize', false);
+        $this->Auth->setConfig('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
+
+        $event = new Event('Controller.startup', $this->Controller);
+        $return = $this->Auth->startup($event);
+        $this->assertNull($return);
+    }
+
+    /**
      * Default to loginRedirect, if set, on authError.
      *
      * @return void

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -879,13 +879,13 @@ class EmailTest extends TestCase
         $this->Email->addAttachments([CORE_PATH . 'config' . DS . 'bootstrap.php']);
         $this->Email->addAttachments([
             'other.txt' => CORE_PATH . 'config' . DS . 'bootstrap.php',
-            'license' => CORE_PATH . 'LICENSE.txt'
+            'license' => CORE_PATH . 'LICENSE'
         ]);
         $expected = [
             'basics.php' => ['file' => CAKE . 'basics.php', 'mimetype' => 'text/plain'],
             'bootstrap.php' => ['file' => CORE_PATH . 'config' . DS . 'bootstrap.php', 'mimetype' => 'text/x-php'],
             'other.txt' => ['file' => CORE_PATH . 'config' . DS . 'bootstrap.php', 'mimetype' => 'text/x-php'],
-            'license' => ['file' => CORE_PATH . 'LICENSE.txt', 'mimetype' => 'text/plain']
+            'license' => ['file' => CORE_PATH . 'LICENSE', 'mimetype' => 'text/plain']
         ];
         $this->assertSame($expected, $this->Email->getAttachments());
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
request->getRequestTarget() returns query string data in addition to the path. This causes comparison issues with loginAction that is generally path only.

Refs #11943