### PR TITLE
Change wordwrap to Text::wordwrap at CakeEmail for multi-byte

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2432,7 +2432,7 @@ class Email implements JsonSerializable, Serializable
             if (!preg_match('/<[a-z]+.*>/i', $line)) {
                 $formatted = array_merge(
                     $formatted,
-                    explode("\n", wordwrap($line, $wrapLength, "\n", $cut))
+                    explode("\n", Text::wordWrap($line, $wrapLength, "\n", $cut))
                 );
                 continue;
             }
@@ -2453,7 +2453,7 @@ class Email implements JsonSerializable, Serializable
                             if ($tmpLineLength > 0) {
                                 $formatted = array_merge(
                                     $formatted,
-                                    explode("\n", wordwrap(trim($tmpLine), $wrapLength, "\n", $cut))
+                                    explode("\n", Text::wordWrap(trim($tmpLine), $wrapLength, "\n", $cut))
                                 );
                                 $tmpLine = '';
                                 $tmpLineLength = 0;


### PR DESCRIPTION
Garbled characters may occur when multi-byte text is input.
Because wordwrap does not support multi-byte.

before
--
![before](https://user-images.githubusercontent.com/30764014/40772351-b0d3bf36-64fa-11e8-89e5-9284c1896add.png)

after
--
![after](https://user-images.githubusercontent.com/30764014/40772354-b367b3ec-64fa-11e8-8714-da72a5dc2e25.png)
