### PR TITLE
Fix URL arrays not working with IntegrationTestCase and RoutingMiddleware

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -684,18 +684,6 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
-     * Convert an array URL into a string so we can dispatch it.
-     *
-     * This requires loading routes.
-     *
-     * @param array $url The routing URL to resolve.
-     * @return string The resolved route.
-     */
-    protected function resolveRoute(array $url)
-    {
-    }
-
-    /**
      * Get the response body as string
      *
      * @return string The response body.

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -488,6 +488,8 @@ abstract class IntegrationTestCase extends TestCase
     protected function _sendRequest($url, $method, $data = [])
     {
         $dispatcher = $this->_makeDispatcher();
+        $url = $dispatcher->resolveUrl($url);
+
         try {
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
@@ -661,14 +663,14 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Creates a valid request url and parameter array more like Request::_url()
      *
-     * @param string|array $url The URL
+     * @param string $url The URL
      * @return array Qualified URL and the query parameters
      */
     protected function _url($url)
     {
         // re-create URL in ServerRequest's context so
         // query strings are encoded as expected
-        $request = new ServerRequest(['url' => Router::url($url)]);
+        $request = new ServerRequest(['url' => $url]);
         $url = $request->getRequestTarget();
 
         $query = '';
@@ -679,6 +681,18 @@ abstract class IntegrationTestCase extends TestCase
         }
 
         return [$path, $query];
+    }
+
+    /**
+     * Convert an array URL into a string so we can dispatch it.
+     *
+     * This requires loading routes.
+     *
+     * @param array $url The routing URL to resolve.
+     * @return string The resolved route.
+     */
+    protected function resolveRoute(array $url)
+    {
     }
 
     /**

--- a/src/TestSuite/LegacyRequestDispatcher.php
+++ b/src/TestSuite/LegacyRequestDispatcher.php
@@ -15,6 +15,7 @@ namespace Cake\TestSuite;
 
 use Cake\Http\ServerRequest;
 use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
 use Cake\TestSuite\Stub\Response;
 
 /**
@@ -39,6 +40,17 @@ class LegacyRequestDispatcher
     public function __construct($test)
     {
         $this->_test = $test;
+    }
+
+    /**
+     * Resolve the user provided URL into the actual request URL.
+     *
+     * @param array|string $url The URL array/string to resolve.
+     * @return string
+     */
+    public function resolveUrl($url)
+    {
+        return Router::url($url);
     }
 
     /**

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -14,9 +14,12 @@
 namespace Cake\TestSuite;
 
 use Cake\Core\Configure;
+use Cake\Core\HttpApplicationInterface;
+use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventManager;
 use Cake\Http\Server;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\Router;
 use LogicException;
 use ReflectionClass;
 use ReflectionException;
@@ -52,6 +55,13 @@ class MiddlewareDispatcher
     protected $_constructorArgs;
 
     /**
+     * The application that is being dispatched.
+     *
+     * @var \Cake\Core\HttpApplicationInterface
+     */
+    protected $app;
+
+    /**
      * Constructor
      *
      * @param \Cake\TestSuite\IntegrationTestCase $test The test case to run.
@@ -64,6 +74,53 @@ class MiddlewareDispatcher
         $this->_test = $test;
         $this->_class = $class ?: Configure::read('App.namespace') . '\Application';
         $this->_constructorArgs = $constructorArgs ?: [CONFIG];
+
+        try {
+            $reflect = new ReflectionClass($this->_class);
+            $this->app = $reflect->newInstanceArgs($this->_constructorArgs);
+        } catch (ReflectionException $e) {
+            throw new LogicException(sprintf('Cannot load "%s" for use in integration testing.', $this->_class));
+        }
+
+        $this->bootstrap();
+        $this->loadRoutes();
+    }
+
+    /**
+     * Application bootstrap wrapper.
+     *
+     * Calls `bootstrap()` and `events()` if application implements `EventApplicationInterface`.
+     * After the application is bootstrapped and events are attached, plugins are bootstrapped
+     * and have their events attached.
+     *
+     * @return void
+     */
+    protected function bootstrap()
+    {
+        $this->app->bootstrap();
+        if ($this->app instanceof PluginApplicationInterface) {
+            $this->app->pluginBootstrap();
+        }
+    }
+
+    /**
+     * Ensure that the application's routes are loaded.
+     *
+     * Console commands and shells often need to generate URLs.
+     *
+     * @return void
+     */
+    protected function loadRoutes()
+    {
+        Router::reload();
+        $builder = Router::createRouteBuilder('/');
+
+        if ($this->app instanceof HttpApplicationInterface) {
+            $this->app->routes($builder);
+        }
+        if ($this->app instanceof PluginApplicationInterface) {
+            $this->app->pluginRoutes($builder);
+        }
     }
 
     /**
@@ -74,16 +131,6 @@ class MiddlewareDispatcher
      */
     public function execute($request)
     {
-        try {
-            $reflect = new ReflectionClass($this->_class);
-            $app = $reflect->newInstanceArgs($this->_constructorArgs);
-        } catch (ReflectionException $e) {
-            throw new LogicException(sprintf(
-                'Cannot load "%s" for use in integration testing.',
-                $this->_class
-            ));
-        }
-
         // Spy on the controller using the initialize hook instead
         // of the dispatcher hooks as those will be going away one day.
         EventManager::instance()->on(
@@ -91,7 +138,8 @@ class MiddlewareDispatcher
             [$this->_test, 'controllerSpy']
         );
 
-        $server = new Server($app);
+        Router::reload();
+        $server = new Server($this->app);
         $psrRequest = $this->_createRequest($request);
 
         return $server->run($psrRequest);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -512,6 +512,20 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test array URLs with an empty router.
+     *
+     * @return void
+     */
+    public function testArrayUrlsEmptyRouter()
+    {
+        Router::reload();
+        $this->assertFalse(Router::$initialized);
+
+        $this->post(['controller' => 'Posts', 'action' => 'index']);
+        $this->assertEquals('value', $this->viewVariable('test'));
+    }
+
+    /**
      * Test flash and cookie assertions
      *
      * @return void


### PR DESCRIPTION
If an application upgrades to RoutingMiddleware and not eagerly loading its routes, then test cases cannot use array URLs. This resolves that problem but introduces overhead by loading routes an additional time. This is not ideal, and could be mitigated by conditionally loading routes in `RoutingMiddleware` if the collection is empty.

Refs #12146 
Refs #12150 