### PR TITLE
Add missing HTML encoding to templates.

### DIFF
--- a/src/Template/Error/duplicate_named_route.ctp
+++ b/src/Template/Error/duplicate_named_route.ctp
@@ -25,7 +25,7 @@ $attributes = $error->getAttributes();
 $this->start('subheading');
 ?>
     <strong>Error: </strong>
-    <?= $error->getMessage(); ?>
+    <?= h($error->getMessage()); ?>
 <?php $this->end() ?>
 
 <?php $this->start('file') ?>
@@ -50,9 +50,9 @@ Remove duplicate route names in your route configuration.</p>
     echo '<tr>';
     printf(
         '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
-        $other->template,
-        Debugger::exportVar($other->defaults),
-        Debugger::exportVar($other->options)
+        h($other->template),
+        h(Debugger::exportVar($other->defaults)),
+        h(Debugger::exportVar($other->options))
     );
     echo '</tr>';
     ?>

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -26,7 +26,7 @@ $attributes = $error->getAttributes();
 $this->start('subheading');
 ?>
     <strong>Error: </strong>
-    <?= $error->getMessage(); ?>
+    <?= h($error->getMessage()); ?>
 <?php $this->end() ?>
 
 <?php $this->start('file') ?>
@@ -36,7 +36,7 @@ Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 <?php if (!empty($attributes['context'])): ?>
 <p>The passed context was:</p>
 <pre>
-<?=  Debugger::exportVar($attributes['context']); ?>
+<?= h(Debugger::exportVar($attributes['context'])); ?>
 </pre>
 <?php endif; ?>
 
@@ -48,9 +48,9 @@ foreach (Router::routes() as $route):
     echo '<tr>';
     printf(
         '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
-        $route->template,
-        Debugger::exportVar($route->defaults),
-        Debugger::exportVar($route->options)
+        h($route->template),
+        h(Debugger::exportVar($route->defaults)),
+        h(Debugger::exportVar($route->options))
     );
     echo '</tr>';
 endforeach;


### PR DESCRIPTION
These templates were missing encoding and we were notified by Nancer via the responsible disclosure process. Once this is merged I'll do releases for 3.4, 3.5 and 3.6