### PR TITLE
3.7 cell deprecations

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -299,8 +299,7 @@ abstract class Cell
         if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(
                 'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
-                $name,
-                $method
+                $name
             ));
         }
 
@@ -343,8 +342,7 @@ abstract class Cell
         if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(
                 'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
-                $name,
-                $method
+                $name
             ));
         }
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -51,13 +51,6 @@ abstract class Cell
     public $View;
 
     /**
-     * Automatically set to the name of a plugin.
-     *
-     * @var string
-     */
-    public $plugin;
-
-    /**
      * An instance of a Cake\Http\ServerRequest object that contains information about the current request.
      * This object contains all the information about a request and several methods for reading
      * additional information about the request.
@@ -294,6 +287,7 @@ abstract class Cell
     {
         $deprecated = [
             'template' => 'getTemplate',
+            'plugin' => 'getPlugin',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
@@ -320,6 +314,7 @@ abstract class Cell
     {
         $deprecated = [
             'template' => 'setTemplate',
+            'plugin' => 'setPlugin',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
@@ -344,7 +339,6 @@ abstract class Cell
     public function __debugInfo()
     {
         return [
-            'plugin' => $this->plugin,
             'action' => $this->action,
             'args' => $this->args,
             'viewClass' => $this->viewClass,

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -69,15 +69,6 @@ abstract class Cell
     public $response;
 
     /**
-     * The helpers this cell uses.
-     *
-     * This property is copied automatically when using the CellTrait
-     *
-     * @var array
-     */
-    public $helpers = [];
-
-    /**
      * The cell's action to invoke.
      *
      * @var string
@@ -288,6 +279,7 @@ abstract class Cell
         $deprecated = [
             'template' => 'getTemplate',
             'plugin' => 'getPlugin',
+            'helpers' => 'getHelpers',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
@@ -315,6 +307,7 @@ abstract class Cell
         $deprecated = [
             'template' => 'setTemplate',
             'plugin' => 'setPlugin',
+            'helpers' => 'setHelpers',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -43,12 +43,11 @@ abstract class Cell
 
     /**
      * Instance of the View created during rendering. Won't be set until after
-     * Cell::__toString() is called.
+     * Cell::__toString()/render() is called.
      *
      * @var \Cake\View\View
-     * @deprecated 3.1.0 Use createView() instead.
      */
-    public $View;
+    protected $View;
 
     /**
      * An instance of a Cake\Http\ServerRequest object that contains information about the current request.
@@ -295,6 +294,7 @@ abstract class Cell
             'args',
             'request',
             'response',
+            'View',
         ];
         if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(
@@ -338,6 +338,7 @@ abstract class Cell
             'args',
             'request',
             'response',
+            'View',
         ];
         if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -56,17 +56,15 @@ abstract class Cell
      * additional information about the request.
      *
      * @var \Cake\Http\ServerRequest
-     * @deprecated 3.7.0 The property will become protected in 4.0.0.
      */
-    public $request;
+    protected $request;
 
     /**
      * An instance of a Response object that contains information about the impending response
      *
      * @var \Cake\Http\Response
-     * @deprecated 3.7.0 The property will become protected in 4.0.0.
      */
-    public $response;
+    protected $response;
 
     /**
      * The cell's action to invoke.
@@ -293,10 +291,12 @@ abstract class Cell
         }
 
         $protected = [
-            'action' => 'action',
-            'args' => 'args',
+            'action',
+            'args',
+            'request',
+            'response',
         ];
-        if (isset($deprecated[$name])) {
+        if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(
                 'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
                 $name,
@@ -334,10 +334,12 @@ abstract class Cell
         }
 
         $protected = [
-            'action' => 'action',
-            'args' => 'args',
+            'action',
+            'args',
+            'request',
+            'response',
         ];
-        if (isset($deprecated[$name])) {
+        if (in_array($name, $protected, true)) {
             deprecationWarning(sprintf(
                 'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
                 $name,

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -73,14 +73,14 @@ abstract class Cell
      *
      * @var string
      */
-    public $action;
+    protected $action;
 
     /**
      * Arguments to pass to cell's action.
      *
      * @var array
      */
-    public $args = [];
+    protected $args = [];
 
     /**
      * These properties can be set directly on Cell and passed to the View as options.
@@ -292,6 +292,18 @@ abstract class Cell
             return $this->viewBuilder()->{$method}();
         }
 
+        $protected = [
+            'action' => 'action',
+            'args' => 'args',
+        ];
+        if (isset($deprecated[$name])) {
+            deprecationWarning(sprintf(
+                'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
+                $name,
+                $method
+            ));
+        }
+
         return $this->{$name};
     }
 
@@ -319,6 +331,18 @@ abstract class Cell
             $this->viewBuilder()->{$method}($value);
 
             return;
+        }
+
+        $protected = [
+            'action' => 'action',
+            'args' => 'args',
+        ];
+        if (isset($deprecated[$name])) {
+            deprecationWarning(sprintf(
+                'Cell::$%s is now protected and shouldn\'t be accessed from outside a child class.',
+                $name,
+                $method
+            ));
         }
 
         $this->{$name} = $value;

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -359,7 +359,6 @@ abstract class Cell
         return [
             'action' => $this->action,
             'args' => $this->args,
-            'viewClass' => $this->viewClass,
             'request' => $this->request,
             'response' => $this->response,
             'viewBuilder' => $this->viewBuilder(),

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -103,7 +103,6 @@ trait CellTrait
         }
         if (!empty($this->helpers)) {
             $builder->setHelpers($this->helpers);
-            $instance->helpers = $this->helpers;
         }
 
         if ($this instanceof View) {

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -94,9 +94,10 @@ trait CellTrait
     {
         /* @var \Cake\View\Cell $instance */
         $instance = new $className($this->request, $this->response, $this->getEventManager(), $options);
-        $instance->template = Inflector::underscore($action);
 
         $builder = $instance->viewBuilder();
+        $builder->setTemplate(Inflector::underscore($action));
+
         if (!empty($plugin)) {
             $builder->setPlugin($plugin);
         }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -74,7 +74,7 @@ class CellTest extends TestCase
         $cell = $this->View->cell('Articles::teaserList');
         $render = "{$cell}";
 
-        $this->assertEquals('teaser_list', $cell->template);
+        $this->assertEquals('teaser_list', $cell->viewBuilder()->getTemplate());
         $this->assertContains('<h2>Lorem ipsum</h2>', $render);
         $this->assertContains('<h2>Usectetur adipiscing eli</h2>', $render);
         $this->assertContains('<h2>Topis semper blandit eu non</h2>', $render);
@@ -100,7 +100,7 @@ class CellTest extends TestCase
         set_error_handler($capture);
 
         $cell = $this->View->cell('Articles::teaserList');
-        $cell->template = 'nope';
+        $cell->viewBuilder()->setTemplate('nope');
         $result = "{$cell}";
     }
 
@@ -128,12 +128,12 @@ class CellTest extends TestCase
     {
         $appCell = $this->View->cell('Articles');
 
-        $this->assertEquals('display', $appCell->template);
+        $this->assertEquals('display', $appCell->viewBuilder()->getTemplate());
         $this->assertContains('dummy', "{$appCell}");
 
         $pluginCell = $this->View->cell('TestPlugin.Dummy');
         $this->assertContains('dummy', "{$pluginCell}");
-        $this->assertEquals('display', $pluginCell->template);
+        $this->assertEquals('display', $pluginCell->viewBuilder()->getTemplate());
     }
 
     /**
@@ -143,11 +143,13 @@ class CellTest extends TestCase
      */
     public function testSettingCellTemplateFromAction()
     {
-        $appCell = $this->View->cell('Articles::customTemplate');
+        $this->deprecated(function () {
+            $appCell = $this->View->cell('Articles::customTemplate');
 
-        $this->assertContains('This is the alternate template', "{$appCell}");
-        $this->assertEquals('alternate_teaser_list', $appCell->template);
-        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
+            $this->assertContains('This is the alternate template', "{$appCell}");
+            $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
+            $this->assertEquals('alternate_teaser_list', $appCell->template);
+        });
     }
 
     /**
@@ -160,7 +162,7 @@ class CellTest extends TestCase
         $appCell = $this->View->cell('Articles::customTemplatePath');
 
         $this->assertContains('Articles subdir custom_template_path template', "{$appCell}");
-        $this->assertEquals('custom_template_path', $appCell->template);
+        $this->assertEquals('custom_template_path', $appCell->viewBuilder()->getTemplate());
         $this->assertEquals('Cell/Articles/Subdir', $appCell->viewBuilder()->getTemplatePath());
     }
 
@@ -287,7 +289,7 @@ class CellTest extends TestCase
     public function testPluginCellAlternateTemplate()
     {
         $cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
-        $cell->template = '../../Element/translate';
+        $cell->viewBuilder()->setTemplate('../../Element/translate');
         $this->assertContains('This is a translatable string', "{$cell}");
     }
 
@@ -479,9 +481,11 @@ class CellTest extends TestCase
             ->with('cell_test_app_view_cell_articles_cell_customTemplate_default', "<h1>This is the alternate template</h1>\n");
         Cache::setConfig('default', $mock);
 
-        $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);
-        $result = $cell->render();
-        $this->assertContains('This is the alternate template', $result);
+        $this->deprecated(function () {
+            $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);
+            $result = $cell->render();
+            $this->assertContains('This is the alternate template', $result);
+        });
 
         Cache::drop('default');
     }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -241,7 +241,7 @@ class CellTest extends TestCase
         );
 
         $cell = $this->View->cell('Articles');
-        $cell->plugin = 'TestPlugin';
+        $cell->viewBuilder()->setPlugin('TestPlugin');
         $this->assertContains(
             'TestPlugin Articles/display',
             $cell->render('display')

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -356,7 +356,11 @@ class CellTest extends TestCase
         $view = new View($request, $response, null, ['helpers' => $helpers]);
 
         $cell = $view->cell('Articles');
-        $this->assertSame($helpers, $cell->helpers);
+        $this->assertSame($helpers, $cell->viewBuilder()->getHelpers());
+
+        $this->deprecated(function () use ($cell, $helpers) {
+            $this->assertSame($helpers, $cell->helpers);
+        });
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -94,11 +94,9 @@ class CellTest extends TestCase
     {
         $cell = $this->View->cell('Articles::teaserList');
         $data = $cell->__debugInfo();
-        $this->assertArrayHasKey('plugin', $data);
         $this->assertArrayHasKey('request', $data);
         $this->assertArrayHasKey('response', $data);
         $this->assertEquals('teaserList', $data['action']);
-        $this->assertEquals('teaser_list', $data['template']);
         $this->assertEquals([], $data['args']);
     }
 

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -76,7 +76,6 @@ class ArticlesCell extends \Cake\View\Cell
      */
     public function customTemplateViewBuilder()
     {
-        $this->template = 'derp';
         $this->counter++;
         $this->viewBuilder()->setTemplate('alternate_teaser_list');
     }


### PR DESCRIPTION
* `template`, `plugin`, `helpers` properties have been removed. Having them was redundant since they can be got/set through cell's view builder.
* `View`, `request`, `response`, `action`, `args` have been made protected. I see no reason for these to be accessible from outside the cell class. Hence no getter/setter have been provided for them.