### PR TITLE
Fatal errors are not properly handled/logged.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -38,6 +38,11 @@ abstract class BaseErrorHandler
     protected $_options = [];
 
     /**
+     * @var bool
+     */
+    protected $_handled = false;
+
+    /**
      * Display an error message in an environment specific way.
      *
      * Subclasses should implement this method to display the error as
@@ -75,7 +80,7 @@ abstract class BaseErrorHandler
         set_error_handler([$this, 'handleError'], $level);
         set_exception_handler([$this, 'wrapAndHandleException']);
         register_shutdown_function(function () {
-            if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
+            if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && $this->_handled) {
                 return;
             }
             $megabytes = Configure::read('Error.extraFatalErrorMemory');
@@ -128,6 +133,7 @@ abstract class BaseErrorHandler
         if (error_reporting() === 0) {
             return false;
         }
+        $this->_handled = true;
         list($error, $log) = static::mapErrorCode($code);
         if ($log === LOG_ERR) {
             return $this->handleFatalError($code, $description, $file, $line);


### PR DESCRIPTION
Fatal errors on CLI (debug on or off) are not logged at all.
This is very dangerous on production if you do not get notified about it (inside cronjobs).
In our specific case it was using a require-dev class and that one was then gone live.

Demo: `$x = new Demo();` with `class Demo extends Foo` and Foo does not exist

I found out that none of the configured handlers are invoked in that case

        set_error_handler([$this, 'handleError'], $level);
        set_exception_handler([$this, 'wrapAndHandleException']);
        register_shutdown_function(function () {}

Only the register_shutdown_function() which is then return early here:

    if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
        return;
    }

This is very bad.

I added a handled propery - if there are better ways I am all ears.

Now it at least logs it again

    Fatal Error (1): Class 'App\Foo' not found in ...

This can only be fixed/relevant for PHP7 of course. We are running 7.1 and 7.2 here.