### PR TITLE
Sort route defaults consistently in the routes cli

### DIFF
--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -65,6 +65,7 @@ class RoutesShell extends Shell
             }
 
             unset($route['_matchedRoute']);
+            ksort($route);
 
             $output = [
                 ['Route name', 'URI template', 'Defaults'],

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -38,6 +38,7 @@ class RoutesShell extends Shell
         ];
         foreach (Router::routes() as $route) {
             $name = isset($route->options['_name']) ? $route->options['_name'] : $route->getName();
+            ksort($route->defaults);
             $output[] = [$name, $route->template, json_encode($route->defaults)];
         }
         $this->helper('table')->output($output);

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -65,17 +65,17 @@ class RoutesShellTest extends ConsoleIntegrationTestCase
         $this->assertOutputContainsRow([
             'articles:_action',
             '/articles/:action/*',
-            '{"controller":"Articles","action":"index","plugin":null}'
+            '{"action":"index","controller":"Articles","plugin":null}'
         ]);
         $this->assertOutputContainsRow([
             'bake._controller:_action',
             '/bake/:controller/:action',
-            '{"plugin":"Bake","action":"index"}'
+            '{"action":"index","plugin":"Bake"}'
         ]);
         $this->assertOutputContainsRow([
             'testName',
             '/tests/:action/*',
-            '{"controller":"Tests","action":"index","plugin":null}'
+            '{"action":"index","controller":"Tests","plugin":null}'
         ]);
     }
 
@@ -96,7 +96,7 @@ class RoutesShellTest extends ConsoleIntegrationTestCase
         $this->assertOutputContainsRow([
             'articles:_action',
             '/articles/check',
-            '{"action":"check","pass":[],"controller":"Articles","plugin":null}'
+            '{"action":"check","controller":"Articles","pass":[],"plugin":null}'
         ]);
     }
 
@@ -117,7 +117,7 @@ class RoutesShellTest extends ConsoleIntegrationTestCase
         $this->assertOutputContainsRow([
             'testName',
             '/tests/index',
-            '{"action":"index","pass":[],"controller":"Tests","plugin":null,"_name":"testName"}'
+            '{"_name":"testName","action":"index","controller":"Tests","pass":[],"plugin":null}'
         ]);
     }
 


### PR DESCRIPTION
In a minor refactor of some routes definitions I noticed there was no functional change - but the `bin/cake routes` output did change the order of default parameters.

This just makes it consistent.