### PR TITLE
Deprecate Security::rijndael().

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -208,7 +208,12 @@ class Security
      * @param string $key Key to use as the encryption key for encrypted data.
      * @param string $operation Operation to perform, encrypt or decrypt
      * @throws \InvalidArgumentException When there are errors.
-     * @return string Encrypted/Decrypted string
+     * @return string Encrypted/Decrypted string.
+     * @deprecated 3.6.3 This method relies on functions provided by mcrypt
+     *   extension which has been deprecated in PHP 7.1 and removed in PHP 7.2.
+     *   There's no 1:1 replacement for this method.
+     *   Upgrade your code to use Security::encrypt()/Security::decrypt() with
+     *   OpenSsl engine instead.
      */
     public static function rijndael($text, $key, $operation)
     {


### PR DESCRIPTION
This should have been done earlier when `Crypt\Mcrypt` itself was deprecated.