### PR TITLE
4.x - Remove automatic route loading.

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -164,10 +164,8 @@ abstract class BaseApplication implements
      */
     public function routes($routes)
     {
-        if (!Router::$initialized) {
-            // Prevent routes from being loaded again
-            Router::$initialized = true;
-
+        // Only load routes if the router is empty
+        if (!Router::routes()) {
             require $this->configDir . '/routes.php';
         }
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -37,14 +37,6 @@ class Router
 {
 
     /**
-     * Have routes been loaded
-     *
-     * @var bool
-     * @deprecated 3.5.0 Routes will be loaded via the Application::routes() hook in 4.0.0
-     */
-    public static $initialized = false;
-
-    /**
      * Default route class.
      *
      * @var string
@@ -205,7 +197,6 @@ class Router
      */
     public static function connect($route, $defaults = [], $options = [])
     {
-        static::$initialized = true;
         static::scope('/', function ($routes) use ($route, $defaults, $options) {
             $routes->connect($route, $defaults, $options);
         });
@@ -220,10 +211,6 @@ class Router
      */
     public static function parseRequest(ServerRequestInterface $request)
     {
-        if (!static::$initialized) {
-            static::_loadRoutes();
-        }
-
         return static::$_collection->parseRequest($request);
     }
 
@@ -426,10 +413,6 @@ class Router
      */
     public static function url($url = null, $full = false)
     {
-        if (!static::$initialized) {
-            static::_loadRoutes();
-        }
-
         $params = [
             'plugin' => null,
             'controller' => null,
@@ -719,10 +702,6 @@ class Router
     {
         $collection = static::$_collection;
         if ($extensions === null) {
-            if (!static::$initialized) {
-                static::_loadRoutes();
-            }
-
             return array_unique(array_merge(static::$_defaultExtensions, $collection->getExtensions()));
         }
         $extensions = (array)$extensions;
@@ -892,23 +871,7 @@ class Router
      */
     public static function routes()
     {
-        if (!static::$initialized) {
-            static::_loadRoutes();
-        }
-
         return static::$_collection->routes();
-    }
-
-    /**
-     * Loads route configuration
-     *
-     * @deprecated 3.5.0 Routes will be loaded via the Application::routes() hook in 4.0.0
-     * @return void
-     */
-    protected static function _loadRoutes()
-    {
-        static::$initialized = true;
-        include CONFIG . 'routes.php';
     }
 
     /**
@@ -930,6 +893,5 @@ class Router
     public static function setRouteCollection($routeCollection)
     {
         static::$_collection = $routeCollection;
-        static::$initialized = true;
     }
 }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -146,7 +146,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeContentTypeSettingExt()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->Controller->setRequest($this->request->withHeader('Accept', 'application/json'));
 
         $this->RequestHandler->ext = null;
@@ -162,7 +161,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeContentTypeWithjQueryAccept()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->Controller->setRequest($this->request
             ->withHeader('Accept', 'application/json, application/javascript, */*; q=0.01')
             ->withHeader('X-Requested-With', 'XMLHttpRequest'));
@@ -181,7 +179,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeContentTypeWithjQueryTextPlainAccept()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->Controller->setRequest($this->request->withHeader('Accept', 'text/plain, */*; q=0.01'));
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
@@ -197,7 +194,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeContentTypeWithjQueryAcceptAndMultiplesExtensions()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->Controller->setRequest($this->request->withHeader('Accept', 'application/json, application/javascript, */*; q=0.01'));
         $this->RequestHandler->ext = null;
         Router::extensions(['rss', 'json'], false);
@@ -214,7 +210,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeNoContentTypeWithSingleAccept()
     {
         Router::reload();
-        Router::$initialized = true;
         $_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
         $this->assertNull($this->RequestHandler->ext);
 
@@ -257,7 +252,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeContentTypeWithMultipleAcceptedTypes()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->Controller->setRequest($this->request->withHeader(
             'Accept',
             'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7'
@@ -276,7 +270,6 @@ class RequestHandlerComponentTest extends TestCase
     public function testInitializeAmbiguousAndroidAccepts()
     {
         Router::reload();
-        Router::$initialized = true;
         $this->request = $this->request->withEnv(
             'HTTP_ACCEPT',
             'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5'

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -212,28 +212,4 @@ class BaseApplicationTest extends TestCase
             'Nested plugin should have bootstrap run'
         );
     }
-
-    /**
-     * Ensure that Router::$initialized is toggled even if the routes
-     * file fails. This prevents the routes file from being re-parsed
-     * during the error handling process.
-     *
-     * @return void
-     */
-    public function testRouteHookInitializesRouterOnError()
-    {
-        $app = $this->getMockForAbstractClass(
-            'Cake\Http\BaseApplication',
-            [TEST_APP . 'invalid_routes' . DS]
-        );
-        $builder = Router::createRouteBuilder('/');
-        try {
-            $app->routes($builder);
-
-            $this->fail('invalid_routes/routes.php file should raise an error.');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(Router::$initialized, 'Should be toggled to prevent duplicate route errors');
-            $this->assertContains('route class', $e->getMessage());
-        }
-    }
 }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -147,7 +147,6 @@ class RoutingMiddlewareTest extends TestCase
     public function testRoutesHookInvokedOnApp()
     {
         Router::reload();
-        $this->assertFalse(Router::$initialized, 'Router precondition failed');
 
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/app/articles']);
         $response = new Response();
@@ -160,7 +159,6 @@ class RoutingMiddlewareTest extends TestCase
                 '_matchedRoute' => '/app/articles'
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
-            $this->assertTrue(Router::$initialized, 'Router state should indicate routes loaded');
             $this->assertNotEmpty(Router::routes());
             $this->assertEquals('/app/articles', Router::routes()[0]->template);
         };
@@ -177,7 +175,6 @@ class RoutingMiddlewareTest extends TestCase
     public function testRoutesHookCallsPluginHook()
     {
         Router::reload();
-        $this->assertFalse(Router::$initialized, 'Router precondition failed');
 
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/app/articles']);
         $response = new Response();
@@ -470,7 +467,6 @@ class RoutingMiddlewareTest extends TestCase
             'engine' => 'File',
             'path' => TMP,
         ]);
-        Router::$initialized = false;
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $response = new Response();
         $next = function ($req, $res) use ($cacheConfigName) {
@@ -500,7 +496,6 @@ class RoutingMiddlewareTest extends TestCase
             'engine' => 'File',
             'path' => TMP,
         ]);
-        Router::$initialized = false;
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $response = new Response();
         $next = function ($req, $res) use ($cacheConfigName) {
@@ -532,7 +527,6 @@ class RoutingMiddlewareTest extends TestCase
             'engine' => 'File',
             'path' => TMP,
         ]);
-        Router::$initialized = false;
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $response = new Response();
         $next = function ($req, $res) {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -63,6 +63,9 @@ class RouterTest extends TestCase
      */
     public function testBaseUrl()
     {
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
         $this->assertRegExp('/^http(s)?:\/\//', Router::url('/', true));
         $this->assertRegExp('/^http(s)?:\/\//', Router::url(null, true));
         $this->assertRegExp('/^http(s)?:\/\//', Router::url(['_full' => true]));
@@ -75,6 +78,9 @@ class RouterTest extends TestCase
      */
     public function testFullBaseURL()
     {
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
         Router::fullBaseUrl('http://example.com');
         $this->assertEquals('http://example.com/', Router::url('/', true));
         $this->assertEquals('http://example.com', Configure::read('App.fullBaseUrl'));
@@ -2466,6 +2472,9 @@ class RouterTest extends TestCase
 
     public function testReverseFull()
     {
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
         $params = [
             'lang' => 'eng',
             'controller' => 'posts',

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -49,7 +49,6 @@ class IntegrationTestCaseTest extends IntegrationTestCase
             $routes->options('/options/:controller/:action', []);
             $routes->connect('/:controller/:action/*', []);
         });
-        Router::$initialized = true;
     }
 
     /**

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\View\Helper;
 
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\BreadcrumbsHelper;
 use Cake\View\View;
@@ -38,6 +39,11 @@ class BreadcrumbsHelperTest extends TestCase
         parent::setUp();
         $view = new View();
         $this->breadcrumbs = new BreadcrumbsHelper($view);
+
+        Router::reload();
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
     }
 
     /**
@@ -399,7 +405,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/span',
             '/li',
             ['li' => []],
-            ['a' => ['href' => '/some_alias']],
+            ['a' => ['href' => '/tests_apps/some_method']],
             'Some text',
             '/a',
             '/li',

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -76,6 +76,10 @@ class HtmlHelperTest extends TestCase
         Plugin::load(['TestTheme']);
         static::setAppNamespace();
         Configure::write('Asset.timestamp', false);
+
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
     }
 
     /**
@@ -87,6 +91,7 @@ class HtmlHelperTest extends TestCase
     {
         parent::tearDown();
         Plugin::unload('TestTheme');
+        Router::reload();
         unset($this->Html, $this->View);
     }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -42,13 +42,15 @@ class UrlHelperTest extends TestCase
     {
         parent::setUp();
 
-        Router::reload();
         $this->View = new View();
         $this->Helper = new UrlHelper($this->View);
         $this->Helper->request = new ServerRequest();
 
         static::setAppNamespace();
         Plugin::load(['TestTheme']);
+        Router::scope('/', function ($routes) {
+            $routes->fallbacks();
+        });
     }
 
     /**
@@ -62,6 +64,7 @@ class UrlHelperTest extends TestCase
         Configure::delete('Asset');
 
         Plugin::unload();
+        Router::reload();
         unset($this->Helper, $this->View);
     }
 
@@ -81,7 +84,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('/controller/action/1?one=1&amp;two=2', $result);
 
         $result = $this->Helper->build(['controller' => 'posts', 'action' => 'index', 'page' => '1" onclick="alert(\'XSS\');"']);
-        $this->assertEquals('/posts/index?page=1%22+onclick%3D%22alert%28%27XSS%27%29%3B%22', $result);
+        $this->assertEquals('/posts?page=1%22+onclick%3D%22alert%28%27XSS%27%29%3B%22', $result);
 
         $result = $this->Helper->build('/controller/action/1/param:this+one+more');
         $this->assertEquals('/controller/action/1/param:this+one+more', $result);
@@ -95,13 +98,13 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->build([
             'controller' => 'posts', 'action' => 'index', 'param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24'
         ]);
-        $this->assertEquals('/posts/index?param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
+        $this->assertEquals('/posts?param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
 
         $result = $this->Helper->build([
             'controller' => 'posts', 'action' => 'index', 'page' => '1',
             '?' => ['one' => 'value', 'two' => 'value', 'three' => 'purple']
         ]);
-        $this->assertEquals('/posts/index?one=value&amp;two=value&amp;three=purple&amp;page=1', $result);
+        $this->assertEquals('/posts?one=value&amp;two=value&amp;three=purple&amp;page=1', $result);
     }
 
     /**


### PR DESCRIPTION
Routes are now loaded by the `RoutingMiddleware`. This removes a bunch of checks in Router that look at internal state.

This may require moving when routes are loaded to be closer to application bootstrap as people will likely want to use `Router::url()` when setting up other middleware like Authentication or Authorization.

I'll solve that issue in a separate pull request as I feel it could be big enough to warrant separate changes.
