### PR TITLE
Correct deprecation warnings for viewBuilder properties.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -757,8 +757,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($this->getRequest()->getParam('bare')) {
             $builder->enableAutoLayout(false);
         }
-        $builder->getClassName($this->viewClass);
-
         $this->autoRender = false;
 
         $event = $this->dispatchEvent('Controller.beforeRender');

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -74,6 +74,7 @@ trait ViewVarsTrait
         $builder = $this->viewBuilder();
         if ($viewClass === null && $builder->getClassName() === null) {
             $builder->setClassName($this->viewClass);
+            unset($this->viewClass);
         }
         if ($viewClass) {
             $builder->setClassName($viewClass);
@@ -88,21 +89,22 @@ trait ViewVarsTrait
         }
 
         $deprecatedOptions = [
-            'layout' => 'layout',
-            'view' => 'template',
-            'theme' => 'theme',
-            'autoLayout' => 'autoLayout',
-            'viewPath' => 'templatePath',
-            'layoutPath' => 'layoutPath',
+            'layout' => 'setLayout',
+            'view' => 'setTemplate',
+            'theme' => 'setTheme',
+            'autoLayout' => 'enableAutoLayout',
+            'viewPath' => 'setTemplatePath',
+            'layoutPath' => 'setLayoutPath',
         ];
         foreach ($deprecatedOptions as $old => $new) {
             if (property_exists($this, $old)) {
                 $builder->{$new}($this->{$old});
-                trigger_error(sprintf(
+                $message = sprintf(
                     'Property $%s is deprecated. Use $this->viewBuilder()->%s() instead in beforeRender().',
                     $old,
                     $new
-                ), E_USER_DEPRECATED);
+                );
+                deprecationWarning($message);
             }
         }
 

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -22,6 +22,9 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Cake\View\AjaxView;
+use Cake\View\JsonView;
+use Cake\View\XmlView;
 use TestApp\Controller\RequestHandlerTestController;
 use Zend\Diactoros\Stream;
 
@@ -399,7 +402,7 @@ class RequestHandlerComponentTest extends TestCase
             $this->assertEquals($expected, $result);
 
             $this->RequestHandler->renderAs($this->Controller, 'json');
-            $this->assertEquals('TestApp\View\CustomJsonView', $this->Controller->viewClass);
+            $this->assertEquals('TestApp\View\CustomJsonView', $this->Controller->viewBuilder()->getClassName());
         });
     }
 
@@ -434,15 +437,15 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
 
-        $this->assertEquals($this->Controller->viewClass, 'Cake\View\AjaxView');
         $view = $this->Controller->createView();
+        $this->assertInstanceOf(AjaxView::class, $view);
         $this->assertEquals('ajax', $view->getLayout());
 
         $this->_init();
         $this->Controller->request = $this->Controller->request->withParam('_ext', 'js');
         $this->RequestHandler->initialize([]);
         $this->RequestHandler->startup($event);
-        $this->assertNotEquals($this->Controller->viewClass, 'Cake\View\AjaxView');
+        $this->assertNotEquals(AjaxView::class, $this->Controller->viewBuilder()->getClassName());
     }
 
     /**
@@ -460,8 +463,8 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup($event);
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
-        $this->assertEquals('Cake\View\JsonView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
+        $this->assertInstanceOf(JsonView::class, $view);
         $this->assertEquals('json', $view->getLayoutPath());
         $this->assertEquals('json', $view->subDir);
     }
@@ -481,8 +484,8 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup($event);
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
-        $this->assertEquals('Cake\View\XmlView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
+        $this->assertInstanceOf(XmlView::class, $view);
         $this->assertEquals('xml', $view->getLayoutPath());
         $this->assertEquals('xml', $view->subDir);
     }
@@ -502,8 +505,8 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup($event);
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
-        $this->assertEquals('Cake\View\AjaxView', $this->Controller->viewClass);
         $view = $this->Controller->createView();
+        $this->assertInstanceOf(AjaxView::class, $view);
         $this->assertEquals('ajax', $view->getLayout());
     }
 
@@ -866,7 +869,7 @@ XML;
         $this->Controller->request = $this->request->withHeader('Accept', 'application/xml;q=1.0');
 
         $this->RequestHandler->renderAs($this->Controller, 'xml', ['attachment' => 'myfile.xml']);
-        $this->assertEquals('Cake\View\XmlView', $this->Controller->viewClass);
+        $this->assertEquals(XmlView::class, $this->Controller->viewBuilder()->getClassName());
         $this->assertEquals('application/xml', $this->Controller->response->getType());
         $this->assertEquals('UTF-8', $this->Controller->response->getCharset());
         $this->assertContains('myfile.xml', $this->Controller->response->getHeaderLine('Content-Disposition'));

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -223,7 +223,6 @@ class CellTest extends TestCase
 
         $this->assertEquals($this->View->theme, $cell->viewBuilder()->getTheme());
         $this->assertContains('Themed cell content.', $cell->render());
-        $this->assertEquals($cell->View->theme, $cell->viewBuilder()->getTheme());
     }
 
     /**

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -195,13 +195,16 @@ class ViewVarsTraitTest extends TestCase
     /**
      * test that viewClass is used to create the view
      *
+     * @deprecated
      * @return void
      */
     public function testCreateViewViewClass()
     {
-        $this->subject->viewClass = 'Json';
-        $view = $this->subject->createView();
-        $this->assertInstanceOf('Cake\View\JsonView', $view);
+        $this->deprecated(function () {
+            $this->subject->viewClass = 'Json';
+            $view = $this->subject->createView();
+            $this->assertInstanceOf('Cake\View\JsonView', $view);
+        });
     }
 
     /**

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -47,7 +47,7 @@ class XmlViewTest extends TestCase
         $Controller = new Controller($Request, $Response);
         $data = ['users' => ['user' => ['user1', 'user2']]];
         $Controller->set(['users' => $data, '_serialize' => 'users']);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render(false);
 
@@ -67,7 +67,7 @@ class XmlViewTest extends TestCase
             ]
         ];
         $Controller->set(['users' => $data, '_serialize' => 'users']);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render(false);
 
@@ -75,7 +75,7 @@ class XmlViewTest extends TestCase
         $this->assertSame($expected, $output);
 
         $Controller->set('_rootNode', 'custom_name');
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render(false);
 
@@ -98,7 +98,7 @@ class XmlViewTest extends TestCase
             '_serialize' => 'tags',
             'tags' => ['cakephp', 'framework']
         ]);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $View->render();
         $this->assertFalse(isset($View->Html), 'No helper loaded.');
@@ -131,7 +131,7 @@ class XmlViewTest extends TestCase
             ]
         ];
         $Controller->set($data);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $result = $View->render();
 
@@ -168,7 +168,7 @@ class XmlViewTest extends TestCase
             ]
         ];
         $Controller->set($data);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $result = $View->render();
 
@@ -189,7 +189,7 @@ class XmlViewTest extends TestCase
         $data = ['no' => 'nope', 'user' => 'fake', 'list' => ['item1', 'item2']];
         $Controller->set($data);
         $Controller->set('_serialize', ['no', 'user']);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $this->assertSame('application/xml', $View->response->getType());
         $output = $View->render(false);
@@ -199,7 +199,7 @@ class XmlViewTest extends TestCase
         $this->assertSame(Xml::build($expected)->asXML(), $output);
 
         $Controller->set('_rootNode', 'custom_name');
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render(false);
         $expected = [
@@ -221,7 +221,7 @@ class XmlViewTest extends TestCase
         $data = ['original_name' => 'my epic name', 'user' => 'fake', 'list' => ['item1', 'item2']];
         $Controller->set($data);
         $Controller->set('_serialize', ['new_name' => 'original_name', 'user']);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $this->assertSame('application/xml', $View->response->getType());
         $output = $View->render(false);
@@ -231,7 +231,7 @@ class XmlViewTest extends TestCase
         $this->assertSame(Xml::build($expected)->asXML(), $output);
 
         $Controller->set('_rootNode', 'custom_name');
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render(false);
         $expected = [
@@ -252,7 +252,7 @@ class XmlViewTest extends TestCase
         $Controller = new Controller($Request, $Response);
         $data = ['users' => ['user' => ['user1', 'user2']]];
         $Controller->set(['users' => $data, '_serialize' => true]);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $output = $View->render();
 
@@ -296,7 +296,7 @@ class XmlViewTest extends TestCase
             ]
         ];
         $Controller->set('users', $data);
-        $Controller->viewClass = 'Xml';
+        $Controller->viewBuilder()->setClassName('Xml');
         $View = $Controller->createView();
         $View->setTemplatePath('Posts');
         $output = $View->render('index');


### PR DESCRIPTION
Fix warnings for view builder related properties. The old deprecation warnings recommended using mehods that are also deprecated. I've added an unset() for viewClass to avoid a permanent deprecation warning when RequestHandlerComponent is used. I wasn't brave enough to remove that property set as there is probably userland code hanging on it.
