### PR TITLE
3.7 view props

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2739,9 +2739,9 @@ class Email implements JsonSerializable, Serializable
         list($templatePlugin) = pluginSplit($View->getTemplate());
         list($layoutPlugin) = pluginSplit($View->getLayout());
         if ($templatePlugin) {
-            $View->plugin = $templatePlugin;
+            $View->setPlugin($templatePlugin);
         } elseif ($layoutPlugin) {
-            $View->plugin = $layoutPlugin;
+            $View->setPlugin($layoutPlugin);
         }
 
         if ($View->get('content') === null) {

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -27,10 +27,9 @@ class AjaxView extends View
 {
 
     /**
-     *
-     * @var string
+     * {@inheritDoc}
      */
-    public $layout = 'ajax';
+    protected $layout = 'ajax';
 
     /**
      * Constructor

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -144,10 +144,10 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
     protected function _create($class, $alias, $settings)
     {
         $instance = new $class($this->_View, $settings);
-        $vars = ['theme', 'plugin'];
-        foreach ($vars as $var) {
-            $instance->{$var} = $this->_View->{$var};
-        }
+
+        $instance->theme = $this->_View->getTheme();
+        $instance->plugin = $this->_View->plugin;
+
         $enable = isset($settings['enabled']) ? $settings['enabled'] : true;
         if ($enable) {
             $this->getEventManager()->on($instance);

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -66,8 +66,8 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         try {
             $this->load($helper);
         } catch (Exception\MissingHelperException $exception) {
-            if ($this->_View->plugin) {
-                $this->load($this->_View->plugin . '.' . $helper);
+            if ($this->_View->getPlugin()) {
+                $this->load($this->_View->getPlugin() . '.' . $helper);
 
                 return true;
             }
@@ -146,7 +146,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         $instance = new $class($this->_View, $settings);
 
         $instance->theme = $this->_View->getTheme();
-        $instance->plugin = $this->_View->plugin;
+        $instance->plugin = $this->_View->getRequest()->getParam('Plugin');
 
         $enable = isset($settings['enabled']) ? $settings['enabled'] : true;
         if ($enable) {

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -68,7 +68,7 @@ class JsonView extends SerializedView
      *
      * @var string
      */
-    public $subDir = 'json';
+    protected $subDir = 'json';
 
     /**
      * Response type.

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -61,7 +61,7 @@ class JsonView extends SerializedView
      *
      * @var string
      */
-    public $layoutPath = 'json';
+    protected $layoutPath = 'json';
 
     /**
      * JSON views are located in the 'json' sub directory for controllers' views.

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -108,7 +108,7 @@ class View implements EventDispatcherInterface
      *
      * @var string
      */
-    public $name;
+    protected $name;
 
     /**
      * Current passed params. Passed to View from the creating Controller for convenience.
@@ -1201,6 +1201,7 @@ class View implements EventDispatcherInterface
             'response' => 'getResponse',
             'subDir' => 'getSubdir',
             'plugin' => 'getPlugin',
+            'name' => 'getName',
         ];
         if (isset($protected[$name])) {
             $method = $protected[$name];
@@ -1278,6 +1279,7 @@ class View implements EventDispatcherInterface
             'response' => 'setResponse',
             'subDir' => 'setSubDir',
             'plugin' => 'setPlugin',
+            'name' => 'setName',
             'elementCache' => 'setElementCache',
         ];
         if (isset($protected[$name])) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -94,7 +94,7 @@ class View implements EventDispatcherInterface
      *
      * @var \Cake\View\ViewBlock
      */
-    public $Blocks;
+    protected $Blocks;
 
     /**
      * The name of the plugin.
@@ -1209,6 +1209,15 @@ class View implements EventDispatcherInterface
             ));
 
             return $this->{$method}();
+        }
+
+        if ($name === 'Blocks') {
+            deprecationWarning(
+                'View::$Blocks is protected now. ' .
+                'Use one of the wrapper methods like View::fetch() etc. instead.'
+            );
+
+            return $this->Blocks;
         }
 
         $registry = $this->helpers();

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1423,6 +1423,7 @@ class View implements EventDispatcherInterface
      * Check whether the view has been rendered.
      *
      * @return bool
+     * @since 3.7.0
      */
     public function hasRendered()
     {
@@ -1435,6 +1436,7 @@ class View implements EventDispatcherInterface
      * @param string $subDir Sub-directory name.
      * @return $this
      * @see \Cake\View\View::$subDir
+     * @since 3.7.0
      */
     public function setSubDir($subDir)
     {
@@ -1448,6 +1450,7 @@ class View implements EventDispatcherInterface
      *
      * @return string
      * @see \Cake\View\View::$subDir
+     * @since 3.7.0
      */
     public function getSubDir()
     {
@@ -1458,6 +1461,7 @@ class View implements EventDispatcherInterface
      * Returns the plugin name.
      *
      * @return string|null
+     * @since 3.7.0
      */
     public function getPlugin()
     {
@@ -1469,6 +1473,7 @@ class View implements EventDispatcherInterface
      *
      * @param string $name Plugin name.
      * @return $this
+     * @since 3.7.0
      */
     public function setPlugin($name)
     {
@@ -1483,6 +1488,7 @@ class View implements EventDispatcherInterface
      * @param string $elementCache Cache config name.
      * @return $this
      * @see \Cake\View\View::$elementCache
+     * @since 3.7.0
      */
     public function setElementCache($elementCache)
     {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -129,6 +129,7 @@ class View implements EventDispatcherInterface
      * The name of the subfolder containing templates for this View.
      *
      * @var string
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTemplatePath()/setTemplatePath() instead.
      */
     public $templatePath;
 
@@ -137,6 +138,7 @@ class View implements EventDispatcherInterface
      * is the filename in /src/Template/<SubFolder> without the .ctp extension.
      *
      * @var string
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTemplate()/setTemplate() instead.
      */
     public $template;
 
@@ -146,6 +148,7 @@ class View implements EventDispatcherInterface
      * extension.
      *
      * @var string
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getLayout()/setLayout() instead.
      */
     public $layout = 'default';
 
@@ -153,6 +156,7 @@ class View implements EventDispatcherInterface
      * The name of the layouts subfolder containing layouts for this View.
      *
      * @var string
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getLayoutPath()/setLayoutPath() instead.
      */
     public $layoutPath;
 
@@ -161,6 +165,7 @@ class View implements EventDispatcherInterface
      * Setting to off means that layouts will not be automatically applied to rendered templates.
      *
      * @var bool
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use enableAutoLayout()/isAutoLayoutEnabled() instead.
      */
     public $autoLayout = true;
 
@@ -183,6 +188,7 @@ class View implements EventDispatcherInterface
      * The view theme to use.
      *
      * @var string|null
+     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTheme()/setTheme() instead.
      */
     public $theme;
 
@@ -197,6 +203,7 @@ class View implements EventDispatcherInterface
      * List of generated DOM UUIDs.
      *
      * @var array
+     * @deprecated 3.7.0 The property is unused and will be removed in 4.0.0.
      */
     public $uuids = [];
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -225,7 +225,7 @@ class View implements EventDispatcherInterface
      * @var string
      * @see \Cake\View\View::element()
      */
-    public $elementCache = 'default';
+    protected $elementCache = 'default';
 
     /**
      * List of variables to collect from the associated controller.
@@ -1267,6 +1267,7 @@ class View implements EventDispatcherInterface
             'request' => 'setRequest',
             'response' => 'setResponse',
             'subDir' => 'setSubDir',
+            'elementCache' => 'setElementCache',
         ];
         if (isset($protected[$name])) {
             $method = $protected[$name];
@@ -1429,6 +1430,20 @@ class View implements EventDispatcherInterface
     public function getSubDir()
     {
         return $this->subDir;
+    }
+
+    /**
+     * Set The cache configuration View will use to store cached elements
+     *
+     * @param string $elementCache Cache config name.
+     * @return $this
+     * @see \Cake\View\View::$elementCache
+     */
+    public function setElementCache($elementCache)
+    {
+        $this->elementCache = $elementCache;
+
+        return $this;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -99,9 +99,9 @@ class View implements EventDispatcherInterface
     /**
      * The name of the plugin.
      *
-     * @var string
+     * @var string|null
      */
-    public $plugin;
+    protected $plugin;
 
     /**
      * Name of the controller that created the View if any.
@@ -1200,6 +1200,7 @@ class View implements EventDispatcherInterface
             'request' => 'getRequest',
             'response' => 'getResponse',
             'subDir' => 'getSubdir',
+            'plugin' => 'getPlugin',
         ];
         if (isset($protected[$name])) {
             $method = $protected[$name];
@@ -1276,6 +1277,7 @@ class View implements EventDispatcherInterface
             'request' => 'setRequest',
             'response' => 'setResponse',
             'subDir' => 'setSubDir',
+            'plugin' => 'setPlugin',
             'elementCache' => 'setElementCache',
         ];
         if (isset($protected[$name])) {
@@ -1448,6 +1450,29 @@ class View implements EventDispatcherInterface
     public function getSubDir()
     {
         return $this->subDir;
+    }
+
+    /**
+     * Returns the plugin name.
+     *
+     * @return string|null
+     */
+    public function getPlugin()
+    {
+        return $this->plugin;
+    }
+
+    /**
+     * Sets the plugin name.
+     *
+     * @param string $name Plugin name.
+     * @return $this
+     */
+    public function setPlugin($name)
+    {
+        $this->plugin = $name;
+
+        return $this;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -191,7 +191,7 @@ class View implements EventDispatcherInterface
      *
      * @var bool
      */
-    public $hasRendered = false;
+    protected $hasRendered = false;
 
     /**
      * List of generated DOM UUIDs.
@@ -1392,6 +1392,16 @@ class View implements EventDispatcherInterface
         $helpers = $this->helpers();
 
         return $this->{$class} = $helpers->load($name, $config);
+    }
+
+    /**
+     * Check whether the view has been rendered.
+     *
+     * @return bool
+     */
+    public function hasRendered()
+    {
+        return $this->hasRendered;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -175,9 +175,9 @@ class View implements EventDispatcherInterface
      * Sub-directory for this template file. This is often used for extension based routing.
      * Eg. With an `xml` extension, $subDir would be `xml/`
      *
-     * @var string|null
+     * @var string
      */
-    public $subDir;
+    protected $subDir = '';
 
     /**
      * The view theme to use.
@@ -1199,6 +1199,7 @@ class View implements EventDispatcherInterface
             'theme' => 'getTheme',
             'request' => 'getRequest',
             'response' => 'getResponse',
+            'subDir' => 'getSubdir',
         ];
         if (isset($protected[$name])) {
             $method = $protected[$name];
@@ -1265,6 +1266,7 @@ class View implements EventDispatcherInterface
             'theme' => 'setTheme',
             'request' => 'setRequest',
             'response' => 'setResponse',
+            'subDir' => 'setSubDir',
         ];
         if (isset($protected[$name])) {
             $method = $protected[$name];
@@ -1402,6 +1404,31 @@ class View implements EventDispatcherInterface
     public function hasRendered()
     {
         return $this->hasRendered;
+    }
+
+    /**
+     * Set sub-directory for this template files.
+     *
+     * @param string $subDir Sub-directory name.
+     * @return $this
+     * @see \Cake\View\View::$subDir
+     */
+    public function setSubDir($subDir)
+    {
+        $this->subDir = $subDir;
+
+        return $this;
+    }
+
+    /**
+     * Get sub-directory for this template files.
+     *
+     * @return string
+     * @see \Cake\View\View::$subDir
+     */
+    public function getSubDir()
+    {
+        return $this->subDir;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -123,7 +123,7 @@ class View implements EventDispatcherInterface
      *
      * @var array
      */
-    public $helpers = [];
+    protected $helpers = [];
 
     /**
      * The name of the subfolder containing templates for this View.
@@ -1221,6 +1221,15 @@ class View implements EventDispatcherInterface
             return $this->Blocks;
         }
 
+        if ($name === 'helpers') {
+            deprecationWarning(
+                'View::$helpers is protected now. ' .
+                'Use the helper registry through View::helpers() to manage helpers.'
+            );
+
+            return $this->helpers;
+        }
+
         $registry = $this->helpers();
         if (isset($registry->{$name})) {
             $this->{$name} = $registry->{$name};
@@ -1280,6 +1289,15 @@ class View implements EventDispatcherInterface
             $this->{$method}($value);
 
             return;
+        }
+
+        if ($name === 'helpers') {
+            deprecationWarning(
+                'View::$helpers is protected now. ' .
+                'Use the helper registry through View::helpers() to manage helpers.'
+            );
+
+            return $this->helpers = $value;
         }
 
         $this->{$name} = $value;

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -129,18 +129,16 @@ class View implements EventDispatcherInterface
      * The name of the subfolder containing templates for this View.
      *
      * @var string
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTemplatePath()/setTemplatePath() instead.
      */
-    public $templatePath;
+    protected $templatePath;
 
     /**
      * The name of the template file to render. The name specified
      * is the filename in /src/Template/<SubFolder> without the .ctp extension.
      *
      * @var string
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTemplate()/setTemplate() instead.
      */
-    public $template;
+    protected $template;
 
     /**
      * The name of the layout file to render the template inside of. The name specified
@@ -148,26 +146,23 @@ class View implements EventDispatcherInterface
      * extension.
      *
      * @var string
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getLayout()/setLayout() instead.
      */
-    public $layout = 'default';
+    protected $layout = 'default';
 
     /**
      * The name of the layouts subfolder containing layouts for this View.
      *
      * @var string
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getLayoutPath()/setLayoutPath() instead.
      */
-    public $layoutPath;
+    protected $layoutPath;
 
     /**
      * Turns on or off CakePHP's conventional mode of applying layout files. On by default.
      * Setting to off means that layouts will not be automatically applied to rendered templates.
      *
      * @var bool
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use enableAutoLayout()/isAutoLayoutEnabled() instead.
      */
-    public $autoLayout = true;
+    protected $autoLayout = true;
 
     /**
      * File extension. Defaults to CakePHP's template ".ctp".
@@ -188,9 +183,8 @@ class View implements EventDispatcherInterface
      * The view theme to use.
      *
      * @var string|null
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getTheme()/setTheme() instead.
      */
-    public $theme;
+    protected $theme;
 
     /**
      * True when the view has been rendered.
@@ -213,17 +207,15 @@ class View implements EventDispatcherInterface
      * additional information about the request.
      *
      * @var \Cake\Http\ServerRequest
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getRequest()/setRequest() instead.
      */
-    public $request;
+    protected $request;
 
     /**
      * Reference to the Response object
      *
      * @var \Cake\Http\Response
-     * @deprecated 3.7.0 The property will become protected in 4.0.0. Use getResponse()/setResponse() instead.
      */
-    public $response;
+    protected $response;
 
     /**
      * The Cache configuration View will use to store cached elements. Changing this will change
@@ -1183,15 +1175,40 @@ class View implements EventDispatcherInterface
      */
     public function __get($name)
     {
-        if ($name === 'view') {
-            deprecationWarning('The `view` property is deprecated. Use View::getTemplate() instead.');
+        $deprecated = [
+            'view' => 'getTemplate',
+            'viewPath' => 'getTemplatePath',
+        ];
+        if (isset($deprecated[$name])) {
+            $method = $deprecated[$name];
+            deprecationWarning(sprintf(
+                'View::$%s is deprecated. Use View::%s() instead.',
+                $name,
+                $method
+            ));
 
-            return $this->template;
+            return $this->{$method}();
         }
-        if ($name === 'viewPath') {
-            deprecationWarning('The `viewPath` property is deprecated. Use View::getTemplatePath() instead.');
 
-            return $this->templatePath;
+        $protected = [
+            'templatePath' => 'getTemplatePath',
+            'template' => 'getTemplate',
+            'layout' => 'getLayout',
+            'layoutPath' => 'setLayoutPath',
+            'autoLayout' => 'isAutoLayoutEnabled',
+            'theme' => 'getTheme',
+            'request' => 'getRequest',
+            'response' => 'getResponse',
+        ];
+        if (isset($protected[$name])) {
+            $method = $protected[$name];
+            deprecationWarning(sprintf(
+                'View::$%s is protected now. Use View::%s() instead.',
+                $name,
+                $method
+            ));
+
+            return $this->{$method}();
         }
 
         $registry = $this->helpers();
@@ -1213,15 +1230,42 @@ class View implements EventDispatcherInterface
      */
     public function __set($name, $value)
     {
-        if ($name === 'view') {
-            deprecationWarning('The `view` property is deprecated. Use View::setTemplate() instead.');
-            $this->template = $value;
+        $deprecated = [
+            'view' => 'setTemplate',
+            'viewPath' => 'setTemplatePath',
+        ];
+        if (isset($deprecated[$name])) {
+            $method = $deprecated[$name];
+            deprecationWarning(sprintf(
+                'View::$%s is deprecated. Use View::%s() instead.',
+                $name,
+                $method
+            ));
+
+            $this->{$method}($value);
 
             return;
         }
-        if ($name === 'viewPath') {
-            deprecationWarning('The `viewPath` property is deprecated. Use View::setTemplatePath() instead.');
-            $this->templatePath = $value;
+
+        $protected = [
+            'templatePath' => 'setTemplatePath',
+            'template' => 'setTemplate',
+            'layout' => 'setLayout',
+            'layoutPath' => 'setLayoutPath',
+            'autoLayout' => 'enableAutoLayout',
+            'theme' => 'setTheme',
+            'request' => 'setRequest',
+            'response' => 'setResponse',
+        ];
+        if (isset($protected[$name])) {
+            $method = $protected[$name];
+            deprecationWarning(sprintf(
+                'View::$%s is protected now. Use View::%s() instead.',
+                $name,
+                $method
+            ));
+
+            $this->{$method}($value);
 
             return;
         }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -70,7 +70,7 @@ class XmlView extends SerializedView
      *
      * @var string
      */
-    public $subDir = 'xml';
+    protected $subDir = 'xml';
 
     /**
      * Response type.

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -63,7 +63,7 @@ class XmlView extends SerializedView
      *
      * @var string
      */
-    public $layoutPath = 'xml';
+    protected $layoutPath = 'xml';
 
     /**
      * XML views are located in the 'xml' sub directory for controllers' views.

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -466,7 +466,7 @@ class RequestHandlerComponentTest extends TestCase
         $view = $this->Controller->createView();
         $this->assertInstanceOf(JsonView::class, $view);
         $this->assertEquals('json', $view->getLayoutPath());
-        $this->assertEquals('json', $view->subDir);
+        $this->assertEquals('json', $view->getSubDir());
     }
 
     /**
@@ -487,7 +487,7 @@ class RequestHandlerComponentTest extends TestCase
         $view = $this->Controller->createView();
         $this->assertInstanceOf(XmlView::class, $view);
         $this->assertEquals('xml', $view->getLayoutPath());
-        $this->assertEquals('xml', $view->subDir);
+        $this->assertEquals('xml', $view->getSubDir());
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -356,26 +356,10 @@ class DebuggerTest extends TestCase
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
 object(Cake\View\View) {
-	Blocks => object(Cake\View\ViewBlock) {}
 	plugin => null
 	name => ''
 	passedArgs => []
-	helpers => [
-		(int) 0 => 'Html',
-		(int) 1 => 'Form'
-	]
-	templatePath => null
-	template => null
-	layout => 'default'
-	layoutPath => null
-	autoLayout => true
-	subDir => null
-	theme => null
-	hasRendered => false
 	uuids => []
-	request => object(Cake\Http\ServerRequest) {}
-	response => object(Cake\Http\Response) {}
-	elementCache => 'default'
 	viewClass => null
 	viewVars => []
 	Html => object(Cake\View\Helper\HtmlHelper) {}
@@ -384,7 +368,23 @@ object(Cake\View\View) {
 	float => (float) 1.333
 	string => '  '
 	[protected] _helpers => object(Cake\View\HelperRegistry) {}
+	[protected] Blocks => object(Cake\View\ViewBlock) {}
+	[protected] helpers => [
+		(int) 0 => 'Html',
+		(int) 1 => 'Form'
+	]
+	[protected] templatePath => null
+	[protected] template => null
+	[protected] layout => 'default'
+	[protected] layoutPath => null
+	[protected] autoLayout => true
 	[protected] _ext => '.ctp'
+	[protected] subDir => ''
+	[protected] theme => null
+	[protected] hasRendered => false
+	[protected] request => object(Cake\Http\ServerRequest) {}
+	[protected] response => object(Cake\Http\Response) {}
+	[protected] elementCache => 'default'
 	[protected] _passedVars => [
 		(int) 0 => 'viewVars',
 		(int) 1 => 'autoLayout',

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -356,7 +356,6 @@ class DebuggerTest extends TestCase
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
 object(Cake\View\View) {
-	name => ''
 	passedArgs => []
 	uuids => []
 	viewClass => null
@@ -369,6 +368,7 @@ object(Cake\View\View) {
 	[protected] _helpers => object(Cake\View\HelperRegistry) {}
 	[protected] Blocks => object(Cake\View\ViewBlock) {}
 	[protected] plugin => null
+	[protected] name => ''
 	[protected] helpers => [
 		(int) 0 => 'Html',
 		(int) 1 => 'Form'

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -356,7 +356,6 @@ class DebuggerTest extends TestCase
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
 object(Cake\View\View) {
-	plugin => null
 	name => ''
 	passedArgs => []
 	uuids => []
@@ -369,6 +368,7 @@ object(Cake\View\View) {
 	string => '  '
 	[protected] _helpers => object(Cake\View\HelperRegistry) {}
 	[protected] Blocks => object(Cake\View\ViewBlock) {}
+	[protected] plugin => null
 	[protected] helpers => [
 		(int) 0 => 'Html',
 		(int) 1 => 'Form'

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -218,10 +218,10 @@ class CellTest extends TestCase
      */
     public function testCellRenderThemed()
     {
-        $this->View->theme = 'TestTheme';
+        $this->View->setTheme('TestTheme');
         $cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
 
-        $this->assertEquals($this->View->theme, $cell->viewBuilder()->getTheme());
+        $this->assertEquals($this->View->getTheme(), $cell->viewBuilder()->getTheme());
         $this->assertContains('Themed cell content.', $cell->render());
     }
 
@@ -362,7 +362,7 @@ class CellTest extends TestCase
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
         $view = new CustomJsonView($request, $response);
-        $view->theme = 'Pretty';
+        $view->setTheme('Pretty');
         $cell = $view->cell('Articles');
         $this->assertSame('TestApp\View\CustomJsonView', $cell->viewClass);
         $this->assertSame('TestApp\View\CustomJsonView', $cell->viewBuilder()->getClassName());

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -347,9 +347,14 @@ class CellTest extends TestCase
      */
     public function testCellInheritsHelperConfig()
     {
-        $this->View->helpers = ['Url', 'Form', 'Banana'];
-        $cell = $this->View->cell('Articles');
-        $this->assertSame($this->View->helpers, $cell->helpers);
+        $request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
+        $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
+        $helpers = ['Url', 'Form', 'Banana'];
+
+        $view = new View($request, $response, null, ['helpers' => $helpers]);
+
+        $cell = $view->cell('Articles');
+        $this->assertSame($helpers, $cell->helpers);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -191,7 +191,7 @@ class FlashHelperTest extends TestCase
     {
         Plugin::load('TestTheme');
 
-        $this->View->theme = 'TestTheme';
+        $this->View->setTheme('TestTheme');
         $result = $this->Flash->render('flash');
         $expected = 'flash element from TestTheme';
         $this->assertContains($expected, $result);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1062,8 +1062,7 @@ class PaginatorHelperTest extends TestCase
                 'article' => [
                     'puppy' => 'no'
                 ]
-            ])
-        );
+            ]));
         // Need to run __construct to update _config['url']
         $paginator = new PaginatorHelper($this->View);
         $paginator->options(['model' => 'Article']);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1054,7 +1054,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->View->request = $this->Paginator->request
+        $this->View->setRequest($this->Paginator->request
             ->withParam('paging.Article.scope', 'article')
             ->withParam('paging.Article.page', 3)
             ->withParam('paging.Article.prevPage', true)
@@ -1062,7 +1062,8 @@ class PaginatorHelperTest extends TestCase
                 'article' => [
                     'puppy' => 'no'
                 ]
-            ]);
+            ])
+        );
         // Need to run __construct to update _config['url']
         $paginator = new PaginatorHelper($this->View);
         $paginator->options(['model' => 'Article']);
@@ -1147,7 +1148,7 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator->request = $this->Paginator->request
             ->withParam('pass', [2])
             ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0]);
-        $this->View->request = $this->Paginator->request;
+        $this->View->setRequest($this->Paginator->request);
         $this->Paginator = new PaginatorHelper($this->View);
 
         $result = $this->Paginator->sort('title');

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -100,7 +100,7 @@ class HelperRegistryTest extends TestCase
         $result = $this->Helpers->Form;
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $result);
 
-        $this->View->plugin = 'TestPlugin';
+        $this->View->setPlugin('TestPlugin');
         Plugin::load(['TestPlugin']);
         $result = $this->Helpers->OtherHelper;
         $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result);

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -295,13 +295,13 @@ class JsonViewTest extends TestCase
         $this->assertSame(json_encode($data), $output);
         $this->assertSame('application/json', $View->getResponse()->getType());
 
-        $View->request = $View->getRequest()->withQueryParams(['callback' => 'jfunc']);
+        $View->setRequest($View->getRequest()->withQueryParams(['callback' => 'jfunc']));
         $output = $View->render(false);
         $expected = 'jfunc(' . json_encode($data) . ')';
         $this->assertSame($expected, $output);
         $this->assertSame('application/javascript', $View->getResponse()->getType());
 
-        $View->request = $View->getRequest()->withQueryParams(['jsonCallback' => 'jfunc']);
+        $View->setRequest($View->getRequest()->withQueryParams(['jsonCallback' => 'jfunc']));
         $View->viewVars['_jsonp'] = 'jsonCallback';
         $output = $View->render(false);
         $expected = 'jfunc(' . json_encode($data) . ')';

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -245,7 +245,7 @@ class ViewBuilderTest extends TestCase
         $this->assertEquals('default', $view->getLayout());
         $this->assertEquals('Articles/', $view->getTemplatePath());
         $this->assertEquals('Admin/', $view->getLayoutPath());
-        $this->assertEquals('TestPlugin', $view->plugin);
+        $this->assertEquals('TestPlugin', $view->getPlugin());
         $this->assertEquals('TestTheme', $view->getTheme());
         $this->assertSame($request, $view->getRequest());
         $this->assertInstanceOf(Response::class, $view->getResponse());

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -246,7 +246,7 @@ class ViewBuilderTest extends TestCase
         $this->assertEquals('Articles/', $view->getTemplatePath());
         $this->assertEquals('Admin/', $view->getLayoutPath());
         $this->assertEquals('TestPlugin', $view->plugin);
-        $this->assertEquals('TestTheme', $view->theme);
+        $this->assertEquals('TestTheme', $view->getTheme());
         $this->assertSame($request, $view->getRequest());
         $this->assertInstanceOf(Response::class, $view->getResponse());
         $this->assertSame($events, $view->getEventManager());

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1034,7 +1034,7 @@ class ViewTest extends TestCase
         Cache::clear(false, 'test_view');
 
         $View = $this->PostsController->createView();
-        $View->elementCache = 'test_view';
+        $View->setElementCache('test_view');
 
         $result = $View->element('test_element', [], ['cache' => true]);
         $expected = 'this is the test element';
@@ -1058,7 +1058,7 @@ class ViewTest extends TestCase
         $result = Cache::read('element_custom_key', 'test_view');
         $this->assertEquals($expected, $result);
 
-        $View->elementCache = 'default';
+        $View->setElementCache('default');
         $View->element('test_element', [
             'param' => 'one',
             'foo' => 'two'

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -659,7 +659,7 @@ class ViewTest extends TestCase
         $result = $view->getViewFileName('index');
         $this->assertPathEquals($expected, $result);
 
-        $view->subDir = 'json';
+        $view->setSubDir('json');
         $result = $view->getViewFileName('index');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'json' . DS . 'index.ctp';
         $this->assertPathEquals($expected, $result);
@@ -680,7 +680,7 @@ class ViewTest extends TestCase
         ];
         $view = new TestView(null, null, null, $viewOptions);
 
-        $view->subDir = 'json';
+        $view->setSubDir('json');
         $result = $view->getViewFileName('index');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Jobs' . DS . 'json' . DS . 'index.ctp';
         $this->assertPathEquals($expected, $result);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -737,7 +737,7 @@ class ViewTest extends TestCase
         $result = $View->getLayoutFileName('TestPlugin.default');
         $this->assertPathEquals($expected, $result);
 
-        $View->plugin = 'TestPlugin';
+        $View->setRequest($View->getRequest()->withParam('plugin', 'TestPlugin'));
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'src' . DS .
             'Template' . DS . 'Layout' . DS . 'default.ctp';
         $result = $View->getLayoutFileName('default');
@@ -888,7 +888,7 @@ class ViewTest extends TestCase
         $result = $this->View->elementExists('TestPlugin.element');
         $this->assertFalse($result);
 
-        $this->View->plugin = 'TestPlugin';
+        $this->View->setRequest($this->View->getRequest()->withParam('plugin', 'TestPlugin'));
         $result = $this->View->elementExists('plugin_element');
         $this->assertTrue($result);
     }
@@ -906,7 +906,7 @@ class ViewTest extends TestCase
         $result = $this->View->element('TestPlugin.plugin_element');
         $this->assertEquals("Element in the TestPlugin\n", $result);
 
-        $this->View->plugin = 'TestPlugin';
+        $this->View->setRequest($this->View->getRequest()->withParam('plugin', 'TestPlugin'));
         $result = $this->View->element('plugin_element');
         $this->assertEquals("Element in the TestPlugin\n", $result);
 
@@ -928,7 +928,7 @@ class ViewTest extends TestCase
         $result = $this->View->element('TestPlugin.plugin_element');
         $this->assertEquals('this is the plugin prefixed element using params[plugin]', $result);
 
-        $this->View->plugin = 'TestPlugin';
+        $this->View->setRequest($this->View->getRequest()->withParam('plugin', 'TestPlugin'));
         $result = $this->View->element('test_plugin_element');
         $this->assertEquals('this is the test set using View::$plugin plugin prefixed element', $result);
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -347,7 +347,7 @@ class ViewTest extends TestCase
         ];
 
         $ThemeView = new TestView(null, null, null, $viewOptions);
-        $ThemeView->theme = 'TestTheme';
+        $ThemeView->setTheme('TestTheme');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
         $result = $ThemeView->getViewFileName('home');
         $this->assertPathEquals($expected, $result);
@@ -360,19 +360,19 @@ class ViewTest extends TestCase
         $result = $ThemeView->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $ThemeView->layoutPath = 'rss';
+        $ThemeView->setLayoutPath('rss');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'rss' . DS . 'default.ctp';
         $result = $ThemeView->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $ThemeView->layoutPath = 'Email' . DS . 'html';
+        $ThemeView->setLayoutPath('Email' . DS . 'html');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'Email' . DS . 'html' . DS . 'default.ctp';
         $result = $ThemeView->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $ThemeView = new TestView(null, null, null, $viewOptions);
 
-        $ThemeView->theme = 'Company/TestPluginThree';
+        $ThemeView->setTheme('Company/TestPluginThree');
         $expected = Plugin::path('Company/TestPluginThree') . 'src' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
         $result = $ThemeView->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
@@ -705,12 +705,12 @@ class ViewTest extends TestCase
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $View->layoutPath = 'rss';
+        $View->setLayoutPath('rss');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'rss' . DS . 'default.ctp';
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
-        $View->layoutPath = 'Email' . DS . 'html';
+        $View->setLayoutPath('Email' . DS . 'html');
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'Email' . DS . 'html' . DS . 'default.ctp';
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
@@ -1838,7 +1838,7 @@ class ViewTest extends TestCase
      */
     public function testExtendNested()
     {
-        $this->View->layout = false;
+        $this->View->setLayout(false);
         $content = $this->View->render('nested_extends');
         $expected = <<<TEXT
 This is the second parent.
@@ -1857,7 +1857,7 @@ TEXT;
     public function testExtendSelf()
     {
         try {
-            $this->View->layout = false;
+            $this->View->setLayout(false);
             $this->View->render('extend_self');
             $this->fail('No exception');
         } catch (\LogicException $e) {
@@ -1874,7 +1874,7 @@ TEXT;
     public function testExtendLoop()
     {
         try {
-            $this->View->layout = false;
+            $this->View->setLayout(false);
             $this->View->render('extend_loop');
             $this->fail('No exception');
         } catch (\LogicException $e) {
@@ -1890,7 +1890,7 @@ TEXT;
      */
     public function testExtendElement()
     {
-        $this->View->layout = false;
+        $this->View->setLayout(false);
         $content = $this->View->render('extend_element');
         $expected = <<<TEXT
 Parent View.
@@ -1910,7 +1910,7 @@ TEXT;
     public function testExtendPrefixElement()
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
-        $this->View->layout = false;
+        $this->View->setLayout(false);
         $content = $this->View->render('extend_element');
         $expected = <<<TEXT
 Parent View.
@@ -1930,7 +1930,7 @@ TEXT;
     public function testExtendMissingElement()
     {
         try {
-            $this->View->layout = false;
+            $this->View->setLayout(false);
             $this->View->render('extend_missing_element');
             $this->fail('No exception');
         } catch (\LogicException $e) {
@@ -1947,7 +1947,7 @@ TEXT;
      */
     public function testExtendWithElementBeforeExtend()
     {
-        $this->View->layout = false;
+        $this->View->setLayout(false);
         $result = $this->View->render('extend_with_element');
         $expected = <<<TEXT
 Parent View.
@@ -1965,7 +1965,7 @@ TEXT;
     public function testExtendWithPrefixElementBeforeExtend()
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
-        $this->View->layout = false;
+        $this->View->setLayout(false);
         $result = $this->View->render('extend_with_element');
         $expected = <<<TEXT
 Parent View.
@@ -1988,8 +1988,8 @@ TEXT;
 
         $View = $this->ThemeController->createView();
         $View->setTemplatePath('Posts');
-        $View->layout = 'whatever';
-        $View->theme = 'TestTheme';
+        $View->setLayout('whatever');
+        $View->setTheme('TestTheme');
         $View->element('test_element');
 
         $start = memory_get_usage();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1139,9 +1139,10 @@ class ViewTest extends TestCase
      */
     public function testLoadHelpers()
     {
-        $View = new View();
+        $View = new View(null, null, null, [
+            'helpers' => ['Html' => ['foo' => 'bar'], 'Form' => ['foo' => 'baz']]
+        ]);
 
-        $View->helpers = ['Html' => ['foo' => 'bar'], 'Form' => ['foo' => 'baz']];
         $result = $View->loadHelpers();
         $this->assertSame($View, $result);
 
@@ -1164,7 +1165,6 @@ class ViewTest extends TestCase
     {
         $View = new View();
 
-        $View->helpers = [];
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
     }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -2136,6 +2136,19 @@ TEXT;
     }
 
     /**
+     * Test testHasRendered()
+     *
+     * @return void
+     */
+    public function testHasRendered()
+    {
+        $this->assertFalse($this->View->hasRendered());
+
+        $this->View->render('index');
+        $this->assertTrue($this->View->hasRendered());
+    }
+
+    /**
      * Test magic getter and setter for removed properties.
      *
      * @group deprecated


### PR DESCRIPTION
- All the properties which I have marked as deprecated have getter/setter methods.
- `View::$uuids` seems unused hence marked for removal in 4.0.
- The following public properties still need to be dealt with:
  - `$Blocks`: We already have wrapper methods like `View::fetch()` etc. for most `ViewBlocks` methods. Could add `getBlocks()` and make `$Blocks` protected.
  - `$plugin`: Should we deprecate and remove in 4.0 and just use request instance to get plugin name?
  - `$name`:  Deprecate as public and add `getName()`?
  - `$subDir`
  - `$hasRendered`
  - `$elementCache`
  - `$helpers`