### PR TITLE
Add ServerRequest::getPath().

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -2347,21 +2347,18 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Get the path of current request.
      *
-     * The returned value does not contain leading slash and is identical to
-     * the deprecated ServerRequest::$url property.
-     *
      * @return string
      * @since 3.6.1
      */
     public function getPath()
     {
-        $path = $this->uri->getPath();
-
-        if ($this->requestTarget !== null) {
-            list($path) = explode('?', $this->requestTarget);
+        if ($this->requestTarget === null) {
+            return $this->uri->getPath();
         }
 
-        return substr($path, 1);
+        list($path) = explode('?', $this->requestTarget);
+
+        return $path;
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -230,7 +230,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         'query' => ['get' => 'getQuery()', 'set' => 'withQueryParams()'],
         'params' => ['get' => 'getParam()', 'set' => 'withParam()'],
         'cookies' => ['get' => 'getCookie()', 'set' => 'withCookieParams()'],
-        'url' => ['get' => 'getRequestTarget()', 'set' => 'withRequestTarget()'],
+        'url' => ['get' => 'getPath()', 'set' => 'withRequestTarget()'],
         'base' => ['get' => 'getAttribute("base")', 'set' => 'withAttribute("base")'],
         'webroot' => ['get' => 'getAttribute("webroot")', 'set' => 'withAttribute("webroot")'],
         'here' => ['get' => 'getRequestTarget()', 'set' => 'withRequestTarget()'],
@@ -2342,6 +2342,26 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return $target;
+    }
+
+    /**
+     * Get the path of current request.
+     *
+     * The returned value does not contain leading slash and is identical to
+     * the deprecated ServerRequest::$url property.
+     *
+     * @return string
+     * @since 3.6.1
+     */
+    public function getPath()
+    {
+        $path = $this->uri->getPath();
+
+        if ($this->requestTarget !== null) {
+            list($path) = explode('?', $this->requestTarget);
+        }
+
+        return substr($path, 1);
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -212,6 +212,23 @@ class ServerRequestTest extends TestCase
     }
 
     /**
+     * Test getPath().
+     *
+     * @return void
+     */
+    public function testGetPath()
+    {
+        $request = new ServerRequest(['url' => '']);
+        $this->assertSame('', $request->getPath());
+
+        $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
+        $this->assertEquals('some/path', $request->getPath());
+
+        $request = $request->withRequestTarget('/foo/bar?x=y');
+        $this->assertEquals('foo/bar', $request->getPath());
+    }
+
+    /**
      * Test addParams() method
      *
      * @group deprecated

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -219,13 +219,13 @@ class ServerRequestTest extends TestCase
     public function testGetPath()
     {
         $request = new ServerRequest(['url' => '']);
-        $this->assertSame('', $request->getPath());
+        $this->assertSame('/', $request->getPath());
 
         $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
-        $this->assertEquals('some/path', $request->getPath());
+        $this->assertEquals('/some/path', $request->getPath());
 
         $request = $request->withRequestTarget('/foo/bar?x=y');
-        $this->assertEquals('foo/bar', $request->getPath());
+        $this->assertEquals('/foo/bar', $request->getPath());
     }
 
     /**


### PR DESCRIPTION
`ServerRequest::getRequestTarget()` is not a valid alternative for deprecated
`ServerRequest::$url` as value returned by the former includes "/" prefix and
request query string.