### PR TITLE
Don't display deprecation warnings by default.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -149,7 +149,14 @@ abstract class BaseErrorHandler
                 'path' => Debugger::trimPath($file)
             ];
         }
-        $this->_displayError($data, $debug);
+
+        $shouldDisplay = (
+            $error !== 'Deprecated' ||
+            ($error === 'Deprecated' && $this->_options['displayDeprecations'])
+        );
+        if ($shouldDisplay) {
+            $this->_displayError($data, $debug);
+        }
         $this->_logError($log, $data);
 
         return true;

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -97,6 +97,7 @@ class ErrorHandler extends BaseErrorHandler
             'log' => true,
             'trace' => false,
             'exceptionRenderer' => ExceptionRenderer::class,
+            'displayDeprecations' => false,
         ];
         $this->_options = $options + $defaults;
     }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -202,6 +202,59 @@ class ErrorHandlerTest extends TestCase
     }
 
     /**
+     * test deprecation logging only
+     *
+     * @return void
+     */
+    public function testHandleErrorLogDeprecation()
+    {
+        Configure::write('debug', true);
+
+        $errorHandler = new ErrorHandler();
+        $errorHandler->register();
+        $this->_restoreError = true;
+
+        $this->_logger->expects($this->once())
+            ->method('log')
+            ->with(
+                $this->matchesRegularExpression('(notice|debug)'),
+                'Deprecated (16384): Going away! in [' . __FILE__ . ', line ' . (__LINE__ + 4) . ']' . "\n\n"
+            );
+
+        ob_start();
+        trigger_error('Going away!', E_USER_DEPRECATED);
+        $result = ob_get_clean();
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * test deprecation display
+     *
+     * @return void
+     */
+    public function testHandleErrorDisplayDeprecation()
+    {
+        Configure::write('debug', true);
+
+        $errorHandler = new ErrorHandler(['displayDeprecations' => true]);
+        $errorHandler->register();
+        $this->_restoreError = true;
+
+        $this->_logger->expects($this->once())
+            ->method('log')
+            ->with(
+                $this->matchesRegularExpression('(notice|debug)'),
+                'Deprecated (16384): Going away! in [' . __FILE__ . ', line ' . (__LINE__ + 4) . ']' . "\n\n"
+            );
+
+        ob_start();
+        trigger_error('Going away!', E_USER_DEPRECATED);
+        $result = ob_get_clean();
+        $this->assertContains('<pre class="cake-error"', $result);
+        $this->assertContains('Going away!', $result);
+    }
+
+    /**
      * Test that errors go into Cake Log when debug = 0.
      *
      * @return void


### PR DESCRIPTION
Change the default error handling so that deprecations are not displayed by default. Instead deprecations are only logged and can be displayed through an opt-in setting.

I thinks this addresses the opt-in concern, without adding significantly more complexity. It does add another knob, but in order to achieve an 'opt-in, off by default' behavior we need an additional setting.

This also doesn't block/disrupt the changes being done in cakephp/debug_kit#605

Refs #11956
Refs #11889