### PR TITLE
Only emit deprecation warnings if validator() has been implemented.

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -23,6 +23,7 @@ use Cake\Form\Schema;
 use Cake\Validation\Validator;
 use Cake\Validation\ValidatorAwareInterface;
 use Cake\Validation\ValidatorAwareTrait;
+use ReflectionMethod;
 
 /**
  * Form abstraction used to create forms not tied to ORM backed models,
@@ -224,7 +225,10 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     {
         $validator = $this->getValidator();
         if (!$validator->count()) {
-            $validator = $this->validator();
+            $method = new ReflectionMethod($this, 'validator');
+            if ($method->getDeclaringClass() !== __CLASS__) {
+                $validator = $this->validator();
+            }
         }
         $this->_errors = $validator->errors($data);
 


### PR DESCRIPTION
We shouldn't be emitting deprecation warnings if the Form instance
doesn't override the `validator()` method.

Refs #11982