### PR TITLE
Move start/end calculation into datasource.

### DIFF
--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -200,12 +200,23 @@ class Paginator implements PaginatorInterface
             $directionDefault = current($defaults['order']);
         }
 
+        $start = 0;
+        if ($count >= 1) {
+            $start = (($page - 1) * $limit) + 1;
+        }
+        $end = $start + $limit - 1;
+        if ($count < $end) {
+            $end = $count;
+        }
+
         $paging = [
             'finder' => $finder,
             'page' => $page,
             'current' => $numResults,
             'count' => $count,
             'perPage' => $limit,
+            'start' => $start,
+            'end' => $end,
             'prevPage' => $page > 1,
             'nextPage' => $count > ($page * $limit),
             'pageCount' => $pageCount,

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -686,14 +686,6 @@ class PaginatorHelper extends Helper
         if (!$paging['pageCount']) {
             $paging['pageCount'] = 1;
         }
-        $start = 0;
-        if ($paging['count'] >= 1) {
-            $start = (($paging['page'] - 1) * $paging['perPage']) + 1;
-        }
-        $end = $start + $paging['perPage'] - 1;
-        if ($paging['count'] < $end) {
-            $end = $paging['count'];
-        }
 
         switch ($options['format']) {
             case 'range':
@@ -709,8 +701,8 @@ class PaginatorHelper extends Helper
             'pages' => $paging['pageCount'],
             'current' => $paging['current'],
             'count' => $paging['count'],
-            'start' => $start,
-            'end' => $end
+            'start' => $paging['start'],
+            'end' => $paging['end']
         ]);
 
         $map += [

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -182,7 +182,10 @@ class PaginatorTest extends TestCase
 
         $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals('popular', $pagingParams['PaginatorPosts']['finder']);
+        $this->assertSame('popular', $pagingParams['PaginatorPosts']['finder']);
+
+        $this->assertSame(1, $pagingParams['PaginatorPosts']['start']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['end']);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2780,31 +2780,31 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator->request = $this->Paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1523,
-                'current' => 1230,
-                'count' => 234567,
+                'current' => 3000,
+                'count' => 4800001,
                 'perPage' => 3000,
                 'prevPage' => false,
                 'nextPage' => true,
-                'pageCount' => 1000,
+                'pageCount' => 1600,
                 'limit' => 5000,
                 'sort' => 'Client.name',
                 'order' => 'DESC',
                 'start' => 4566001,
-                'end' => 234567,
+                'end' => 4569001,
             ]
         ]);
 
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
         $input .= 'starting on record {{start}}, ending on {{end}}';
 
-        $expected = 'Page 1,523 of 1,000, showing 1,230 records out of 234,567 total, ';
-        $expected .= 'starting on record 4,566,001, ending on 234,567';
+        $expected = 'Page 1,523 of 1,600, showing 3,000 records out of 4,800,001 total, ';
+        $expected .= 'starting on record 4,566,001, ending on 4,569,001';
         $result = $this->Paginator->counter($input);
         $this->assertEquals($expected, $result);
 
         I18n::setLocale('de-DE');
-        $expected = 'Page 1.523 of 1.000, showing 1.230 records out of 234.567 total, ';
-        $expected .= 'starting on record 4.566.001, ending on 234.567';
+        $expected = 'Page 1.523 of 1.600, showing 3.000 records out of 4.800.001 total, ';
+        $expected .= 'starting on record 4.566.001, ending on 4.569.001';
         $result = $this->Paginator->counter($input);
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2746,6 +2746,8 @@ class PaginatorHelperTest extends TestCase
                 'limit' => 3,
                 'sort' => 'Client.name',
                 'order' => 'DESC',
+                'start' => 1,
+                'end' => 3,
             ]
         ]);
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
@@ -2787,6 +2789,8 @@ class PaginatorHelperTest extends TestCase
                 'limit' => 5000,
                 'sort' => 'Client.name',
                 'order' => 'DESC',
+                'start' => 4566001,
+                'end' => 234567,
             ]
         ]);
 
@@ -2950,6 +2954,8 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 0,
                 'limit' => 10,
+                'start' => 0,
+                'end' => 0,
             ]
         ]);
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/11707 as it moves the calculation into Datasource for better usability outside of view/helper layer and just re-uses data there.

During the tests adjustment I noticed some very strange test expectations however.
So I fixed the values up to make sense.