### PR TITLE
3.next - Fix Buffered query interactions with Collection

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -257,7 +257,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * @see \Cake\Collection\CollectionIterface::sortBy()
      * @return mixed The value of the top element in the collection
      */
-    public function max($callback, $type = SORT_NUMERIC);
+    public function max($callback, $type = \SORT_NUMERIC);
 
     /**
      * Returns the bottom element in this collection after being sorted by a property.
@@ -283,7 +283,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * @see \Cake\Collection\CollectionInterface::sortBy()
      * @return mixed The value of the bottom element in the collection
      */
-    public function min($callback, $type = SORT_NUMERIC);
+    public function min($callback, $type = \SORT_NUMERIC);
 
     /**
      * Returns the average of all the values extracted with $matcher
@@ -378,7 +378,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * SORT_NUMERIC or SORT_NATURAL
      * @return \Cake\Collection\CollectionInterface
      */
-    public function sortBy($callback, $dir = SORT_DESC, $type = SORT_NUMERIC);
+    public function sortBy($callback, $dir = SORT_DESC, $type = \SORT_NUMERIC);
 
     /**
      * Splits a collection into sets, grouped by the result of running each value

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -177,17 +177,17 @@ trait CollectionTrait
     /**
      * {@inheritDoc}
      */
-    public function max($callback, $type = SORT_NUMERIC)
+    public function max($callback, $type = \SORT_NUMERIC)
     {
-        return (new SortIterator($this->unwrap(), $callback, SORT_DESC, $type))->first();
+        return (new SortIterator($this->unwrap(), $callback, \SORT_DESC, $type))->first();
     }
 
     /**
      * {@inheritDoc}
      */
-    public function min($callback, $type = SORT_NUMERIC)
+    public function min($callback, $type = \SORT_NUMERIC)
     {
-        return (new SortIterator($this->unwrap(), $callback, SORT_ASC, $type))->first();
+        return (new SortIterator($this->unwrap(), $callback, \SORT_ASC, $type))->first();
     }
 
     /**
@@ -242,7 +242,7 @@ trait CollectionTrait
     /**
      * {@inheritDoc}
      */
-    public function sortBy($callback, $dir = SORT_DESC, $type = SORT_NUMERIC)
+    public function sortBy($callback, $dir = \SORT_DESC, $type = \SORT_NUMERIC)
     {
         return new SortIterator($this->unwrap(), $callback, $dir, $type);
     }

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -57,7 +57,7 @@ class SortIterator extends Collection
      * @param int $type the type of comparison to perform, either SORT_STRING
      * SORT_NUMERIC or SORT_NATURAL
      */
-    public function __construct($items, $callback, $dir = SORT_DESC, $type = SORT_NUMERIC)
+    public function __construct($items, $callback, $dir = \SORT_DESC, $type = \SORT_NUMERIC)
     {
         if (!is_array($items)) {
             $items = iterator_to_array((new Collection($items))->unwrap(), false);
@@ -67,7 +67,7 @@ class SortIterator extends Collection
         $results = [];
         foreach ($items as $key => $val) {
             $val = $callback($val);
-            if ($val instanceof DateTimeInterface && $type === SORT_NUMERIC) {
+            if ($val instanceof DateTimeInterface && $type === \SORT_NUMERIC) {
                 $val = $val->format('U');
             }
             $results[$key] = $val;

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -507,8 +507,9 @@ class SqliteSchema extends BaseSchema
      */
     public function hasSequences()
     {
-        $result = $this->_driver
-            ->prepare('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"');
+        $result = $this->_driver->prepare(
+            'SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"'
+        );
         $result->execute();
         $this->_hasSequences = (bool)$result->rowCount();
         $result->closeCursor();

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -215,7 +215,7 @@ class BufferedStatement implements Iterator, StatementInterface
      * @param string $type The type to fetch.
      * @return array|false
      */
-    public function fetch($type = parent::FETCH_TYPE_NUM)
+    public function fetch($type = self::FETCH_TYPE_NUM)
     {
         if ($this->_allFetched) {
             $row = false;

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -14,6 +14,9 @@
  */
 namespace Cake\Database\Statement;
 
+use CachingIterator;
+use IteratorIterator;
+
 /**
  * A statement decorator that implements buffered results.
  *
@@ -159,5 +162,20 @@ class BufferedStatement extends StatementDecorator
         $this->_count = $this->_counter = 0;
         $this->_records = [];
         $this->_allFetched = false;
+    }
+
+    /**
+     * Get an iterator that buffers results.
+     *
+     * @return Traversable
+     */
+    public function getIterator()
+    {
+        $statement = parent::getIterator();
+        if (!$this->_iterator) {
+            $this->_iterator = new BufferedIterator(new IteratorIterator($statement));
+        }
+
+        return $this->_iterator;
     }
 }

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -302,9 +302,6 @@ class BufferedStatement implements Iterator, StatementInterface
      */
     public function rewind()
     {
-        if (!$this->_hasExecuted) {
-            $this->execute();
-        }
         $this->index = 0;
     }
 

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -47,7 +47,7 @@ class BufferedStatement implements Iterator, StatementInterface
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $driver;
+    protected $_driver;
 
     /**
      * The in-memory cache containing results from previous iterators
@@ -79,7 +79,7 @@ class BufferedStatement implements Iterator, StatementInterface
     public function __construct($statement, $driver)
     {
         $this->statement = $statement;
-        $this->driver = $driver;
+        $this->_driver = $driver;
     }
 
     /**
@@ -206,7 +206,7 @@ class BufferedStatement implements Iterator, StatementInterface
             return $row[$column];
         }
 
-        return $this->driver->lastInsertId($table, $column);
+        return $this->_driver->lastInsertId($table, $column);
     }
 
     /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -38,7 +38,7 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * The decorated statement
      *
-     * @var \Cake\Database\StatementInterface|\PDOStatement
+     * @var \Cake\Database\StatementInterface
      */
     protected $statement;
 
@@ -76,7 +76,7 @@ class BufferedStatement implements Iterator, StatementInterface
      * @param \Cake\Database\StatementInterface $statement Statement implementation such as PDOStatement
      * @param \Cake\Database\Driver $driver Driver instance
      */
-    public function __construct($statement, $driver)
+    public function __construct(StatementInterface $statement, $driver)
     {
         $this->statement = $statement;
         $this->_driver = $driver;
@@ -175,22 +175,7 @@ class BufferedStatement implements Iterator, StatementInterface
      */
     public function bind($params, $types)
     {
-        if (empty($params)) {
-            return;
-        }
-
-        $anonymousParams = is_int(key($params)) ? true : false;
-        $offset = 1;
-        foreach ($params as $index => $value) {
-            $type = null;
-            if (isset($types[$index])) {
-                $type = $types[$index];
-            }
-            if ($anonymousParams) {
-                $index += $offset;
-            }
-            $this->bindValue($index, $value, $type);
-        }
+        $this->statement->bind($params, $types);
     }
 
     /**
@@ -198,15 +183,7 @@ class BufferedStatement implements Iterator, StatementInterface
      */
     public function lastInsertId($table = null, $column = null)
     {
-        $row = null;
-        if ($column && $this->columnCount()) {
-            $row = $this->fetch(static::FETCH_TYPE_ASSOC);
-        }
-        if (isset($row[$column])) {
-            return $row[$column];
-        }
-
-        return $this->_driver->lastInsertId($table, $column);
+        return $this->_statement->lastInsertId($table, $column);
     }
 
     /**

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -183,7 +183,7 @@ class BufferedStatement implements Iterator, StatementInterface
      */
     public function lastInsertId($table = null, $column = null)
     {
-        return $this->_statement->lastInsertId($table, $column);
+        return $this->statement->lastInsertId($table, $column);
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -32,29 +32,7 @@ use IteratorAggregate;
  */
 class StatementDecorator implements StatementInterface, Countable, IteratorAggregate
 {
-
     use TypeConverterTrait;
-
-    /**
-     * Used to designate that numeric indexes be returned in a result when calling fetch methods
-     *
-     * @var string
-     */
-    const FETCH_TYPE_NUM = 'num';
-
-    /**
-     * Used to designate that an associated array be returned in a result when calling fetch methods
-     *
-     * @var string
-     */
-    const FETCH_TYPE_ASSOC = 'assoc';
-
-    /**
-     * Used to designate that a stdClass object be returned in a result when calling fetch methods
-     *
-     * @var string
-     */
-    const FETCH_TYPE_OBJ = 'obj';
 
     /**
      * Statement instance implementation, such as PDOStatement

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -17,6 +17,8 @@ namespace Cake\Database;
 /**
  * Represents a database statement. Concrete implementations
  * can either use PDOStatement or a native driver
+ *
+ * @property-read string $queryString
  */
 interface StatementInterface
 {

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -20,6 +20,26 @@ namespace Cake\Database;
  */
 interface StatementInterface
 {
+    /**
+     * Used to designate that numeric indexes be returned in a result when calling fetch methods
+     *
+     * @var string
+     */
+    const FETCH_TYPE_NUM = 'num';
+
+    /**
+     * Used to designate that an associated array be returned in a result when calling fetch methods
+     *
+     * @var string
+     */
+    const FETCH_TYPE_ASSOC = 'assoc';
+
+    /**
+     * Used to designate that a stdClass object be returned in a result when calling fetch methods
+     *
+     * @var string
+     */
+    const FETCH_TYPE_OBJ = 'obj';
 
     /**
      * Assign a value to a positional or named variable in prepared query. If using

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -997,20 +997,20 @@ class Hash
         $type = strtolower($type);
 
         if ($dir === 'asc') {
-            $dir = SORT_ASC;
+            $dir = \SORT_ASC;
         } else {
-            $dir = SORT_DESC;
+            $dir = \SORT_DESC;
         }
         if ($type === 'numeric') {
-            $type = SORT_NUMERIC;
+            $type = \SORT_NUMERIC;
         } elseif ($type === 'string') {
-            $type = SORT_STRING;
+            $type = \SORT_STRING;
         } elseif ($type === 'natural') {
-            $type = SORT_NATURAL;
+            $type = \SORT_NATURAL;
         } elseif ($type === 'locale') {
-            $type = SORT_LOCALE_STRING;
+            $type = \SORT_LOCALE_STRING;
         } else {
-            $type = SORT_REGULAR;
+            $type = \SORT_REGULAR;
         }
         if ($ignoreCase) {
             $values = array_map('mb_strtolower', $values);

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Database;
 
+use Cake\Collection\Collection;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Exception\MissingConnectionException;
@@ -247,6 +248,29 @@ class ConnectionTest extends TestCase
         $result = $statement->fetch();
         $statement->closeCursor();
         $this->assertTrue((bool)$result[0]);
+    }
+
+    /**
+     * test executing a buffered query interacts with Collection well.
+     *
+     * @return void
+     */
+    public function testBufferedStatementCollectionWrappingStatement()
+    {
+        $this->loadFixtures('Things');
+        $statement = $this->connection->query('SELECT * FROM things LIMIT 3');
+        $statement->bufferResults(true);
+
+        $collection = new Collection($statement);
+        $result = $collection->extract('id')->toArray();
+        $this->assertSame(['1', '2'], $result);
+
+        // Check iteration after extraction
+        $result = [];
+        foreach ($collection as $v) {
+            $result[] = $v['id'];
+        }
+        $this->assertSame(['1', '2'], $result);
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -24,6 +24,7 @@ use Cake\Database\Log\QueryLogger;
 use Cake\Database\Retry\CommandRetry;
 use Cake\Database\Retry\ReconnectStrategy;
 use Cake\Database\StatementInterface;
+use Cake\Database\Statement\BufferedStatement;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
@@ -257,9 +258,12 @@ class ConnectionTest extends TestCase
      */
     public function testBufferedStatementCollectionWrappingStatement()
     {
+        $this->skipIf(
+            !($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite),
+            'Only required for SQLite driver which does not support buffered results natively'
+        );
         $this->loadFixtures('Things');
         $statement = $this->connection->query('SELECT * FROM things LIMIT 3');
-        $statement->bufferResults(true);
 
         $collection = new Collection($statement);
         $result = $collection->extract('id')->toArray();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2869,7 +2869,7 @@ class QueryTest extends TestCase
         }
 
         $results = $query->decorateResults(null, true)->execute();
-        while ($row = $result->fetch('assoc')) {
+        while ($row = $results->fetch('assoc')) {
             $this->assertArrayNotHasKey('foo', $row);
             $this->assertArrayNotHasKey('modified_id', $row);
         }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -1024,15 +1024,15 @@ SQL;
             ->will($this->returnValue($driver));
 
         $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
+            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetchAll'])
             ->getMock();
-        $driver->getConnection()->expects($this->once())->method('prepare')
+        $driver->getConnection()->expects($this->once())
+            ->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
-        $statement->expects($this->at(0))->method('fetch')
+        $statement->expects($this->once())
+            ->method('fetchAll')
             ->will($this->returnValue(['1']));
-        $statement->expects($this->at(2))->method('fetch')
-            ->will($this->returnValue(false));
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
@@ -1056,12 +1056,15 @@ SQL;
             ->will($this->returnValue($driver));
 
         $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
+            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetchAll'])
             ->getMock();
-        $driver->getConnection()->expects($this->once())->method('prepare')
+        $driver->getConnection()
+            ->expects($this->once())
+            ->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
-        $statement->expects($this->once())->method('fetch')
+        $statement->expects($this->once())
+            ->method('fetchAll')
             ->will($this->returnValue(false));
 
         $table = new TableSchema('articles');


### PR DESCRIPTION
`BufferedStatements` have a few problems with Collection as outlined in #12096. These changes solve that problem and allow BufferedStatements to be iterated multiple times. This required significant changes to `BufferedStatement` so I'm targeting 3.next for these changes.