### PR TITLE
4.x - remove deprecation code from console 

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -227,26 +227,6 @@ class CommandRunner implements EventDispatcherInterface
      * If the application does not support events and this method is used as
      * a setter, an exception will be raised.
      *
-     * @param \Cake\Event\EventManager|null $events The event manager to set.
-     * @return \Cake\Event\EventManager|$this
-     * @deprecated 3.6.0 Will be removed in 4.0
-     */
-    public function eventManager(EventManager $events = null)
-    {
-        deprecationWarning('eventManager() is deprecated. Use getEventManager()/setEventManager() instead.');
-        if ($events === null) {
-            return $this->getEventManager();
-        }
-
-        return $this->setEventManager($events);
-    }
-
-    /**
-     * Get/set the application's event manager.
-     *
-     * If the application does not support events and this method is used as
-     * a setter, an exception will be raised.
-     *
      * @param \Cake\Event\EventManager $events The event manager to set.
      * @return $this
      */

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -373,20 +373,6 @@ class ConsoleIo
     }
 
     /**
-     * Change the output mode of the stdout stream
-     *
-     * @deprecated 3.5.0 Use setOutputAs() instead.
-     * @param int $mode The output mode.
-     * @return void
-     * @see \Cake\Console\ConsoleOutput::outputAs()
-     */
-    public function outputAs($mode)
-    {
-        deprecationWarning('ConsoleIo::outputAs() is deprecated. Use ConsoleIo::setOutputAs() instead.');
-        $this->_out->setOutputAs($mode);
-    }
-
-    /**
      * Add a new output style or get defined styles.
      *
      * @param string|null $style The style to get or create.

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -309,26 +309,6 @@ class ConsoleOptionParser
     }
 
     /**
-     * Gets or sets the command name for shell/task.
-     *
-     * @deprecated 3.4.0 Use setCommand()/getCommand() instead.
-     * @param string|null $text The text to set, or null if you want to read
-     * @return string|$this If reading, the value of the command. If setting $this will be returned.
-     */
-    public function command($text = null)
-    {
-        deprecationWarning(
-            'ConsoleOptionParser::command() is deprecated. ' .
-            'Use ConsoleOptionParser::setCommand()/getCommand() instead.'
-        );
-        if ($text !== null) {
-            return $this->setCommand($text);
-        }
-
-        return $this->getCommand();
-    }
-
-    /**
      * Sets the description text for shell/task.
      *
      * @param string|array $text The text to set. If an array the
@@ -353,27 +333,6 @@ class ConsoleOptionParser
     public function getDescription()
     {
         return $this->_description;
-    }
-
-    /**
-     * Get or set the description text for shell/task.
-     *
-     * @deprecated 3.4.0 Use setDescription()/getDescription() instead.
-     * @param string|array|null $text The text to set, or null if you want to read. If an array the
-     *   text will be imploded with "\n".
-     * @return string|$this If reading, the value of the description. If setting $this will be returned.
-     */
-    public function description($text = null)
-    {
-        deprecationWarning(
-            'ConsoleOptionParser::description() is deprecated. ' .
-            'Use ConsoleOptionParser::setDescription()/getDescription() instead.'
-        );
-        if ($text !== null) {
-            return $this->setDescription($text);
-        }
-
-        return $this->getDescription();
     }
 
     /**
@@ -402,28 +361,6 @@ class ConsoleOptionParser
     public function getEpilog()
     {
         return $this->_epilog;
-    }
-
-    /**
-     * Gets or sets an epilog to the parser. The epilog is added to the end of
-     * the options and arguments listing when help is generated.
-     *
-     * @deprecated 3.4.0 Use setEpilog()/getEpilog() instead.
-     * @param string|array|null $text Text when setting or null when reading. If an array the text will
-     *   be imploded with "\n".
-     * @return string|$this If reading, the value of the epilog. If setting $this will be returned.
-     */
-    public function epilog($text = null)
-    {
-        deprecationWarning(
-            'ConsoleOptionParser::epliog() is deprecated. ' .
-            'Use ConsoleOptionParser::setEpilog()/getEpilog() instead.'
-        );
-        if ($text !== null) {
-            return $this->setEpilog($text);
-        }
-
-        return $this->getEpilog();
     }
 
     /**
@@ -818,22 +755,6 @@ class ConsoleOptionParser
         }
 
         return $this->getCommandError($subcommand);
-    }
-
-    /**
-     * Set the alias used in the HelpFormatter
-     *
-     * @param string $alias The alias
-     * @return void
-     * @deprecated 3.5.0 Use setRootName() instead.
-     */
-    public function setHelpAlias($alias)
-    {
-        deprecationWarning(
-            'ConsoleOptionParser::setHelpAlias() is deprecated. ' .
-            'Use ConsoleOptionParser::setRootName() instead.'
-        );
-        $this->rootName = $alias;
     }
 
     /**

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -82,7 +82,7 @@ class ConsoleOutput
     protected $_output;
 
     /**
-     * The current output type. Manipulated with ConsoleOutput::outputAs();
+     * The current output type. Manipulated with ConsoleOutput::setOutputAs();
      *
      * @var int
      */
@@ -327,25 +327,6 @@ class ConsoleOutput
             throw new InvalidArgumentException(sprintf('Invalid output type "%s".', $type));
         }
 
-        $this->_outputAs = $type;
-    }
-
-    /**
-     * Get/Set the output type to use. The output type how formatting tags are treated.
-     *
-     * @deprecated 3.5.0 Use getOutputAs()/setOutputAs() instead.
-     * @param int|null $type The output type to use. Should be one of the class constants.
-     * @return int|null Either null or the value if getting.
-     */
-    public function outputAs($type = null)
-    {
-        deprecationWarning(
-            'ConsoleOutput::outputAs() is deprecated. ' .
-            'Use ConsoleOutput::setOutputAs()/getOutputAs() instead.'
-        );
-        if ($type === null) {
-            return $this->_outputAs;
-        }
         $this->_outputAs = $type;
     }
 

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -19,7 +19,7 @@ use Cake\Core\Exception\Exception;
  * Exception class for halting errors in console tasks
  *
  * @see \Cake\Console\Shell::_stop()
- * @see \Cake\Console\Shell::error()
+ * @see \Cake\Console\Shell::abort()
  */
 class StopException extends Exception
 {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -236,26 +236,6 @@ class Shell
     }
 
     /**
-     * Get/Set the io object for this shell.
-     *
-     * @deprecated 3.5.0 Use getIo()/setIo() instead.
-     * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo object to use.
-     * @return \Cake\Console\ConsoleIo The current ConsoleIo object.
-     */
-    public function io(ConsoleIo $io = null)
-    {
-        deprecationWarning(
-            'Shell::io() is deprecated. ' .
-            'Use Shell::setIo()/getIo() instead.'
-        );
-        if ($io !== null) {
-            $this->_io = $io;
-        }
-
-        return $this->_io;
-    }
-
-    /**
      * Initializes the Shell
      * acts as constructor for subclasses
      * allows configuration of tasks prior to shell execution
@@ -776,31 +756,6 @@ class Shell
     }
 
     /**
-     * Wraps a message with a given message type, e.g. <warning>
-     *
-     * @param string $messageType The message type, e.g. "warning".
-     * @param string|array $message The message to wrap.
-     * @return array|string The message wrapped with the given message type.
-     * @deprecated 3.6.0 Will be removed in 4.0.0 as it is no longer in use.
-     */
-    protected function wrapMessageWithType($messageType, $message)
-    {
-        deprecationWarning(
-            'Shell::wrapMessageWithType() is deprecated. ' .
-            'Use output methods on ConsoleIo instead.'
-        );
-        if (is_array($message)) {
-            foreach ($message as $k => $v) {
-                $message[$k] = "<$messageType>" . $v . "</$messageType>";
-            }
-        } else {
-            $message = "<$messageType>" . $message . "</$messageType>";
-        }
-
-        return $message;
-    }
-
-    /**
      * Returns a single or multiple linefeeds sequences.
      *
      * @param int $multiplier Number of times the linefeed sequence should be repeated
@@ -839,32 +794,6 @@ class Shell
     {
         $this->_io->err('<error>' . $message . '</error>');
         throw new StopException($message, $exitCode);
-    }
-
-    /**
-     * Displays a formatted error message
-     * and exits the application with status code 1
-     *
-     * @param string $title Title of the error
-     * @param string|null $message An optional error message
-     * @param int $exitCode The exit code for the shell task.
-     * @throws \Cake\Console\Exception\StopException
-     * @return int Error code
-     * @link https://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
-     * @deprecated 3.2.0 Use Shell::abort() instead.
-     */
-    public function error($title, $message = null, $exitCode = self::CODE_ERROR)
-    {
-        deprecationWarning('Shell::error() is deprecated. `Use Shell::abort() instead.');
-        $this->_io->err(sprintf('<error>Error:</error> %s', $title));
-
-        if (!empty($message)) {
-            $this->_io->err($message);
-        }
-
-        $this->_stop($exitCode);
-
-        return $exitCode;
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -29,23 +29,6 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test setting the console description
      *
-     * @group deprecated
-     * @return void
-     */
-    public function testDescriptionDeprecated()
-    {
-        $this->deprecated(function () {
-            $parser = new ConsoleOptionParser('test', false);
-            $result = $parser->description('A test');
-
-            $this->assertEquals($parser, $result, 'Setting description is not chainable');
-            $this->assertEquals('A test', $parser->description(), 'getting value is wrong.');
-        });
-    }
-
-    /**
-     * test setting the console description
-     *
      * @return void
      */
     public function testDescription()
@@ -61,24 +44,7 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
-     * test setting the console description
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testEplilogDeprecated()
-    {
-        $this->deprecated(function () {
-            $parser = new ConsoleOptionParser('test', false);
-            $result = $parser->epilog('A test');
-
-            $this->assertEquals($parser, $result, 'Setting epilog is not chainable');
-            $this->assertEquals('A test', $parser->epilog(), 'getting value is wrong.');
-        });
-    }
-
-    /**
-     * test setting the console epilog
+     * test setting and getting the console epilog
      *
      * @return void
      */
@@ -952,7 +918,7 @@ TEXT;
     }
 
     /**
-     * test that command() inflects the command name.
+     * test that getCommand() inflects the command name.
      *
      * @return void
      */

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -222,24 +222,6 @@ class ConsoleOutputTest extends TestCase
     }
 
     /**
-     * test deprecated outputAs
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testOutputAsPlain()
-    {
-        $this->deprecated(function () {
-            $this->output->outputAs(ConsoleOutput::PLAIN);
-            $this->assertSame(ConsoleOutput::PLAIN, $this->output->outputAs());
-            $this->output->expects($this->once())->method('_write')
-                ->with('Bad Regular');
-
-            $this->output->write('<error>Bad</error> Regular', false);
-        });
-    }
-
-    /**
      * test raw output not getting tags replaced.
      *
      * @return void
@@ -254,27 +236,14 @@ class ConsoleOutputTest extends TestCase
     }
 
     /**
-     * test plain output.
+     * test set/get plain output.
      *
      * @return void
      */
     public function testSetOutputAsPlain()
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
-        $this->output->expects($this->once())->method('_write')
-            ->with('Bad Regular');
-
-        $this->output->write('<error>Bad</error> Regular', false);
-    }
-
-    /**
-     * test set plain output.
-     *
-     * @return void
-     */
-    public function testSetSetOutputAsPlain()
-    {
-        $this->output->setOutputAs(ConsoleOutput::PLAIN);
+        $this->assertSame(ConsoleOutput::PLAIN, $this->output->getOutputAs());
         $this->output->expects($this->once())->method('_write')
             ->with('Bad Regular');
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -102,25 +102,6 @@ class ShellTest extends TestCase
     }
 
     /**
-     * test io method
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testIo()
-    {
-        $this->deprecated(function () {
-            $this->assertInstanceOf(ConsoleIo::class, $this->Shell->io());
-
-            $io = $this->getMockBuilder(ConsoleIo::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $this->assertSame($io, $this->Shell->io($io));
-            $this->assertSame($io, $this->Shell->io());
-        });
-    }
-
-    /**
      * testInitialize method
      *
      * @return void
@@ -396,25 +377,20 @@ class ShellTest extends TestCase
     }
 
     /**
-     * testError
+     * testAbort
      *
-     * @group deprecated
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionMessage Foo Not Found
+     * @expectedExceptionCode 1
      * @return void
      */
-    public function testError()
+    public function testAbort()
     {
         $this->io->expects($this->at(0))
             ->method('err')
-            ->with('<error>Error:</error> Foo Not Found');
+            ->with('<error>Foo Not Found</error>');
 
-        $this->io->expects($this->at(1))
-            ->method('err')
-            ->with('Searched all...');
-
-        $this->deprecated(function () {
-            $this->Shell->error('Foo Not Found', 'Searched all...');
-            $this->assertSame($this->Shell->stopped, 1);
-        });
+        $this->Shell->abort('Foo Not Found');
     }
 
     /**

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -31,7 +31,8 @@ class ConsoleLogTest extends TestCase
         $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
         $output->expects($this->at(0))
-            ->method('outputAs');
+            ->method('setOutputAs')
+            ->with($this->stringContains(ConsoleOutput::COLOR));
 
         $message = ' Error: oh noes</error>';
         $output->expects($this->at(1))


### PR DESCRIPTION
remove deprecation code from console 
+
 add a test for console\Shell::abort()
+
remove duplicated testCase

Refs : https://github.com/cakephp/cakephp/issues/11934