### PR TITLE
Nullable is a lie. Also fixed up deprecations to soft ones.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -136,7 +136,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * An instance of a Response object that contains information about the impending response
      *
      * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
-     
+
      * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
      */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -579,7 +579,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function invokeAction()
     {
         $request = $this->request;
-        if (!isset($request)) {
+        if (!$request) {
             throw new LogicException('No Request object configured. Cannot invoke action');
         }
         if (!$this->isAction($request->getParam('action'))) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -125,18 +125,20 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * This object contains all the information about a request and several methods for reading
      * additional information about the request.
      *
-     * @var \Cake\Http\ServerRequest|null
+     * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getRequest()/setRequest instead.
+     *
+     * @var \Cake\Http\ServerRequest
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#request
-     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getRequest()/setRequest instead.
      */
     public $request;
 
     /**
      * An instance of a Response object that contains information about the impending response
      *
-     * @var \Cake\Http\Response|null
+     * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
+     
+     * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
-     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
      */
     public $response;
 


### PR DESCRIPTION
As per constructor the properties must never (=cannot) be null on instance.

Also, the IDEs are causing the false impression you cannot use the properties from inside the controller (every day use case), thus a soft deprecation makes more sense. No need for getRequest() here.

![screenshot from 2018-05-09 15-30-17](https://user-images.githubusercontent.com/39854/39817390-4e93a786-539e-11e8-8334-9efc9f2fa574.png)
