### PR TITLE
Remove redundant code.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - echo extension=php_wincache.dll >> php.ini
   - echo wincache.enablecli = 1 >> php.ini
   - cd C:\projects\cakephp
-  - appveyor DownloadFile https://getcomposer.org/composer.phar
+  - curl -fsS https://getcomposer.org/composer.phar -o composer.phar
   - php composer.phar install --prefer-dist --no-interaction --ansi --no-progress
   - php -i | grep "ICU version"
 

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -42,7 +42,7 @@ class BufferedStatement extends StatementDecorator
      *
      * @var bool
      */
-    protected $_allFetched = true;
+    protected $_allFetched = false;
 
     /**
      * Current record pointer
@@ -50,18 +50,6 @@ class BufferedStatement extends StatementDecorator
      * @var int
      */
     protected $_counter = 0;
-
-    /**
-     * Constructor
-     *
-     * @param \Cake\Database\StatementInterface|null $statement Statement implementation such as PDOStatement
-     * @param \Cake\Database\Driver|null $driver Driver instance
-     */
-    public function __construct($statement = null, $driver = null)
-    {
-        parent::__construct($statement, $driver);
-        $this->_reset();
-    }
 
     /**
      * Execute the statement and return the results.


### PR DESCRIPTION
By initializing properties correctly in the class we can avoid method calls to setup initial state.