### PR TITLE
4.x db type

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -440,7 +440,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             return null;
         }
 
-        if (Type::map($type)) {
+        if (Type::getMap($type)) {
             $type = Type::build($type)->getBaseType();
         }
 

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -108,22 +108,18 @@ class Type
     }
 
     /**
-     * Registers a new type identifier and maps it to a fully namespaced classname,
-     * If $className is omitted it will return mapped class for $type
+     * Registers a new type identifier and maps it to a fully namespaced classname.
      *
      * @param string|string[] $type If string name of type to map, if array list of arrays to be mapped.
      * @param string|\Cake\Database\TypeInterface|null $className The classname or object instance of it to register.
-     * @return string|null If $className is null string configured class name for give $type, null otherwise
+     * @return void
      */
     public static function map($type, $className = null)
     {
         if (is_array($type)) {
             static::$_types = $type;
 
-            return null;
-        }
-        if ($className === null) {
-            return isset(static::$_types[$type]) ? static::$_types[$type] : null;
+            return;
         }
 
         static::$_types[$type] = $className;
@@ -131,13 +127,18 @@ class Type
     }
 
     /**
-     * Get current types map.
+     * Get mapped class name or instance for type(s).
      *
-     * @return array
+     * @package string|null $type Type name to get mapped class for or null to get map array.
+     * @return array|string|\Cake\Database\TypeInterface Configured class name or instance for give $type or map array.
      */
-    public static function getMap()
+    public static function getMap(?string $type = null)
     {
-        return static::$_types;
+        if ($type === null) {
+            return static::$_types;
+        }
+
+        return isset(static::$_types[$type]) ? static::$_types[$type] : null;
     }
 
     /**

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -110,20 +110,26 @@ class Type
     /**
      * Registers a new type identifier and maps it to a fully namespaced classname.
      *
-     * @param string|string[] $type If string name of type to map, if array list of arrays to be mapped.
-     * @param string|\Cake\Database\TypeInterface|null $className The classname or object instance of it to register.
+     * @param string $type Name of type to map.
+     * @param string|\Cake\Database\TypeInterface $className The classname or object instance of it to register.
      * @return void
      */
-    public static function map($type, $className = null)
+    public static function map(string $type, $className)
     {
-        if (is_array($type)) {
-            static::$_types = $type;
-
-            return;
-        }
-
         static::$_types[$type] = $className;
         unset(static::$_builtTypes[$type]);
+    }
+
+    /**
+     * Set type to classname mapping.
+     *
+     * @param string[] $map List of types to be mapped.
+     * @return void
+     */
+    public static function setMap(array $map)
+    {
+        static::$_types = $map;
+        static::$_builtTypes = [];
     }
 
     /**

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -96,7 +96,7 @@ class Type
     }
 
     /**
-     * Returns a Type object capable of converting a type identified by $name
+     * Set TypeInterface instance capable of converting a type identified by $name
      *
      * @param string $name The type identifier you want to set.
      * @param \Cake\Database\TypeInterface $instance The type instance you want to set.

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -135,10 +135,10 @@ class Type
     /**
      * Get mapped class name or instance for type(s).
      *
-     * @package string|null $type Type name to get mapped class for or null to get map array.
-     * @return array|string|\Cake\Database\TypeInterface Configured class name or instance for give $type or map array.
+     * @param string|null $type Type name to get mapped class for or null to get map array.
+     * @return array|string|\Cake\Database\TypeInterface|null Configured class name or instance for give $type or map array.
      */
-    public static function getMap(?string $type = null)
+    public static function getMap(string $type = null)
     {
         if ($type === null) {
             return static::$_types;

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -117,9 +117,6 @@ class Type
      */
     public static function map($type, $className = null)
     {
-        if ($type === null) {
-            return static::$_types;
-        }
         if (is_array($type)) {
             static::$_types = $type;
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -58,7 +58,7 @@ class TableTest extends TestCase
     {
         $this->getTableLocator()->clear();
         Type::clear();
-        Type::map($this->_map);
+        Type::setMap($this->_map);
         parent::tearDown();
     }
 

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -16,8 +16,6 @@ namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
-use Cake\Database\Type\BoolType;
-use Cake\Database\Type\IntegerType;
 use Cake\Database\Type\UuidType;
 use Cake\TestSuite\TestCase;
 use PDO;

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -129,12 +129,12 @@ class TypeTest extends TestCase
         Type::map('foo', $fooType);
         $map = Type::getMap();
         $this->assertEquals($fooType, $map['foo']);
-        $this->assertEquals($fooType, Type::map('foo'));
+        $this->assertEquals($fooType, Type::getMap('foo'));
 
         Type::map('foo2', $fooType);
         $map = Type::getMap();
         $this->assertSame($fooType, $map['foo2']);
-        $this->assertSame($fooType, Type::map('foo2'));
+        $this->assertSame($fooType, Type::getMap('foo2'));
 
         $type = Type::build('foo2');
         $this->assertInstanceOf($fooType, $type);

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -57,7 +57,7 @@ class TypeTest extends TestCase
     {
         parent::tearDown();
 
-        Type::map($this->_originalMap);
+        Type::setMap($this->_originalMap);
     }
 
     /**
@@ -172,7 +172,7 @@ class TypeTest extends TestCase
         Type::map('uuid', $uuidType);
 
         $this->assertSame($uuidType, Type::build('uuid'));
-        Type::map($map);
+        Type::setMap($map);
     }
 
     /**
@@ -189,7 +189,7 @@ class TypeTest extends TestCase
         Type::clear();
 
         $this->assertEmpty(Type::getMap());
-        Type::map($map);
+        Type::setMap($map);
         $newMap = Type::getMap();
 
         $this->assertEquals(array_keys($map), array_keys($newMap));


### PR DESCRIPTION
- `Type::map()` is now only used as setter for individual types.
- `Type::setMap()` is used to set complete map.
- `Type::getMap()` is used as getter for individual type or get complete map.