### PR TITLE
Improve field quoting a bit and use simpler patterns

### DIFF
--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -33,12 +33,8 @@ trait SqlDialectTrait
     {
         $identifier = trim($identifier);
 
-        if ($identifier === '*') {
-            return '*';
-        }
-
-        if ($identifier === '') {
-            return '';
+        if ($identifier === '*' || $identifier === '') {
+            return $identifier;
         }
 
         // string

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -54,8 +54,8 @@ trait SqlDialectTrait
             return $this->_startQuote . str_replace('.*', $this->_endQuote . '.*', $identifier);
         }
 
+        // Functions
         if (preg_match('/^([\w-]+)\((.*)\)$/', $identifier, $matches)) {
-            // Functions
             return $matches[1] . '(' . $this->quoteIdentifier($matches[2]) . ')';
         }
 
@@ -65,10 +65,11 @@ trait SqlDialectTrait
         }
 
         // string.string with spaces
-        if (preg_match('/^[\w-_]+\.[\w-_\s]+[\w_]*/', $identifier)) {
-            $items = explode('.', $identifier);
+        if (preg_match('/^([\w-]+\.[\w][\w\s\-]*[\w])(.*)/', $identifier, $matches)) {
+            $items = explode('.', $matches[1]);
+            $field = implode($this->_endQuote . '.' . $this->_startQuote, $items);
 
-            return $this->_startQuote . implode($this->_endQuote . '.' . $this->_startQuote, $items) . $this->_endQuote;
+            return $this->_startQuote . $field . $this->_endQuote . $matches[2];
         }
 
         if (preg_match('/^[\w-_\s]*[\w-_]+/', $identifier)) {

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -777,6 +777,10 @@ class ConnectionTest extends TestCase
         $expected = '"Items"."No_ 2 thing" AS "thing"';
         $this->assertEquals($expected, $result);
 
+        $result = $connection->quoteIdentifier('Items.Item Category Code = :c1');
+        $expected = '"Items"."Item Category Code" = :c1';
+        $this->assertEquals($expected, $result);
+
         $result = $connection->quoteIdentifier('MTD()');
         $expected = 'MTD()';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Improve and simplify the regex patterns used to munge fields when quoting identifiers. This was done during my investigation for #12079.