### PR TITLE
Improve error message for missing shells

### DIFF
--- a/src/Console/Exception/MissingShellException.php
+++ b/src/Console/Exception/MissingShellException.php
@@ -20,5 +20,5 @@ use Cake\Core\Exception\Exception;
 class MissingShellException extends Exception
 {
 
-    protected $_messageTemplate = 'Shell class for "%s" could not be found.';
+    protected $_messageTemplate = 'Shell class for "%s" could not be found. If you are trying to use a plugin shell, that was loaded via $this->addPlugin(), you may need to update bin/cake.php to match https://github.com/cakephp/app/tree/master/bin/cake.php';
 }


### PR DESCRIPTION
Attempt to improve the missing shell error to cover the scenario when someone is using a new style plugin but has an outdated bin/cake.php that isn't using CommandRunner.

Refs markstory/asset_compress#324