### PR TITLE
findOrCreate never fires Model.afterSaveCommit

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1678,14 +1678,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += [
             'atomic' => true,
             'defaults' => true,
-            '_primary' => true,
         ];
 
         $entity = $this->_executeTransaction(function () use ($search, $callback, $options) {
             return $this->_processFindOrCreate($search, $callback, $options);
         }, $options['atomic']);
 
-        if ($entity && $this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+        if ($entity && $this->_transactionCommitted($options['atomic'], true)) {
             $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1680,9 +1680,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'defaults' => true
         ];
 
-        return $this->_executeTransaction(function () use ($search, $callback, $options) {
-            return $this->_processFindOrCreate($search, $callback, $options);
-        }, $options['atomic']);
+        return $this->_processFindOrCreate($search, $callback, $options);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6157,9 +6157,11 @@ class TableTest extends TestCase
         $article = $articles->findOrCreate(function ($query) {
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $query->where(['title' => 'Find Something New']);
+            $this->assertTrue($this->connection->inTransaction());
         }, function ($article) {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
             $article->title = 'Success';
+            $this->assertTrue($this->connection->inTransaction());
         });
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6150,19 +6150,21 @@ class TableTest extends TestCase
     public function testFindOrCreateTransactions()
     {
         $articles = $this->getTableLocator()->get('Articles');
+        $articles->getEventManager()->on('Model.afterSaveCommit', function ($event, $entity) {
+            $entity->afterSaveCommit = true;
+        });
 
         $article = $articles->findOrCreate(function ($query) {
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $query->where(['title' => 'Find Something New']);
-            $this->assertTrue($this->connection->inTransaction());
         }, function ($article) {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
-            $this->assertTrue($this->connection->inTransaction());
             $article->title = 'Success';
         });
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
         $this->assertEquals('Success', $article->title);
+        $this->assertTrue($article->afterSaveCommit);
     }
 
     /**


### PR DESCRIPTION
`Table::findOrCreate` would never fire `Model.afterSaveCommit`. I don't know anything about nested transactions, so perhaps someone can illuminate why it wrapped `_processFindOrCreate` in a transaction when the save operation in that method would take care of the transaction itself.