### PR TITLE
Deprecate Plugin::routes()

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -337,9 +337,16 @@ class Plugin
      * @param string|null $name name of the plugin, if null will operate on all
      *   plugins having enabled the loading of routes files.
      * @return bool
+     * @deprecated 3.6.5 This method is no longer needed when using HttpApplicationInterface based applications.
+     *   This method will be removed in 4.0.0
      */
     public static function routes($name = null)
     {
+        deprecationWarning(
+            'You no longer need to call `Plugin::routes()` after upgrading to use Http\Server. ' .
+            'See https://book.cakephp.org/3.0/en/development/application.html#adding-the-new-http-stack-to-an-existing-application ' .
+            'for upgrade information.'
+        );
         if ($name === null) {
             foreach (static::loaded() as $p) {
                 static::routes($p);

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -177,16 +177,19 @@ class PluginTest extends TestCase
     /**
      * Tests loading a plugin with bootstrap file and routes file
      *
+     * @deprecated
      * @return void
      */
     public function testLoadSingleWithBootstrapAndRoutes()
     {
-        Plugin::load('TestPlugin', ['bootstrap' => true, 'routes' => true]);
-        $this->assertTrue(Plugin::loaded('TestPlugin'));
-        $this->assertEquals('loaded plugin bootstrap', Configure::read('PluginTest.test_plugin.bootstrap'));
+        $this->deprecated(function () {
+            Plugin::load('TestPlugin', ['bootstrap' => true, 'routes' => true]);
+            $this->assertTrue(Plugin::loaded('TestPlugin'));
+            $this->assertEquals('loaded plugin bootstrap', Configure::read('PluginTest.test_plugin.bootstrap'));
 
-        Plugin::routes();
-        $this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));
+            Plugin::routes();
+            $this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));
+        });
     }
 
     /**
@@ -247,16 +250,19 @@ class PluginTest extends TestCase
     /**
      * Test ignoring missing bootstrap/routes file
      *
+     * @deprecated
      * @return void
      */
     public function testIgnoreMissingFiles()
     {
-        Plugin::loadAll([[
-            'bootstrap' => true,
-            'routes' => true,
-            'ignoreMissing' => true
-        ]]);
-        $this->assertTrue(Plugin::routes());
+        $this->deprecated(function () {
+            Plugin::loadAll([[
+                'bootstrap' => true,
+                'routes' => true,
+                'ignoreMissing' => true
+            ]]);
+            $this->assertTrue(Plugin::routes());
+        });
     }
 
     /**
@@ -390,29 +396,32 @@ class PluginTest extends TestCase
      * Tests that Plugin::loadAll() will load all plugins in the configured folder wit defaults
      * and overrides for a plugin
      *
+     * @deprecated
      * @return void
      */
     public function testLoadAllWithDefaultsAndOverride()
     {
-        Plugin::loadAll([
-            ['bootstrap' => true, 'ignoreMissing' => true],
-            'TestPlugin' => ['routes' => true],
-            'TestPluginFour' => ['bootstrap' => true, 'classBase' => '']
-        ]);
-        Plugin::routes();
+        $this->deprecated(function () {
+            Plugin::loadAll([
+                ['bootstrap' => true, 'ignoreMissing' => true],
+                'TestPlugin' => ['routes' => true],
+                'TestPluginFour' => ['bootstrap' => true, 'classBase' => '']
+            ]);
+            Plugin::routes();
 
-        $expected = [
-            'Company', 'ParentPlugin', 'PluginJs', 'TestPlugin',
-            'TestPluginFour', 'TestPluginTwo', 'TestTheme'
-        ];
-        $this->assertEquals($expected, Plugin::loaded());
-        $this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
-        $this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));
-        $this->assertNull(Configure::read('PluginTest.test_plugin.bootstrap'));
-        $this->assertEquals('loaded plugin two bootstrap', Configure::read('PluginTest.test_plugin_two.bootstrap'));
-        $this->assertEquals('loaded plugin four bootstrap', Configure::read('PluginTest.test_plugin_four.bootstrap'));
+            $expected = [
+                'Company', 'ParentPlugin', 'PluginJs', 'TestPlugin',
+                'TestPluginFour', 'TestPluginTwo', 'TestTheme'
+            ];
+            $this->assertEquals($expected, Plugin::loaded());
+            $this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
+            $this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));
+            $this->assertNull(Configure::read('PluginTest.test_plugin.bootstrap'));
+            $this->assertEquals('loaded plugin two bootstrap', Configure::read('PluginTest.test_plugin_two.bootstrap'));
+            $this->assertEquals('loaded plugin four bootstrap', Configure::read('PluginTest.test_plugin_four.bootstrap'));
 
-        // TestPluginThree won't get loaded by loadAll() since it's in a sub directory.
-        $this->assertNull(Configure::read('PluginTest.test_plugin_three.bootstrap'));
+            // TestPluginThree won't get loaded by loadAll() since it's in a sub directory.
+            $this->assertNull(Configure::read('PluginTest.test_plugin_three.bootstrap'));
+        });
     }
 }


### PR DESCRIPTION
I missed this earlier as I had updated my applications and removed this line. With this method undeprecated plugins will have their routes loaded twice. Once by `Application::pluginRoutes()` and again by `Plugin::routes()`. Because we're trending away from static APIs, and the `BasePlugin::route()` gives more control/flexibility I'm deprecating this method.

Refs #12130
