### PR TITLE
4.x - Database type

### DIFF
--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Database;
 
-use Cake\Database\Type;
 use Cake\Database\Type\BatchCastingInterface;
 use Cake\Database\Type\OptionalConvertInterface;
 
@@ -77,15 +76,7 @@ class FieldTypeConverter
                 continue;
             }
 
-            // Because of backwards compatibility reasons, we won't allow classes
-            // inheriting Type in userland code to be batchable, even if they implement
-            // the interface. Users can implement the TypeInterface instead to have
-            // access to this feature.
-            $batchingType = $type instanceof BatchCastingInterface &&
-                !($type instanceof Type &&
-                strpos(get_class($type), 'Cake\Database\Type') === false);
-
-            if ($batchingType) {
+            if ($type instanceof BatchCastingInterface) {
                 $batchingMap[$k] = $type;
                 continue;
             }

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -109,15 +109,13 @@ class Type
 
     /**
      * Registers a new type identifier and maps it to a fully namespaced classname,
-     * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
      *
-     * @param string|string[]|null $type If string name of type to map, if array list of arrays to be mapped
+     * @param string|string[] $type If string name of type to map, if array list of arrays to be mapped.
      * @param string|\Cake\Database\TypeInterface|null $className The classname or object instance of it to register.
-     * @return array|string|null If $type is null then array with current map, if $className is null string
-     * configured class name for give $type, null otherwise
+     * @return string|null If $className is null string configured class name for give $type, null otherwise
      */
-    public static function map($type = null, $className = null)
+    public static function map($type, $className = null)
     {
         if ($type === null) {
             return static::$_types;
@@ -133,6 +131,16 @@ class Type
 
         static::$_types[$type] = $className;
         unset(static::$_builtTypes[$type]);
+    }
+
+    /**
+     * Get current types map.
+     *
+     * @return array
+     */
+    public static function getMap()
+    {
+        return static::$_types;
     }
 
     /**

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -52,7 +52,7 @@ class Type
     /**
      * Contains a map of type object instances to be reused if needed.
      *
-     * @var \Cake\Database\Type[]
+     * @var \Cake\Database\TypeInterface[]
      */
     protected static $_builtTypes = [];
 
@@ -61,7 +61,7 @@ class Type
      *
      * @param string $name type identifier
      * @throws \InvalidArgumentException If type identifier is unknown
-     * @return \Cake\Database\Type
+     * @return \Cake\Database\TypeInterface
      */
     public static function build($name)
     {
@@ -87,7 +87,9 @@ class Type
     {
         $result = [];
         foreach (static::$_types as $name => $type) {
-            $result[$name] = isset(static::$_builtTypes[$name]) ? static::$_builtTypes[$name] : static::build($name);
+            $result[$name] = isset(static::$_builtTypes[$name])
+                ? static::$_builtTypes[$name]
+                : static::build($name);
         }
 
         return $result;
@@ -97,10 +99,10 @@ class Type
      * Returns a Type object capable of converting a type identified by $name
      *
      * @param string $name The type identifier you want to set.
-     * @param \Cake\Database\Type $instance The type instance you want to set.
+     * @param \Cake\Database\TypeInterface $instance The type instance you want to set.
      * @return void
      */
-    public static function set($name, Type $instance)
+    public static function set($name, TypeInterface $instance)
     {
         static::$_builtTypes[$name] = $instance;
     }
@@ -110,11 +112,8 @@ class Type
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
      *
-     * Deprecated: The usage of $type as \Cake\Database\Type[] is deprecated. Please always use string[] if you pass an array
-     * as first argument.
-     *
-     * @param string|string[]|\Cake\Database\Type[]|null $type If string name of type to map, if array list of arrays to be mapped
-     * @param string|\Cake\Database\Type|null $className The classname or object instance of it to register.
+     * @param string|string[]|null $type If string name of type to map, if array list of arrays to be mapped
+     * @param string|\Cake\Database\TypeInterface|null $className The classname or object instance of it to register.
      * @return array|string|null If $type is null then array with current map, if $className is null string
      * configured class name for give $type, null otherwise
      */

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\TypeInterface;
+use PDO;
+
+/**
+ * Base type class.
+ */
+abstract class BaseType implements TypeInterface
+{
+
+    /**
+     * Identifier name for this type
+     *
+     * @var string|null
+     */
+    protected $_name;
+
+    /**
+     * Constructor
+     *
+     * @param string|null $name The name identifying this type
+     */
+    public function __construct($name = null)
+    {
+        $this->_name = $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBaseType()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toStatement($value, Driver $driver)
+    {
+        if ($value === null) {
+            return PDO::PARAM_NULL;
+        }
+
+        return PDO::PARAM_STR;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function newId()
+    {
+        return null;
+    }
+
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'name' => $this->_name,
+        ];
+    }
+}

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -17,8 +17,6 @@ namespace Cake\Database\Type;
 use Cake\Core\Exception\Exception;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use PDO;
 
 /**
@@ -26,30 +24,8 @@ use PDO;
  *
  * Use to convert binary data between PHP and the database types.
  */
-class BinaryType extends Type implements TypeInterface
+class BinaryType extends BaseType
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * Convert binary data into the database format.

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -17,8 +17,6 @@ namespace Cake\Database\Type;
 use Cake\Core\Exception\Exception;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Utility\Text;
 use PDO;
 
@@ -27,30 +25,8 @@ use PDO;
  *
  * Use to convert binary uuid data between PHP and the database types.
  */
-class BinaryUuidType extends Type implements TypeInterface
+class BinaryUuidType extends BaseType
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * Convert binary uuid data into the database format.

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
@@ -26,30 +24,8 @@ use PDO;
  *
  * Use to convert bool data between PHP and the database types.
  */
-class BoolType extends Type implements TypeInterface, BatchCastingInterface
+class BoolType extends BaseType implements BatchCastingInterface
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * Convert bool data into the database format.

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -30,17 +28,8 @@ use RuntimeException;
  *
  * Use to convert datetime instances to strings & back.
  */
-class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
+class DateTimeType extends BaseType
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
 
     /**
      * The class to use for representing date objects

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
@@ -27,30 +25,8 @@ use RuntimeException;
  *
  * Use to convert decimal data between PHP and the database types.
  */
-class DecimalType extends Type implements TypeInterface, BatchCastingInterface
+class DecimalType extends BaseType implements BatchCastingInterface
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * The class to use for representing number objects

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use PDO;
 use RuntimeException;
@@ -26,8 +24,9 @@ use RuntimeException;
  *
  * Use to convert float/decimal data between PHP and the database types.
  */
-class FloatType extends Type implements TypeInterface, BatchCastingInterface
+class FloatType extends BaseType implements BatchCastingInterface
 {
+
     /**
      * Identifier name for this type.
      *

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
@@ -26,30 +24,8 @@ use PDO;
  *
  * Use to convert integer data between PHP and the database types.
  */
-class IntegerType extends Type implements TypeInterface, BatchCastingInterface
+class IntegerType extends BaseType implements BatchCastingInterface
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * Convert integer data into the database format.

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use Cake\Database\Type\BatchCastingInterface;
 use InvalidArgumentException;
 use PDO;
@@ -26,30 +24,8 @@ use PDO;
  *
  * Use to convert json data between PHP and the database types.
  */
-class JsonType extends Type implements TypeInterface, BatchCastingInterface
+class JsonType extends BaseType implements BatchCastingInterface
 {
-    /**
-     * Identifier name for this type.
-     *
-     * (This property is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @var string|null
-     */
-    protected $_name;
-
-    /**
-     * Constructor.
-     *
-     * (This method is declared here again so that the inheritance from
-     * Cake\Database\Type can be removed in the future.)
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
 
     /**
      * Convert a value data into a JSON string

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -15,8 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type;
-use Cake\Database\TypeInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -25,7 +23,7 @@ use PDO;
  *
  * Use to convert string data between PHP and the database types.
  */
-class StringType extends Type implements OptionalConvertInterface, TypeInterface
+class StringType extends BaseType implements OptionalConvertInterface
 {
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -424,52 +424,6 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * Creates a map of Type converter classes for each of the columns that should
-     * be fetched by this object.
-     *
-     * @deprecated 3.2.0 Not used anymore. Type casting is done at the statement level
-     * @return void
-     */
-    protected function _calculateTypeMap()
-    {
-        deprecationWarning('ResultSet::_calculateTypeMap() is deprecated, and will be removed in 4.0.0.');
-    }
-
-    /**
-     * Returns the Type classes for each of the passed fields belonging to the
-     * table.
-     *
-     * @param \Cake\ORM\Table $table The table from which to get the schema
-     * @param array $fields The fields whitelist to use for fields in the schema.
-     * @return array
-     */
-    protected function _getTypes($table, $fields)
-    {
-        $types = [];
-        $schema = $table->getSchema();
-        $map = array_keys(Type::getMap() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
-        $typeMap = array_combine(
-            $map,
-            array_map(['Cake\Database\Type', 'build'], $map)
-        );
-
-        foreach (['string', 'text'] as $t) {
-            if (get_class($typeMap[$t]) === 'Cake\Database\Type') {
-                unset($typeMap[$t]);
-            }
-        }
-
-        foreach (array_intersect($fields, $schema->columns()) as $col) {
-            $typeName = $schema->getColumnType($col);
-            if (isset($typeMap[$typeName])) {
-                $types[$col] = $typeMap[$typeName];
-            }
-        }
-
-        return $types;
-    }
-
-    /**
      * Helper function to fetch the next result from the statement or
      * seeded results.
      *

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -447,7 +447,7 @@ class ResultSet implements ResultSetInterface
     {
         $types = [];
         $schema = $table->getSchema();
-        $map = array_keys(Type::map() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
+        $map = array_keys(Type::getMap() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
         $typeMap = array_combine(
             $map,
             array_map(['Cake\Database\Type', 'build'], $map)

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -16,13 +16,14 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Type;
+use Cake\Database\Type\IntegerType;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
 /**
  * Mock class for testing baseType inheritance
  */
-class FooType extends Type
+class FooType extends IntegerType
 {
 
     public function getBaseType()
@@ -49,7 +50,7 @@ class TableTest extends TestCase
 
     public function setUp()
     {
-        $this->_map = Type::map();
+        $this->_map = Type::getMap();
         parent::setUp();
     }
 

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -44,7 +44,7 @@ class TypeTest extends TestCase
      */
     public function setUp()
     {
-        $this->_originalMap = Type::map();
+        $this->_originalMap = Type::getMap();
         parent::setUp();
     }
 
@@ -121,18 +121,18 @@ class TypeTest extends TestCase
      */
     public function testMapAndBuild()
     {
-        $map = Type::map();
+        $map = Type::getMap();
         $this->assertNotEmpty($map);
         $this->assertArrayNotHasKey('foo', $map);
 
         $fooType = FooType::class;
         Type::map('foo', $fooType);
-        $map = Type::map();
+        $map = Type::getMap();
         $this->assertEquals($fooType, $map['foo']);
         $this->assertEquals($fooType, Type::map('foo'));
 
         Type::map('foo2', $fooType);
-        $map = Type::map();
+        $map = Type::getMap();
         $this->assertSame($fooType, $map['foo2']);
         $this->assertSame($fooType, Type::map('foo2'));
 
@@ -165,7 +165,7 @@ class TypeTest extends TestCase
      */
     public function testMapAndBuildWithObjects()
     {
-        $map = Type::map();
+        $map = Type::getMap();
         Type::clear();
 
         $uuidType = new UuidType('uuid');
@@ -182,15 +182,15 @@ class TypeTest extends TestCase
      */
     public function testClear()
     {
-        $map = Type::map();
+        $map = Type::getMap();
         $this->assertNotEmpty($map);
 
         $type = Type::build('float');
         Type::clear();
 
-        $this->assertEmpty(Type::map());
+        $this->assertEmpty(Type::getMap());
         Type::map($map);
-        $newMap = Type::map();
+        $newMap = Type::getMap();
 
         $this->assertEquals(array_keys($map), array_keys($newMap));
         $this->assertEquals($map['integer'], $newMap['integer']);

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -264,7 +264,7 @@ class TypeTest extends TestCase
      */
     public function testSet()
     {
-        $instance = $this->getMockBuilder('Cake\Database\Type')->getMock();
+        $instance = $this->getMockBuilder(TypeInterface::class)->getMock();
         Type::set('random', $instance);
         $this->assertSame($instance, Type::build('random'));
     }

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Type;
+use Cake\Database\TypeInterface;
 use Cake\Database\Type\BoolType;
 use Cake\Database\Type\IntegerType;
 use Cake\Database\Type\UuidType;
@@ -68,7 +69,7 @@ class TypeTest extends TestCase
     public function testBuildBasicTypes($name)
     {
         $type = Type::build($name);
-        $this->assertInstanceOf('Cake\Database\Type', $type);
+        $this->assertInstanceOf(TypeInterface::class, $type);
         $this->assertEquals($name, $type->getName());
         $this->assertEquals($name, $type->getBaseType());
     }
@@ -129,11 +130,6 @@ class TypeTest extends TestCase
         $map = Type::map();
         $this->assertEquals($fooType, $map['foo']);
         $this->assertEquals($fooType, Type::map('foo'));
-
-        $type = Type::build('foo');
-        $this->assertInstanceOf($fooType, $type);
-        $this->assertEquals('foo', $type->getName());
-        $this->assertEquals('text', $type->getBaseType());
 
         Type::map('foo2', $fooType);
         $map = Type::map();
@@ -271,18 +267,5 @@ class TypeTest extends TestCase
         $instance = $this->getMockBuilder('Cake\Database\Type')->getMock();
         Type::set('random', $instance);
         $this->assertSame($instance, Type::build('random'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testDebugInfo()
-    {
-        $type = new Type('foo');
-        $result = $type->__debugInfo();
-        $expected = [
-            'name' => 'foo',
-        ];
-        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
- Converted `Cake\Database\Type` to pure factory class instead of current hybrid.
- Added `Cake\Database\BaseType` and made type classes extend it to keep code DRY.
- Added new getter for map `Type::getMap()`. This should probably be backported to 3.x and using `Type::map()` as getter deprecated.