### PR TITLE
3.next fixes

### DIFF
--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -130,7 +130,7 @@ class AssetMiddleware
      * Builds asset file path based off url
      *
      * @param string $url Asset URL
-     * @return string Absolute path for asset file
+     * @return string|null Absolute path for asset file, null on failure
      */
     protected function _getAssetFile($url)
     {
@@ -151,7 +151,7 @@ class AssetMiddleware
             }
         }
 
-        return '';
+        return null;
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -286,7 +286,7 @@ class ArrayContext implements ContextInterface
             return [];
         }
 
-        return Hash::get($this->_context['errors'], $field);
+        return (array)Hash::get($this->_context['errors'], $field);
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -796,7 +796,7 @@ class FormHelper extends Helper
         if (!$context->hasError($field)) {
             return '';
         }
-        $error = (array)$context->error($field);
+        $error = $context->error($field);
 
         if (is_array($text)) {
             $tmp = [];

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -302,9 +302,9 @@ class ArrayContextTest extends TestCase
             ]
         ]);
         $this->assertEquals(['Comment is required'], $context->error('Comments.comment'));
-        $this->assertEquals('A valid userid is required', $context->error('Comments.user_id'));
+        $this->assertEquals(['A valid userid is required'], $context->error('Comments.user_id'));
         $this->assertEquals([], $context->error('Comments.empty'));
-        $this->assertNull($context->error('Comments.not_there'));
+        $this->assertEquals([], $context->error('Comments.not_there'));
     }
 
     /**


### PR DESCRIPTION
Couple of issues worth fixing in 3.x, I found while working on 4.x.

- AssetMiddleware::_getAssetFile() returned empty string on failure while calling class `__invoke()` checked for `null` return value causing an unnecessary `file_exists()` call with empty string. I changed return type of `_getAssetFile()` as `null` better represents a value not found.
- `ArrayContext::error()` didn't always return an array as dictated by return type of `ContextInterface::error()`.