### PR TITLE
Add deprecation warnings for Response methods.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1365,6 +1365,10 @@ class Response implements ResponseInterface
      */
     public function sharable($public = null, $time = null)
     {
+        deprecationWarning(
+            'Response::sharable() is deprecated. ' .
+            'Use withSharable() instead.'
+        );
         if ($public === null) {
             $public = array_key_exists('public', $this->_cacheDirectives);
             $private = array_key_exists('private', $this->_cacheDirectives);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1422,11 +1422,16 @@ class Response implements ResponseInterface
      * a good candidate to be fetched from a shared cache (like in a proxy server).
      * If called with no parameters, this function will return the current max-age value if any
      *
+     * @deprecated 3.6.5 Use withSharedMaxAge() instead.
      * @param int|null $seconds if null, the method will return the current s-maxage value
      * @return int|null
      */
     public function sharedMaxAge($seconds = null)
     {
+        deprecationWarning(
+            'Response::sharedMaxAge() is deprecated. ' .
+            'Use withSharedMaxAge() instead.'
+        );
         if ($seconds !== null) {
             $this->_cacheDirectives['s-maxage'] = $seconds;
             $this->_setCacheControl();
@@ -1462,11 +1467,16 @@ class Response implements ResponseInterface
      * a good candidate to be fetched from the local (client) cache.
      * If called with no parameters, this function will return the current max-age value if any
      *
+     * @deprecated 3.6.5 Use withMaxAge() instead.
      * @param int|null $seconds if null, the method will return the current max-age value
      * @return int|null
      */
     public function maxAge($seconds = null)
     {
+        deprecationWarning(
+            'Response::maxAge() is deprecated. ' .
+            'Use withMaxAge() instead.'
+        );
         if ($seconds !== null) {
             $this->_cacheDirectives['max-age'] = $seconds;
             $this->_setCacheControl();

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -1074,28 +1074,31 @@ class ResponseTest extends TestCase
     /**
      * Tests setting of public/private Cache-Control directives
      *
+     * @deprecated
      * @return void
      */
     public function testSharable()
     {
-        $response = new Response();
-        $this->assertNull($response->sharable());
-        $response->sharable(true);
-        $this->assertTrue($response->sharable());
-        $this->assertEquals('public', $response->getHeaderLine('Cache-Control'));
+        $this->deprecated(function () {
+            $response = new Response();
+            $this->assertNull($response->sharable());
+            $response->sharable(true);
+            $this->assertTrue($response->sharable());
+            $this->assertEquals('public', $response->getHeaderLine('Cache-Control'));
 
-        $response = new Response();
-        $response->sharable(false);
-        $this->assertFalse($response->sharable());
-        $this->assertEquals('private', $response->getHeaderLine('Cache-Control'));
+            $response = new Response();
+            $response->sharable(false);
+            $this->assertFalse($response->sharable());
+            $this->assertEquals('private', $response->getHeaderLine('Cache-Control'));
 
-        $response = new Response();
-        $response->sharable(true, 3600);
-        $this->assertEquals('public, max-age=3600', $response->getHeaderLine('Cache-Control'));
+            $response = new Response();
+            $response->sharable(true, 3600);
+            $this->assertEquals('public, max-age=3600', $response->getHeaderLine('Cache-Control'));
 
-        $response = new Response();
-        $response->sharable(false, 3600);
-        $this->assertEquals('private, max-age=3600', $response->getHeaderLine('Cache-Control'));
+            $response = new Response();
+            $response->sharable(false, 3600);
+            $this->assertEquals('private, max-age=3600', $response->getHeaderLine('Cache-Control'));
+        });
     }
 
     /**
@@ -1123,20 +1126,23 @@ class ResponseTest extends TestCase
     /**
      * Tests setting of max-age Cache-Control directive
      *
+     * @deprecated
      * @return void
      */
     public function testMaxAge()
     {
-        $response = new Response();
-        $this->assertNull($response->maxAge());
-        $response->maxAge(3600);
-        $this->assertEquals(3600, $response->maxAge());
-        $this->assertEquals('max-age=3600', $response->getHeaderLine('Cache-Control'));
+        $this->deprecated(function () {
+            $response = new Response();
+            $this->assertNull($response->maxAge());
+            $response->maxAge(3600);
+            $this->assertEquals(3600, $response->maxAge());
+            $this->assertEquals('max-age=3600', $response->getHeaderLine('Cache-Control'));
 
-        $response = new Response();
-        $response->maxAge(3600);
-        $response->sharable(false);
-        $this->assertEquals('max-age=3600, private', $response->getHeaderLine('Cache-Control'));
+            $response = new Response();
+            $response->maxAge(3600);
+            $response->sharable(false);
+            $this->assertEquals('max-age=3600, private', $response->getHeaderLine('Cache-Control'));
+        });
     }
 
     /**
@@ -1160,20 +1166,23 @@ class ResponseTest extends TestCase
     /**
      * Tests setting of s-maxage Cache-Control directive
      *
+     * @deprecated
      * @return void
      */
     public function testSharedMaxAge()
     {
-        $response = new Response();
-        $this->assertNull($response->maxAge());
-        $response->sharedMaxAge(3600);
-        $this->assertEquals(3600, $response->sharedMaxAge());
-        $this->assertEquals('s-maxage=3600', $response->getHeaderLine('Cache-Control'));
+        $this->deprecated(function () {
+            $response = new Response();
+            $this->assertNull($response->maxAge());
+            $response->sharedMaxAge(3600);
+            $this->assertEquals(3600, $response->sharedMaxAge());
+            $this->assertEquals('s-maxage=3600', $response->getHeaderLine('Cache-Control'));
 
-        $response = new Response();
-        $response->sharedMaxAge(3600);
-        $response->sharable(true);
-        $this->assertEquals('s-maxage=3600, public', $response->getHeaderLine('Cache-Control'));
+            $response = new Response();
+            $response->sharedMaxAge(3600);
+            $response->sharable(true);
+            $this->assertEquals('s-maxage=3600, public', $response->getHeaderLine('Cache-Control'));
+        });
     }
 
     /**


### PR DESCRIPTION
I missed these before, but they are part of the mutable interface for responses that needs to go away.
