### PR TITLE
Fix handling of base paths.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -633,7 +633,7 @@ class Router
         }
 
         if (empty($url)) {
-            $output = isset($here) ? $here : $base . '/';
+            $output = $base . (isset($here) ? $here : '/');
             if ($full) {
                 $output = static::fullBaseUrl() . $output;
             }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -61,7 +61,7 @@ class RouterTest extends TestCase
      *
      * @return void
      */
-    public function testbaseUrl()
+    public function testBaseUrl()
     {
         $this->assertRegExp('/^http(s)?:\/\//', Router::url('/', true));
         $this->assertRegExp('/^http(s)?:\/\//', Router::url(null, true));
@@ -73,7 +73,7 @@ class RouterTest extends TestCase
      *
      * @return void
      */
-    public function testfullBaseURL()
+    public function testFullBaseURL()
     {
         Router::fullBaseUrl('http://example.com');
         $this->assertEquals('http://example.com/', Router::url('/', true));
@@ -571,14 +571,17 @@ class RouterTest extends TestCase
                 'plugin' => null,
                 'controller' => 'subscribe',
             ],
-            'url' => '/magazine/',
+            'url' => '/subscribe',
             'base' => '/magazine',
             'webroot' => '/magazine/'
         ]);
         Router::pushRequest($request);
 
         $result = Router::url();
-        $this->assertEquals('/magazine/', $result);
+        $this->assertEquals('/magazine/subscribe', $result);
+
+        $result = Router::url([]);
+        $this->assertEquals('/magazine/subscribe', $result);
 
         $result = Router::url('/');
         $this->assertEquals('/magazine/', $result);
@@ -933,7 +936,7 @@ class RouterTest extends TestCase
             ],
             'webroot' => '/magazine/',
             'base' => '/magazine',
-            'url' => '/magazine/admin/subscriptions/edit/1',
+            'url' => '/admin/subscriptions/edit/1',
         ]);
         Router::setRequestInfo($request);
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -70,7 +70,7 @@ class UrlHelperTest extends TestCase
      *
      * @return void
      */
-    public function testUrlConversion()
+    public function testBuildUrlConversion()
     {
         Router::connect('/:controller/:action/*');
 
@@ -105,9 +105,36 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * ensure that build factors in base paths.
+     *
      * @return void
      */
-    public function testUrlConversionUnescaped()
+    public function testBuildBasePath()
+    {
+        Router::connect('/:controller/:action/*');
+        $request = new ServerRequest([
+            'params' => [
+                'action' => 'index',
+                'plugin' => null,
+                'controller' => 'subscribe',
+            ],
+            'url' => '/subscribe',
+            'base' => '/magazine',
+            'webroot' => '/magazine/'
+        ]);
+        Router::pushRequest($request);
+
+        $this->assertEquals('/magazine/subscribe', $this->Helper->build());
+        $this->assertEquals(
+            '/magazine/articles/add',
+            $this->Helper->build(['controller' => 'articles', 'action' => 'add'])
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildUrlConversionUnescaped()
     {
         $result = $this->Helper->build('/controller/action/1?one=1&two=2', ['escape' => false]);
         $this->assertEquals('/controller/action/1?one=1&two=2', $result);


### PR DESCRIPTION
When the implementation was switched to use getRequestTarget(), the tests incorrectly handled the base paths for empty urls.

Refs #11958
