### PR TITLE
3.7 helper deprecations

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -175,7 +175,7 @@ class Helper implements EventListenerInterface
     public function __set($name, $value)
     {
         $removed = [
-            'template' => 'setTemplate',
+            'theme' => 'setTheme',
             'plugin' => 'setPlugin',
         ];
         if (isset($removed[$name])) {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -72,17 +72,18 @@ class Helper implements EventListenerInterface
     public $request;
 
     /**
-     * Holds the fields ['field_name' => ['type' => 'string', 'length' => 100]],
-     * primaryKey and validates ['field_name']
+     * Unused.
      *
      * @var array
+     * @deprecated 3.7.0 This property is unused and will be removed in 4.0.0.
      */
     public $fieldset = [];
 
     /**
-     * Holds tag templates.
+     * Unused.
      *
      * @var array
+     * @deprecated 3.7.0 This property is unused and will be removed in 4.0.0.
      */
     public $tags = [];
 
@@ -302,8 +303,6 @@ class Helper implements EventListenerInterface
     {
         return [
             'helpers' => $this->helpers,
-            'fieldset' => $this->fieldset,
-            'tags' => $this->tags,
             'implementedEvents' => $this->implementedEvents(),
             '_config' => $this->getConfig(),
         ];

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -65,25 +65,11 @@ class Helper implements EventListenerInterface
     protected $_helperMap = [];
 
     /**
-     * The current theme name if any.
-     *
-     * @var string
-     */
-    public $theme;
-
-    /**
      * Request object
      *
      * @var \Cake\Http\ServerRequest
      */
     public $request;
-
-    /**
-     * Plugin path
-     *
-     * @var string
-     */
-    public $plugin;
 
     /**
      * Holds the fields ['field_name' => ['type' => 'string', 'length' => 100]],
@@ -153,6 +139,49 @@ class Helper implements EventListenerInterface
 
             return $this->{$name};
         }
+
+        $removed = [
+            'theme' => 'getTheme',
+            'plugin' => 'getPlugin',
+        ];
+        if (isset($removed[$name])) {
+            $method = $removed[$name];
+            deprecationWarning(sprintf(
+                'Helper::$%s is deprecated. Use $view->%s() instead.',
+                $name,
+                $method
+            ));
+
+            return $this->_View->{$method}();
+        }
+    }
+
+    /**
+     * Magic setter for removed properties.
+     *
+     * @param string $name Property name.
+     * @param mixed $value Value to set.
+     * @return void
+     */
+    public function __set($name, $value)
+    {
+        $removed = [
+            'template' => 'setTemplate',
+            'plugin' => 'setPlugin',
+        ];
+        if (isset($removed[$name])) {
+            $method = $removed[$name];
+            deprecationWarning(sprintf(
+                'Helper::$%s is deprecated. Use $view->%s() instead.',
+                $name,
+                $method
+            ));
+            $this->_View->{$method}($value);
+
+            return;
+        }
+
+        $this->{$name} = $value;
     }
 
     /**
@@ -273,8 +302,6 @@ class Helper implements EventListenerInterface
     {
         return [
             'helpers' => $this->helpers,
-            'theme' => $this->theme,
-            'plugin' => $this->plugin,
             'fieldset' => $this->fieldset,
             'tags' => $this->tags,
             'implementedEvents' => $this->implementedEvents(),

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -148,7 +148,7 @@ class Helper implements EventListenerInterface
         if (isset($removed[$name])) {
             $method = $removed[$name];
             deprecationWarning(sprintf(
-                'Helper::$%s is deprecated. Use $view->%s() instead.',
+                'Helper::$%s is removed. Use $view->%s() instead.',
                 $name,
                 $method
             ));
@@ -158,7 +158,7 @@ class Helper implements EventListenerInterface
 
         if ($name === 'helpers') {
             deprecationWarning(
-                'Helper::$helpers is now deprecated and should be accessed from outside a helper class.'
+                'Helper::$helpers is now protected and should not be accessed from outside a helper class.'
             );
 
             return $this->helpers;
@@ -181,7 +181,7 @@ class Helper implements EventListenerInterface
         if (isset($removed[$name])) {
             $method = $removed[$name];
             deprecationWarning(sprintf(
-                'Helper::$%s is deprecated. Use $view->%s() instead.',
+                'Helper::$%s is removed. Use $view->%s() instead.',
                 $name,
                 $method
             ));
@@ -192,7 +192,7 @@ class Helper implements EventListenerInterface
 
         if ($name === 'helpers') {
             deprecationWarning(
-                'Helper::$helpers is now deprecated and should be accessed from outside a helper class.'
+                'Helper::$helpers is now protected and should not be accessed from outside a helper class.'
             );
         }
 

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -48,7 +48,7 @@ class Helper implements EventListenerInterface
      *
      * @var array
      */
-    public $helpers = [];
+    protected $helpers = [];
 
     /**
      * Default config for this helper.
@@ -155,6 +155,14 @@ class Helper implements EventListenerInterface
 
             return $this->_View->{$method}();
         }
+
+        if ($name === 'helpers') {
+            deprecationWarning(
+                'Helper::$helpers is now deprecated and should be accessed from outside a helper class.'
+            );
+
+            return $this->helpers;
+        }
     }
 
     /**
@@ -180,6 +188,12 @@ class Helper implements EventListenerInterface
             $this->_View->{$method}($value);
 
             return;
+        }
+
+        if ($name === 'helpers') {
+            deprecationWarning(
+                'Helper::$helpers is now deprecated and should be accessed from outside a helper class.'
+            );
         }
 
         $this->{$name} = $value;

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -65,13 +65,6 @@ class Helper implements EventListenerInterface
     protected $_helperMap = [];
 
     /**
-     * Request object
-     *
-     * @var \Cake\Http\ServerRequest
-     */
-    public $request;
-
-    /**
      * Unused.
      *
      * @var array
@@ -103,8 +96,6 @@ class Helper implements EventListenerInterface
     public function __construct(View $View, array $config = [])
     {
         $this->_View = $View;
-        $this->request = $View->getRequest();
-
         $this->setConfig($config);
 
         if (!empty($this->helpers)) {
@@ -156,6 +147,14 @@ class Helper implements EventListenerInterface
             return $this->_View->{$method}();
         }
 
+        if ($name === 'request') {
+            deprecationWarning(
+                'Helper::$%s is removed. Use $view->%s() instead. Use $helper->getView()->getRequest() instead.'
+            );
+
+            return $this->_View->getRequest();
+        }
+
         if ($name === 'helpers') {
             deprecationWarning(
                 'Helper::$helpers is now protected and should not be accessed from outside a helper class.'
@@ -186,6 +185,16 @@ class Helper implements EventListenerInterface
                 $method
             ));
             $this->_View->{$method}($value);
+
+            return;
+        }
+
+        if ($name === 'request') {
+            deprecationWarning(
+                'Helper::$%s is removed. Use $view->%s() instead. Use $helper->getView()->setRequest() instead.'
+            );
+
+            $this->_View->setRequest($value);
 
             return;
         }

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -70,18 +70,20 @@ class FlashHelper extends Helper
      */
     public function render($key = 'flash', array $options = [])
     {
-        if (!$this->request->getSession()->check("Flash.$key")) {
+        $session = $this->_View->getRequest()->getSession();
+
+        if (!$session->check("Flash.$key")) {
             return null;
         }
 
-        $flash = $this->request->getSession()->read("Flash.$key");
+        $flash = $session->read("Flash.$key");
         if (!is_array($flash)) {
             throw new UnexpectedValueException(sprintf(
                 'Value for flash setting key "%s" must be an array.',
                 $key
             ));
         }
-        $this->request->getSession()->delete("Flash.$key");
+        $session->delete("Flash.$key");
 
         $out = '';
         foreach ($flash as $message) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -544,7 +544,7 @@ class FormHelper extends Helper
         }
 
         $actionDefaults = [
-            'plugin' => $this->plugin,
+            'plugin' => $this->_View->getPlugin(),
             'controller' => $this->request->getParam('controller'),
             'action' => $this->request->getParam('action'),
         ];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -451,7 +451,7 @@ class FormHelper extends Helper
         unset($options['templates']);
 
         if ($options['action'] === false || $options['url'] === false) {
-            $url = $this->request->getRequestTarget();
+            $url = $this->_View->getRequest()->getRequestTarget();
             $action = null;
         } else {
             $url = $this->_formUrl($context, $options);
@@ -529,8 +529,10 @@ class FormHelper extends Helper
      */
     protected function _formUrl($context, $options)
     {
+        $request = $this->_View->getRequest();
+
         if ($options['action'] === null && $options['url'] === null) {
-            return $this->request->getRequestTarget();
+            return $request->getRequestTarget();
         }
 
         if (is_string($options['url']) ||
@@ -545,8 +547,8 @@ class FormHelper extends Helper
 
         $actionDefaults = [
             'plugin' => $this->_View->getPlugin(),
-            'controller' => $this->request->getParam('controller'),
-            'action' => $this->request->getParam('action'),
+            'controller' => $request->getParam('controller'),
+            'action' => $request->getParam('action'),
         ];
 
         $action = (array)$options['url'] + $actionDefaults;
@@ -585,17 +587,19 @@ class FormHelper extends Helper
      */
     protected function _csrfField()
     {
-        if ($this->request->getParam('_Token.unlockedFields')) {
-            foreach ((array)$this->request->getParam('_Token.unlockedFields') as $unlocked) {
+        $request = $this->_View->getRequest();
+
+        if ($request->getParam('_Token.unlockedFields')) {
+            foreach ((array)$request->getParam('_Token.unlockedFields') as $unlocked) {
                 $this->_unlockedFields[] = $unlocked;
             }
         }
-        if (!$this->request->getParam('_csrfToken')) {
+        if (!$request->getParam('_csrfToken')) {
             return '';
         }
 
         return $this->hidden('_csrfToken', [
-            'value' => $this->request->getParam('_csrfToken'),
+            'value' => $request->getParam('_csrfToken'),
             'secure' => static::SECURE_SKIP,
             'autocomplete' => 'off',
         ]);
@@ -616,7 +620,7 @@ class FormHelper extends Helper
     {
         $out = '';
 
-        if ($this->requestType !== 'get' && $this->request->getParam('_Token')) {
+        if ($this->requestType !== 'get' && $this->_View->getRequest()->getParam('_Token')) {
             $out .= $this->secure($this->fields, $secureAttributes);
             $this->fields = [];
             $this->_unlockedFields = [];
@@ -649,7 +653,7 @@ class FormHelper extends Helper
      */
     public function secure(array $fields = [], array $secureAttributes = [])
     {
-        if (!$this->request->getParam('_Token')) {
+        if (!$this->_View->getRequest()->getParam('_Token')) {
             return '';
         }
         $debugSecurity = Configure::read('debug');
@@ -1096,7 +1100,7 @@ class FormHelper extends Helper
 
         if ($legend === true) {
             $isCreate = $context->isCreate();
-            $modelName = Inflector::humanize(Inflector::singularize($this->request->getParam('controller')));
+            $modelName = Inflector::humanize(Inflector::singularize($this->_View->getRequest()->getParam('controller')));
             if (!$isCreate) {
                 $legend = __d('cake', 'Edit {0}', $modelName);
             } else {
@@ -2654,7 +2658,7 @@ class FormHelper extends Helper
     protected function _initInputField($field, $options = [])
     {
         if (!isset($options['secure'])) {
-            $options['secure'] = (bool)$this->request->getParam('_Token');
+            $options['secure'] = (bool)$this->_View->getRequest()->getParam('_Token');
         }
         $context = $this->_getContext();
 
@@ -2830,7 +2834,8 @@ class FormHelper extends Helper
         }
         $data += ['entity' => null];
 
-        return $this->_context = $this->contextFactory()->get($this->request, $data);
+        return $this->_context = $this->contextFactory()
+            ->get($this->_View->getRequest(), $data);
     }
 
     /**
@@ -2950,7 +2955,7 @@ class FormHelper extends Helper
             }
             if (isset($valueMap[$valuesSource])) {
                 $method = $valueMap[$valuesSource];
-                $value = $this->request->{$method}($fieldname);
+                $value = $this->_View->getRequest()->{$method}($fieldname);
                 if ($value !== null) {
                     return $value;
                 }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -100,11 +100,11 @@ class PaginatorHelper extends Helper
     {
         parent::__construct($View, $config);
 
-        $query = $this->request->getQueryParams();
+        $query = $this->_View->getRequest()->getQueryParams();
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
         $this->setConfig(
             'options.url',
-            array_merge($this->request->getParam('pass', []), ['?' => $query])
+            array_merge($this->_View->getRequest()->getParam('pass', []), ['?' => $query])
         );
     }
 
@@ -116,14 +116,16 @@ class PaginatorHelper extends Helper
      */
     public function params($model = null)
     {
+        $request = $this->_View->getRequest();
+
         if (empty($model)) {
             $model = $this->defaultModel();
         }
-        if (!$this->request->getParam('paging') || !$this->request->getParam('paging.' . $model)) {
+        if (!$request->getParam('paging') || !$request->getParam('paging.' . $model)) {
             return [];
         }
 
-        return $this->request->getParam('paging.' . $model);
+        return $request->getParam('paging.' . $model);
     }
 
     /**
@@ -152,22 +154,27 @@ class PaginatorHelper extends Helper
      */
     public function options(array $options = [])
     {
+        $request = $this->_View->getRequest();
+
         if (!empty($options['paging'])) {
-            $this->request = $this->request->withParam(
+            $request = $request->withParam(
                 'paging',
-                $options['paging'] + $this->request->getParam('paging', [])
+                $options['paging'] + $request->getParam('paging', [])
             );
             unset($options['paging']);
         }
-        $model = $this->defaultModel();
 
+        $model = $this->defaultModel();
         if (!empty($options[$model])) {
-            $this->request = $this->request->withParam(
+            $request = $request->withParam(
                 'paging.' . $model,
-                $options[$model] + (array)$this->request->getParam('paging.' . $model, [])
+                $options[$model] + (array)$request->getParam('paging.' . $model, [])
             );
             unset($options[$model]);
         }
+
+        $this->_View->setRequest($request);
+
         $this->_config['options'] = array_filter($options + $this->_config['options']);
         if (empty($this->_config['options']['url'])) {
             $this->_config['options']['url'] = [];
@@ -647,10 +654,10 @@ class PaginatorHelper extends Helper
         if ($this->_defaultModel) {
             return $this->_defaultModel;
         }
-        if (!$this->request->getParam('paging')) {
+        if (!$this->_View->getRequest()->getParam('paging')) {
             return null;
         }
-        list($this->_defaultModel) = array_keys($this->request->getParam('paging'));
+        list($this->_defaultModel) = array_keys($this->_View->getRequest()->getParam('paging'));
 
         return $this->_defaultModel;
     }

--- a/src/View/Helper/SessionHelper.php
+++ b/src/View/Helper/SessionHelper.php
@@ -58,7 +58,7 @@ class SessionHelper extends Helper
      */
     public function read($name = null)
     {
-        return $this->request->getSession()->read($name);
+        return $this->_View->getRequest()->getSession()->read($name);
     }
 
     /**
@@ -74,7 +74,7 @@ class SessionHelper extends Helper
      */
     public function check($name)
     {
-        return $this->request->getSession()->check($name);
+        return $this->_View->getRequest()->getSession()->check($name);
     }
 
     /**

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -273,9 +273,9 @@ class UrlHelper extends Helper
         $webPath = $this->request->getAttribute('webroot') . $asset[0];
         $file = $asset[0];
 
-        if (!empty($this->theme)) {
+        if (!empty($this->_View->getTheme())) {
             $file = trim($file, '/');
-            $theme = $this->_inflectThemeName($this->theme) . '/';
+            $theme = $this->_inflectThemeName($this->_View->getTheme()) . '/';
 
             if (DIRECTORY_SEPARATOR === '\\') {
                 $file = str_replace('/', '\\', $file);
@@ -284,7 +284,7 @@ class UrlHelper extends Helper
             if (file_exists(Configure::read('App.wwwRoot') . $theme . $file)) {
                 $webPath = $this->request->getAttribute('webroot') . $theme . $asset[0];
             } else {
-                $themePath = Plugin::path($this->theme);
+                $themePath = Plugin::path($this->_View->getTheme());
                 $path = $themePath . 'webroot/' . $file;
                 if (file_exists($path)) {
                     $webPath = $this->request->getAttribute('webroot') . $theme . $asset[0];

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -238,7 +238,7 @@ class UrlHelper extends Helper
         $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));
         if ($timestampEnabled && strpos($path, '?') === false) {
             $filepath = preg_replace(
-                '/^' . preg_quote($this->request->getAttribute('webroot'), '/') . '/',
+                '/^' . preg_quote($this->_View->getRequest()->getAttribute('webroot'), '/') . '/',
                 '',
                 urldecode($path)
             );
@@ -268,9 +268,11 @@ class UrlHelper extends Helper
      */
     public function webroot($file)
     {
+        $request = $this->_View->getRequest();
+
         $asset = explode('?', $file);
         $asset[1] = isset($asset[1]) ? '?' . $asset[1] : null;
-        $webPath = $this->request->getAttribute('webroot') . $asset[0];
+        $webPath = $request->getAttribute('webroot') . $asset[0];
         $file = $asset[0];
 
         if (!empty($this->_View->getTheme())) {
@@ -282,12 +284,12 @@ class UrlHelper extends Helper
             }
 
             if (file_exists(Configure::read('App.wwwRoot') . $theme . $file)) {
-                $webPath = $this->request->getAttribute('webroot') . $theme . $asset[0];
+                $webPath = $request->getAttribute('webroot') . $theme . $asset[0];
             } else {
                 $themePath = Plugin::path($this->_View->getTheme());
                 $path = $themePath . 'webroot/' . $file;
                 if (file_exists($path)) {
-                    $webPath = $this->request->getAttribute('webroot') . $theme . $asset[0];
+                    $webPath = $request->getAttribute('webroot') . $theme . $asset[0];
                 }
             }
         }

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -145,9 +145,6 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
     {
         $instance = new $class($this->_View, $settings);
 
-        $instance->theme = $this->_View->getTheme();
-        $instance->plugin = $this->_View->getRequest()->getParam('Plugin');
-
         $enable = isset($settings['enabled']) ? $settings['enabled'] : true;
         if ($enable) {
             $this->getEventManager()->on($instance);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -751,8 +751,7 @@ class FormHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/edit/1')
-            ->withParam('action', 'edit')
-        );
+            ->withParam('action', 'edit'));
 
         $this->article['defaults']['id'] = 1;
 
@@ -781,8 +780,7 @@ class FormHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/delete/10')
-            ->withParam('action', 'delete')
-        );
+            ->withParam('action', 'delete'));
         $result = $this->Form->create($this->article);
         $expected = [
             'form' => [
@@ -798,8 +796,7 @@ class FormHelperTest extends TestCase
         $this->article['defaults'] = ['id' => 1];
         $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/edit/1')
-            ->withParam('action', 'delete')
-        );
+            ->withParam('action', 'delete'));
         $result = $this->Form->create($this->article, ['url' => ['action' => 'edit']]);
         $expected = [
             'form' => [
@@ -814,8 +811,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('action', 'add')
-        );
+            ->withParam('action', 'add'));
         $result = $this->Form->create($this->article, ['url' => ['action' => 'publish']]);
         $expected = [
             'form' => [
@@ -839,8 +835,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('controller', 'Pages')
-        );
+            ->withParam('controller', 'Pages'));
         $result = $this->Form->create($this->article, ['url' => ['action' => 'signup']]);
         $expected = [
             'form' => [
@@ -885,8 +880,7 @@ class FormHelperTest extends TestCase
         $encoding = strtolower(Configure::read('App.encoding'));
 
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('controller', 'users')
-        );
+            ->withParam('controller', 'users'));
 
         $result = $this->Form->create(false, ['url' => ['action' => 'login']]);
         $expected = [
@@ -2009,7 +2003,8 @@ class FormHelperTest extends TestCase
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField()
+            $this->View->getRequest()->getParam('_Token.unlockedFields'),
+            $this->Form->unlockField()
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -2081,8 +2076,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withParam('_Token', 'stuff')
-            ->withParam('_csrfToken', 'testKey')
-        );
+            ->withParam('_csrfToken', 'testKey'));
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
             'population' => ['type' => 'decimal', 'length' => 15, 'precision' => 0],
@@ -4061,8 +4055,7 @@ class FormHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('prefix', 'admin')
             ->withParam('action', 'admin_edit')
-            ->withParam('controller', 'articles')
-        );
+            ->withParam('controller', 'articles'));
         $result = $this->Form->allControls();
         $expected = [
             '<fieldset',
@@ -4390,8 +4383,7 @@ class FormHelperTest extends TestCase
         ];
         $this->View->setRequest($this->View->getRequest()
             ->withData('Model.text', 'test <strong>HTML</strong> values')
-            ->withData('Contact.text', 'test')
-        );
+            ->withData('Contact.text', 'test'));
         $this->Form->create($this->article);
 
         $result = $this->Form->text('Model.text');
@@ -6232,7 +6224,6 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest(
             $this->View->getRequest()->withParam('_Token', ['unlockedFields' => []])
-
         );
         $this->Form->dateTime('Contact.date');
         $expected = [
@@ -7242,8 +7233,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest($this->View->getRequest()
-            ->withData('field', 'some <strong>test</strong> data with <a href="#">HTML</a> chars')
-        );
+            ->withData('field', 'some <strong>test</strong> data with <a href="#">HTML</a> chars'));
         $this->Form->create();
         $result = $this->Form->textarea('field');
         $expected = [
@@ -7570,8 +7560,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withParam('_csrfToken', 'testkey')
-            ->withParam('_Token.unlockedFields', [])
-        );
+            ->withParam('_Token.unlockedFields', []));
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
@@ -7861,8 +7850,7 @@ class FormHelperTest extends TestCase
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('_Token.key', 'test')
-        );
+            ->withParam('_Token.key', 'test'));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7921,8 +7909,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withParam('_csrfToken', 'testkey')
-            ->withParam('_Token', 'val')
-        );
+            ->withParam('_Token', 'val'));
 
         $this->Form->create($this->article, ['type' => 'get']);
         $this->Form->end();
@@ -8969,8 +8956,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withData('id', '1')
-            ->withQueryParams(['id' => '2'])
-        );
+            ->withQueryParams(['id' => '2']));
 
         $expected = ['context'];
         $result = $this->Form->getValueSources();
@@ -9036,8 +9022,7 @@ class FormHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withQueryParams(['id' => '5a'])
-            ->withData('id', '5b')
-        );
+            ->withData('id', '5b'));
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article);
@@ -9101,8 +9086,7 @@ class FormHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withData('id', '8')
-            ->withQueryParams(['id' => '9'])
-        );
+            ->withQueryParams(['id' => '9']));
         $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->control('id');
         $expected = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -145,9 +145,7 @@ class FormHelperTest extends TestCase
         Configure::write('Config.language', 'eng');
         Configure::write('App.base', '');
         static::setAppNamespace('Cake\Test\TestCase\View\Helper');
-        $this->View = new View();
 
-        $this->Form = new FormHelper($this->View);
         $request = new ServerRequest([
             'webroot' => '',
             'base' => '',
@@ -157,7 +155,9 @@ class FormHelperTest extends TestCase
                 'action' => 'add',
             ]
         ]);
-        $this->Form->Url->request = $this->Form->request = $request;
+        $this->View = new View($request);
+
+        $this->Form = new FormHelper($this->View);
 
         $this->dateRegex = [
             'daysRegex' => 'preg:/(?:<option value="0?([\d]+)">\\1<\/option>[\r\n]*)*/',
@@ -749,9 +749,10 @@ class FormHelperTest extends TestCase
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/edit/1')
-            ->withParam('action', 'edit');
+            ->withParam('action', 'edit')
+        );
 
         $this->article['defaults']['id'] = 1;
 
@@ -778,9 +779,10 @@ class FormHelperTest extends TestCase
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/delete/10')
-            ->withParam('action', 'delete');
+            ->withParam('action', 'delete')
+        );
         $result = $this->Form->create($this->article);
         $expected = [
             'form' => [
@@ -794,9 +796,10 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->article['defaults'] = ['id' => 1];
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withRequestTarget('/articles/edit/1')
-            ->withParam('action', 'delete');
+            ->withParam('action', 'delete')
+        );
         $result = $this->Form->create($this->article, ['url' => ['action' => 'edit']]);
         $expected = [
             'form' => [
@@ -810,8 +813,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request
-            ->withParam('action', 'add');
+        $this->View->setRequest($this->View->getRequest()
+            ->withParam('action', 'add')
+        );
         $result = $this->Form->create($this->article, ['url' => ['action' => 'publish']]);
         $expected = [
             'form' => [
@@ -834,8 +838,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request
-            ->withParam('controller', 'Pages');
+        $this->View->setRequest($this->View->getRequest()
+            ->withParam('controller', 'Pages')
+        );
         $result = $this->Form->create($this->article, ['url' => ['action' => 'signup']]);
         $expected = [
             'form' => [
@@ -879,8 +884,9 @@ class FormHelperTest extends TestCase
         Router::connect('/login', ['controller' => 'users', 'action' => 'login']);
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request = $this->Form->request
-            ->withParam('controller', 'users');
+        $this->View->setRequest($this->View->getRequest()
+            ->withParam('controller', 'users')
+        );
 
         $result = $this->Form->create(false, ['url' => ['action' => 'login']]);
         $expected = [
@@ -986,7 +992,7 @@ class FormHelperTest extends TestCase
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
-        $this->Form->request = $this->Form->request->withData('Article.id', [1, 2]);
+        $this->View->setRequest($this->View->getRequest()->withData('Article.id', [1, 2]));
         $result = $this->Form->create($this->article);
         $expected = [
             'form' => [
@@ -1009,7 +1015,7 @@ class FormHelperTest extends TestCase
     public function testCreatePassedArgs()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $this->Form->request = $this->Form->request->withData('Article.id', 1);
+        $this->View->setRequest($this->View->getRequest()->withData('Article.id', 1));
         $result = $this->Form->create($this->article, [
             'type' => 'post',
             'escape' => false,
@@ -1074,7 +1080,7 @@ class FormHelperTest extends TestCase
     public function testGetFormWithFalseModel()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $this->Form->request = $this->Form->request->withParam('controller', 'contact_test');
+        $this->View->setRequest($this->View->getRequest()->withParam('controller', 'contact_test'));
         $result = $this->Form->create(false, [
             'type' => 'get', 'url' => ['controller' => 'contact_test']
         ]);
@@ -1101,7 +1107,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateWithSecurity()
     {
-        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create($this->article, [
             'url' => '/articles/publish',
@@ -1134,7 +1140,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateEndGetNoSecurity()
     {
-        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
         $article = new Article();
         $result = $this->Form->create($article, [
             'type' => 'get',
@@ -1165,7 +1171,7 @@ class FormHelperTest extends TestCase
      */
     public function testValidateHashNoModel()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
 
         $fields = ['anything'];
         $result = $this->Form->secure($fields);
@@ -1181,7 +1187,7 @@ class FormHelperTest extends TestCase
      */
     public function testNoCheckboxLocking()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
         $this->assertSame([], $this->Form->fields);
 
         $this->Form->checkbox('check', ['value' => '1']);
@@ -1199,7 +1205,7 @@ class FormHelperTest extends TestCase
     {
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1247,7 +1253,7 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1434,7 +1440,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'foo');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
 
         $fields = [
             'Model.0.password', 'Model.0.username', 'Model.0.hidden' => 'value',
@@ -1485,7 +1491,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleSubmitButtons()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->text('Address.title');
@@ -1549,7 +1555,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecurityButtonNestedNamed()
     {
-        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
 
         $this->Form->create('Addresses');
         $this->Form->button('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1564,7 +1570,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitNestedNamed()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->submit('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1579,7 +1585,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageNoName()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->create(false);
         $result = $this->Form->submit('save.png');
@@ -1599,7 +1605,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageName()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->create(null);
         $result = $this->Form->submit('save.png', ['name' => 'test']);
@@ -1621,7 +1627,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1700,7 +1706,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityArrayFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->create();
         $this->Form->text('Address.primary.1');
@@ -1719,9 +1725,9 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlDisabledFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ]);
+        ]));
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1795,11 +1801,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ]);
+        ]));
         $this->Form->create();
-        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1870,11 +1876,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ]);
+        ]));
         $this->Form->create();
-        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1944,11 +1950,11 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ]);
+        ]));
         $this->Form->create();
-        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1998,11 +2004,13 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => ['first_name', 'address']
-        ]);
+        ]));
         $this->Form->create();
-        $this->assertEquals($this->Form->request->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals(
+            $this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField()
+        );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -2053,7 +2061,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecureWithCustomNameAttribute()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom]']);
         $this->assertEquals('User.custom', $this->Form->fields[0]);
@@ -2071,9 +2079,10 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredControl()
     {
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('_Token', 'stuff')
-            ->withParam('_csrfToken', 'testKey');
+            ->withParam('_csrfToken', 'testKey')
+        );
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
             'population' => ['type' => 'decimal', 'length' => 15, 'precision' => 0],
@@ -2238,7 +2247,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlCustomName()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->text('text_input', [
@@ -2268,7 +2277,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlDuplicate()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
@@ -2314,7 +2323,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredMultipleSelect()
     {
-        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'one', '2' => 'two'];
 
@@ -2334,7 +2343,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredRadio()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'option1', '2' => 'option2'];
@@ -2365,7 +2374,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabledNotAssoc()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->select('Model.select', [1, 2], ['disabled']);
         $this->Form->checkbox('Model.checkbox', ['disabled']);
@@ -2390,7 +2399,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabled()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->checkbox('Model.checkbox', ['disabled' => true]);
         $this->Form->text('Model.text', ['disabled' => true]);
@@ -2418,9 +2427,9 @@ class FormHelperTest extends TestCase
      */
     public function testDisableSecurityUsingForm()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'disabledFields' => []
-        ]);
+        ]));
         $this->Form->create();
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -2445,9 +2454,9 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldAddsToList()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => []
-        ]);
+        ]));
         $this->Form->unlockField('Contact.name');
         $this->Form->text('Contact.name');
 
@@ -2464,9 +2473,9 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldRemovingFromFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'unlockedFields' => []
-        ]);
+        ]));
         $this->Form->create($this->article);
         $this->Form->hidden('Article.id', ['value' => 1]);
         $this->Form->text('Article.title');
@@ -2488,10 +2497,10 @@ class FormHelperTest extends TestCase
      */
     public function testResetUnlockFields()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
             'key' => 'testKey',
             'unlockedFields' => []
-        ]);
+        ]));
 
         $this->Form->unlockField('Contact.id');
         $this->Form->create('Contact');
@@ -2513,7 +2522,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlIgnoresHost()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', ['key' => 'testKey']);
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', ['key' => 'testKey']));
 
         $expected = '2548654895b160d724042ed269a2a863fd9d66ee%3A';
         $this->Form->create($this->article, [
@@ -2544,7 +2553,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlHasHtmlAndIdentifier()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $expected = '0a913f45b887b4d9cc2650ef1edc50183896959c%3A';
         $this->Form->create($this->article, [
@@ -3058,7 +3067,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.0.OtherModel.field', 'My value');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.0.OtherModel.field', 'My value')
+        );
         $this->Form->create();
         $result = $this->Form->control('Model.0.OtherModel.field', ['id' => 'myId']);
         $expected = [
@@ -3074,7 +3085,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->View->setRequest($this->View->getRequest()->withParsedBody([]));
         $this->Form->create();
 
         $entity->setError('field', 'Badness!');
@@ -3692,7 +3703,9 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request = $this->Form->request->withData('Model', ['user_id' => 'value']);
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model', ['user_id' => 'value'])
+        );
         $this->Form->create();
         $result = $this->Form->control('Model.user_id', ['empty' => true]);
         $expected = [
@@ -3715,7 +3728,9 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request = $this->Form->request->withData('Thing', ['user_id' => null]);
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Thing', ['user_id' => null])
+        );
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3738,7 +3753,9 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $this->Form->request = $this->Form->request->withData('Thing', ['user_id' => 'value']);
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Thing', ['user_id' => 'value'])
+        );
         $this->Form->create();
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
@@ -4041,10 +4058,11 @@ class FormHelperTest extends TestCase
         $this->assertNotContains('<fieldset>', $result);
 
         $this->Form->create($this->article);
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('prefix', 'admin')
             ->withParam('action', 'admin_edit')
-            ->withParam('controller', 'articles');
+            ->withParam('controller', 'articles')
+        );
         $result = $this->Form->allControls();
         $expected = [
             '<fieldset',
@@ -4370,9 +4388,10 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'Contact' => ['text' => 'wrong']
         ];
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withData('Model.text', 'test <strong>HTML</strong> values')
-            ->withData('Contact.text', 'test');
+            ->withData('Contact.text', 'test')
+        );
         $this->Form->create($this->article);
 
         $result = $this->Form->text('Model.text');
@@ -4407,12 +4426,12 @@ class FormHelperTest extends TestCase
      */
     public function testTextDefaultValue()
     {
-        $this->Form->request = $this->Form->request->withData('Model.field', 'test');
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', 'test'));
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'test']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->View->setRequest($this->View->getRequest()->withParsedBody([]));
         $this->Form->create();
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'default value']];
@@ -4616,7 +4635,7 @@ class FormHelperTest extends TestCase
         $expected = ['input' => ['type' => 'password', 'name' => 'Contact[field]']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Contact.passwd', 'test');
+        $this->View->setRequest($this->View->getRequest()->withData('Contact.passwd', 'test'));
         $this->Form->create($this->article);
         $result = $this->Form->password('Contact.passwd', ['id' => 'theID']);
         $expected = ['input' => ['type' => 'password', 'name' => 'Contact[passwd]', 'value' => 'test', 'id' => 'theID', 'class' => 'form-error']];
@@ -4989,7 +5008,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model', ['field' => 'value']);
+        $this->View->setRequest($this->View->getRequest()->withData('Model', ['field' => 'value']));
         $this->Form->create();
         $result = $this->Form->select('Model.field', ['value' => 'good', 'other' => 'bad']);
         $expected = [
@@ -5007,7 +5026,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select('Model.field', new Collection(['value' => 'good', 'other' => 'bad']));
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withParsedBody([]);
+        $this->View->setRequest($this->View->getRequest()->withParsedBody([]));
         $this->Form->create();
         $result = $this->Form->select('Model.field', ['value' => 'good', 'other' => 'bad']);
         $expected = [
@@ -5043,7 +5062,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withParsedBody(['Model' => ['contact_id' => 228]]);
+        $this->View->setRequest($this->View->getRequest()->withParsedBody(['Model' => ['contact_id' => 228]]));
         $this->Form->create();
         $result = $this->Form->select(
             'Model.contact_id',
@@ -5061,7 +5080,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', 0);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', 0));
         $this->Form->create();
         $result = $this->Form->select('Model.field', ['0' => 'No', '1' => 'Yes']);
         $expected = [
@@ -5576,7 +5595,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxRequestData()
     {
-        $this->Form->request = $this->Form->request->withData('Model', ['tags' => [1]]);
+        $this->View->setRequest($this->View->getRequest()->withData('Model', ['tags' => [1]]));
         $result = $this->Form->select(
             'Model.tags',
             ['1' => 'first', 'Array' => 'Array'],
@@ -5618,7 +5637,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxSecurity()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testKey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5663,7 +5682,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectNoSecureWithNoOptions()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'testkey');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testkey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5891,24 +5910,24 @@ class FormHelperTest extends TestCase
      */
     public function testCheckboxDefaultValue()
     {
-        $this->Form->request = $this->Form->request->withData('Model.field', false);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', false));
         $result = $this->Form->checkbox('Model.field', ['default' => true, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', null));
         $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => true, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', true);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', true));
         $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => false, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', null));
         $this->Form->create();
         $result = $this->Form->checkbox('Model.field', ['default' => false, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1']];
@@ -5938,7 +5957,7 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'published' => true
         ];
-        $this->Form->request = $this->Form->request->withData('published', 'myvalue');
+        $this->View->setRequest($this->View->getRequest()->withData('published', 'myvalue'));
         $this->Form->create($this->article);
 
         $result = $this->Form->checkbox('published', ['id' => 'theID', 'value' => 'myvalue']);
@@ -5955,7 +5974,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('published', '');
+        $this->View->setRequest($this->View->getRequest()->withData('published', ''));
         $this->Form->create($this->article);
         $result = $this->Form->checkbox('published');
         $expected = [
@@ -6211,7 +6230,10 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeSecured()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', ['unlockedFields' => []]);
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('_Token', ['unlockedFields' => []])
+
+        );
         $this->Form->dateTime('Contact.date');
         $expected = [
             'Contact.date.year',
@@ -6241,7 +6263,9 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeSecuredDisabled()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', ['unlockedFields' => []]);
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('_Token', ['unlockedFields' => []])
+        );
         $this->Form->dateTime('Contact.date', ['secure' => false]);
         $expected = [];
         $this->assertEquals($expected, $this->Form->fields);
@@ -6376,7 +6400,7 @@ class FormHelperTest extends TestCase
      */
     public function testDateTimeRounding()
     {
-        $this->Form->request = $this->Form->request->withData('Contact', [
+        $this->View->setRequest($this->View->getRequest()->withData('Contact', [
             'date' => [
                 'day' => '13',
                 'month' => '12',
@@ -6385,7 +6409,7 @@ class FormHelperTest extends TestCase
                 'minute' => '19',
                 'meridian' => 'AM'
             ]
-        ]);
+        ]));
 
         $result = $this->Form->dateTime('Contact.date', ['interval' => 15]);
         $this->assertTextContains('<option value="15" selected="selected">15</option>', $result);
@@ -6608,7 +6632,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Project.release', '2050-02-10');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Project.release', '2050-02-10')
+        );
         $this->Form->create();
         $result = $this->Form->month('Project.release');
 
@@ -6659,7 +6685,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 23:12:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2006-10-10 23:12:32')
+        );
         $this->Form->create();
         $result = $this->Form->day('Model.field');
         $expected = [
@@ -6681,7 +6709,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', ''));
         $this->Form->create();
         $result = $this->Form->day('Model.field', ['value' => '10']);
         $expected = [
@@ -6703,7 +6731,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Project.release', '2050-10-10');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Project.release', '2050-10-10')
+        );
         $this->Form->create();
         $result = $this->Form->day('Project.release');
 
@@ -6762,7 +6792,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2006-10-10 00:12:32')
+        );
         $this->Form->create();
         $result = $this->Form->minute('Model.field');
         $expected = [
@@ -6787,7 +6819,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', ''));
         $this->Form->create();
         $result = $this->Form->minute('Model.field', ['interval' => 5]);
         $expected = [
@@ -6808,7 +6840,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:10:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2006-10-10 00:10:32')
+        );
         $this->Form->create();
         $result = $this->Form->minute('Model.field', ['interval' => 5]);
         $expected = [
@@ -6883,7 +6917,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2006-10-10 00:12:32')
+        );
         $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 12]);
         $expected = [
@@ -6904,7 +6940,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '');
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', ''));
         $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24, 'value' => '23']);
         $this->assertContains('<option value="23" selected="selected">23</option>', $result);
@@ -6912,7 +6948,9 @@ class FormHelperTest extends TestCase
         $result = $this->Form->hour('Model.field', ['format' => 12, 'value' => '23']);
         $this->assertContains('<option value="11" selected="selected">11</option>', $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2006-10-10 00:12:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2006-10-10 00:12:32')
+        );
         $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24]);
         $expected = [
@@ -6933,14 +6971,16 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', null);
+        $this->View->setRequest($this->View->getRequest()->withData('Model.field', null));
         $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24, 'value' => 'now']);
         $thisHour = date('H');
         $optValue = date('G');
         $this->assertRegExp('/<option value="' . $thisHour . '" selected="selected">' . $optValue . '<\/option>/', $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.field', '2050-10-10 01:12:32');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.field', '2050-10-10 01:12:32')
+        );
         $this->Form->create();
         $result = $this->Form->hour('Model.field', ['format' => 24]);
         $expected = [
@@ -6971,7 +7011,9 @@ class FormHelperTest extends TestCase
      */
     public function testYear()
     {
-        $this->Form->request = $this->Form->request->withData('Contact.published', '2006-10-10');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Contact.published', '2006-10-10')
+        );
         $result = $this->Form->year('Model.field', ['value' => '', 'minYear' => 2006, 'maxYear' => 2007]);
         $expected = [
             ['select' => ['name' => 'Model[field][year]']],
@@ -7078,7 +7120,7 @@ class FormHelperTest extends TestCase
      */
     public function testYearAutoExpandRange()
     {
-        $this->Form->request = $this->Form->request->withData('User.birthday', '1930-10-10');
+        $this->View->setRequest($this->View->getRequest()->withData('User.birthday', '1930-10-10'));
         $result = $this->Form->year('User.birthday');
         preg_match_all('/<option value="([\d]+)"/', $result, $matches);
 
@@ -7086,7 +7128,7 @@ class FormHelperTest extends TestCase
         $expected = range(date('Y') + 5, 1930);
         $this->assertEquals($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Project.release', '2050-10-10');
+        $this->View->setRequest($this->View->getRequest()->withData('Project.release', '2050-10-10'));
         $this->Form->create();
         $result = $this->Form->year('Project.release');
         preg_match_all('/<option value="([\d]+)"/', $result, $matches);
@@ -7095,7 +7137,7 @@ class FormHelperTest extends TestCase
         $expected = range(2050, date('Y') - 5);
         $this->assertEquals($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Project.release', '1881-10-10');
+        $this->View->setRequest($this->View->getRequest()->withData('Project.release', '1881-10-10'));
         $this->Form->create();
         $result = $this->Form->year('Project.release', [
             'minYear' => 1890,
@@ -7117,9 +7159,9 @@ class FormHelperTest extends TestCase
      */
     public function testControlDate()
     {
-        $this->Form->request = $this->Form->request->withParsedBody([
+        $this->View->setRequest($this->View->getRequest()->withParsedBody([
             'month_year' => ['month' => date('m')],
-        ]);
+        ]));
         $this->Form->create($this->article);
         $result = $this->Form->control('month_year', [
                 'label' => false,
@@ -7183,7 +7225,7 @@ class FormHelperTest extends TestCase
      */
     public function testTextArea()
     {
-        $this->Form->request = $this->Form->request->withData('field', 'some test data');
+        $this->View->setRequest($this->View->getRequest()->withData('field', 'some test data'));
         $result = $this->Form->textarea('field');
         $expected = [
             'textarea' => ['name' => 'field', 'rows' => 5],
@@ -7199,8 +7241,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request
-            ->withData('field', 'some <strong>test</strong> data with <a href="#">HTML</a> chars');
+        $this->View->setRequest($this->View->getRequest()
+            ->withData('field', 'some <strong>test</strong> data with <a href="#">HTML</a> chars')
+        );
         $this->Form->create();
         $result = $this->Form->textarea('field');
         $expected = [
@@ -7210,10 +7253,10 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData(
+        $this->View->setRequest($this->View->getRequest()->withData(
             'Model.field',
             'some <strong>test</strong> data with <a href="#">HTML</a> chars'
-        );
+        ));
         $this->Form->create();
         $result = $this->Form->textarea('Model.field', ['escape' => false]);
         $expected = [
@@ -7304,7 +7347,7 @@ class FormHelperTest extends TestCase
         $this->article['errors'] = [
             'field' => true
         ];
-        $this->Form->request = $this->Form->request->withData('field', 'test');
+        $this->View->setRequest($this->View->getRequest()->withData('field', 'test'));
         $this->Form->create($this->article);
         $result = $this->Form->hidden('field', ['id' => 'theID']);
         $expected = [
@@ -7332,14 +7375,16 @@ class FormHelperTest extends TestCase
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.upload', [
+        $this->View->setRequest($this->View->getRequest()->withData('Model.upload', [
             'name' => '', 'type' => '', 'tmp_name' => '',
             'error' => 4, 'size' => 0
-        ]);
+        ]));
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('Model.upload', 'no data should be set in value');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('Model.upload', 'no data should be set in value')
+        );
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
     }
@@ -7406,7 +7451,7 @@ class FormHelperTest extends TestCase
      */
     public function testButtonUnlockedByDefault()
     {
-        $this->Form->request = $this->Form->request->withParam('_csrfToken', 'secured');
+        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'secured'));
         $this->Form->button('Save', ['name' => 'save']);
         $this->Form->button('Clear');
 
@@ -7523,9 +7568,10 @@ class FormHelperTest extends TestCase
      */
     public function testSecurePostButton()
     {
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('_csrfToken', 'testkey')
-            ->withParam('_Token.unlockedFields', []);
+            ->withParam('_Token.unlockedFields', [])
+        );
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
@@ -7737,7 +7783,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->Form->request = $this->Form->request->withParam('_Token.key', 'test');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token.key', 'test'));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7790,7 +7836,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize([]) . session_id(), Security::getSalt());
         $hash .= '%3A';
-        $this->Form->request = $this->Form->request->withParam('_Token.key', 'test');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token.key', 'test'));
 
         $this->Form->create('Post', ['url' => ['action' => 'add']]);
         $this->Form->control('title');
@@ -7814,8 +7860,9 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->Form->request = $this->Form->request
-            ->withParam('_Token.key', 'test');
+        $this->View->setRequest($this->View->getRequest()
+            ->withParam('_Token.key', 'test')
+        );
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7872,9 +7919,10 @@ class FormHelperTest extends TestCase
      */
     public function testPostLinkAfterGetForm()
     {
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('_csrfToken', 'testkey')
-            ->withParam('_Token', 'val');
+            ->withParam('_Token', 'val')
+        );
 
         $this->Form->create($this->article, ['type' => 'get']);
         $this->Form->end();
@@ -8088,7 +8136,7 @@ class FormHelperTest extends TestCase
      */
     public function testSubmitUnlockedByDefault()
     {
-        $this->Form->request = $this->Form->request->withParam('_Token', 'secured');
+        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'secured'));
         $this->Form->submit('Go go');
         $this->Form->submit('Save', ['name' => 'save']);
 
@@ -8171,7 +8219,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withData('non_existing_nor_validated', 'CakePHP magic');
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('non_existing_nor_validated', 'CakePHP magic')
+        );
         $this->Form->create($this->article);
         $result = $this->Form->control('non_existing_nor_validated');
         $expected = [
@@ -8917,9 +8967,10 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesSettersGetters()
     {
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withData('id', '1')
-            ->withQueryParams(['id' => '2']);
+            ->withQueryParams(['id' => '2'])
+        );
 
         $expected = ['context'];
         $result = $this->Form->getValueSources();
@@ -8975,7 +9026,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request->withQueryParams(['id' => 5]);
+        $this->View->setRequest($this->View->getRequest()->withQueryParams(['id' => 5]));
         $this->Form->setValueSources(['query']);
         $result = $this->Form->control('id');
         $expected = [
@@ -8983,9 +9034,10 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withQueryParams(['id' => '5a'])
-            ->withData('id', '5b');
+            ->withData('id', '5b')
+        );
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article);
@@ -9023,7 +9075,7 @@ class FormHelperTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
-        $this->Form->request = $this->Form->request->withQueryParams(['id' => '9']);
+        $this->View->setRequest($this->View->getRequest()->withQueryParams(['id' => '9']));
 
         $this->Form->create($article);
         $this->Form->setValueSources(['context', 'query']);
@@ -9047,9 +9099,10 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request = $this->Form->request
+        $this->View->setRequest($this->View->getRequest()
             ->withData('id', '8')
-            ->withQueryParams(['id' => '9']);
+            ->withQueryParams(['id' => '9'])
+        );
         $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->control('id');
         $expected = [
@@ -9070,7 +9123,9 @@ class FormHelperTest extends TestCase
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
 
-        $this->Form->request = $this->Form->request->withData('id', 4)->withQueryParams(['id' => 5]);
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('id', 4)->withQueryParams(['id' => 5])
+        );
 
         $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->control('id');
@@ -9125,7 +9180,9 @@ class FormHelperTest extends TestCase
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
 
-        $this->Form->request = $this->Form->request->withData('id', 10)->withQueryParams(['id' => 11]);
+        $this->View->setRequest(
+            $this->View->getRequest()->withData('id', 10)->withQueryParams(['id' => 11])
+        );
 
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
@@ -9137,7 +9194,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals('11', $result);
 
-        $this->Form->request = $this->Form->request->withQueryParams([]);
+        $this->View->setRequest($this->View->getRequest()->withQueryParams([]));
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->control('id');
@@ -9182,7 +9239,9 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesDefaults()
     {
-        $this->Form->request = $this->Form->request->withQueryParams(['password' => 'open Sesame']);
+        $this->View->setRequest(
+            $this->View->getRequest()->withQueryParams(['password' => 'open Sesame'])
+        );
         $this->Form->create();
 
         $result = $this->Form->password('password');
@@ -9211,7 +9270,7 @@ class FormHelperTest extends TestCase
      */
     public function testSourcesValueDoesntExistPassThrough()
     {
-        $this->Form->request = $this->Form->request->withQueryParams(['category' => 'sesame-cookies']);
+        $this->View->setRequest($this->View->getRequest()->withQueryParams(['category' => 'sesame-cookies']));
 
         $articles = $this->getTableLocator()->get('Articles');
         $entity = $articles->newEntity();

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -519,7 +519,7 @@ class HtmlHelperTest extends TestCase
         Configure::write('debug', true);
 
         $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
-        $this->Html->Url->theme = 'TestTheme';
+        $this->Html->Url->getView()->setTheme('TestTheme');
         $result = $this->Html->image('__cake_test_image.gif');
         $expected = [
             'img' => [
@@ -549,14 +549,14 @@ class HtmlHelperTest extends TestCase
     {
         Configure::write('App.wwwRoot', TEST_APP . 'webroot/');
 
-        $this->Html->Url->theme = 'TestTheme';
+        $this->Html->Url->getView()->setTheme('TestTheme');
         $result = $this->Html->css('webroot_test');
         $expected = [
             'link' => ['rel' => 'stylesheet', 'href' => 'preg:/.*test_theme\/css\/webroot_test\.css/']
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->theme = 'TestTheme';
+        $this->Html->getView()->setTheme('TestTheme');
         $result = $this->Html->css('theme_webroot');
         $expected = [
             'link' => ['rel' => 'stylesheet', 'href' => 'preg:/.*test_theme\/css\/theme_webroot\.css/']
@@ -1128,7 +1128,7 @@ class HtmlHelperTest extends TestCase
         $File = new File($testfile, true);
 
         $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
-        $this->Html->Url->theme = 'TestTheme';
+        $this->Html->Url->getView()->setTheme('TestTheme');
         $result = $this->Html->script('__test_js.js');
         $expected = [
             'script' => ['src' => '/test_theme/js/__test_js.js']
@@ -1816,7 +1816,7 @@ class HtmlHelperTest extends TestCase
      */
     public function testMetaIconWithTheme()
     {
-        $this->Html->Url->theme = 'TestTheme';
+        $this->Html->Url->getView()->setTheme('TestTheme');
 
         $result = $this->Html->meta('icon', 'favicon.ico');
         $expected = [

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -64,14 +64,15 @@ class HtmlHelperTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->View = $this->getMockBuilder('Cake\View\View')
-            ->setMethods(['append'])
-            ->getMock();
-        $this->Html = new HtmlHelper($this->View);
-        $this->Html->request = new ServerRequest([
+
+        $request = new ServerRequest([
             'webroot' => '',
         ]);
-        $this->Html->Url->request = $this->Html->request;
+        $this->View = $this->getMockBuilder('Cake\View\View')
+            ->setMethods(['append'])
+            ->setConstructorArgs([$request])
+            ->getMock();
+        $this->Html = new HtmlHelper($this->View);
 
         Plugin::load(['TestTheme']);
         static::setAppNamespace();
@@ -117,7 +118,7 @@ class HtmlHelperTest extends TestCase
     {
         Router::connect('/:controller/:action/*');
 
-        $this->Html->request = $this->Html->request->withAttribute('webroot', '');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', ''));
 
         $result = $this->Html->link('/home');
         $expected = ['a' => ['href' => '/home'], 'preg:/\/home/', '/a'];
@@ -381,10 +382,10 @@ class HtmlHelperTest extends TestCase
      */
     public function testImageDataUriBaseDir()
     {
-        $request = $this->Html->request
+        $request = $this->View->getRequest()
             ->withAttribute('base', 'subdir')
             ->withAttribute('webroot', 'subdir/');
-        $this->Html->Url->request = $this->Html->request = $request;
+        $this->View->setRequest($request);
         Router::pushRequest($request);
 
         $data = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4' .
@@ -464,9 +465,10 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => $here . 'img/sub/test.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request
+        $this->View->setRequest($this->View->getRequest()
             ->withAttribute('webroot', '/myproject/')
-            ->withAttribute('base', '/myproject');
+            ->withAttribute('base', '/myproject')
+        );
 
         $result = $this->Html->image('sub/test.gif', ['fullBase' => true]);
         $here = $this->Html->Url->build('/', true);
@@ -483,7 +485,7 @@ class HtmlHelperTest extends TestCase
     {
         Configure::write('Asset.timestamp', 'force');
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/'));
         $result = $this->Html->image('cake.icon.png');
         $expected = ['img' => ['src' => 'preg:/\/img\/cake\.icon\.png\?\d+/', 'alt' => '']];
         $this->assertHtml($expected, $result);
@@ -495,7 +497,7 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => 'preg:/\/img\/cake\.icon\.png\?\d+/', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/longer/'));
         $result = $this->Html->image('cake.icon.png');
         $expected = [
             'img' => ['src' => 'preg:/\/testing\/longer\/img\/cake\.icon\.png\?[0-9]+/', 'alt' => '']
@@ -518,7 +520,7 @@ class HtmlHelperTest extends TestCase
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', true);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/'));
         $this->Html->Url->getView()->setTheme('TestTheme');
         $result = $this->Html->image('__cake_test_image.gif');
         $expected = [
@@ -529,7 +531,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/'));
         $result = $this->Html->image('__cake_test_image.gif');
         $expected = [
         'img' => [
@@ -769,12 +771,12 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'preg:/.*css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/'));
         $result = $this->Html->css('cake.generic', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/longer/'));
         $result = $this->Html->css('cake.generic', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/longer\/css\/cake\.generic\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
@@ -812,12 +814,12 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/'));
         $result = $this->Html->css('TestPlugin.test_plugin_asset', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/longer/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/longer/'));
         $result = $this->Html->css('TestPlugin.test_plugin_asset', ['once' => false]);
         $expected['link']['href'] = 'preg:/\/testing\/longer\/test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
@@ -1127,7 +1129,7 @@ class HtmlHelperTest extends TestCase
         $testfile = WWW_ROOT . '/test_theme/js/__test_js.js';
         $File = new File($testfile, true);
 
-        $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/'));
         $this->Html->Url->getView()->setTheme('TestTheme');
         $result = $this->Html->script('__test_js.js');
         $expected = [
@@ -1800,7 +1802,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->request = $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/'));
         $result = $this->Html->meta('icon');
         $expected = [
             'link' => ['href' => '/testing/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],
@@ -1832,7 +1834,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Html->request = $this->Html->Url->request = $this->Html->request->withAttribute('webroot', '/testing/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/testing/'));
         $result = $this->Html->meta('icon');
         $expected = [
             'link' => ['href' => '/testing/test_theme/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -467,8 +467,7 @@ class HtmlHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('webroot', '/myproject/')
-            ->withAttribute('base', '/myproject')
-        );
+            ->withAttribute('base', '/myproject'));
 
         $result = $this->Html->image('sub/test.gif', ['fullBase' => true]);
         $here = $this->Html->Url->build('/', true);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -52,9 +52,7 @@ class PaginatorHelperTest extends TestCase
     {
         parent::setUp();
         Configure::write('Config.language', 'eng');
-        $this->View = new View();
-        $this->Paginator = new PaginatorHelper($this->View);
-        $this->Paginator->request = new ServerRequest([
+        $request = new ServerRequest([
             'url' => '/',
             'params' => [
                 'paging' => [
@@ -72,6 +70,8 @@ class PaginatorHelperTest extends TestCase
                 ]
             ]
         ]);
+        $this->View = new View($request);
+        $this->Paginator = new PaginatorHelper($this->View);
 
         Router::reload();
         Router::connect('/:controller/:action/*');
@@ -124,7 +124,9 @@ class PaginatorHelperTest extends TestCase
     public function testHasPrevious()
     {
         $this->assertFalse($this->Paginator->hasPrev());
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.prevPage', true);
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('paging.Article.prevPage', true)
+        );
         $this->assertTrue($this->Paginator->hasPrev());
     }
 
@@ -136,7 +138,9 @@ class PaginatorHelperTest extends TestCase
     public function testHasNext()
     {
         $this->assertTrue($this->Paginator->hasNext());
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.nextPage', false);
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('paging.Article.nextPage', false)
+        );
         $this->assertFalse($this->Paginator->hasNext());
     }
 
@@ -158,7 +162,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequestInfo($request);
 
         $this->Paginator->options(['url' => ['param']]);
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'current' => 9,
                 'count' => 62,
@@ -169,7 +173,7 @@ class PaginatorHelperTest extends TestCase
                 'direction' => 'asc',
                 'page' => 1,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->sort('title');
         $expected = [
@@ -209,7 +213,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.sort', 'title');
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('paging.Article.sort', 'title')
+        );
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -218,9 +224,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -229,9 +236,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -240,9 +248,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -251,9 +260,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'ASC']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -262,9 +272,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'asc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -273,9 +284,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
 
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
@@ -328,9 +340,10 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
 
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
@@ -348,9 +361,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
@@ -421,9 +435,10 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('Article.title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -432,9 +447,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -443,9 +459,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
@@ -454,9 +471,10 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Account.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=title&amp;direction=asc'],
@@ -484,7 +502,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequestInfo($request);
 
         $this->Paginator->options(['model' => 'Articles']);
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Articles' => [
                 'current' => 9,
                 'count' => 62,
@@ -507,7 +525,7 @@ class PaginatorHelperTest extends TestCase
                 'page' => 1,
                 'scope' => 'tags',
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->sort('title', 'Title', ['model' => 'Articles']);
         $expected = [
@@ -584,16 +602,17 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortKeyFallbackToParams()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.sort', 'Article.body');
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.sort', 'Article.body'));
         $result = $this->Paginator->sortKey();
         $this->assertEquals('Article.body', $result);
 
         $result = $this->Paginator->sortKey('Article');
         $this->assertEquals('Article.body', $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.order', 'DESC');
+            ->withParam('paging.Article.order', 'DESC')
+        );
         $result = $this->Paginator->sortKey();
         $this->assertEquals('Article.body', $result);
 
@@ -612,31 +631,37 @@ class PaginatorHelperTest extends TestCase
         $expected = 'asc';
         $this->assertEquals($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'desc');
+            ->withParam('paging.Article.direction', 'desc')
+        );
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.direction', null);
+        $this->View->setRequest(
+            $this->View->getRequest()->withParam('paging.Article.direction', null)
+        );
         $result = $this->Paginator->sortDir('Article', ['direction' => 'asc']);
         $this->assertEquals('asc', $result);
 
@@ -655,9 +680,9 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortDirFallbackToParams()
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc'));
 
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
@@ -665,9 +690,9 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->sortDir('Article');
         $this->assertEquals('asc', $result);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.direction', 'DESC');
+            ->withParam('paging.Article.direction', 'DESC'));
 
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
@@ -696,7 +721,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 1);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 1));
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -743,14 +768,14 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sortDefault' => 'Article.title', 'directionDefault' => 'ASC',
                 'sort' => null
             ]
-        ]);
+        ]));
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -780,7 +805,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl();
         $this->assertEquals('/index', $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
         $result = $this->Paginator->generateUrl();
         $this->assertEquals('/index?page=2', $result);
 
@@ -788,23 +813,23 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl($options);
         $this->assertEquals('/index?page=2&amp;sort=Article&amp;direction=desc', $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
         $this->assertEquals('/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, ['escape' => false]);
         $this->assertEquals('/index?page=3&sort=Article.name&direction=desc', $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, ['fullBase' => true]);
         $this->assertEquals('http://localhost/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 
         // @deprecated 3.3.5 Use fullBase array option instead.
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, true);
         $this->assertEquals('http://localhost/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
@@ -821,10 +846,11 @@ class PaginatorHelperTest extends TestCase
      */
     public function testUrlGenerationResetsToPage1($field, $options, $expected)
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 2)
             ->withParam('paging.Article.sort', 'name')
-            ->withParam('paging.Article.direction', 'asc');
+            ->withParam('paging.Article.direction', 'asc')
+        );
         $result = $this->Paginator->sort($field, null, ['url' => $options]);
         $this->assertSame($expected, $result);
     }
@@ -884,9 +910,10 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 2)
-            ->withParam('paging.Article.prevPage', true);
+            ->withParam('paging.Article.prevPage', true)
+        );
         $options = ['prefix' => 'members'];
 
         $result = $this->Paginator->generateUrl($options);
@@ -956,7 +983,7 @@ class PaginatorHelperTest extends TestCase
             'webroot' => '/'
         ]);
         Router::setRequestInfo($request);
-        $this->Paginator->request = $request;
+        $this->View->setRequest($request);
 
         $result = $this->Paginator->generateUrl();
         $expected = '/members/posts/index?page=2';
@@ -992,10 +1019,11 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.scope', 'article')
             ->withParam('paging.Article.page', 3)
-            ->withParam('paging.Article.prevPage', true);
+            ->withParam('paging.Article.prevPage', true)
+        );
         $this->Paginator->options(['model' => 'Article']);
 
         $result = $this->Paginator->generateUrl([]);
@@ -1054,7 +1082,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->View->setRequest($this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.scope', 'article')
             ->withParam('paging.Article.page', 3)
             ->withParam('paging.Article.prevPage', true)
@@ -1062,7 +1090,8 @@ class PaginatorHelperTest extends TestCase
                 'article' => [
                     'puppy' => 'no'
                 ]
-            ]));
+            ])
+        );
         // Need to run __construct to update _config['url']
         $paginator = new PaginatorHelper($this->View);
         $paginator->options(['model' => 'Article']);
@@ -1084,7 +1113,7 @@ class PaginatorHelperTest extends TestCase
     public function testOptions()
     {
         $this->Paginator->options = [];
-        $this->Paginator->request = $this->Paginator->request->withAttribute('params', []);
+        $this->View->setRequest($this->View->getRequest()->withAttribute('params', []));
 
         $options = ['paging' => ['Article' => [
             'direction' => 'desc',
@@ -1096,17 +1125,16 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'title'
         ]];
-        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
 
         $this->Paginator->options = [];
-        $this->Paginator->request = $this->Paginator->request->withAttribute('params', []);
 
         $options = ['Article' => [
             'direction' => 'desc',
             'sort' => 'title'
         ]];
         $this->Paginator->options($options);
-        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
 
         $options = ['paging' => ['Article' => [
             'direction' => 'desc',
@@ -1118,7 +1146,7 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'Article.title'
         ]];
-        $this->assertEquals($expected, $this->Paginator->request->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
     }
 
     /**
@@ -1136,18 +1164,18 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sort' => null, 'direction' => null,
             ]
-        ]);
+        ]));
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('pass', [2])
-            ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0]);
-        $this->View->setRequest($this->Paginator->request);
+            ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0])
+        );
         $this->Paginator = new PaginatorHelper($this->View);
 
         $result = $this->Paginator->sort('title');
@@ -1196,14 +1224,14 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
                 'sort' => 'Article.title', 'direction' => 'ASC',
                 'sortDefault' => 'Article.title', 'directionDefault' => 'ASC'
             ]
-        ]);
+        ]));
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -1222,7 +1250,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrev()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1231,7 +1259,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => true,
                 'pageCount' => 5,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev disabled'],
@@ -1255,9 +1283,10 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->prev('<< Previous', ['disabledTitle' => false]);
         $this->assertEquals('', $result, 'disabled + no text = no link');
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Client.page', 2)
-            ->withParam('paging.Client.prevPage', true);
+            ->withParam('paging.Client.prevPage', true)
+        );
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev'],
@@ -1288,13 +1317,13 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrevWithOptions()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 2, 'current' => 1, 'count' => 13, 'prevPage' => true,
                 'nextPage' => false, 'pageCount' => 2,
                 'limit' => 10,
             ]
-        ]);
+        ]));
         $this->Paginator->options(['url' => [12, 'page' => 3]]);
         $result = $this->Paginator->prev('Prev', ['url' => ['foo' => 'bar']]);
         $expected = [
@@ -1354,7 +1383,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextDisabled()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 5,
                 'current' => 3,
@@ -1363,7 +1392,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->next('Next >>');
         $expected = [
             'li' => ['class' => 'next disabled'],
@@ -1395,7 +1424,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextAndPrevNonDefaultModel()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1412,7 +1441,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->next('Next', [
             'model' => 'Client'
         ]);
@@ -1457,7 +1486,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbers()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -1466,7 +1495,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
@@ -1535,7 +1564,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1544,7 +1573,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => ['class' => 'active']], '<a href=""', '1', '/a', '/li',
@@ -1559,7 +1588,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 14,
                 'current' => 3,
@@ -1568,7 +1597,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=7']], '7', '/a', '/li',
@@ -1583,7 +1612,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 3,
@@ -1592,7 +1621,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 9,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 1]);
         $expected = [
@@ -1622,7 +1651,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 15,
                 'current' => 3,
@@ -1631,7 +1660,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 1]);
         $expected = [
@@ -1649,7 +1678,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 10,
                 'current' => 3,
@@ -1658,7 +1687,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1677,7 +1706,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 6,
                 'current' => 15,
@@ -1686,7 +1715,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1705,7 +1734,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 37,
                 'current' => 15,
@@ -1714,7 +1743,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
@@ -1936,16 +1965,16 @@ class PaginatorHelperTest extends TestCase
             'ellipsis' => '... ',
         ];
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'pageCount' => $pageCount,
             ]
-        ]);
+        ]));
 
         $result = [];
         foreach ($pagesToCheck as $page) {
-            $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', $page);
+            $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', $page));
 
             $result[$page] = $this->Paginator->numbers($options);
         }
@@ -1962,7 +1991,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersTemplates()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -1971,7 +2000,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers(['templates' => 'htmlhelper_tags']);
         $expected = [
             ['a' => ['href' => '/index?page=4']], '4', '/a',
@@ -2000,7 +2029,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersModulus()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 10,
@@ -2009,7 +2038,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 3,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['modulus' => 10]);
         $expected = [
@@ -2027,7 +2056,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 4895,
                 'current' => 10,
@@ -2036,7 +2065,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 4897,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
@@ -2050,7 +2079,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
 
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
@@ -2081,7 +2110,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 4893);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 4893));
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2100,7 +2129,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 58);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 58));
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2123,7 +2152,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 5);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 5));
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2142,7 +2171,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2155,7 +2184,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Client.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 0, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2250,7 +2279,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testModulusDisabled()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 2,
@@ -2259,7 +2288,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 6,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->numbers(['modulus' => false]);
         $expected = [
@@ -2280,7 +2309,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersWithUrlOptions()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -2289,7 +2318,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers(['url' => ['#' => 'foo']]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index?page=4#foo']], '4', '/a', '/li',
@@ -2304,7 +2333,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 3,
                 'current' => 10,
@@ -2313,7 +2342,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 1,
                 'pageCount' => 4897,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers([
             'first' => 2,
             'modulus' => 2,
@@ -2338,7 +2367,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersRouting()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 2,
@@ -2347,7 +2376,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => 3,
                 'pageCount' => 3,
             ]
-        ]);
+        ]));
 
         $request = new ServerRequest([
             'params' => ['controller' => 'clients', 'action' => 'index', 'plugin' => null],
@@ -2371,7 +2400,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersNonDefaultModel()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2388,7 +2417,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => false,
                 'pageCount' => 5,
             ]
-        ]);
+        ]));
         $result = $this->Paginator->numbers(['model' => 'Server']);
         $this->assertContains('<li class="active"><a href="">5</a></li>', $result);
         $this->assertNotContains('<li class="active"><a href="">1</a></li>', $result);
@@ -2405,7 +2434,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstAndLastTag()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
         $result = $this->Paginator->first('<<');
         $expected = [
             'li' => ['class' => 'first'],
@@ -2455,9 +2484,10 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNoOutput()
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 15)
-            ->withParam('paging.Article.pageCount', 15);
+            ->withParam('paging.Article.pageCount', 15)
+        );
 
         $result = $this->Paginator->last();
         $expected = '';
@@ -2471,7 +2501,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstNonDefaultModel()
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 1)
             ->withParam('paging.Client', [
                 'page' => 3,
@@ -2480,7 +2510,8 @@ class PaginatorHelperTest extends TestCase
                 'prevPage' => false,
                 'nextPage' => true,
                 'pageCount' => 5,
-            ]);
+            ])
+        );
 
         $result = $this->Paginator->first('first', ['model' => 'Article']);
         $this->assertEquals('', $result);
@@ -2503,7 +2534,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstEmpty()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 1);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 1));
 
         $result = $this->Paginator->first();
         $expected = '';
@@ -2517,10 +2548,11 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstFullBaseUrl()
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 3)
             ->withParam('paging.Article.direction', 'DESC')
-            ->withParam('paging.Article.sort', 'Article.title');
+            ->withParam('paging.Article.sort', 'Article.title')
+        );
 
         $this->Paginator->options(['url' => ['_full' => true]]);
 
@@ -2544,7 +2576,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstBoundaries()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 3);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $result = $this->Paginator->first();
         $expected = [
             'li' => ['class' => 'first'],
@@ -2566,7 +2598,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 2);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
         $result = $this->Paginator->first(3);
         $this->assertEquals('', $result, 'When inside the first links range, no links should be made');
     }
@@ -2627,7 +2659,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Paginator->request = $this->Paginator->request->withParam('paging.Article.page', 6);
+        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 6));
 
         $result = $this->Paginator->last(2);
         $expected = [
@@ -2651,7 +2683,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastOptions()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 3,
@@ -2662,7 +2694,7 @@ class PaginatorHelperTest extends TestCase
                 'sort' => 'Client.name',
                 'direction' => 'DESC',
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->last();
         $expected = [
@@ -2702,7 +2734,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNonDefaultModel()
     {
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 7)
             ->withParam('paging.Client', [
                 'page' => 3,
@@ -2711,7 +2743,7 @@ class PaginatorHelperTest extends TestCase
                 'prevPage' => false,
                 'nextPage' => true,
                 'pageCount' => 5,
-            ]);
+            ]));
 
         $result = $this->Paginator->last('last', ['model' => 'Article']);
         $this->assertEquals('', $result);
@@ -2734,7 +2766,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounter()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2749,7 +2781,7 @@ class PaginatorHelperTest extends TestCase
                 'start' => 1,
                 'end' => 3,
             ]
-        ]);
+        ]));
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
         $input .= 'starting on record {{start}}, ending on {{end}}';
 
@@ -2777,7 +2809,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounterBigNumbers()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Client' => [
                 'page' => 1523,
                 'current' => 3000,
@@ -2792,7 +2824,7 @@ class PaginatorHelperTest extends TestCase
                 'start' => 4566001,
                 'end' => 4569001,
             ]
-        ]);
+        ]));
 
         $input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
         $input .= 'starting on record {{start}}, ending on {{end}}';
@@ -2844,10 +2876,11 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequestInfo($request);
 
-        $this->Paginator->request = $this->Paginator->request
+        $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
             ->withParam('paging.Article.direction', 'asc')
-            ->withParam('paging.Article.page', 1);
+            ->withParam('paging.Article.page', 1)
+        );
 
         $test = ['url' => [
             'page' => '1',
@@ -2878,7 +2911,7 @@ class PaginatorHelperTest extends TestCase
     public function testCurrent()
     {
         $result = $this->Paginator->current();
-        $this->assertEquals($this->Paginator->request->getParam('paging.Article.page'), $result);
+        $this->assertEquals($this->View->getRequest()->getParam('paging.Article.page'), $result);
 
         $result = $this->Paginator->current('Incorrect');
         $this->assertEquals(1, $result);
@@ -2892,7 +2925,7 @@ class PaginatorHelperTest extends TestCase
     public function testTotal()
     {
         $result = $this->Paginator->total();
-        $this->assertSame($this->Paginator->request->getParam('paging.Article.pageCount'), $result);
+        $this->assertSame($this->View->getRequest()->getParam('paging.Article.pageCount'), $result);
 
         $result = $this->Paginator->total('Incorrect');
         $this->assertSame(0, $result);
@@ -2905,7 +2938,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNoDefaultModel()
     {
-        $this->Paginator->request = new ServerRequest();
+        $this->View->setRequest(new ServerRequest());
         $this->assertNull($this->Paginator->defaultModel());
 
         $this->Paginator->defaultModel('Article');
@@ -2922,7 +2955,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithOnePage()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => 1,
                 'current' => 2,
@@ -2931,7 +2964,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => true,
                 'pageCount' => 1,
             ]
-        ]);
+        ]));
         $this->assertFalse($this->Paginator->numbers());
         $this->assertFalse($this->Paginator->first());
         $this->assertFalse($this->Paginator->last());
@@ -2944,7 +2977,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithZeroPages()
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => 0,
                 'current' => 0,
@@ -2957,7 +2990,7 @@ class PaginatorHelperTest extends TestCase
                 'start' => 0,
                 'end' => 0,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->counter(['format' => 'pages']);
         $expected = '0 of 1';
@@ -3021,14 +3054,14 @@ class PaginatorHelperTest extends TestCase
      */
     public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected)
     {
-        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
             'Article' => [
                 'page' => $page,
                 'prevPage' => $prevPage,
                 'nextPage' => $nextPage,
                 'pageCount' => $pageCount,
             ]
-        ]);
+        ]));
 
         $result = $this->Paginator->meta($options);
         $this->assertSame($expected, $result);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -226,8 +226,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -238,8 +237,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -250,8 +248,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -262,8 +259,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'ASC']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -274,8 +270,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'asc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -286,8 +281,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
 
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
@@ -342,8 +336,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
 
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
@@ -363,8 +356,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
@@ -437,8 +429,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('Article.title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -449,8 +440,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -461,8 +451,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
@@ -473,8 +462,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Account.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=title&amp;direction=asc'],
@@ -611,8 +599,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.order', 'DESC')
-        );
+            ->withParam('paging.Article.order', 'DESC'));
         $result = $this->Paginator->sortKey();
         $this->assertEquals('Article.body', $result);
 
@@ -633,29 +620,25 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'desc')
-        );
+            ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sortDir();
         $this->assertEquals('desc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sortDir();
         $this->assertEquals('asc', $result);
 
@@ -849,8 +832,7 @@ class PaginatorHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 2)
             ->withParam('paging.Article.sort', 'name')
-            ->withParam('paging.Article.direction', 'asc')
-        );
+            ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sort($field, null, ['url' => $options]);
         $this->assertSame($expected, $result);
     }
@@ -912,8 +894,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 2)
-            ->withParam('paging.Article.prevPage', true)
-        );
+            ->withParam('paging.Article.prevPage', true));
         $options = ['prefix' => 'members'];
 
         $result = $this->Paginator->generateUrl($options);
@@ -1022,8 +1003,7 @@ class PaginatorHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.scope', 'article')
             ->withParam('paging.Article.page', 3)
-            ->withParam('paging.Article.prevPage', true)
-        );
+            ->withParam('paging.Article.prevPage', true));
         $this->Paginator->options(['model' => 'Article']);
 
         $result = $this->Paginator->generateUrl([]);
@@ -1090,8 +1070,7 @@ class PaginatorHelperTest extends TestCase
                 'article' => [
                     'puppy' => 'no'
                 ]
-            ])
-        );
+            ]));
         // Need to run __construct to update _config['url']
         $paginator = new PaginatorHelper($this->View);
         $paginator->options(['model' => 'Article']);
@@ -1174,8 +1153,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('pass', [2])
-            ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0])
-        );
+            ->withQueryParams(['page' => 1, 'foo' => 'bar', 'x' => 'y', 'num' => 0]));
         $this->Paginator = new PaginatorHelper($this->View);
 
         $result = $this->Paginator->sort('title');
@@ -1285,8 +1263,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Client.page', 2)
-            ->withParam('paging.Client.prevPage', true)
-        );
+            ->withParam('paging.Client.prevPage', true));
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev'],
@@ -2486,8 +2463,7 @@ class PaginatorHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 15)
-            ->withParam('paging.Article.pageCount', 15)
-        );
+            ->withParam('paging.Article.pageCount', 15));
 
         $result = $this->Paginator->last();
         $expected = '';
@@ -2510,8 +2486,7 @@ class PaginatorHelperTest extends TestCase
                 'prevPage' => false,
                 'nextPage' => true,
                 'pageCount' => 5,
-            ])
-        );
+            ]));
 
         $result = $this->Paginator->first('first', ['model' => 'Article']);
         $this->assertEquals('', $result);
@@ -2551,8 +2526,7 @@ class PaginatorHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.page', 3)
             ->withParam('paging.Article.direction', 'DESC')
-            ->withParam('paging.Article.sort', 'Article.title')
-        );
+            ->withParam('paging.Article.sort', 'Article.title'));
 
         $this->Paginator->options(['url' => ['_full' => true]]);
 
@@ -2879,8 +2853,7 @@ class PaginatorHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
             ->withParam('paging.Article.direction', 'asc')
-            ->withParam('paging.Article.page', 1)
-        );
+            ->withParam('paging.Article.page', 1));
 
         $test = ['url' => [
             'page' => '1',

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -498,7 +498,7 @@ class UrlHelperTest extends TestCase
         $expected = '/img/cake.power.gif';
         $this->assertEquals($expected, $result);
 
-        $this->Helper->theme = 'TestTheme';
+        $this->Helper->getView()->setTheme('TestTheme');
 
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/test_theme/img/cake.power.gif';

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -43,9 +43,8 @@ class UrlHelperTest extends TestCase
         parent::setUp();
 
         Router::reload();
-        $this->View = new View();
+        $this->View = new View(new ServerRequest());
         $this->Helper = new UrlHelper($this->View);
-        $this->Helper->request = new ServerRequest();
 
         static::setAppNamespace();
         Plugin::load(['TestTheme']);
@@ -185,7 +184,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam');
         $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
 
-        $this->Helper->request = $this->Helper->request->withAttribute('webroot', '/some/dir/');
+        $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', '/some/dir/'));
         $result = $this->Helper->assetTimestamp('/some/dir/' . Configure::read('App.cssBaseUrl') . 'cake.generic.css');
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
     }
@@ -239,11 +238,11 @@ class UrlHelperTest extends TestCase
      */
     public function testAssetUrlDataUri()
     {
-        $request = $this->Helper->request
+        $request = $this->View->getRequest()
             ->withAttribute('base', 'subdir')
             ->withAttribute('webroot', 'subdir/');
 
-        $this->Helper->request = $request;
+        $this->View->setRequest($request);
         Router::pushRequest($request);
 
         $data = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4' .
@@ -263,10 +262,10 @@ class UrlHelperTest extends TestCase
      */
     public function testAssetUrlNoRewrite()
     {
-        $this->Helper->request = $this->Helper->request
+        $this->View->setRequest($this->View->getRequest()
             ->withAttribute('base', '/cake_dev/index.php')
             ->withAttribute('webroot', '/cake_dev/app/webroot/')
-            ->withRequestTarget('/cake_dev/index.php/tasks');
+            ->withRequestTarget('/cake_dev/index.php/tasks'));
         $result = $this->Helper->assetUrl('img/cake.icon.png', ['fullBase' => true]);
         $expected = Configure::read('App.fullBaseUrl') . '/cake_dev/app/webroot/img/cake.icon.png';
         $this->assertEquals($expected, $result);
@@ -493,7 +492,9 @@ class UrlHelperTest extends TestCase
      */
     public function testWebrootPaths()
     {
-        $this->Helper->request = $this->Helper->request->withAttribute('webroot', '/');
+        $this->View->setRequest(
+            $this->View->getRequest()->withAttribute('webroot', '/')
+        );
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/img/cake.power.gif';
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -174,8 +174,6 @@ class HelperTest extends TestCase
                 'Html',
                 'TestPlugin.OtherHelper'
             ],
-            'theme' => null,
-            'plugin' => null,
             'fieldset' => [],
             'tags' => [],
             'implementedEvents' => [

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -174,8 +174,6 @@ class HelperTest extends TestCase
                 'Html',
                 'TestPlugin.OtherHelper'
             ],
-            'fieldset' => [],
-            'tags' => [],
             'implementedEvents' => [
             ],
             '_config' => [


### PR DESCRIPTION
- Removed `Helper::$theme` and `Helper::$plugin` then can be accessed through their respective getter/setter methods of `View` class.
- `Helper::$fieldset` and `Helper::$tags` are unsed, hence marked them and deprecated and removed from debug info.
- Made `Helper::$helpers` protected. I don't see the need from it to be accessible outside the class so haven't added any getter/setter for it.
- Removed `Helper::$request`. `View::getRequest()/seRequest()` can be used instead.