### PR TITLE
Confirm javascript postLink/Link is templatable

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -176,7 +176,7 @@ class Helper implements EventListenerInterface
      */
     protected function _confirm($message, $okCode, $cancelCode = '', $options = [])
     {
-        $message = str_replace('\\\n', '\n', json_encode($message));
+        $message = $this->_cleanConfirmMessage($message);
         $confirm = "if (confirm({$message})) { {$okCode} } {$cancelCode}";
         // We cannot change the key here in 3.x, but the behavior is inverted in this case
         $escape = isset($options['escape']) && $options['escape'] === false;
@@ -186,6 +186,17 @@ class Helper implements EventListenerInterface
         }
 
         return $confirm;
+    }
+
+    /**
+     * Returns a string read to be used in confirm()
+     *
+     * @param string $message The message to clean
+     * @return mixed
+     */
+    protected function _cleanConfirmMessage($message)
+    {
+        return str_replace('\\\n', '\n', json_encode($message));
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -163,6 +163,8 @@ class FormHelper extends Helper
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
             // Container for submit buttons.
             'submitContainer' => '<div class="submit">{{content}}</div>',
+            //Confirm javascript template for postLink()
+            'confirmJs' => '{{confirm}}',
         ]
     ];
 
@@ -1950,11 +1952,16 @@ class FormHelper extends Helper
         $url = '#';
         $onClick = 'document.' . $formName . '.submit();';
         if ($confirmMessage) {
-            $options['onclick'] = $this->_confirm($confirmMessage, $onClick, '', $options);
+            $confirm = $this->_confirm($confirmMessage, $onClick, '', $options);
         } else {
-            $options['onclick'] = $onClick . ' ';
+            $confirm = $onClick . ' ';
         }
-        $options['onclick'] .= 'event.returnValue = false; return false;';
+        $confirm .= 'event.returnValue = false; return false;';
+        $options['onclick'] = $this->templater()->format('confirmJs', [
+            'confirmMessage' => $this->_cleanConfirmMessage($confirmMessage),
+            'formName' => $formName,
+            'confirm' => $confirm
+        ]);
 
         $out .= $this->Html->link($title, $url, $options);
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -81,7 +81,8 @@ class HtmlHelper extends Helper
             'javascriptblock' => '<script{{attrs}}>{{content}}</script>',
             'javascriptstart' => '<script>',
             'javascriptlink' => '<script src="{{url}}"{{attrs}}></script>',
-            'javascriptend' => '</script>'
+            'javascriptend' => '</script>',
+            'confirmJs' => '{{confirm}}'
         ]
     ];
 
@@ -373,16 +374,19 @@ class HtmlHelper extends Helper
             $title = htmlentities($title, ENT_QUOTES, $escapeTitle);
         }
 
+        $templater = $this->templater();
         $confirmMessage = null;
         if (isset($options['confirm'])) {
             $confirmMessage = $options['confirm'];
             unset($options['confirm']);
         }
         if ($confirmMessage) {
-            $options['onclick'] = $this->_confirm($confirmMessage, 'return true;', 'return false;', $options);
+            $confirm = $this->_confirm($confirmMessage, 'return true;', 'return false;', $options);
+            $options['onclick'] = $templater->format('confirmJs', [
+                'confirmMessage' => $this->_cleanConfirmMessage($confirmMessage),
+                'confirm' => $confirm
+            ]);
         }
-
-        $templater = $this->templater();
 
         return $templater->format('link', [
             'url' => $url,

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7654,6 +7654,26 @@ class FormHelperTest extends TestCase
             '/a'
         ];
         $this->assertHtml($expected, $result);
+
+        $this->Form->setTemplates(['confirmJs' => 'if (confirm({{confirmMessage}})) { $(\'form[name="{{formName}}"]\').submit();};']);
+        $result = $this->Form->postLink(
+            'Delete',
+            '/posts/delete/1',
+            ['escape' => false, 'confirm' => 'Confirm this deletion?']
+        );
+        $expected = [
+            'form' => [
+                'method' => 'post', 'action' => '/posts/delete/1',
+                'name' => 'preg:/post_\w+/', 'style' => 'display:none;'
+            ],
+            'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
+            '/form',
+            'a' => ['href' => '#', 'onclick' => 'preg:/if \(confirm\("Confirm this deletion\?"\)\) \{ \$\(\'form\[name="post_\w+"\]\'\)\.submit\(\);\};/'],
+            'Delete',
+            '/a'
+        ];
+
+        $this->assertHtml($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -147,6 +147,17 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
+        $this->Html->setTemplates(['confirmJs' => 'if (confirm({{confirmMessage}})) { window.location="/";};']);
+        $result = $this->Html->link('Home', '/home', ['confirm' => 'Are you sure you want to do this?']);
+        $expected = [
+            'a' => ['href' => '/home', 'onclick' => 'preg:/if \(confirm\(&quot;Are you sure you want to do this\?&quot;\)\) \{ window\.location=&quot;\/&quot;;\};/'],
+            'Home',
+            '/a'
+        ];
+
+        $this->assertHtml($expected, $result);
+        $this->Html->setTemplates(['confirmJs' => '{{confirm}}']);
+
         $result = $this->Html->link('Home', '/home', ['escape' => false, 'confirm' => 'Confirm\'s "nightmares"']);
         $expected = [
             'a' => ['href' => '/home', 'onclick' => 'if (confirm(&quot;Confirm&#039;s \&quot;nightmares\&quot;&quot;)) { return true; } return false;'],


### PR DESCRIPTION
FormHelper::postLink(), and HtmlHelper::link() updated to allow users to supply their own javascript template for displaying a confirm window. Milestone #11924
 