### PR TITLE
Fix mismatched URL comparisions in SecurityComponent.

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -22,6 +22,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 
@@ -378,14 +379,21 @@ class SecurityComponent extends Component
      */
     protected function _hashParts(Controller $controller)
     {
-        $fieldList = $this->_fieldsList($controller->request->getData());
-        $unlocked = $this->_sortedUnlocked($controller->request->getData());
+        $request = $controller->getRequest();
+
+        // Start the session to ensure we get the correct session id.
+        $session = $request->getSession();
+        $session->start();
+
+        $data = $request->getData();
+        $fieldList = $this->_fieldsList($data);
+        $unlocked = $this->_sortedUnlocked($data);
 
         return [
-            $controller->request->getRequestTarget(),
+            Router::url($request->getRequestTarget()),
             serialize($fieldList),
             $unlocked,
-            session_id(),
+            $session->id()
         ];
     }
 

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -106,8 +106,6 @@ class ErrorHandler extends BaseErrorHandler
      *
      * Template method of BaseErrorHandler.
      *
-     * Only when debug > 2 will a formatted error be displayed.
-     *
      * @param array $error An array of error data.
      * @param bool $debug Whether or not the app is in debug mode.
      * @return void


### PR DESCRIPTION
When SecurityComponent was updated to use new request methods, I forgot to take into account base URL paths. In order to get those applied, we can use Router::url(). This ensures we get the same urls that FormHelper creates. I've also fixed an issue where if the session hadn't already been started secured forms would fail as session_id() would return '' instead of the actual session id.

Refs #11932 
Refs #11944