### PR TITLE
Load routing in console environments.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -372,7 +372,9 @@ class CommandRunner implements EventDispatcherInterface
     {
         $builder = Router::createRouteBuilder('/');
 
-        $this->app->routes($builder);
+        if ($this->app instanceof HttpApplicationInterface) {
+            $this->app->routes($builder);
+        }
         if ($this->app instanceof PluginApplicationInterface) {
             $this->app->pluginRoutes($builder);
         }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -22,6 +22,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Console\Shell;
 use Cake\Core\ConsoleApplicationInterface;
+use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -26,6 +26,7 @@ use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
+use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use RuntimeException;
@@ -145,6 +146,7 @@ class CommandRunner implements EventDispatcherInterface
         }
         $this->checkCollection($commands, 'pluginConsole');
         $this->dispatchEvent('Console.buildCommands', ['commands' => $commands]);
+        $this->loadRoutes();
 
         if (empty($argv)) {
             throw new RuntimeException("Cannot run any commands. No arguments received.");
@@ -357,5 +359,22 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         return $shell;
+    }
+
+    /**
+     * Ensure that the application's routes are loaded.
+     *
+     * Console commands and shells often need to generate URLs.
+     *
+     * @return void
+     */
+    protected function loadRoutes()
+    {
+        $builder = Router::createRouteBuilder('/');
+
+        $this->app->routes($builder);
+        if ($this->app instanceof PluginApplicationInterface) {
+            $this->app->pluginRoutes($builder);
+        }
     }
 }


### PR DESCRIPTION
Ensure that the CommandRunner framework uses the application routes() hook to load routes. This enables the routes shell and other commands/shells to generate URLs properly.

Refs #12030 
Refs cakephp/app#593