### PR TITLE
Set PHP_SELF in the integration test case.

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -108,8 +108,12 @@ class MiddlewareDispatcher
         if (isset($spec['input'])) {
             $spec['post'] = [];
         }
+        $environment = array_merge(
+            array_merge($_SERVER, ['REQUEST_URI' => $spec['url'], 'PHP_SELF' => '/']),
+            $spec['environment']
+        );
         $request = ServerRequestFactory::fromGlobals(
-            array_merge($_SERVER, $spec['environment'], ['REQUEST_URI' => $spec['url']]),
+            $environment,
             $spec['query'],
             $spec['post'],
             $spec['cookies']

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -139,6 +139,3 @@ loadPHPUnitAliases();
 // does not allow the sessionid to be set after stdout
 // has been written to.
 session_id('cli');
-
-// Fix multiple http/server requests in a single test method.
-$_SERVER['PHP_SELF'] = '/';


### PR DESCRIPTION
This removes the need for users to set `$_SERVER['PHP_SELF']` in their tests/bootstrap.php. While this is something included in the app template existing apps don't have it and it leads to hard to debug failures.

Refs #12075
