### PR TITLE
4.x - Remove deprecated code in ServerRequest.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Http;
 
-use ArrayAccess;
 use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Http\Cookie\CookieCollection;
@@ -34,14 +33,13 @@ use Zend\Diactoros\UploadedFile;
  * A class that helps wrap Request information and particulars about a single request.
  * Provides methods commonly used to introspect on the request headers and request body.
  */
-class ServerRequest implements ArrayAccess, ServerRequestInterface
+class ServerRequest implements ServerRequestInterface
 {
 
     /**
      * Array of parameters parsed from the URL.
      *
      * @var array
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getParam() instead.
      */
     protected $params = [
         'plugin' => null,
@@ -57,7 +55,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * data.
      *
      * @var null|array|object
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getData() instead.
      */
     protected $data = [];
 
@@ -65,7 +62,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Array of query string arguments
      *
      * @var array
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getQuery() or getQueryParams() instead.
      */
     protected $query = [];
 
@@ -73,7 +69,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Array of cookie data.
      *
      * @var array
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getCookie() instead.
      */
     protected $cookies = [];
 
@@ -88,7 +83,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * The URL string used for the request.
      *
      * @var string
-     * @deprecated 3.6.0 This public property will be removed in 4.0.0. Use getRequestTarget() instead.
      */
     protected $url;
 
@@ -96,7 +90,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Base URL path.
      *
      * @var string
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getAttribute('base') instead.
      */
     protected $base;
 
@@ -104,7 +97,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * webroot path segment for the request.
      *
      * @var string
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getAttribute('webroot') instead.
      */
     protected $webroot = '/';
 
@@ -112,7 +104,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * The full address to the current request
      *
      * @var string
-     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getAttribute('here') or getUri()->getPath() instead.
      */
     protected $here;
 
@@ -220,42 +211,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     protected $requestTarget;
 
     /**
-     * List of deprecated properties that have backwards
-     * compatibility offered through magic methods.
-     *
-     * @var array
-     */
-    private $deprecatedProperties = [
-        'data' => ['get' => 'getData()', 'set' => 'withData()'],
-        'query' => ['get' => 'getQuery()', 'set' => 'withQueryParams()'],
-        'params' => ['get' => 'getParam()', 'set' => 'withParam()'],
-        'cookies' => ['get' => 'getCookie()', 'set' => 'withCookieParams()'],
-        'url' => ['get' => 'getPath()', 'set' => 'withRequestTarget()'],
-        'base' => ['get' => 'getAttribute("base")', 'set' => 'withAttribute("base")'],
-        'webroot' => ['get' => 'getAttribute("webroot")', 'set' => 'withAttribute("webroot")'],
-        'here' => ['get' => 'getAttribute("here")', 'set' => 'withAttribute("here")'],
-    ];
-
-    /**
-     * Wrapper method to create a new request from PHP superglobals.
-     *
-     * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
-     * the request.
-     *
-     * @return self
-     * @deprecated 3.4.0 Use `Cake\Http\ServerRequestFactory` instead.
-     */
-    public static function createFromGlobals()
-    {
-        deprecationWarning(
-            'ServerRequest::createFromGlobals() is deprecated. ' .
-            'Use `Cake\Http\ServerRequestFactory` instead.'
-        );
-
-        return ServerRequestFactory::fromGlobals();
-    }
-
-    /**
      * Create a new request object.
      *
      * You can supply the data as either an array or as a string. If you use
@@ -267,8 +222,8 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * - `files` Uploaded file data formatted like $_FILES.
      * - `cookies` Cookies for this request.
      * - `environment` $_SERVER and $_ENV data.
-     * - ~~`url`~~ The URL without the base path for the request. This option is deprecated and will be removed in 4.0.0
-     * - `uri` The PSR7 UriInterface object. If null, one will be created.
+     * - `url` The URL without the base path for the request.
+     * - `uri` The PSR7 UriInterface object. If null, one will be created from `url` or `environment`.
      * - `base` The base URL for the request.
      * - `webroot` The webroot directory for the request.
      * - `input` The data that would come from php://input this is useful for simulating
@@ -281,7 +236,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     public function __construct($config = [])
     {
         if (is_string($config)) {
-            $config = ['url' => $config];
+            trigger_error('ServerRequest no longer accepts a string as its argument.', E_USER_WARNING);
         }
         $config += [
             'params' => $this->params,
@@ -547,30 +502,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 
     /**
-     * Returns the instance of the Session object for this request
-     *
-     * If a session object is passed as first argument it will be set as
-     * the session to use for this request
-     *
-     * @deprecated 3.5.0 Use getSession() instead. The setter part will be removed.
-     * @param \Cake\Http\Session|null $session the session object to use
-     * @return \Cake\Http\Session
-     */
-    public function session(Session $session = null)
-    {
-        deprecationWarning(
-            'ServerRequest::session() is deprecated. ' .
-            'Use getSession() instead. The setter part will be removed.'
-        );
-
-        if ($session === null) {
-            return $this->session;
-        }
-
-        return $this->session = $session;
-    }
-
-    /**
      * Get the IP the client is using, or says they are using.
      *
      * @return string The client IP.
@@ -639,95 +570,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
             return $this->is(...$params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
-    }
-
-    /**
-     * Magic set method allows backward compatibility for former public properties
-     *
-     *
-     * @param string $name The property being accessed.
-     * @param mixed $value The property value.
-     * @return mixed Either the value of the parameter or null.
-     * @deprecated 3.6.0 Public properties will be removed in 4.0.0.
-     *   Use appropriate setters instead.
-     */
-    public function __set($name, $value)
-    {
-        if (isset($this->deprecatedProperties[$name])) {
-            $method = $this->deprecatedProperties[$name]['set'];
-            deprecationWarning(
-                "Setting {$name} as a property will be removed in 4.0.0. " .
-                "Use {$method} instead."
-            );
-
-            return $this->{$name} = $value;
-        }
-        throw new BadMethodCallException("Cannot set {$name} it is not a known property.");
-    }
-
-    /**
-     * Magic get method allows access to parsed routing parameters directly on the object.
-     *
-     * Allows access to `$this->params['controller']` via `$this->controller`
-     *
-     * @param string $name The property being accessed.
-     * @return mixed Either the value of the parameter or null.
-     * @deprecated 3.4.0 Accessing routing parameters through __get will removed in 4.0.0.
-     *   Use getParam() instead.
-     */
-    public function &__get($name)
-    {
-        if (isset($this->deprecatedProperties[$name])) {
-            $method = $this->deprecatedProperties[$name]['get'];
-            deprecationWarning(
-                "Accessing `{$name}` as a property will be removed in 4.0.0. " .
-                "Use request->{$method} instead."
-            );
-
-            return $this->{$name};
-        }
-
-        deprecationWarning(sprintf(
-            'Accessing routing parameters through `%s` will removed in 4.0.0. ' .
-            'Use `getParam()` instead.',
-            $name
-        ));
-
-        if (isset($this->params[$name])) {
-            return $this->params[$name];
-        }
-        $value = null;
-
-        return $value;
-    }
-
-    /**
-     * Magic isset method allows isset/empty checks
-     * on routing parameters.
-     *
-     * @param string $name The property being accessed.
-     * @return bool Existence
-     * @deprecated 3.4.0 Accessing routing parameters through __isset will removed in 4.0.0.
-     *   Use getParam() instead.
-     */
-    public function __isset($name)
-    {
-        if (isset($this->deprecatedProperties[$name])) {
-            $method = $this->deprecatedProperties[$name]['get'];
-            deprecationWarning(
-                "Accessing {$name} as a property will be removed in 4.0.0. " .
-                "Use {$method} instead."
-            );
-
-            return isset($this->{$name});
-        }
-
-        deprecationWarning(
-            'Accessing routing parameters through __isset will removed in 4.0.0. ' .
-            'Use getParam() instead.'
-        );
-
-        return isset($this->params[$name]);
     }
 
     /**
@@ -978,73 +820,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 
     /**
-     * Add parameters to the request's parsed parameter set. This will overwrite any existing parameters.
-     * This modifies the parameters available through `$request->getParam()`.
-     *
-     * @param array $params Array of parameters to merge in
-     * @return $this The current object, you can chain this method.
-     * @deprecated 3.6.0 ServerRequest::addParams() is deprecated. Use `withParam()` or
-     *   `withAttribute('params')` instead.
-     */
-    public function addParams(array $params)
-    {
-        deprecationWarning(
-            'ServerRequest::addParams() is deprecated. ' .
-            'Use `withParam()` or `withAttribute("params", $params)` instead.'
-        );
-        $this->params = array_merge($this->params, $params);
-
-        return $this;
-    }
-
-    /**
-     * Add paths to the requests' paths vars. This will overwrite any existing paths.
-     * Provides an easy way to modify, here, webroot and base.
-     *
-     * @param array $paths Array of paths to merge in
-     * @return $this The current object, you can chain this method.
-     * @deprecated 3.6.0 Mutating a request in place is deprecated. Use `withAttribute()` to modify paths instead.
-     */
-    public function addPaths(array $paths)
-    {
-        deprecationWarning(
-            'ServerRequest::addPaths() is deprecated. ' .
-            'Use `withAttribute($key, $value)` instead.'
-        );
-        foreach (['webroot', 'here', 'base'] as $element) {
-            if (isset($paths[$element])) {
-                $this->{$element} = $paths[$element];
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get the value of the current requests URL. Will include the query string arguments.
-     *
-     * @param bool $base Include the base path, set to false to trim the base path off.
-     * @return string The current request URL including query string args.
-     * @deprecated 3.4.0 This method will be removed in 4.0.0. You should use getRequestTarget() instead.
-     */
-    public function here($base = true)
-    {
-        deprecationWarning(
-            'ServerRequest::here() will be removed in 4.0.0. You should use getRequestTarget() instead.'
-        );
-
-        $url = $this->here;
-        if (!empty($this->query)) {
-            $url .= '?' . http_build_query($this->query, null, '&');
-        }
-        if (!$base) {
-            $url = preg_replace('/^' . preg_quote($this->base, '/') . '/', '', $url, 1);
-        }
-
-        return $url;
-    }
-
-    /**
      * Normalize a header name into the SERVER version.
      *
      * @param string $name The header name.
@@ -1058,29 +833,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return $name;
-    }
-
-    /**
-     * Read an HTTP header from the Request information.
-     *
-     * If the header is not defined in the request, this method
-     * will fallback to reading data from $_SERVER and $_ENV.
-     * This fallback behavior is deprecated, and will be removed in 4.0.0
-     *
-     * @param string $name Name of the header you want.
-     * @return string|null Either null on no header being set or the value of the header.
-     * @deprecated 4.0.0 The automatic fallback to env() will be removed in 4.0.0, see getHeader()
-     */
-    public function header($name)
-    {
-        deprecationWarning(
-            'ServerRequest::header() is deprecated. ' .
-            'The automatic fallback to env() will be removed in 4.0.0, see getHeader()'
-        );
-
-        $name = $this->normalizeHeaderName($name);
-
-        return $this->getEnv($name);
     }
 
     /**
@@ -1221,22 +973,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         unset($new->_environment[$name]);
 
         return $new;
-    }
-
-    /**
-     * Get the HTTP method used for this request.
-     *
-     * @return string The name of the HTTP method used.
-     * @deprecated 3.4.0 This method will be removed in 4.0.0. Use getMethod() instead.
-     */
-    public function method()
-    {
-        deprecationWarning(
-            'ServerRequest::method() is deprecated. ' .
-            'This method will be removed in 4.0.0. Use getMethod() instead.'
-        );
-
-        return $this->getEnv('REQUEST_METHOD');
     }
 
     /**
@@ -1523,28 +1259,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 
     /**
-     * Provides a read accessor for `$this->query`.
-     * Allows you to use a `Hash::get()` compatible syntax for reading post data.
-     *
-     * @param string|null $name Query string variable name or null to read all.
-     * @return string|array|null The value being read
-     * @deprecated 3.4.0 Use getQuery() or the PSR-7 getQueryParams() and withQueryParams() methods instead.
-     */
-    public function query($name = null)
-    {
-        deprecationWarning(
-            'ServerRequest::query() is deprecated. ' .
-            'Use getQuery() or the PSR-7 getQueryParams() and withQueryParams() methods instead.'
-        );
-
-        if ($name === null) {
-            return $this->query;
-        }
-
-        return $this->getQuery($name);
-    }
-
-    /**
      * Read a specific query value or dotted path.
      *
      * Developers are encouraged to use getQueryParams() when possible as it is PSR-7 compliant, and this method
@@ -1568,51 +1282,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return Hash::get($this->query, $name, $default);
-    }
-
-    /**
-     * Provides a read/write accessor for `$this->data`.
-     * Allows you to use a `Hash::get()` compatible syntax for reading post data.
-     *
-     * ### Reading values.
-     *
-     * ```
-     * $request->data('Post.title');
-     * ```
-     *
-     * When reading values you will get `null` for keys/values that do not exist.
-     *
-     * ### Writing values
-     *
-     * ```
-     * $request->data('Post.title', 'New post!');
-     * ```
-     *
-     * You can write to any value, even paths/keys that do not exist, and the arrays
-     * will be created for you.
-     *
-     * @param string|null $name Dot separated name of the value to read/write
-     * @param mixed ...$args The data to set (deprecated)
-     * @return mixed|$this Either the value being read, or this so you can chain consecutive writes.
-     * @deprecated 3.4.0 Use withData() and getData() or getParsedBody() instead.
-     */
-    public function data($name = null, ...$args)
-    {
-        deprecationWarning(
-            'ServerRequest::data() is deprecated. ' .
-            'Use withData() and getData() or getParsedBody() instead.'
-        );
-
-        if (count($args) === 1) {
-            $this->data = Hash::insert($this->data, $name, $args[0]);
-
-            return $this;
-        }
-        if ($name !== null) {
-            return Hash::get($this->data, $name);
-        }
-
-        return $this->data;
     }
 
     /**
@@ -1651,31 +1320,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 
     /**
-     * Safely access the values in $this->params.
-     *
-     * @param string $name The name of the parameter to get.
-     * @param mixed ...$args Value to set (deprecated).
-     * @return mixed|$this The value of the provided parameter. Will
-     *   return false if the parameter doesn't exist or is falsey.
-     * @deprecated 3.4.0 Use getParam() and withParam() instead.
-     */
-    public function param($name, ...$args)
-    {
-        deprecationWarning(
-            'ServerRequest::param() is deprecated. ' .
-            'Use getParam() and withParam() instead.'
-        );
-
-        if (count($args) === 1) {
-            $this->params = Hash::insert($this->params, $name, $args[0]);
-
-            return $this;
-        }
-
-        return $this->getParam($name);
-    }
-
-    /**
      * Read data from `php://input`. Useful when interacting with XML or JSON
      * request body content.
      *
@@ -1710,27 +1354,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return $input;
-    }
-
-    /**
-     * Read cookie data from the request's cookie data.
-     *
-     * @param string $key The key you want to read.
-     * @return null|string Either the cookie value, or null if the value doesn't exist.
-     * @deprecated 3.4.0 Use getCookie() instead.
-     */
-    public function cookie($key)
-    {
-        deprecationWarning(
-            'ServerRequest::cookie() is deprecated. ' .
-            'Use getCookie() instead.'
-        );
-
-        if (isset($this->cookies[$key])) {
-            return $this->cookies[$key];
-        }
-
-        return null;
     }
 
     /**
@@ -1920,40 +1543,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 
     /**
-     * Get/Set value from the request's environment data.
-     * Fallback to using env() if key not set in $environment property.
-     *
-     * @deprecated 3.5.0 Use getEnv()/withEnv() instead.
-     * @param string $key The key you want to read/write from/to.
-     * @param string|null $value Value to set. Default null.
-     * @param string|null $default Default value when trying to retrieve an environment
-     *   variable's value that does not exist. The value parameter must be null.
-     * @return $this|string|null This instance if used as setter,
-     *   if used as getter either the environment value, or null if the value doesn't exist.
-     */
-    public function env($key, $value = null, $default = null)
-    {
-        deprecationWarning(
-            'ServerRequest::env() is deprecated. ' .
-            'Use getEnv()/withEnv() instead.'
-        );
-
-        if ($value !== null) {
-            $this->_environment[$key] = $value;
-            $this->clearDetectorCache();
-
-            return $this;
-        }
-
-        $key = strtoupper($key);
-        if (!array_key_exists($key, $this->_environment)) {
-            $this->_environment[$key] = env($key);
-        }
-
-        return $this->_environment[$key] !== null ? $this->_environment[$key] : $default;
-    }
-
-    /**
      * Allow only certain HTTP request methods, if the request method does not match
      * a 405 error will be shown and the required "Allow" response header will be set.
      *
@@ -1999,27 +1588,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return $this->_input;
-    }
-
-    /**
-     * Modify data originally from `php://input`. Useful for altering json/xml data
-     * in middleware or DispatcherFilters before it gets to RequestHandlerComponent
-     *
-     * @param string $input A string to replace original parsed data from input()
-     * @return void
-     * @deprecated 3.4.0 This method will be removed in 4.0.0. Use withBody() instead.
-     */
-    public function setInput($input)
-    {
-        deprecationWarning(
-            'This method will be removed in 4.0.0.' .
-            'Use withBody() instead.'
-        );
-
-        $stream = new Stream('php://memory', 'rw');
-        $stream->write($input);
-        $stream->rewind();
-        $this->stream = $stream;
     }
 
     /**
@@ -2360,88 +1928,5 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         list($path) = explode('?', $this->requestTarget);
 
         return $path;
-    }
-
-    /**
-     * Array access read implementation
-     *
-     * @param string $name Name of the key being accessed.
-     * @return mixed
-     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use getParam(), getData() and getQuery() instead.
-     */
-    public function offsetGet($name)
-    {
-        deprecationWarning(
-            'The ArrayAccess methods will be removed in 4.0.0.' .
-            'Use getParam(), getData() and getQuery() instead.'
-        );
-
-        if (isset($this->params[$name])) {
-            return $this->params[$name];
-        }
-        if ($name === 'url') {
-            return $this->query;
-        }
-        if ($name === 'data') {
-            return $this->data;
-        }
-
-        return null;
-    }
-
-    /**
-     * Array access write implementation
-     *
-     * @param string $name Name of the key being written
-     * @param mixed $value The value being written.
-     * @return void
-     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use withParam() instead.
-     */
-    public function offsetSet($name, $value)
-    {
-        deprecationWarning(
-            'The ArrayAccess methods will be removed in 4.0.0.' .
-            'Use withParam() instead.'
-        );
-
-        $this->params[$name] = $value;
-    }
-
-    /**
-     * Array access isset() implementation
-     *
-     * @param string $name thing to check.
-     * @return bool
-     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use getParam() instead.
-     */
-    public function offsetExists($name)
-    {
-        deprecationWarning(
-            'The ArrayAccess methods will be removed in 4.0.0.' .
-            'Use getParam() instead.'
-        );
-
-        if ($name === 'url' || $name === 'data') {
-            return true;
-        }
-
-        return isset($this->params[$name]);
-    }
-
-    /**
-     * Array access unset() implementation
-     *
-     * @param string $name Name to unset.
-     * @return void
-     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use withParam() instead.
-     */
-    public function offsetUnset($name)
-    {
-        deprecationWarning(
-            'The ArrayAccess methods will be removed in 4.0.0.' .
-            'Use withParam() instead.'
-        );
-
-        unset($this->params[$name]);
     }
 }

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -78,7 +78,7 @@ class BasicAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoData()
     {
-        $request = new ServerRequest('posts/index');
+        $request = new ServerRequest(['url' => 'posts/index']);
 
         $this->response->expects($this->never())
             ->method('withHeader');
@@ -173,7 +173,7 @@ class BasicAuthenticateTest extends TestCase
      */
     public function testAuthenticateChallenge()
     {
-        $request = new ServerRequest('posts/index');
+        $request = new ServerRequest(['url' => 'posts/index']);
 
         try {
             $this->auth->unauthenticated($request, $this->response);

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -65,7 +65,7 @@ class ControllerAuthorizeTest extends TestCase
     public function testAuthorizeFailure()
     {
         $user = [];
-        $request = new ServerRequest('/posts/index');
+        $request = new ServerRequest(['url' => '/posts/index']);
         $this->assertFalse($this->auth->authorize($user, $request));
     }
 
@@ -77,7 +77,7 @@ class ControllerAuthorizeTest extends TestCase
     public function testAuthorizeSuccess()
     {
         $user = ['User' => ['username' => 'mark']];
-        $request = new ServerRequest('/posts/index');
+        $request = new ServerRequest(['url' => '/posts/index']);
 
         $this->controller->expects($this->once())
             ->method('isAuthorized')

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -95,7 +95,7 @@ class DigestAuthenticateTest extends TestCase
      */
     public function testAuthenticateNoData()
     {
-        $request = new ServerRequest('posts/index');
+        $request = new ServerRequest(['url' => 'posts/index']);
 
         $this->response->expects($this->never())
             ->method('withHeader');

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -127,7 +127,6 @@ class FormAuthenticateTest extends TestCase
      */
     public function testAuthenticatePasswordIsFalse()
     {
-        $request = new ServerRequest('posts/index', false);
         $request = new ServerRequest([
             'url' => 'posts/index',
             'post' => [

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -79,7 +79,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     protected function _init()
     {
-        $request = new ServerRequest('controller_posts/index');
+        $request = new ServerRequest(['url' => 'controller_posts/index']);
         $response = $this->getMockBuilder('Cake\Http\Response')
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -238,7 +238,7 @@ class ControllerTest extends TestCase
      */
     public function testTableAutoload()
     {
-        $request = new ServerRequest('controller_posts/index');
+        $request = new ServerRequest(['url' => 'controller/posts/index']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $Controller = new Controller($request, $response);
         $Controller->modelClass = 'SiteArticles';
@@ -266,7 +266,7 @@ class ControllerTest extends TestCase
      */
     public function testLoadModel()
     {
-        $request = new ServerRequest('controller_posts/index');
+        $request = new ServerRequest(['url' => 'controller/posts/index']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $Controller = new Controller($request, $response);
 
@@ -615,7 +615,7 @@ class ControllerTest extends TestCase
      */
     public function testSetAction()
     {
-        $request = new ServerRequest('controller_posts/index');
+        $request = new ServerRequest(['url' => 'controller/posts/index']);
 
         $TestController = new TestController($request);
         $TestController->setAction('view', 1, 2);
@@ -925,7 +925,7 @@ class ControllerTest extends TestCase
      */
     public function testComponents()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $controller = new TestController($request, $response);
@@ -972,7 +972,7 @@ class ControllerTest extends TestCase
      */
     public function testComponentsWithCustomRegistry()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $componentRegistry = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
             ->setMethods(['offsetGet'])
@@ -992,7 +992,7 @@ class ControllerTest extends TestCase
      */
     public function testLoadComponent()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $controller = new TestController($request, $response);
@@ -1011,7 +1011,7 @@ class ControllerTest extends TestCase
      */
     public function testLoadComponentDuplicate()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
 
         $controller = new TestController($request, $response);
@@ -1032,7 +1032,7 @@ class ControllerTest extends TestCase
      */
     public function testIsAction()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $controller = new TestController($request, $response);
 

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -366,7 +366,7 @@ class ExceptionRendererTest extends TestCase
     {
         Router::reload();
 
-        $request = new ServerRequest('posts/view/1000');
+        $request = new ServerRequest(['url' => 'posts/view/1000']);
         Router::setRequestInfo($request);
 
         $exception = new NotFoundException('Custom message');
@@ -389,7 +389,7 @@ class ExceptionRendererTest extends TestCase
     {
         Router::reload();
 
-        $request = new ServerRequest('posts/view/1000?sort=title&direction=desc');
+        $request = new ServerRequest(['url' => 'posts/view/1000?sort=title&direction=desc']);
         $request = $request->withHeader('Accept', 'application/json');
         $request = $request->withHeader('Content-Type', 'application/json');
         Router::setRequestInfo($request);
@@ -442,7 +442,7 @@ class ExceptionRendererTest extends TestCase
     {
         Router::reload();
 
-        $request = new ServerRequest('pages/<span id=333>pink</span></id><script>document.body.style.background = t=document.getElementById(333).innerHTML;window.alert(t);</script>');
+        $request = new ServerRequest(['url' => 'pages/<span id=333>pink</span></id><script>document.body.style.background = t=document.getElementById(333).innerHTML;window.alert(t);</script>']);
         Router::setRequestInfo($request);
 
         $exception = new NotFoundException('Custom message');

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -229,52 +229,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test addParams() method
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testAddParams()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $request = $request
-                ->withParam('controller', 'posts')
-                ->withParam('action', 'view');
-            $result = $request->addParams(['plugin' => null, 'action' => 'index']);
-
-            $this->assertSame($result, $request, 'Method did not return itself. %s');
-
-            $this->assertEquals('posts', $request->getParam('controller'));
-            $this->assertEquals('index', $request->getParam('action'));
-            $this->assertEquals(null, $request->getParam('plugin'));
-        });
-    }
-
-    /**
-     * Test splicing in paths.
-     *
-     * @return void
-     */
-    public function testAddPaths()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $request->webroot = '/some/path/going/here/';
-            $result = $request->addPaths([
-                'random' => '/something', 'webroot' => '/', 'here' => '/', 'base' => '/base_dir'
-            ]);
-
-            $this->assertSame($result, $request, 'Method did not return itself. %s');
-
-            $this->assertEquals('/', $request->webroot);
-            $this->assertEquals('/base_dir', $request->base);
-            $this->assertEquals('/', $request->here);
-            $this->assertFalse(isset($request->random));
-        });
-    }
-
-    /**
      * Test parsing POST data into the object.
      *
      * @return void
@@ -679,34 +633,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Tests the env() method returning a default value in case the requested environment variable is not set.
-     */
-    public function testDefaultEnvValue()
-    {
-        $this->deprecated(function () {
-            $_ENV['DOES_NOT_EXIST'] = null;
-            $request = new ServerRequest();
-            $this->assertNull($request->getEnv('DOES_NOT_EXIST'));
-            $this->assertEquals('default', $request->env('DOES_NOT_EXIST', null, 'default'));
-
-            $_ENV['DOES_EXIST'] = 'some value';
-            $request = new ServerRequest();
-            $this->assertEquals('some value', $request->env('DOES_EXIST'));
-            $this->assertEquals('some value', $request->env('DOES_EXIST', null, 'default'));
-
-            $_ENV['EMPTY_VALUE'] = '';
-            $request = new ServerRequest();
-            $this->assertEquals('', $request->env('EMPTY_VALUE'));
-            $this->assertEquals('', $request->env('EMPTY_VALUE', null, 'default'));
-
-            $_ENV['ZERO'] = '0';
-            $request = new ServerRequest();
-            $this->assertEquals('0', $request->env('ZERO'));
-            $this->assertEquals('0', $request->env('ZERO', null, 'default'));
-        });
-    }
-
-    /**
      * Test the clientIp method.
      *
      * @return void
@@ -878,21 +804,6 @@ class ServerRequestTest extends TestCase
         $this->assertTrue($request->isAll(['ajax', 'get']));
         $this->assertFalse($request->isAll(['post', 'get']));
         $this->assertFalse($request->isAll(['ajax', 'post']));
-    }
-
-    /**
-     * Test the method() method.
-     *
-     * @return void
-     * @deprecated
-     */
-    public function testMethod()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest(['environment' => ['REQUEST_METHOD' => 'delete']]);
-
-            $this->assertEquals('delete', $request->method());
-        });
     }
 
     /**
@@ -1141,79 +1052,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test getting request params with object properties.
-     *
-     * @return void
-     */
-    public function testMagicget()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $request->params = ['controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs'];
-
-            $this->assertEquals('posts', $request->controller);
-            $this->assertEquals('view', $request->action);
-            $this->assertEquals('blogs', $request->plugin);
-            $this->assertNull($request->banana);
-        });
-    }
-
-    /**
-     * Test isset()/empty() with overloaded properties.
-     *
-     * @return void
-     */
-    public function testMagicisset()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $request->params = [
-                'controller' => 'posts',
-                'action' => 'view',
-                'plugin' => 'blogs',
-            ];
-
-            $this->assertTrue(isset($request->controller));
-            $this->assertFalse(isset($request->notthere));
-            $this->assertNotEmpty($request->controller);
-        });
-    }
-
-    /**
-     * Test the array access implementation
-     *
-     * @return void
-     */
-    public function testArrayAccess()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $request->params = ['controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs'];
-
-            $this->assertEquals('posts', $request['controller']);
-
-            $request['slug'] = 'speedy-slug';
-            $this->assertEquals('speedy-slug', $request->slug);
-            $this->assertEquals('speedy-slug', $request['slug']);
-
-            $this->assertArrayHasKey('action', $request);
-            $this->assertArrayNotHasKey('wrong-param', $request);
-
-            $this->assertArrayHasKey('plugin', $request);
-            unset($request['plugin']);
-            $this->assertArrayNotHasKey('plugin', $request);
-            $this->assertNull($request['plugin']);
-            $this->assertNull($request->plugin);
-
-            $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
-            $this->assertTrue(isset($request['url']['one']));
-
-            $request->data = ['Post' => ['title' => 'something']];
-            $this->assertEquals('something', $request['data']['Post']['title']);
-        });
-    }
-
-    /**
      * Test adding detectors and having them work.
      *
      * @return void
@@ -1424,16 +1262,9 @@ class ServerRequestTest extends TestCase
 
         $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
         $this->assertEquals(999, $new->getHeaderLine('Content-length'), 'new request is correct');
-        $this->deprecated(function () use ($new) {
-            $this->assertEquals(999, $new->header('Content-Length'));
-        });
 
         $new = $request->withHeader('Double', ['a']);
         $this->assertEquals(['a'], $new->getHeader('Double'), 'List values are overwritten');
-
-        $this->deprecated(function () use ($new) {
-            $this->assertEquals(['a'], $new->header('Double'), 'headers written in bc way.');
-        });
     }
 
     /**
@@ -1455,10 +1286,6 @@ class ServerRequestTest extends TestCase
 
         $this->assertEquals('a, b', $request->getHeaderLine('Double'), 'old request is unchanged');
         $this->assertEquals('a, b, c', $new->getHeaderLine('Double'), 'new request is correct');
-
-        $this->deprecated(function () use ($new) {
-            $this->assertEquals(['a', 'b', 'c'], $new->header('Double'));
-        });
 
         $new = $request->withAddedHeader('Content-Length', 777);
         $this->assertEquals([1337, 777], $new->getHeader('Content-Length'), 'scalar values are appended');
@@ -1486,10 +1313,6 @@ class ServerRequestTest extends TestCase
 
         $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
         $this->assertEquals('', $new->getHeaderLine('Content-length'), 'new request is correct');
-
-        $this->deprecated(function () use ($new) {
-            $this->assertNull($new->header('Content-Length'));
-        });
     }
 
     /**
@@ -2411,32 +2234,6 @@ class ServerRequestTest extends TestCase
         if (isset($expected['urlParams'])) {
             $this->assertEquals($expected['urlParams'], $request->getQueryParams(), 'GET param mismatch');
         }
-
-        $this->deprecated(function () use ($request, $expected) {
-            $this->assertEquals($expected['url'], $request->url, 'URL is incorrect');
-            $this->assertEquals($expected['base'], $request->base, 'base is incorrect');
-            $this->assertEquals($expected['webroot'], $request->webroot, 'webroot error');
-        });
-    }
-
-    /**
-     * Test the query() method
-     *
-     * @return void
-     */
-    public function testQuery()
-    {
-        $this->deprecated(function () {
-            $array = [
-                'query' => ['foo' => 'bar', 'zero' => '0']
-            ];
-            $request = new ServerRequest($array);
-
-            $this->assertSame('bar', $request->query('foo'));
-            $this->assertSame('0', $request->query('zero'));
-            $this->assertNull($request->query('imaginary'));
-            $this->assertSame($array['query'], $request->query());
-        });
     }
 
     /**
@@ -2561,31 +2358,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test using param()
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testReadingParamsOld()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest([
-                'params' => [
-                    'controller' => 'posts',
-                    'admin' => true,
-                    'truthy' => 1,
-                    'zero' => '0',
-                ]
-            ]);
-            $this->assertNull($request->param('not_set'));
-            $this->assertTrue($request->param('admin'));
-            $this->assertSame(1, $request->param('truthy'));
-            $this->assertSame('posts', $request->param('controller'));
-            $this->assertSame('0', $request->param('zero'));
-        });
-    }
-
-    /**
      * Test the data() method reading
      *
      * @return void
@@ -2598,19 +2370,9 @@ class ServerRequestTest extends TestCase
             ]
         ];
         $request = new ServerRequest(compact('post'));
-        $this->deprecated(function () use ($post, $request) {
-            $this->assertEquals($post['Model'], $request->data('Model'));
-        });
         $this->assertEquals($post['Model'], $request->getData('Model'));
 
-        $this->deprecated(function () use ($post, $request) {
-            $this->assertEquals($post, $request->data());
-        });
         $this->assertEquals($post, $request->getData());
-
-        $this->deprecated(function () use ($request) {
-            $this->assertNull($request->data('Model.imaginary'));
-        });
         $this->assertNull($request->getData('Model.imaginary'));
 
         $this->assertSame('value', $request->getData('Model.field', 'default'));
@@ -2628,31 +2390,6 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(compact('post'));
         $this->assertNull($request->getData('Model'));
         $this->assertNull($request->getData('Model.field'));
-    }
-
-    /**
-     * Test writing with data()
-     *
-     * @return void
-     */
-    public function testDataWriting()
-    {
-        $this->deprecated(function () {
-            $_POST['data'] = [
-                'Model' => [
-                    'field' => 'value'
-                ]
-            ];
-            $request = new ServerRequest();
-            $result = $request->data('Model.new_value', 'new value');
-            $this->assertSame($result, $request, 'Return was not $this');
-
-            $this->assertEquals('new value', $request->data['Model']['new_value']);
-
-            $request->data('Post.title', 'New post')->data('Comment.1.author', 'Mark');
-            $this->assertEquals('New post', $request->data['Post']['title']);
-            $this->assertEquals('Mark', $request->data['Comment']['1']['author']);
-        });
     }
 
     /**
@@ -2680,7 +2417,6 @@ class ServerRequestTest extends TestCase
     /**
      * Test reading params
      *
-     * @group deprecated
      * @dataProvider paramReadingDataProvider
      */
     public function testGetParam($toRead, $expected)
@@ -2772,7 +2508,7 @@ class ServerRequestTest extends TestCase
      */
     public function testParamWriting()
     {
-        $request = new ServerRequest('/');
+        $request = new ServerRequest(['url' => '/']);
         $request = $request->withParam('action', 'index');
 
         $this->assertInstanceOf(
@@ -2841,74 +2577,6 @@ class ServerRequestTest extends TestCase
 
         $result = $request->acceptLanguage('en-US');
         $this->assertFalse($result);
-    }
-
-    /**
-     * Test the here() method
-     *
-     * @return void
-     */
-    public function testHere()
-    {
-        $this->deprecated(function () {
-            Configure::write('App.base', '/base_path');
-            $q = ['test' => 'value'];
-            $request = new ServerRequest([
-                'query' => $q,
-                'url' => '/posts/add/1/value',
-                'base' => '/base_path'
-            ]);
-
-            $result = $request->here();
-            $this->assertEquals('/base_path/posts/add/1/value?test=value', $result);
-
-            $result = $request->here(false);
-            $this->assertEquals('/posts/add/1/value?test=value', $result);
-
-            $request = new ServerRequest([
-                'url' => '/posts/base_path/1/value',
-                'query' => ['test' => 'value'],
-                'base' => '/base_path'
-            ]);
-            $result = $request->here();
-            $this->assertEquals('/base_path/posts/base_path/1/value?test=value', $result);
-
-            $result = $request->here(false);
-            $this->assertEquals('/posts/base_path/1/value?test=value', $result);
-        });
-    }
-
-    /**
-     * Test the here() with space in URL
-     *
-     * @return void
-     */
-    public function testHereWithSpaceInUrl()
-    {
-        $this->deprecated(function () {
-            Configure::write('App.base', '');
-            $_GET = ['/admin/settings/settings/prefix/Access_Control' => ''];
-            $request = new ServerRequest('/admin/settings/settings/prefix/Access%20Control');
-
-            $result = $request->here();
-            $this->assertEquals('/admin/settings/settings/prefix/Access%20Control', $result);
-        });
-    }
-
-    /**
-     * Test the input() method.
-     *
-     * @return void
-     */
-    public function testSetInput()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-
-            $request->setInput('I came from setInput');
-            $result = $request->input();
-            $this->assertEquals('I came from setInput', $result);
-        });
     }
 
     /**
@@ -3012,20 +2680,6 @@ XML;
     }
 
     /**
-     * test url property
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testUrlProperty()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest(['url' => 'articles/view/3']);
-            $this->assertEquals('articles/view/3', $request->url);
-        });
-    }
-
-    /**
      * Test withUri
      *
      * @return void
@@ -3043,32 +2697,6 @@ XML;
         $this->assertNotSame($new, $request);
         $this->assertNotSame($uri, $request->getUri());
         $this->assertSame($uri, $new->getUri());
-    }
-
-    /**
-     * Test withUri
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testWithUriCompatibility()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest([
-                'environment' => [
-                    'HTTP_HOST' => 'example.com',
-                ],
-                'url' => 'articles/view/3'
-            ]);
-            $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
-            $new = $request->withUri($uri);
-            $this->assertNotSame($new, $request);
-            $this->assertNotSame($uri, $request->getUri());
-            $this->assertSame($uri, $new->getUri());
-            $this->assertSame('articles/view/3', $new->url);
-            $this->assertSame('articles/view/3', $request->url);
-            $this->assertSame('example.com', $new->getHeaderLine('Host'));
-        });
     }
 
     /**
@@ -3157,16 +2785,7 @@ XML;
                 ]
             ]
         ]);
-
-        $this->deprecated(function () use ($request) {
-            $this->assertEquals('A value in the cookie', $request->cookie('testing'));
-        });
         $this->assertEquals('A value in the cookie', $request->getCookie('testing'));
-
-        $this->deprecated(function () use ($request) {
-            $this->assertNull($request->cookie('not there'));
-        });
-
         $this->assertNull($request->getCookie('not there'));
         $this->assertSame('default', $request->getCookie('not there', 'default'));
 
@@ -3285,23 +2904,6 @@ XML;
         $this->expectException(MethodNotAllowedException::class);
 
         $request->allowMethod('POST');
-    }
-
-    /**
-     * Tests getting the sessions from the request
-     *
-     * @return void
-     */
-    public function testSession()
-    {
-        $this->deprecated(function () {
-            $session = new Session;
-            $request = new ServerRequest(['session' => $session]);
-            $this->assertSame($session, $request->session());
-
-            $request = ServerRequestFactory::fromGlobals();
-            $this->assertEquals($session, $request->session());
-        });
     }
 
     /**
@@ -3530,75 +3132,6 @@ XML;
         $update = $new->withAttribute('key', ['complex']);
         $this->assertNotEquals($update, $new, 'Should be different');
         $this->assertSame(['complex'], $update->getAttribute('key'));
-    }
-
-    /**
-     * Test that withAttribute() can modify the deprecated public properties.
-     *
-     * @group deprecated
-     * @return void
-     */
-    public function testWithAttributesCompatibility()
-    {
-        $this->deprecated(function () {
-            $request = new ServerRequest([
-                'params' => [
-                    'controller' => 'Articles',
-                    'action' => 'index'
-                ],
-                'base' => '/cakeapp',
-                'webroot' => '/cakeapp/'
-            ]);
-
-            $new = $request->withAttribute('base', '/replace')
-                ->withAttribute('webroot', '/replace/')
-                ->withAttribute('params', ['controller' => 'Tags']);
-
-            // Original request should not change.
-            $this->assertSame('/cakeapp', $request->getAttribute('base'));
-            $this->assertSame('/cakeapp/', $request->getAttribute('webroot'));
-            $this->assertSame(
-                ['controller' => 'Articles', 'action' => 'index'],
-                $request->getAttribute('params')
-            );
-
-            $this->assertSame('/replace', $new->getAttribute('base'));
-            $this->assertSame('/replace', $new->base);
-            $this->assertSame('/replace/', $new->getAttribute('webroot'));
-            $this->assertSame('/replace/', $new->webroot);
-
-            $this->assertSame(['controller' => 'Tags'], $new->getAttribute('params'));
-            $this->assertSame(['controller' => 'Tags'], $new->params);
-        });
-    }
-
-    /**
-     * Test that getAttribute() can read deprecated public properties.
-     *
-     * @group deprecated
-     * @dataProvider emulatedPropertyProvider
-     * @return void
-     */
-    public function testGetAttributesCompatibility($prop)
-    {
-        $this->deprecated(function () use ($prop) {
-            $request = new ServerRequest([
-                'params' => [
-                    'controller' => 'Articles',
-                    'action' => 'index'
-                ],
-                'url' => '/articles/view',
-                'base' => '/cakeapp',
-                'webroot' => '/cakeapp/'
-            ]);
-
-            if ($prop === 'session') {
-                $this->assertSame($request->getSession(), $request->getAttribute($prop));
-            } else {
-                $this->assertNotEmpty($request->getAttribute($prop));
-                $this->assertSame($request->{$prop}, $request->getAttribute($prop));
-            }
-        });
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2566,8 +2566,8 @@ class RouterTest extends TestCase
      */
     public function testGetRequest()
     {
-        $requestA = new ServerRequest('/');
-        $requestB = new ServerRequest('/posts');
+        $requestA = new ServerRequest(['url' => '/']);
+        $requestB = new ServerRequest(['url' => '/posts']);
 
         Router::pushRequest($requestA);
         Router::pushRequest($requestB);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -305,7 +305,7 @@ class ViewTest extends TestCase
         $this->View = $this->PostsController->createView();
         $this->View->setTemplatePath('Posts');
 
-        $themeRequest = new ServerRequest('posts/index');
+        $themeRequest = new ServerRequest(['url' => 'posts/index']);
         $this->ThemeController = new Controller($themeRequest);
         $this->ThemePostsController = new ThemePostsController($themeRequest);
         $this->ThemePostsController->index();


### PR DESCRIPTION
Remove the previously deprecated code in ServerRequest. I've opted to not remove the `['url' => '/']` style constructor as it is useful in test cases.

Refs #11934