### PR TITLE
4.x type cleanup

### DIFF
--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -76,17 +76,4 @@ abstract class BaseType implements TypeInterface
     {
         return null;
     }
-
-    /**
-     * Returns an array that can be used to describe the internal state of this
-     * object.
-     *
-     * @return array
-     */
-    public function __debugInfo()
-    {
-        return [
-            'name' => $this->_name,
-        ];
-    }
 }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -96,7 +96,7 @@ class DateTimeType extends BaseType
     {
         $this->_name = $name;
 
-        $this->useMutable();
+        $this->useImmutable();
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -15,7 +15,9 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Database\Type\BatchCastingInterface;
+use Cake\I18n\FrozenTime;
+use Cake\I18n\Time;
+use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
@@ -30,18 +32,6 @@ use RuntimeException;
  */
 class DateTimeType extends BaseType
 {
-
-    /**
-     * The class to use for representing date objects
-     *
-     * This property can only be used before an instance of this type
-     * class is constructed. After that use `useMutable()` or `useImmutable()` instead.
-     *
-     * @var string
-     * @deprecated 3.2.0 Use DateTimeType::useMutable() or DateTimeType::useImmutable() instead.
-     */
-    public static $dateTimeClass = 'Cake\I18n\Time';
-
     /**
      * Whether or not we want to override the time of the converted Time objects
      * so it points to the start of the day.
@@ -106,7 +96,7 @@ class DateTimeType extends BaseType
     {
         $this->_name = $name;
 
-        $this->_setClassName(static::$dateTimeClass, 'DateTime');
+        $this->useMutable();
     }
 
     /**
@@ -343,7 +333,7 @@ class DateTimeType extends BaseType
      */
     public function useImmutable()
     {
-        $this->_setClassName('Cake\I18n\FrozenTime', 'DateTimeImmutable');
+        $this->_setClassName(FrozenTime::class, DateTimeImmutable::class);
 
         return $this;
     }
@@ -381,7 +371,7 @@ class DateTimeType extends BaseType
      */
     public function useMutable()
     {
-        $this->_setClassName('Cake\I18n\Time', 'DateTime');
+        $this->_setClassName(Time::class, DateTime::class);
 
         return $this;
     }

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -14,23 +14,13 @@
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
 use DateTime;
+use DateTimeImmutable;
 
 class DateType extends DateTimeType
 {
-
-    /**
-     * The class to use for representing date objects
-     *
-     * This property can only be used before an instance of this type
-     * class is constructed. After that use `useMutable()` or `useImmutable()` instead.
-     *
-     * @var string
-     * @deprecated 3.2.0 Use DateType::useMutable() or DateType::useImmutable() instead.
-     */
-    public static $dateTimeClass = 'Cake\I18n\Date';
-
     /**
      * Date format for DateTime object
      *
@@ -53,7 +43,7 @@ class DateType extends DateTimeType
      */
     public function useImmutable()
     {
-        $this->_setClassName('Cake\I18n\FrozenDate', 'DateTimeImmutable');
+        $this->_setClassName(FrozenDate::class, DateTimeImmutable::class);
 
         return $this;
     }
@@ -65,7 +55,7 @@ class DateType extends DateTimeType
      */
     public function useMutable()
     {
-        $this->_setClassName('Cake\I18n\Date', 'DateTime');
+        $this->_setClassName(Date::class, DateTime::class);
 
         return $this;
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -22,6 +22,7 @@ use Cake\Database\Statement\StatementDecorator;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use DateTimeImmutable;
 
 /**
  * Tests Query class
@@ -4422,7 +4423,7 @@ class QueryTest extends TestCase
             ->getSelectTypeMap()->setTypes(['id' => 'integer', 'the_date' => 'datetime']);
         $result = $query->execute()->fetchAll('assoc');
         $this->assertInternalType('integer', $result[0]['id']);
-        $this->assertInstanceOf('DateTime', $result[0]['the_date']);
+        $this->assertInstanceOf(DateTimeImmutable::class, $result[0]['the_date']);
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2098,6 +2098,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
             ->group('author_id')
+            ->order(['total' => 'desc'])
             ->execute();
         $expected = [['total' => 2, 'author_id' => 1], ['total' => '1', 'author_id' => 3]];
         $this->assertEquals($expected, $result->fetchAll('assoc'));
@@ -2293,6 +2294,7 @@ class QueryTest extends TestCase
                 ->from('articles')
                 ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
                 ->group('author_id')
+                ->order(['total' => 'desc'])
                 ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
                 ->orHaving(['count(author_id) <=' => 2], ['count(author_id)' => 'integer'])
                 ->execute();
@@ -4254,7 +4256,7 @@ class QueryTest extends TestCase
                 'integer'
             );
 
-        //Postgres requires the case statement to be cast to a integer
+        // Postgres requires the case statement to be cast to a integer
         if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres) {
             $publishedCase = $query->func()
                 ->cast([$publishedCase, 'integer' => 'literal'])

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -61,10 +61,10 @@ class DateTimeTypeTest extends TestCase
      */
     public function testGetDateTimeClassName()
     {
-        $this->assertSame(Time::class, $this->type->getDateTimeClassName());
-
-        $this->type->useImmutable();
         $this->assertSame(FrozenTime::class, $this->type->getDateTimeClassName());
+
+        $this->type->useMutable();
+        $this->assertSame(Time::class, $this->type->getDateTimeClassName());
     }
 
     /**
@@ -86,7 +86,7 @@ class DateTimeTypeTest extends TestCase
     public function testToPHPString()
     {
         $result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
-        $this->assertInstanceOf('Cake\I18n\Time', $result);
+        $this->assertInstanceOf(FrozenTime::class, $result);
         $this->assertEquals('2001', $result->format('Y'));
         $this->assertEquals('01', $result->format('m'));
         $this->assertEquals('04', $result->format('d'));
@@ -128,7 +128,7 @@ class DateTimeTypeTest extends TestCase
     {
         $in = '2014-03-24 20:44:36.315113';
         $result = $this->type->toPHP($in, $this->driver);
-        $this->assertInstanceOf('Cake\I18n\Time', $result);
+        $this->assertInstanceOf(FrozenTime::class, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -18,6 +18,7 @@ use Cake\Chronos\Date;
 use Cake\Database\Type\DateType;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
+use DateTimeImmutable;
 
 /**
  * Test for the Date type.
@@ -57,7 +58,7 @@ class DateTypeTest extends TestCase
         $this->assertNull($this->type->toPHP('0000-00-00', $this->driver));
 
         $result = $this->type->toPHP('2001-01-04', $this->driver);
-        $this->assertInstanceOf('DateTime', $result);
+        $this->assertInstanceOf(DateTimeImmutable::class, $result);
         $this->assertEquals('2001', $result->format('Y'));
         $this->assertEquals('01', $result->format('m'));
         $this->assertEquals('04', $result->format('d'));

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -18,6 +18,7 @@ use Cake\Database\Type\TimeType;
 use Cake\I18n\I18n;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
+use DateTimeImmutable;
 
 /**
  * Test for the Time type.
@@ -79,7 +80,7 @@ class TimeTypeTest extends TestCase
         $this->assertEquals('15', $result->format('s'));
 
         $result = $this->type->toPHP('16:30:15', $this->driver);
-        $this->assertInstanceOf('DateTime', $result);
+        $this->assertInstanceOf(DateTimeImmutable::class, $result);
         $this->assertEquals('16', $result->format('H'));
         $this->assertEquals('30', $result->format('i'));
         $this->assertEquals('15', $result->format('s'));
@@ -213,7 +214,7 @@ class TimeTypeTest extends TestCase
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
             $this->assertEquals($expected, $result);
-            $this->assertInstanceOf('DateTime', $result);
+            $this->assertInstanceOf(DateTimeImmutable::class, $result);
         } else {
             $this->assertSame($expected, $result);
         }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Database\TypeFactory;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
@@ -100,7 +101,7 @@ class TimestampBehaviorTest extends TestCase
 
         $return = $this->Behavior->handleEvent($event, $entity);
         $this->assertTrue($return, 'Handle Event is expected to always return true');
-        $this->assertInstanceOf('Cake\I18n\Time', $entity->created);
+        $this->assertInstanceOf(FrozenTime::class, $entity->created);
         $this->assertSame($ts->format('c'), $entity->created->format('c'), 'Created timestamp is not the same');
     }
 
@@ -167,7 +168,7 @@ class TimestampBehaviorTest extends TestCase
 
         $return = $this->Behavior->handleEvent($event, $entity);
         $this->assertTrue($return, 'Handle Event is expected to always return true');
-        $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
+        $this->assertInstanceOf(FrozenTime::class, $entity->modified);
         $this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is not the same');
     }
 
@@ -192,7 +193,7 @@ class TimestampBehaviorTest extends TestCase
 
         $return = $this->Behavior->handleEvent($event, $entity);
         $this->assertTrue($return, 'Handle Event is expected to always return true');
-        $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
+        $this->assertInstanceOf(FrozenTime::class, $entity->modified);
         $this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is expected to be updated');
     }
 

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -232,7 +232,6 @@ class TimestampBehaviorTest extends TestCase
         $entity = new Entity();
         $event = new Event('Model.beforeSave');
 
-        TypeFactory::build('timestamp')->useImmutable();
         $entity->clean();
         $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf('Cake\I18n\FrozenTime', $entity->modified);
@@ -241,6 +240,9 @@ class TimestampBehaviorTest extends TestCase
         $entity->clean();
         $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf('Cake\I18n\Time', $entity->modified);
+        // Revert back to using immutable class to avoid causing problems in
+        // other test cases when running full test suite.
+        TypeFactory::build('timestamp')->useImmutable();
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
@@ -2511,7 +2512,7 @@ class MarshallerTest extends TestCase
         ];
         $marshall = new Marshaller($this->comments);
         $result = $marshall->merge($entity, $data);
-        $this->assertInstanceOf('DateTime', $entity->created);
+        $this->assertInstanceOf(FrozenTime::class, $entity->created);
         $this->assertEquals('2014-02-14', $entity->created->format('Y-m-d'));
     }
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -19,6 +19,7 @@ use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
 
@@ -1311,7 +1312,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->comment->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->comment->updated);
     }
 
     /**
@@ -1369,7 +1370,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->_matchingData['Comments']->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->_matchingData['Comments']->updated);
 
         $query = $table->find()
             ->matching('Comments.Articles.Authors')
@@ -1379,7 +1380,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->_matchingData['Authors']->updated);
+        $this->assertInstanceOf(Time::class, $result->_matchingData['Authors']->updated);
     }
 
     /**
@@ -1404,7 +1405,7 @@ class QueryRegressionTest extends TestCase
         $result = $query->first();
         $this->assertNotEmpty($result);
         $this->assertEquals(3, $result->id);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->created);
+        $this->assertInstanceOf(FrozenTime::class, $result->created);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1341,7 +1341,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->comment->article->author->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->comment->article->author->updated);
     }
 
     /**
@@ -1380,7 +1380,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf(Time::class, $result->_matchingData['Authors']->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->_matchingData['Authors']->updated);
     }
 
     /**
@@ -1434,7 +1434,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->updated);
 
         $query = $table->find()
             ->innerJoinWith('Comments.Articles.Authors')
@@ -1444,7 +1444,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->updated);
     }
 
     /**
@@ -1473,7 +1473,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->updated);
 
         $query = $table->find()
             ->leftJoinWith('Comments.Articles.Authors')
@@ -1483,7 +1483,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first();
         $this->assertNotEmpty($result);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->updated);
+        $this->assertInstanceOf(FrozenTime::class, $result->updated);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -21,6 +21,7 @@ use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
@@ -732,7 +733,7 @@ class QueryTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Entity', $result);
         $this->assertInstanceOf('Cake\ORM\Entity', $result->_matchingData['Comments']);
         $this->assertInternalType('integer', $result->_matchingData['Comments']->id);
-        $this->assertInstanceOf('Cake\I18n\Time', $result->_matchingData['Comments']->created);
+        $this->assertInstanceOf(FrozenTime::class, $result->_matchingData['Comments']->created);
     }
 
     /**
@@ -1294,7 +1295,7 @@ class QueryTest extends TestCase
             'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
-        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
+        $this->assertInstanceOf(FrozenTime::class, $first->tags[0]->created);
 
         $expected = [
             'id' => 2,
@@ -1304,7 +1305,7 @@ class QueryTest extends TestCase
             'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
-        $this->assertInstanceOf(Time::class, $first->tags[1]->created);
+        $this->assertInstanceOf(FrozenTime::class, $first->tags[1]->created);
     }
 
     /**
@@ -1358,7 +1359,7 @@ class QueryTest extends TestCase
             'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
-        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
+        $this->assertInstanceOf(FrozenTime::class, $first->tags[0]->created);
 
         $expected = [
             'id' => 2,
@@ -1372,7 +1373,7 @@ class QueryTest extends TestCase
             'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
-        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
+        $this->assertInstanceOf(FrozenTime::class, $first->tags[0]->created);
     }
 
     /**
@@ -3218,8 +3219,8 @@ class QueryTest extends TestCase
             ->find()
             ->select(['created', 'updated_time' => 'updated'])
             ->first();
-        $this->assertInstanceOf(Time::class, $result->created);
-        $this->assertInstanceOf(Time::class, $result->updated_time);
+        $this->assertInstanceOf(FrozenTime::class, $result->created);
+        $this->assertInstanceOf(FrozenTime::class, $result->updated_time);
     }
 
     /**


### PR DESCRIPTION
- Remove deprecated property
- Immutable date time classes are now used by default