### PR TITLE
Change name and phpdoc of Email::deliver() $config argument

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -347,7 +347,7 @@ class Email implements JsonSerializable, Serializable
     /**
      * Constructor
      *
-     * @param array|string|null $config Array of configs, or string to load configs from email.php
+     * @param array|string|null $config Array of configs, or string to load configs from app.php
      */
     public function __construct($config = null)
     {
@@ -2218,20 +2218,20 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $to Address to send (see Cake\Mailer\Email::to()). If null, will try to use 'to' from transport config
      * @param string|null $subject String of subject or null to use 'subject' from transport config
      * @param string|array|null $message String with message or array with variables to be used in render
-     * @param string|array $transportConfig String to use config from EmailConfig or array with configs
+     * @param string|array $config String to use Email delivery profile from app.php or array with configs
      * @param bool $send Send the email or just return the instance pre-configured
      * @return static Instance of Cake\Mailer\Email
      * @throws \InvalidArgumentException
      */
-    public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'default', $send = true)
+    public static function deliver($to = null, $subject = null, $message = null, $config = 'default', $send = true)
     {
         $class = __CLASS__;
 
-        if (is_array($transportConfig) && !isset($transportConfig['transport'])) {
-            $transportConfig['transport'] = 'default';
+        if (is_array($config) && !isset($config['transport'])) {
+            $config['transport'] = 'default';
         }
         /* @var \Cake\Mailer\Email $instance */
-        $instance = new $class($transportConfig);
+        $instance = new $class($config);
         if ($to !== null) {
             $instance->setTo($to);
         }


### PR DESCRIPTION
`$transportConfig` is misleading.

I tried to migrate code in my app from `Email::deliver($to, $subject, $message, 'myconfig');` to
```php
$email = new Email();
$email->setTransport('myconfig')
```

I thought I should use `setTransport()` because argument name was `$transportConfig`. But it should be just `$email = new Email('myconfig')`.

I also replaced outdated references of `EmailConfig` and `email.php` to current ones in CakePHP 3.x
