### PR TITLE
Create method for import html

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -142,7 +142,7 @@ class Xml
     {
         $hasDisable = function_exists('libxml_disable_entity_loader');
         $internalErrors = libxml_use_internal_errors(true);
-        if ($hasDisable && empty($options['loadEntities'])) {
+        if ($hasDisable && !$options['loadEntities']) {
             libxml_disable_entity_loader(true);
         }
         $flags = 0;
@@ -162,7 +162,7 @@ class Xml
         } catch (Exception $e) {
             throw new XmlException('Xml cannot be read. ' . $e->getMessage(), null, $e);
         } finally {
-            if ($hasDisable && empty($options['loadEntities'])) {
+            if ($hasDisable && !$options['loadEntities']) {
                 libxml_disable_entity_loader(false);
             }
             libxml_use_internal_errors($internalErrors);
@@ -177,11 +177,17 @@ class Xml
      * @return \SimpleXMLElement|\DOMDocument
      * @throws \Cake\Utility\Exception\XmlException
      */
-    public static function loadHtml($input, $options)
+    public static function loadHtml($input, $options = [])
     {
+        $defaults = [
+            'return' => 'simplexml',
+            'loadEntities' => false,
+        ];
+        $options += $defaults;
+
         $hasDisable = function_exists('libxml_disable_entity_loader');
         $internalErrors = libxml_use_internal_errors(true);
-        if ($hasDisable && empty($options['loadEntities'])) {
+        if ($hasDisable && !$options['loadEntities']) {
             libxml_disable_entity_loader(true);
         }
         $flags = 0;
@@ -201,7 +207,7 @@ class Xml
         } catch (Exception $e) {
             throw new XmlException('Xml cannot be read. ' . $e->getMessage(), null, $e);
         } finally {
-            if ($hasDisable && empty($options['loadEntities'])) {
+            if ($hasDisable && !$options['loadEntities']) {
                 libxml_disable_entity_loader(false);
             }
             libxml_use_internal_errors($internalErrors);

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -194,7 +194,7 @@ class Xml
 
             if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
                 $flags |= LIBXML_NOCDATA;
-                                $xml = simplexml_import_dom($xml);
+                $xml = simplexml_import_dom($xml);
             }
 
             return $xml;

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -194,7 +194,7 @@ class Xml
 
             if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
                 $flags |= LIBXML_NOCDATA;
-								$xml = simplexml_import_dom($xml);
+                                $xml = simplexml_import_dom($xml);
             }
 
             return $xml;

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -142,7 +142,7 @@ class Xml
     {
         $hasDisable = function_exists('libxml_disable_entity_loader');
         $internalErrors = libxml_use_internal_errors(true);
-        if ($hasDisable && !$options['loadEntities']) {
+        if ($hasDisable && empty($options['loadEntities'])) {
             libxml_disable_entity_loader(true);
         }
         $flags = 0;
@@ -162,7 +162,46 @@ class Xml
         } catch (Exception $e) {
             throw new XmlException('Xml cannot be read. ' . $e->getMessage(), null, $e);
         } finally {
-            if ($hasDisable && !$options['loadEntities']) {
+            if ($hasDisable && empty($options['loadEntities'])) {
+                libxml_disable_entity_loader(false);
+            }
+            libxml_use_internal_errors($internalErrors);
+        }
+    }
+
+    /**
+     * Parse the input html string and create either a SimpleXmlElement object or a DOMDocument.
+     *
+     * @param string $input The input html string to load.
+     * @param array $options The options to use. See Xml::build()
+     * @return \SimpleXMLElement|\DOMDocument
+     * @throws \Cake\Utility\Exception\XmlException
+     */
+    public static function loadHtml($input, $options)
+    {
+        $hasDisable = function_exists('libxml_disable_entity_loader');
+        $internalErrors = libxml_use_internal_errors(true);
+        if ($hasDisable && empty($options['loadEntities'])) {
+            libxml_disable_entity_loader(true);
+        }
+        $flags = 0;
+        if (!empty($options['parseHuge'])) {
+            $flags |= LIBXML_PARSEHUGE;
+        }
+        try {
+            $xml = new DOMDocument();
+            $xml->loadHTML($input, $flags);
+
+            if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
+                $flags |= LIBXML_NOCDATA;
+								$xml = simplexml_import_dom($xml);
+            }
+
+            return $xml;
+        } catch (Exception $e) {
+            throw new XmlException('Xml cannot be read. ' . $e->getMessage(), null, $e);
+        } finally {
+            if ($hasDisable && empty($options['loadEntities'])) {
                 libxml_disable_entity_loader(false);
             }
             libxml_use_internal_errors($internalErrors);

--- a/tests/Fixture/sample.html
+++ b/tests/Fixture/sample.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html>
-<body>
+<html><body>
 
 <p>Browsers usually indent blockquote elements.</p>
 
@@ -12,5 +11,4 @@ WWF works in 100 countries and is supported by
 close to 5 million globally.
 </blockquote>
 
-</body>
-</html>
+</body></html>

--- a/tests/Fixture/sample.html
+++ b/tests/Fixture/sample.html
@@ -1,5 +1,4 @@
-<html>
-<body>
+<html><body>
 
 <p>Browsers usually indent blockquote elements.</p>
 
@@ -11,5 +10,4 @@ WWF works in 100 countries and is supported by
 close to 5 million globally.
 </blockquote>
 
-</body>
-</html>
+</body></html>

--- a/tests/Fixture/sample.html
+++ b/tests/Fixture/sample.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+
+<p>Browsers usually indent blockquote elements.</p>
+
+<blockquote cite="http://www.worldwildlife.org/who/index.html">
+For 50 years, WWF has been protecting the future of nature.
+The world's leading conservation organization,
+WWF works in 100 countries and is supported by
+1.2 million members in the United States and
+close to 5 million globally.
+</blockquote>
+
+</body>
+</html>

--- a/tests/Fixture/sample.html
+++ b/tests/Fixture/sample.html
@@ -1,4 +1,6 @@
-<html><body>
+<!DOCTYPE html>
+<html>
+<body>
 
 <p>Browsers usually indent blockquote elements.</p>
 
@@ -10,4 +12,5 @@ WWF works in 100 countries and is supported by
 close to 5 million globally.
 </blockquote>
 
-</body></html>
+</body>
+</html>

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -276,6 +276,12 @@ close to 5 million globally.
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
+
+        $xml = Xml::loadHtml($html);
+        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML() . "\n");
+
+        $xml = Xml::loadHtml($html, ['return' => 'dom']);
+        $this->assertEquals($html, $xml->saveHTML());
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -260,7 +260,7 @@ class XmlTest extends TestCase
         $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
         $this->assertEquals($html, $xml);
 
-        $xml = Xml::build($html, ['parseHuge' => true]);
+        $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
         $this->assertEquals($html, $xml);
     }

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -248,6 +248,20 @@ class XmlTest extends TestCase
     }
 
     /**
+     * testLoadHtml method
+     *
+     * @return void
+     */
+    public function testLoadHtml()
+    {
+        $html = CORE_TESTS . 'Fixture/sample.html';
+        $html = file_get_contents($html);
+        $xml = Xml::loadHtml($html);
+        $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
+        $this->assertEquals($html, $xml);
+    }
+
+    /**
      * testFromArray method
      *
      * @return void

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -267,15 +267,15 @@ close to 5 million globally.
 
         $xml = Xml::loadHtml($html);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
-        $this->assertEquals($paragraph, (string) $xml->body->p);
+        $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
-        $this->assertEquals($blockquote, (string) $xml->body->blockquote);
+        $this->assertEquals($blockquote, (string)$xml->body->blockquote);
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
-        $this->assertEquals($paragraph, (string) $xml->body->p);
+        $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
-        $this->assertEquals($blockquote, (string) $xml->body->blockquote);
+        $this->assertEquals($blockquote, (string)$xml->body->blockquote);
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -270,14 +270,12 @@ close to 5 million globally.
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
-        $this->assertEquals($html, '<!DOCTYPE html>' . "\n" . $xml->asXML());
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
-        $this->assertEquals($html, '<!DOCTYPE html>' . "\n" . $xml->asXML());
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -270,14 +270,14 @@ close to 5 million globally.
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
-        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML());
+        $this->assertEquals($html, '<!DOCTYPE html>' . "\n" . $xml->asXML());
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
-        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML());
+        $this->assertEquals($html, '<!DOCTYPE html>' . "\n" . $xml->asXML());
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -270,12 +270,14 @@ close to 5 million globally.
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
+        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML());
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
         $this->assertEquals($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
         $this->assertEquals($blockquote, (string)$xml->body->blockquote);
+        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML());
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -259,6 +259,25 @@ class XmlTest extends TestCase
         $xml = Xml::loadHtml($html);
         $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
         $this->assertEquals($html, $xml);
+
+        $xml = Xml::build($html, ['parseHuge' => true]);
+        $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
+        $this->assertEquals($html, $xml);
+    }
+
+    /**
+     * test loadHtml with a empty html string
+     *
+     * @return void
+     */
+    public function testLoadHtmlEmptyHtml()
+    {
+        try {
+            Xml::loadHtml(null);
+            $this->fail('No exception');
+        } catch (\Exception $e) {
+            $this->assertTrue(true, 'An exception was raised');
+        }
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -254,15 +254,28 @@ class XmlTest extends TestCase
      */
     public function testLoadHtml()
     {
-        $html = CORE_TESTS . 'Fixture/sample.html';
-        $html = file_get_contents($html);
+        $html_file = CORE_TESTS . 'Fixture/sample.html';
+        $html = file_get_contents($html_file);
+        $paragraph = 'Browsers usually indent blockquote elements.';
+        $blockquote = "
+For 50 years, WWF has been protecting the future of nature.
+The world's leading conservation organization,
+WWF works in 100 countries and is supported by
+1.2 million members in the United States and
+close to 5 million globally.
+";
+
         $xml = Xml::loadHtml($html);
-        $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
-        $this->assertEquals($html, $xml);
+        $this->assertTrue(isset($xml->body->p), 'Paragraph present');
+        $this->assertEquals($paragraph, (string) $xml->body->p);
+        $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
+        $this->assertEquals($blockquote, (string) $xml->body->blockquote);
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
-        $xml = html_entity_decode($xml->asXML(), ENT_NOQUOTES, 'UTF-8');
-        $this->assertEquals($html, $xml);
+        $this->assertTrue(isset($xml->body->p), 'Paragraph present');
+        $this->assertEquals($paragraph, (string) $xml->body->p);
+        $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
+        $this->assertEquals($blockquote, (string) $xml->body->blockquote);
     }
 
     /**


### PR DESCRIPTION
loadHtml parse html string and create either SimpleXmlElement object or a DOMDocument.
use of empty($options['loadEntities']) instead of !$options['loadEntities']

