### PR TITLE
Deprecation of normalizePath to fix it in the new method normalizeFullPath

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -359,6 +359,7 @@ class Folder
      */
     public static function normalizePath($path)
     {
+        deprecationWarning('Folder::normalizePath() is deprecated. Use Folder::correctSlashFor() instead.');
         return Folder::correctSlashFor($path);
     }
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -16,6 +16,7 @@ namespace Cake\Filesystem;
 
 use DirectoryIterator;
 use Exception;
+use FilesystemIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -354,10 +355,26 @@ class Folder
      *
      * @param string $path Path to check
      * @return string Set of slashes ("\\" or "/")
+     *
+     * @deprecated 3.6.5 This method will be removed in 4.0.0. Use correctSlashFor() instead.
      */
     public static function normalizePath($path)
     {
         return Folder::correctSlashFor($path);
+    }
+
+    /**
+     * Returns a correct set of slashes for given $path. (\\ for Windows paths and / for other paths.)
+     *
+     * @param string $path Path to transform
+     * @return string Path with the correct set of slashes ("\\" or "/")
+     */
+    public static function normalizeFullPath($path)
+    {
+        $to = Folder::correctSlashFor($path);
+        $from = ($to == '/' ? '\\' : '/');
+
+        return str_replace($from, $to, $path);
     }
 
     /**
@@ -571,6 +588,10 @@ class Folder
             return [];
         }
 
+        /**
+         * @var string $itemPath
+         * @var FileSystemIterator $fsIterator
+         */
         foreach ($iterator as $itemPath => $fsIterator) {
             if ($skipHidden) {
                 $subPathName = $fsIterator->getSubPathname();

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -16,7 +16,6 @@ namespace Cake\Filesystem;
 
 use DirectoryIterator;
 use Exception;
-use FilesystemIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -590,7 +589,7 @@ class Folder
 
         /**
          * @var string $itemPath
-         * @var FileSystemIterator $fsIterator
+         * @var \FileSystemIterator $fsIterator
          */
         foreach ($iterator as $itemPath => $fsIterator) {
             if ($skipHidden) {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -355,7 +355,7 @@ class Folder
      * @param string $path Path to check
      * @return string Set of slashes ("\\" or "/")
      *
-     * @deprecated 3.6.5 This method will be removed in 4.0.0. Use correctSlashFor() instead.
+     * @deprecated 3.7 This method will be removed in 4.0.0. Use correctSlashFor() instead.
      */
     public static function normalizePath($path)
     {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -355,7 +355,7 @@ class Folder
      * @param string $path Path to check
      * @return string Set of slashes ("\\" or "/")
      *
-     * @deprecated 3.7 This method will be removed in 4.0.0. Use correctSlashFor() instead.
+     * @deprecated 3.6.5 This method will be removed in 4.0.0. Use correctSlashFor() instead.
      */
     public static function normalizePath($path)
     {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -589,7 +589,7 @@ class Folder
 
         /**
          * @var string $itemPath
-         * @var \FileSystemIterator $fsIterator
+         * @var \RecursiveDirectoryIterator $fsIterator
          */
         foreach ($iterator as $itemPath => $fsIterator) {
             if ($skipHidden) {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -360,6 +360,7 @@ class Folder
     public static function normalizePath($path)
     {
         deprecationWarning('Folder::normalizePath() is deprecated. Use Folder::correctSlashFor() instead.');
+
         return Folder::correctSlashFor($path);
     }
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -355,7 +355,7 @@ class Folder
      * @param string $path Path to check
      * @return string Set of slashes ("\\" or "/")
      *
-     * @deprecated 3.6.5 This method will be removed in 4.0.0. Use correctSlashFor() instead.
+     * @deprecated 3.7.0 This method will be removed in 4.0.0. Use correctSlashFor() instead.
      */
     public static function normalizePath($path)
     {

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -686,17 +686,14 @@ class FolderTest extends TestCase
     public function testNormalizePath()
     {
         $path = '/path/to/file';
-        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('/', $result);
 
         $path = '\\path\\\to\\\file';
-        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('/', $result);
 
         $path = 'C:\\path\\to\\file';
-        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('\\', $result);
     }
@@ -756,19 +753,16 @@ class FolderTest extends TestCase
             $Folder = new Folder();
             $Folder->cd(ROOT);
             $path = 'C:\\path\\to\\file';
-            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertFalse($result);
 
             $path = ROOT;
             $Folder->cd(ROOT);
-            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertFalse($result);
 
             $path = DS . 'config';
             $Folder->cd(ROOT . DS . 'config');
-            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertTrue($result);
         });

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -685,17 +685,19 @@ class FolderTest extends TestCase
      */
     public function testNormalizePath()
     {
-        $path = '/path/to/file';
-        $result = Folder::normalizePath($path);
-        $this->assertEquals('/', $result);
+        $this->deprecated(function () {
+            $path = '/path/to/file';
+            $result = Folder::normalizePath($path);
+            $this->assertEquals('/', $result);
 
-        $path = '\\path\\\to\\\file';
-        $result = Folder::normalizePath($path);
-        $this->assertEquals('/', $result);
+            $path = '\\path\\\to\\\file';
+            $result = Folder::normalizePath($path);
+            $this->assertEquals('/', $result);
 
-        $path = 'C:\\path\\to\\file';
-        $result = Folder::normalizePath($path);
-        $this->assertEquals('\\', $result);
+            $path = 'C:\\path\\to\\file';
+            $result = Folder::normalizePath($path);
+            $this->assertEquals('\\', $result);
+        });
     }
 
     /**

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -680,21 +680,48 @@ class FolderTest extends TestCase
     /**
      * testNormalizePath method
      *
+     * @group deprecated
      * @return void
      */
     public function testNormalizePath()
     {
         $path = '/path/to/file';
+        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('/', $result);
 
         $path = '\\path\\\to\\\file';
+        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('/', $result);
 
         $path = 'C:\\path\\to\\file';
+        /** @noinspection PhpDeprecationInspection */
         $result = Folder::normalizePath($path);
         $this->assertEquals('\\', $result);
+    }
+
+    /**
+     * testNormalizeFullPath method
+     *
+     * @return void
+     */
+    public function testNormalizeFullPath()
+    {
+        $path = '/path/to\file';
+        $expected = '/path/to/file';
+        $result = Folder::normalizeFullPath($path);
+        $this->assertEquals($expected, $result);
+
+        $path = '\\path\\to\file';
+        $expected = '/path/to/file';
+        $result = Folder::normalizeFullPath($path);
+        $this->assertEquals($expected, $result);
+
+        $path = 'C:\\path/to/file';
+        $expected = 'C:\\path\\to\\file';
+        $result = Folder::normalizeFullPath($path);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -729,16 +756,19 @@ class FolderTest extends TestCase
             $Folder = new Folder();
             $Folder->cd(ROOT);
             $path = 'C:\\path\\to\\file';
+            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertFalse($result);
 
             $path = ROOT;
             $Folder->cd(ROOT);
+            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertFalse($result);
 
             $path = DS . 'config';
             $Folder->cd(ROOT . DS . 'config');
+            /** @noinspection PhpDeprecationInspection */
             $result = $Folder->inCakePath($path);
             $this->assertTrue($result);
         });
@@ -780,7 +810,7 @@ class FolderTest extends TestCase
         $this->assertSame($expected, $result);
 
         $Folder = new Folder(TMP . 'tests/', true);
-        $File = new File($Folder->pwd() . DS . 'paths.php', true);
+        new File($Folder->pwd() . DS . 'paths.php', true);
         $Folder->create($Folder->pwd() . DS . 'testme');
         $Folder->cd('testme');
         $result = $Folder->find('paths\.php');
@@ -980,6 +1010,17 @@ class FolderTest extends TestCase
      */
     public function testCopy()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
@@ -1010,6 +1051,17 @@ class FolderTest extends TestCase
      */
     public function testCopyWithMerge()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
@@ -1039,6 +1091,17 @@ class FolderTest extends TestCase
      */
     public function testCopyWithSkip()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
@@ -1105,10 +1168,21 @@ class FolderTest extends TestCase
      */
     public function testCopyWithOverwrite()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
-        $result = $Folder->copy(['to' => $folderThree, 'scheme' => Folder::OVERWRITE]);
+        $Folder->copy(['to' => $folderThree, 'scheme' => Folder::OVERWRITE]);
 
         $this->assertFileExists($folderThree . DS . 'file1.php');
         $this->assertFileExists($folderThree . DS . 'folderA' . DS . 'fileA.php');
@@ -1139,10 +1213,21 @@ class FolderTest extends TestCase
      */
     public function testCopyWithoutRecursive()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
-        $result = $Folder->copy(['to' => $folderThree, 'recursive' => false]);
+        $Folder->copy(['to' => $folderThree, 'recursive' => false]);
 
         $this->assertFileExists($folderThree . DS . 'file1.php');
         $this->assertDirectoryNotExists($folderThree . DS . 'folderA');
@@ -1212,6 +1297,17 @@ class FolderTest extends TestCase
      */
     public function testMove()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
@@ -1281,6 +1377,17 @@ class FolderTest extends TestCase
      */
     public function testMoveWithSkip()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);
@@ -1338,6 +1445,17 @@ class FolderTest extends TestCase
 
     public function testMoveWithoutRecursive()
     {
+        /** @var string $path
+         *  @var string $folderOne
+         *  @var string $folderOneA
+         *  @var string $folderTwo
+         *  @var string $folderTwoB
+         *  @var string $folderThree
+         *  @var string $fileOne
+         *  @var string $fileTwo
+         *  @var string $fileOneA
+         *  @var string $fileTwoB
+         */
         extract($this->_setupFilesystem());
 
         $Folder = new Folder($folderOne);


### PR DESCRIPTION
  #12131  

Everything in the title and in the issue.

It seems that other languages change only slashes, it's what I did. It could be possible to suppress double slashes, but because it's not very problematic and rare , so I take the option to not manage that. Tell me what do you think, perhaps other kind of work to do in this new method.

I also added some directives for a correct code analysis.

It misses documentation. I don't know if deprecation is automatically calculated or not. Please tell me and I will do the necessary.

AlPri78
