### PR TITLE
Fix # 11827: Replace use of each() in DboSource::order for PHP 7.2 compatibility

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3043,7 +3043,7 @@ class DboSource extends DataSource {
  * @return string ORDER BY clause
  */
 	public function order($keys, $direction = 'ASC', Model $Model = null) {
-		$keys = array_filter((array) $keys);
+		$keys = array_filter((array)$keys);
 		
 		$result = array();
 		while (!empty($keys)) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3043,8 +3043,11 @@ class DboSource extends DataSource {
  * @return string ORDER BY clause
  */
 	public function order($keys, $direction = 'ASC', Model $Model = null) {
-		$keys = array_filter((array)$keys);
-		
+		if (!is_array($keys)) {
+			$keys = array($keys);
+		}
+		$keys = array_filter($keys);
+
 		$result = array();
 		while (!empty($keys)) {
 			$key = key($keys);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3043,15 +3043,12 @@ class DboSource extends DataSource {
  * @return string ORDER BY clause
  */
 	public function order($keys, $direction = 'ASC', Model $Model = null) {
-		if (!is_array($keys)) {
-			$keys = array($keys);
-		}
-
-		$keys = array_filter($keys);
-
+		$keys = array_filter((array) $keys);
+		
 		$result = array();
 		while (!empty($keys)) {
-			list($key, $dir) = each($keys);
+			$key = key($keys);
+			$dir = current($keys);
 			array_shift($keys);
 
 			if (is_numeric($key)) {


### PR DESCRIPTION
Replaced is_array() check and set of $keys in array with cast to array of $keys in array_filter()

Replaced assignment of $key and $dir through list() with each() with simply key() and current() per tenkoma's suggestion. Resolves # 11827

each() advances the pointer similar to next() but is being negated this particular case by array_shift() which resets the pointer