### PR TITLE
Add 'here' to the emulated property set.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -196,7 +196,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @var array
      */
-    protected $emulatedAttributes = ['session', 'webroot', 'base', 'params'];
+    protected $emulatedAttributes = ['session', 'webroot', 'base', 'params', 'here'];
 
     /**
      * Array of Psr\Http\Message\UploadedFileInterface objects.

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -3590,6 +3590,7 @@ XML;
                     'controller' => 'Articles',
                     'action' => 'index'
                 ],
+                'url' => '/articles/view',
                 'base' => '/cakeapp',
                 'webroot' => '/cakeapp/'
             ]);
@@ -3597,6 +3598,7 @@ XML;
             if ($prop === 'session') {
                 $this->assertSame($request->getSession(), $request->getAttribute($prop));
             } else {
+                $this->assertNotEmpty($request->getAttribute($prop));
                 $this->assertSame($request->{$prop}, $request->getAttribute($prop));
             }
         });
@@ -3733,6 +3735,7 @@ XML;
     public function emulatedPropertyProvider()
     {
         return [
+            ['here'],
             ['params'],
             ['base'],
             ['webroot'],


### PR DESCRIPTION
This makes `here` accessible as an attribute as the deprecation warnings suggest.

Refs #12027
