### PR TITLE
Add identifier quoting for fields with spaces.

### DIFF
--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -46,26 +46,33 @@ trait SqlDialectTrait
             return $this->_startQuote . $identifier . $this->_endQuote;
         }
 
+        // string.string
         if (preg_match('/^[\w-]+\.[^ \*]*$/', $identifier)) {
-// string.string
             $items = explode('.', $identifier);
 
             return $this->_startQuote . implode($this->_endQuote . '.' . $this->_startQuote, $items) . $this->_endQuote;
         }
 
+        // string.*
         if (preg_match('/^[\w-]+\.\*$/', $identifier)) {
-// string.*
             return $this->_startQuote . str_replace('.*', $this->_endQuote . '.*', $identifier);
         }
 
         if (preg_match('/^([\w-]+)\((.*)\)$/', $identifier, $matches)) {
-// Functions
+            // Functions
             return $matches[1] . '(' . $this->quoteIdentifier($matches[2]) . ')';
         }
 
         // Alias.field AS thing
-        if (preg_match('/^([\w-]+(\.[\w-]+|\(.*\))*)\s+AS\s*([\w-]+)$/i', $identifier, $matches)) {
+        if (preg_match('/^([\w-]+(\.[\w-\s]+|\(.*\))*)\s+AS\s*([\w-]+)$/i', $identifier, $matches)) {
             return $this->quoteIdentifier($matches[1]) . ' AS ' . $this->quoteIdentifier($matches[3]);
+        }
+
+        // string.string with spaces
+        if (preg_match('/^[\w-_]+\.[\w-_\s]+[\w_]*/', $identifier)) {
+            $items = explode('.', $identifier);
+
+            return $this->_startQuote . implode($this->_endQuote . '.' . $this->_startQuote, $items) . $this->_endQuote;
         }
 
         if (preg_match('/^[\w-_\s]*[\w-_]+/', $identifier)) {

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -765,6 +765,18 @@ class ConnectionTest extends TestCase
         $expected = '"Model".*';
         $this->assertEquals($expected, $result);
 
+        $result = $connection->quoteIdentifier('Items.No_ 2');
+        $expected = '"Items"."No_ 2"';
+        $this->assertEquals($expected, $result);
+
+        $result = $connection->quoteIdentifier('Items.No_ 2 thing');
+        $expected = '"Items"."No_ 2 thing"';
+        $this->assertEquals($expected, $result);
+
+        $result = $connection->quoteIdentifier('Items.No_ 2 thing AS thing');
+        $expected = '"Items"."No_ 2 thing" AS "thing"';
+        $this->assertEquals($expected, $result);
+
         $result = $connection->quoteIdentifier('MTD()');
         $expected = 'MTD()';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
There is one caveat in that fields containing `AS` will still be misquoted.

Refs #12038