### PR TITLE
Fix X-Forwarded-For Client Ip

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -579,7 +579,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     {
         if ($this->trustProxy && $this->getEnv('HTTP_X_FORWARDED_FOR')) {
             $addresses = explode(',', $this->getEnv('HTTP_X_FORWARDED_FOR'));
-            $ipaddr = end($addresses);
+            $ipaddr = $addresses[0];
         } elseif ($this->trustProxy && $this->getEnv('HTTP_CLIENT_IP')) {
             $ipaddr = $this->getEnv('HTTP_CLIENT_IP');
         } else {

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -714,7 +714,7 @@ class ServerRequestTest extends TestCase
     public function testClientIp()
     {
         $request = new ServerRequest(['environment' => [
-            'HTTP_X_FORWARDED_FOR' => '192.168.1.5, 10.0.1.1, proxy.com, real.ip',
+            'HTTP_X_FORWARDED_FOR' => 'real.ip, 192.168.1.5, 10.0.1.1, proxy.com',
             'HTTP_CLIENT_IP' => '192.168.1.2',
             'REMOTE_ADDR' => '192.168.1.3'
         ]]);


### PR DESCRIPTION
hi :smile: ,
the clinet ip is the first on the header line check this  :
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

