### PR TITLE
Fixed return type (array) #11795

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -136,7 +136,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * An instance of a Response object that contains information about the impending response
      *
      * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
-     
+
      * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
      */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -579,7 +579,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function invokeAction()
     {
         $request = $this->request;
-        if (!isset($request)) {
+        if (!$request) {
             throw new LogicException('No Request object configured. Cannot invoke action');
         }
         if (!$this->isAction($request->getParam('action'))) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -125,18 +125,20 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * This object contains all the information about a request and several methods for reading
      * additional information about the request.
      *
-     * @var \Cake\Http\ServerRequest|null
+     * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getRequest()/setRequest instead.
+     *
+     * @var \Cake\Http\ServerRequest
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#request
-     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getRequest()/setRequest instead.
      */
     public $request;
 
     /**
      * An instance of a Response object that contains information about the impending response
      *
-     * @var \Cake\Http\Response|null
+     * Deprecated 3.6.0: The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
+     
+     * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
-     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
      */
     public $response;
 

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Database\Statement;
 
 /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -113,7 +113,7 @@ class BufferedStatement extends StatementDecorator
     {
         $result = $this->fetch(static::FETCH_TYPE_ASSOC);
 
-        return $result ? $result : [];
+        return $result ?: [];
     }
 
     /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -116,7 +116,7 @@ class BufferedStatement extends StatementDecorator
             return $result;
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -112,11 +112,9 @@ class BufferedStatement extends StatementDecorator
      */
     public function fetchAssoc()
     {
-        if ($result = $this->fetch(static::FETCH_TYPE_ASSOC)) {
-            return $result;
-        }
+        $result = $this->fetch(static::FETCH_TYPE_ASSOC);
 
-        return [];
+        return $result ? $result : [];
     }
 
     /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Database\Statement;
 
 /**
@@ -111,7 +112,11 @@ class BufferedStatement extends StatementDecorator
      */
     public function fetchAssoc()
     {
-        return $this->fetch(static::FETCH_TYPE_ASSOC);
+        if ($result = $this->fetch(static::FETCH_TYPE_ASSOC)) {
+            return $result;
+        }
+
+        return array();
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Database\Statement;
 
 use Cake\Database\StatementInterface;

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -222,7 +222,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * Returns the next row in a result set as an associative array. Calling this function is the same as calling
      * $statement->fetch(StatementDecorator::FETCH_TYPE_ASSOC). If no results are found false is returned.
      *
-     * @return array Result array containing columns and values an an associative array or an empty if no results
+     * @return array Result array containing columns and values an an associative array or an empty array if no results
      */
     public function fetchAssoc()
     {

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -227,7 +227,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
     {
         $result = $this->fetch(static::FETCH_TYPE_ASSOC);
 
-        return $result ? $result : [];
+        return $result ?: [];
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -226,11 +226,9 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      */
     public function fetchAssoc()
     {
-        if ($result = $this->fetch(static::FETCH_TYPE_ASSOC)) {
-            return $result;
-        }
+        $result = $this->fetch(static::FETCH_TYPE_ASSOC);
 
-        return [];
+        return $result ? $result : [];
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Database\Statement;
 
 use Cake\Database\StatementInterface;
@@ -221,11 +222,15 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * Returns the next row in a result set as an associative array. Calling this function is the same as calling
      * $statement->fetch(StatementDecorator::FETCH_TYPE_ASSOC). If no results are found false is returned.
      *
-     * @return array|false Result array containing columns and values an an associative array or false if no results
+     * @return array Result array containing columns and values an an associative array or an empty if no results
      */
     public function fetchAssoc()
     {
-        return $this->fetch(static::FETCH_TYPE_ASSOC);
+        if ($result = $this->fetch(static::FETCH_TYPE_ASSOC)) {
+            return $result;
+        }
+
+        return array();
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -230,7 +230,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
             return $result;
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4780,6 +4780,25 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that calling fetchAssoc return an empty associated array.
+     * @return void
+     * @throws \Exception
+     */
+    public function testFetchAssocWithEmptyResult()
+    {
+        $this->loadFixtures('Profiles');
+        $query = new Query($this->connection);
+
+        $results = $query
+            ->select(['id'])
+            ->from('profiles')
+            ->where(['id' => -1])
+            ->execute()
+            ->fetchAssoc();
+        $this->assertSame([], $results);
+    }
+
+    /**
      * Test that calling fetch with with FETCH_TYPE_OBJ return stdClass object.
      * @return void
      * @throws \Exception


### PR DESCRIPTION
This change ensures that `fetchAll` always returns an array.