### PR TITLE
3.7 - Add curl based Http\Client Adapter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     },
     "suggest": {
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
+        "ext-curl": "To enable more efficient network calls in Http\\Client.",
         "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
     },
     "require-dev": {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -17,6 +17,7 @@ use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Client\AdapterInterface;
+use Cake\Http\Client\Adapter\Curl;
 use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Request;
 use Cake\Http\Cookie\CookieCollection;
@@ -106,7 +107,7 @@ class Client
      * @var array
      */
     protected $_defaultConfig = [
-        'adapter' => Stream::class,
+        'adapter' => null,
         'host' => null,
         'port' => null,
         'scheme' => 'http',
@@ -156,7 +157,8 @@ class Client
      *   Defaults to true.
      * - redirect - Number of redirects to follow. Defaults to false.
      * - adapter - The adapter class name or instance. Defaults to
-     *   \Cake\Http\Client\Adapter\Stream
+     *   \Cake\Http\Client\Adapter\Curl if `curl` extension is loaded else
+     *   \Cake\Http\Client\Adapter\Stream.
      *
      * @param array $config Config options for scoped clients.
      */
@@ -165,7 +167,16 @@ class Client
         $this->setConfig($config);
 
         $adapter = $this->_config['adapter'];
-        $this->setConfig('adapter', null);
+        if ($adapter === null) {
+            $adapter = Curl::class;
+
+            if (!extension_loaded('curl')) {
+                $adapter = Stream::class;
+            }
+        } else {
+            $this->setConfig('adapter', null);
+        }
+
         if (is_string($adapter)) {
             $adapter = new $adapter();
         }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,6 +16,8 @@ namespace Cake\Http;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Client\AdapterInterface;
+use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Request;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Cookie\CookieInterface;
@@ -104,7 +106,7 @@ class Client
      * @var array
      */
     protected $_defaultConfig = [
-        'adapter' => 'Cake\Http\Client\Adapter\Stream',
+        'adapter' => Stream::class,
         'host' => null,
         'port' => null,
         'scheme' => 'http',
@@ -127,10 +129,9 @@ class Client
     protected $_cookies;
 
     /**
-     * Adapter for sending requests. Defaults to
-     * Cake\Http\Client\Adapter\Stream
+     * Adapter for sending requests.
      *
-     * @var \Cake\Http\Client\Adapter\Stream
+     * @var \Cake\Http\Client\AdapterInterface
      */
     protected $_adapter;
 
@@ -154,6 +155,8 @@ class Client
      * - ssl_verify_host - Verify that the certificate and hostname match.
      *   Defaults to true.
      * - redirect - Number of redirects to follow. Defaults to false.
+     * - adapter - The adapter class name or instance. Defaults to
+     *   \Cake\Http\Client\Adapter\Stream
      *
      * @param array $config Config options for scoped clients.
      */
@@ -165,6 +168,10 @@ class Client
         $this->setConfig('adapter', null);
         if (is_string($adapter)) {
             $adapter = new $adapter();
+        }
+
+        if (!$adapter instanceof AdapterInterface) {
+            throw new InvalidArgumentException('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
         }
         $this->_adapter = $adapter;
 

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -27,6 +27,74 @@ class Curl implements AdapterInterface
      */
     public function send(Request $request, array $options)
     {
-        // Do stuff here.
+        $ch = curl_init();
+        $options = $this->buildOptions($request, $options);
+        curl_setopt_array($ch, $options);
+
+        $bodyBuffer = tmpfile();
+        curl_setopt(CURLOPT_FILE, $bodyBuffer);
+
+        $this->exec($ch);
+        curl_close($ch);
+    }
+
+    /**
+     * Convert client options into curl options.
+     *
+     * @param \Cake\Http\Client\Request $request The request.
+     * @param array $options The client options
+     * @return array
+     */
+    public function buildOptions(Request $request, array $options)
+    {
+        $headers = [];
+        foreach ($request->getHeaders() as $key => $values) {
+            $headers[] = $key . ': ' . implode(', ', $values);
+        }
+
+        $out = [
+            CURLOPT_URL => (string)$request->getUri(),
+            CURLOPT_HTTP_VERSION => $request->getProtocolVersion(),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => $headers
+        ];
+        switch ($request->getMethod()) {
+            case Request::METHOD_GET:
+                $out[CURLOPT_HTTPGET] = true;
+                break;
+
+            case Request::METHOD_POST:
+                $out[CURLOPT_POST] = true;
+                break;
+
+            default:
+                $out[CURLOPT_POST] = true;
+                $out[CURLOPT_CUSTOMREQUEST] = $request->getMethod();
+                break;
+        }
+
+        $body = $request->getBody();
+        if ($body) {
+            $body->rewind();
+            $out[CURLOPT_POSTFIELDS] = $body->getContents();
+        }
+
+        if (isset($options['timeout'])) {
+            $out[CURLOPT_TIMEOUT] = $options['timeout'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Execute the curl handle.
+     *
+     * @param resource $ch Curl Resource handle
+     * @return void
+     */
+    protected function exec($ch)
+    {
+        curl_exec($ch);
     }
 }

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -42,7 +42,12 @@ class Curl implements AdapterInterface
             $errorCode = curl_errno($ch);
             $error = curl_error($ch);
             curl_close($ch);
-            throw new HttpException("cURL Error ({$errorCode}) {$error}");
+
+            $status = 500;
+            if ($error === 28) {
+                $status = 504;
+            }
+            throw new HttpException("cURL Error ({$errorCode}) {$error}", $status);
         }
 
         $responses = $this->createResponse($ch, $body);
@@ -95,6 +100,10 @@ class Curl implements AdapterInterface
 
         if (empty($options['ssl_cafile'])) {
             $options['ssl_cafile'] = CORE_PATH . 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';
+        }
+        if (!empty($options['ssl_verify_host'])) {
+            // Value of 1 or true is deprecated. Only 2 or 0 should be used now.
+            $options['ssl_verify_host'] = 2;
         }
         $optionMap = [
             'timeout' => CURLOPT_TIMEOUT,

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -80,8 +80,19 @@ class Curl implements AdapterInterface
             $out[CURLOPT_POSTFIELDS] = $body->getContents();
         }
 
+        $optionMap = [
+            'timeout' => CURLOPT_TIMEOUT,
+            'ssl_verify_peer' => CURLOPT_SSL_VERIFYPEER,
+            'ssl_verify_host' => CURLOPT_SSL_VERIFYHOST,
+            'ssl_verify_depth' => 9000,
+            'ssl_allow_self_signed' => false,
+        ];
+
         if (isset($options['timeout'])) {
             $out[CURLOPT_TIMEOUT] = $options['timeout'];
+        }
+        if (isset($options['ssl_verify_peer'])) {
+            $out[CURLOPT_SSL_VERIFYPEER] = $options['ssl_verify_peer'];
         }
 
         return $out;

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -118,7 +118,7 @@ class Curl implements AdapterInterface
      *
      * @param resource $handle Curl handle
      * @param string $responseData string The response data from curl_exec
-     * @return \Cake\Http\Client\Response[]
+     * @return \Cake\Http\Client\Response
      */
     protected function createResponse($handle, $responseData)
     {

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -16,6 +16,7 @@ namespace Cake\Http\Client\Adapter;
 use Cake\Http\Client\AdapterInterface;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
+use Cake\Http\Exception\HttpException;
 
 /**
  * Implements sending Cake\Http\Client\Request
@@ -33,8 +34,13 @@ class Curl implements AdapterInterface
         curl_setopt_array($ch, $options);
 
         $body = $this->exec($ch);
+        if ($body === false) {
+            $errorCode = curl_errno($ch);
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new HttpException("cURL Error ({$errorCode}) {$error}");
+        }
 
-        // TODO check for timeouts.
         $responses = $this->createResponse($ch, $body);
         curl_close($ch);
 

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -19,8 +19,12 @@ use Cake\Http\Client\Response;
 use Cake\Http\Exception\HttpException;
 
 /**
- * Implements sending Cake\Http\Client\Request
- * via ext/curl.
+ * Implements sending Cake\Http\Client\Request via ext/curl.
+ *
+ * In addition to the standard options documented in Cake\Http\Client,
+ * this adapter supports all available curl options. Additional curl options
+ * can be set via the `curl` option key when making requests or configuring
+ * a client.
  */
 class Curl implements AdapterInterface
 {
@@ -96,7 +100,6 @@ class Curl implements AdapterInterface
             'timeout' => CURLOPT_TIMEOUT,
             'ssl_verify_peer' => CURLOPT_SSL_VERIFYPEER,
             'ssl_verify_host' => CURLOPT_SSL_VERIFYHOST,
-            'ssl_verify_status' => CURLOPT_SSL_VERIFYSTATUS,
             'ssl_cafile' => CURLOPT_CAINFO,
             'ssl_local_cert' => CURLOPT_SSLCERT,
             'ssl_passphrase' => CURLOPT_SSLCERTPASSWD,
@@ -108,6 +111,12 @@ class Curl implements AdapterInterface
         }
         if (isset($options['proxy']['proxy'])) {
             $out[CURLOPT_PROXY] = $options['proxy']['proxy'];
+        }
+        if (isset($options['curl']) && is_array($options['curl'])) {
+            // Can't use array_merge() because keys will be re-ordered.
+            foreach ($options['curl'] as $key => $value) {
+                $out[$key] = $value;
+            }
         }
 
         return $out;

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Client\Adapter;
+
+use Cake\Http\Client\AdapterInterface;
+use Cake\Http\Client\Request;
+
+/**
+ * Implements sending Cake\Http\Client\Request
+ * via CURL.
+ */
+class Curl implements AdapterInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function send(Request $request, array $options)
+    {
+        // Do stuff here.
+    }
+}

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -14,6 +14,7 @@
 namespace Cake\Http\Client\Adapter;
 
 use Cake\Core\Exception\Exception;
+use Cake\Http\Client\AdapterInterface;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\Http\Exception\HttpException;
@@ -24,7 +25,7 @@ use Cake\Http\Exception\HttpException;
  *
  * This approach and implementation is partly inspired by Aura.Http
  */
-class Stream
+class Stream implements AdapterInterface
 {
 
     /**
@@ -63,11 +64,7 @@ class Stream
     protected $_connectionErrors = [];
 
     /**
-     * Send a request and get a response back.
-     *
-     * @param \Cake\Http\Client\Request $request The request object to send.
-     * @param array $options Array of options for the stream.
-     * @return array Array of populated Response objects
+     * {@inheritDoc}
      */
     public function send(Request $request, array $options)
     {

--- a/src/Http/Client/AdapterInterface.php
+++ b/src/Http/Client/AdapterInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Client;
+
+use Cake\Http\Client\Request;
+
+interface AdapterInterface
+{
+    /**
+     * Send a request and get a response back.
+     *
+     * @param \Cake\Http\Client\Request $request The request object to send.
+     * @param array $options Array of options for the stream.
+     * @return \Cake\Http\Client\Response[] Array of populated Response objects
+     */
+    public function send(Request $request, array $options);
+}

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -147,6 +147,37 @@ class CurlTest extends TestCase
     }
 
     /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsSsl()
+    {
+        $options = [
+            'ssl_verify_host' => true,
+            'ssl_verify_peer' => true,
+            'ssl_verify_peer_name' => true,
+            'ssl_verify_depth' => 9000,
+            'ssl_allow_self_signed' => false,
+        ];
+        $request = new Request('http://localhost/things', 'GET');
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_HTTPGET => true,
+            CURLOPT_SSL_VERIFYPEER => true
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Test the send method by using cakephp:// protocol.
      *
      * @return void

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -237,7 +237,7 @@ class CurlTest extends TestCase
             ],
             CURLOPT_HTTPGET => true,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_SSL_VERIFYHOST => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -1,0 +1,482 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Client\Adapter;
+
+use Cake\Http\Client\Adapter\Curl;
+use Cake\Http\Client\Request;
+use Cake\TestSuite\TestCase;
+
+/**
+ * HTTP curl adapter test.
+ */
+class CurlTest extends TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->curl = $this->getMockBuilder('Cake\Http\Client\Adapter\Curl')
+            ->setMethods(['exec'])
+            ->getMock();
+    }
+
+    /**
+     * Test the send method
+     *
+     * @return void
+     */
+    public function testSend()
+    {
+        $this->markTestIncomplete();
+        $request = new Request('http://localhost', 'GET', [
+            'User-Agent' => 'CakePHP TestSuite',
+            'Cookie' => 'testing=value'
+        ]);
+
+        try {
+            $responses = $this->curl->send($request, []);
+        } catch (\Cake\Core\Exception\Exception $e) {
+            $this->markTestSkipped('Could not connect to localhost, skipping');
+        }
+        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
+    }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsGet()
+    {
+        $options = [
+            'timeout' => 5
+        ];
+        $request = new Request(
+            'http://localhost/things',
+            'GET',
+            ['Cookie' => 'testing=value']
+        );
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Cookie: testing=value',
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_HTTPGET => true,
+            CURLOPT_TIMEOUT => 5,
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsPost()
+    {
+        $options = [];
+        $request = new Request(
+            'http://localhost/things',
+            'POST',
+            ['Cookie' => 'testing=value'],
+            ['name' => 'cakephp', 'yes' => 1]
+        );
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Cookie: testing=value',
+                'Connection: close',
+                'User-Agent: CakePHP',
+                'Content-Type: application/x-www-form-urlencoded',
+            ],
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => 'name=cakephp&yes=1'
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsPut()
+    {
+        $options = [];
+        $request = new Request(
+            'http://localhost/things',
+            'PUT',
+            ['Cookie' => 'testing=value']
+        );
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Cookie: testing=value',
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_POST => true,
+            CURLOPT_CUSTOMREQUEST => 'PUT',
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test the send method by using cakephp:// protocol.
+     *
+     * @return void
+     */
+    public function testSendByUsingCakephpProtocol()
+    {
+        $this->markTestIncomplete();
+        $stream = new Stream();
+        $request = new Request('http://dummy/');
+
+        $responses = $stream->send($request, []);
+        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
+
+        $this->assertEquals(20000, strlen($responses[0]->body()));
+    }
+
+    /**
+     * Test stream error_handler cleanup when wrapper throws exception
+     *
+     * @return void
+     */
+    public function testSendWrapperException()
+    {
+        $this->markTestIncomplete();
+        $stream = new Stream();
+        $request = new Request('http://throw_exception/');
+
+        $currentHandler = set_error_handler(function () {
+        });
+        restore_error_handler();
+
+        try {
+            $stream->send($request, []);
+        } catch (\Exception $e) {
+        }
+
+        $newHandler = set_error_handler(function () {
+        });
+        restore_error_handler();
+
+        $this->assertEquals($currentHandler, $newHandler);
+    }
+
+    /**
+     * Test building the context headers
+     *
+     * @return void
+     */
+    public function testBuildingContextHeader()
+    {
+        $this->markTestIncomplete();
+        $request = new Request(
+            'http://localhost',
+            'GET',
+            [
+                'User-Agent' => 'CakePHP TestSuite',
+                'Content-Type' => 'application/json',
+                'Cookie' => 'a=b; c=do%20it'
+            ]
+        );
+
+        $options = [
+            'redirect' => 20,
+        ];
+        $this->stream->send($request, $options);
+        $result = $this->stream->contextOptions();
+        $expected = [
+            'User-Agent: CakePHP TestSuite',
+            'Content-Type: application/json',
+            'Cookie: a=b; c=do%20it',
+            'Connection: close',
+        ];
+        $this->assertEquals(implode("\r\n", $expected), $result['header']);
+        $this->assertSame(0, $result['max_redirects']);
+        $this->assertTrue($result['ignore_errors']);
+    }
+
+    /**
+     * Test send() + context options with string content.
+     *
+     * @return void
+     */
+    public function testSendContextContentString()
+    {
+        $this->markTestIncomplete();
+        $content = json_encode(['a' => 'b']);
+        $request = new Request(
+            'http://localhost',
+            'GET',
+            ['Content-Type' => 'application/json'],
+            $content
+        );
+
+        $options = [
+            'redirect' => 20
+        ];
+        $this->stream->send($request, $options);
+        $result = $this->stream->contextOptions();
+        $expected = [
+            'Content-Type: application/json',
+            'Connection: close',
+            'User-Agent: CakePHP',
+        ];
+        $this->assertEquals(implode("\r\n", $expected), $result['header']);
+        $this->assertEquals($content, $result['content']);
+    }
+
+    /**
+     * Test send() + context options with array content.
+     *
+     * @return void
+     */
+    public function testSendContextContentArray()
+    {
+        $this->markTestIncomplete();
+        $request = new Request(
+            'http://localhost',
+            'GET',
+            [
+                'Content-Type' => 'application/json'
+            ],
+            ['a' => 'my value']
+        );
+
+        $this->stream->send($request, []);
+        $result = $this->stream->contextOptions();
+        $expected = [
+            'Content-Type: application/x-www-form-urlencoded',
+            'Connection: close',
+            'User-Agent: CakePHP',
+        ];
+        $this->assertStringStartsWith(implode("\r\n", $expected), $result['header']);
+        $this->assertContains('a=my+value', $result['content']);
+        $this->assertContains('my+value', $result['content']);
+    }
+
+    /**
+     * Test send() + context options with array content.
+     *
+     * @return void
+     */
+    public function testSendContextContentArrayFiles()
+    {
+        $this->markTestIncomplete();
+        $request = new Request(
+            'http://localhost',
+            'GET',
+            ['Content-Type' => 'application/json'],
+            ['upload' => fopen(CORE_PATH . 'VERSION.txt', 'r')]
+        );
+
+        $this->stream->send($request, []);
+        $result = $this->stream->contextOptions();
+        $this->assertContains("Content-Type: multipart/form-data", $result['header']);
+        $this->assertContains("Connection: close\r\n", $result['header']);
+        $this->assertContains("User-Agent: CakePHP", $result['header']);
+        $this->assertContains('name="upload"', $result['content']);
+        $this->assertContains('filename="VERSION.txt"', $result['content']);
+    }
+
+    /**
+     * Test send() + context options for SSL.
+     *
+     * @return void
+     */
+    public function testSendContextSsl()
+    {
+        $this->markTestIncomplete();
+        $request = new Request('https://localhost.com/test.html');
+        $options = [
+            'ssl_verify_host' => true,
+            'ssl_verify_peer' => true,
+            'ssl_verify_peer_name' => true,
+            'ssl_verify_depth' => 9000,
+            'ssl_allow_self_signed' => false,
+            'proxy' => [
+                'proxy' => '127.0.0.1:8080'
+            ]
+        ];
+
+        $this->stream->send($request, $options);
+        $result = $this->stream->contextOptions();
+        $expected = [
+            'peer_name' => 'localhost.com',
+            'verify_peer' => true,
+            'verify_peer_name' => true,
+            'verify_depth' => 9000,
+            'allow_self_signed' => false,
+            'proxy' => '127.0.0.1:8080',
+        ];
+        foreach ($expected as $k => $v) {
+            $this->assertEquals($v, $result[$k]);
+        }
+        $this->assertIsReadable($result['cafile']);
+    }
+
+    /**
+     * Test send() + context options for SSL.
+     *
+     * @return void
+     */
+    public function testSendContextSslNoVerifyPeerName()
+    {
+        $this->markTestIncomplete();
+        $request = new Request('https://localhost.com/test.html');
+        $options = [
+            'ssl_verify_host' => true,
+            'ssl_verify_peer' => true,
+            'ssl_verify_peer_name' => false,
+            'ssl_verify_depth' => 9000,
+            'ssl_allow_self_signed' => false,
+            'proxy' => [
+                'proxy' => '127.0.0.1:8080'
+            ]
+        ];
+
+        $this->stream->send($request, $options);
+        $result = $this->stream->contextOptions();
+        $expected = [
+            'peer_name' => 'localhost.com',
+            'verify_peer' => true,
+            'verify_peer_name' => false,
+            'verify_depth' => 9000,
+            'allow_self_signed' => false,
+            'proxy' => '127.0.0.1:8080',
+        ];
+        foreach ($expected as $k => $v) {
+            $this->assertEquals($v, $result[$k]);
+        }
+        $this->assertIsReadable($result['cafile']);
+    }
+
+    /**
+     * The PHP stream API returns ALL the headers for ALL the requests when
+     * there are redirects.
+     *
+     * @return void
+     */
+    public function testCreateResponseWithRedirects()
+    {
+        $this->markTestIncomplete();
+        $headers = [
+            'HTTP/1.1 302 Found',
+            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
+            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
+            'X-Powered-By: PHP/5.4.9',
+            'Location: http://localhost/cake3/tasks/second',
+            'Content-Length: 0',
+            'Connection: close',
+            'Content-Type: text/html; charset=UTF-8',
+            'Set-Cookie: first=value',
+            'HTTP/1.1 302 Found',
+            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
+            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
+            'X-Powered-By: PHP/5.4.9',
+            'Location: http://localhost/cake3/tasks/third',
+            'Content-Length: 0',
+            'Connection: close',
+            'Content-Type: text/html; charset=UTF-8',
+            'Set-Cookie: second=val',
+            'HTTP/1.1 200 OK',
+            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
+            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
+            'X-Powered-By: PHP/5.4.9',
+            'Content-Length: 22',
+            'Connection: close',
+            'Content-Type: text/html; charset=UTF-8',
+            'Set-Cookie: third=works',
+        ];
+        $content = 'This is the third page';
+
+        $responses = $this->stream->createResponses($headers, $content);
+        $this->assertCount(3, $responses);
+        $this->assertEquals('close', $responses[0]->getHeaderLine('Connection'));
+        $this->assertEquals('', (string)$responses[0]->getBody());
+        $this->assertEquals('', (string)$responses[1]->getBody());
+        $this->assertEquals($content, (string)$responses[2]->getBody());
+
+        $this->assertEquals(302, $responses[0]->getStatusCode());
+        $this->assertEquals(302, $responses[1]->getStatusCode());
+        $this->assertEquals(200, $responses[2]->getStatusCode());
+
+        $this->assertEquals('value', $responses[0]->getCookie('first'));
+        $this->assertNull($responses[0]->getCookie('second'));
+        $this->assertNull($responses[0]->getCookie('third'));
+
+        $this->assertNull($responses[1]->getCookie('first'));
+        $this->assertEquals('val', $responses[1]->getCookie('second'));
+        $this->assertNull($responses[1]->getCookie('third'));
+
+        $this->assertNull($responses[2]->getCookie('first'));
+        $this->assertNull($responses[2]->getCookie('second'));
+        $this->assertEquals('works', $responses[2]->getCookie('third'));
+    }
+
+    /**
+     * Test that no exception is radied when not timed out.
+     *
+     * @return void
+     */
+    public function testKeepDeadline()
+    {
+        $this->markTestIncomplete();
+        $request = new Request('http://dummy/?sleep');
+        $options = [
+            'timeout' => 5,
+        ];
+
+        $t = microtime(true);
+        $stream = new Stream();
+        $stream->send($request, $options);
+        $this->assertLessThan(5, microtime(true) - $t);
+    }
+
+    /**
+     * Test that an exception is raised when timed out.
+     *
+     * @return void
+     */
+    public function testMissDeadline()
+    {
+        $this->markTestIncomplete();
+        $this->expectException(\Cake\Http\Exception\HttpException::class);
+        $this->expectExceptionMessage('Connection timed out http://dummy/?sleep');
+        $request = new Request('http://dummy/?sleep');
+        $options = [
+            'timeout' => 2,
+        ];
+
+        $stream = new Stream();
+        $stream->send($request, $options);
+    }
+}

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -27,7 +27,7 @@ class CurlTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->skipIf(!extension_exists('curl'), 'Skipping as ext/curl is not installed.');
+        $this->skipIf(!function_exists('curl_init'), 'Skipping as ext/curl is not installed.');
 
         $this->curl = new Curl();
         $this->caFile = CORE_PATH . 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -15,6 +15,7 @@ namespace Cake\Test\TestCase\Http\Client\Adapter;
 
 use Cake\Http\Client\Adapter\Curl;
 use Cake\Http\Client\Request;
+use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -26,9 +27,8 @@ class CurlTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->curl = $this->getMockBuilder('Cake\Http\Client\Adapter\Curl')
-            ->setMethods(['exec'])
-            ->getMock();
+        $this->curl = new Curl();
+        $this->caFile = CORE_PATH . 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';
     }
 
     /**
@@ -36,20 +36,47 @@ class CurlTest extends TestCase
      *
      * @return void
      */
-    public function testSend()
+    public function testSendLive()
     {
-        $this->markTestIncomplete();
         $request = new Request('http://localhost', 'GET', [
             'User-Agent' => 'CakePHP TestSuite',
             'Cookie' => 'testing=value'
         ]);
-
         try {
             $responses = $this->curl->send($request, []);
         } catch (\Cake\Core\Exception\Exception $e) {
             $this->markTestSkipped('Could not connect to localhost, skipping');
         }
-        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotEmpty($response->getHeaders());
+        $this->assertNotEmpty($response->getBody()->getContents());
+    }
+
+    /**
+     * Test the send method
+     *
+     * @return void
+     */
+    public function testSendLiveResponseCheck()
+    {
+        $request = new Request('https://api.cakephp.org/3.0/', 'GET', [
+            'User-Agent' => 'CakePHP TestSuite',
+        ]);
+        try {
+            $responses = $this->curl->send($request, []);
+        } catch (\Cake\Core\Exception\Exception $e) {
+            $this->markTestSkipped('Could not connect to book.cakephp.org, skipping');
+        }
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->hasHeader('Date'));
+        $this->assertTrue($response->hasHeader('Content-type'));
+        $this->assertContains('<html', $response->getBody()->getContents());
     }
 
     /**
@@ -80,6 +107,7 @@ class CurlTest extends TestCase
             ],
             CURLOPT_HTTPGET => true,
             CURLOPT_TIMEOUT => 5,
+            CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);
     }
@@ -111,7 +139,8 @@ class CurlTest extends TestCase
                 'Content-Type: application/x-www-form-urlencoded',
             ],
             CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => 'name=cakephp&yes=1'
+            CURLOPT_POSTFIELDS => 'name=cakephp&yes=1',
+            CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);
     }
@@ -142,6 +171,40 @@ class CurlTest extends TestCase
             ],
             CURLOPT_POST => true,
             CURLOPT_CUSTOMREQUEST => 'PUT',
+            CURLOPT_CAINFO => $this->caFile,
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsJsonPost()
+    {
+        $options = [];
+        $content = json_encode(['a' => 1, 'b' => 2]);
+        $request = new Request(
+            'http://localhost/things',
+            'POST',
+            ['Content-type' => 'application/json'],
+            $content
+        );
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Content-type: application/json',
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $content,
+            CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);
     }
@@ -157,6 +220,7 @@ class CurlTest extends TestCase
             'ssl_verify_host' => true,
             'ssl_verify_peer' => true,
             'ssl_verify_peer_name' => true,
+            // These options do nothing in curl.
             'ssl_verify_depth' => 9000,
             'ssl_allow_self_signed' => false,
         ];
@@ -172,342 +236,40 @@ class CurlTest extends TestCase
                 'User-Agent: CakePHP',
             ],
             CURLOPT_HTTPGET => true,
-            CURLOPT_SSL_VERIFYPEER => true
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => true,
+            CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);
     }
 
     /**
-     * Test the send method by using cakephp:// protocol.
+     * Test converting client options into curl ones.
      *
      * @return void
      */
-    public function testSendByUsingCakephpProtocol()
+    public function testBuildOptionsProxy()
     {
-        $this->markTestIncomplete();
-        $stream = new Stream();
-        $request = new Request('http://dummy/');
-
-        $responses = $stream->send($request, []);
-        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
-
-        $this->assertEquals(20000, strlen($responses[0]->body()));
-    }
-
-    /**
-     * Test stream error_handler cleanup when wrapper throws exception
-     *
-     * @return void
-     */
-    public function testSendWrapperException()
-    {
-        $this->markTestIncomplete();
-        $stream = new Stream();
-        $request = new Request('http://throw_exception/');
-
-        $currentHandler = set_error_handler(function () {
-        });
-        restore_error_handler();
-
-        try {
-            $stream->send($request, []);
-        } catch (\Exception $e) {
-        }
-
-        $newHandler = set_error_handler(function () {
-        });
-        restore_error_handler();
-
-        $this->assertEquals($currentHandler, $newHandler);
-    }
-
-    /**
-     * Test building the context headers
-     *
-     * @return void
-     */
-    public function testBuildingContextHeader()
-    {
-        $this->markTestIncomplete();
-        $request = new Request(
-            'http://localhost',
-            'GET',
-            [
-                'User-Agent' => 'CakePHP TestSuite',
-                'Content-Type' => 'application/json',
-                'Cookie' => 'a=b; c=do%20it'
+        $options = [
+            'proxy' => [
+                'proxy' => '127.0.0.1:8080'
             ]
-        );
-
-        $options = [
-            'redirect' => 20,
         ];
-        $this->stream->send($request, $options);
-        $result = $this->stream->contextOptions();
+        $request = new Request('http://localhost/things', 'GET');
+        $result = $this->curl->buildOptions($request, $options);
         $expected = [
-            'User-Agent: CakePHP TestSuite',
-            'Content-Type: application/json',
-            'Cookie: a=b; c=do%20it',
-            'Connection: close',
-        ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
-        $this->assertSame(0, $result['max_redirects']);
-        $this->assertTrue($result['ignore_errors']);
-    }
-
-    /**
-     * Test send() + context options with string content.
-     *
-     * @return void
-     */
-    public function testSendContextContentString()
-    {
-        $this->markTestIncomplete();
-        $content = json_encode(['a' => 'b']);
-        $request = new Request(
-            'http://localhost',
-            'GET',
-            ['Content-Type' => 'application/json'],
-            $content
-        );
-
-        $options = [
-            'redirect' => 20
-        ];
-        $this->stream->send($request, $options);
-        $result = $this->stream->contextOptions();
-        $expected = [
-            'Content-Type: application/json',
-            'Connection: close',
-            'User-Agent: CakePHP',
-        ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
-        $this->assertEquals($content, $result['content']);
-    }
-
-    /**
-     * Test send() + context options with array content.
-     *
-     * @return void
-     */
-    public function testSendContextContentArray()
-    {
-        $this->markTestIncomplete();
-        $request = new Request(
-            'http://localhost',
-            'GET',
-            [
-                'Content-Type' => 'application/json'
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Connection: close',
+                'User-Agent: CakePHP',
             ],
-            ['a' => 'my value']
-        );
-
-        $this->stream->send($request, []);
-        $result = $this->stream->contextOptions();
-        $expected = [
-            'Content-Type: application/x-www-form-urlencoded',
-            'Connection: close',
-            'User-Agent: CakePHP',
+            CURLOPT_HTTPGET => true,
+            CURLOPT_CAINFO => $this->caFile,
+            CURLOPT_PROXY => '127.0.0.1:8080',
         ];
-        $this->assertStringStartsWith(implode("\r\n", $expected), $result['header']);
-        $this->assertContains('a=my+value', $result['content']);
-        $this->assertContains('my+value', $result['content']);
-    }
-
-    /**
-     * Test send() + context options with array content.
-     *
-     * @return void
-     */
-    public function testSendContextContentArrayFiles()
-    {
-        $this->markTestIncomplete();
-        $request = new Request(
-            'http://localhost',
-            'GET',
-            ['Content-Type' => 'application/json'],
-            ['upload' => fopen(CORE_PATH . 'VERSION.txt', 'r')]
-        );
-
-        $this->stream->send($request, []);
-        $result = $this->stream->contextOptions();
-        $this->assertContains("Content-Type: multipart/form-data", $result['header']);
-        $this->assertContains("Connection: close\r\n", $result['header']);
-        $this->assertContains("User-Agent: CakePHP", $result['header']);
-        $this->assertContains('name="upload"', $result['content']);
-        $this->assertContains('filename="VERSION.txt"', $result['content']);
-    }
-
-    /**
-     * Test send() + context options for SSL.
-     *
-     * @return void
-     */
-    public function testSendContextSsl()
-    {
-        $this->markTestIncomplete();
-        $request = new Request('https://localhost.com/test.html');
-        $options = [
-            'ssl_verify_host' => true,
-            'ssl_verify_peer' => true,
-            'ssl_verify_peer_name' => true,
-            'ssl_verify_depth' => 9000,
-            'ssl_allow_self_signed' => false,
-            'proxy' => [
-                'proxy' => '127.0.0.1:8080'
-            ]
-        ];
-
-        $this->stream->send($request, $options);
-        $result = $this->stream->contextOptions();
-        $expected = [
-            'peer_name' => 'localhost.com',
-            'verify_peer' => true,
-            'verify_peer_name' => true,
-            'verify_depth' => 9000,
-            'allow_self_signed' => false,
-            'proxy' => '127.0.0.1:8080',
-        ];
-        foreach ($expected as $k => $v) {
-            $this->assertEquals($v, $result[$k]);
-        }
-        $this->assertIsReadable($result['cafile']);
-    }
-
-    /**
-     * Test send() + context options for SSL.
-     *
-     * @return void
-     */
-    public function testSendContextSslNoVerifyPeerName()
-    {
-        $this->markTestIncomplete();
-        $request = new Request('https://localhost.com/test.html');
-        $options = [
-            'ssl_verify_host' => true,
-            'ssl_verify_peer' => true,
-            'ssl_verify_peer_name' => false,
-            'ssl_verify_depth' => 9000,
-            'ssl_allow_self_signed' => false,
-            'proxy' => [
-                'proxy' => '127.0.0.1:8080'
-            ]
-        ];
-
-        $this->stream->send($request, $options);
-        $result = $this->stream->contextOptions();
-        $expected = [
-            'peer_name' => 'localhost.com',
-            'verify_peer' => true,
-            'verify_peer_name' => false,
-            'verify_depth' => 9000,
-            'allow_self_signed' => false,
-            'proxy' => '127.0.0.1:8080',
-        ];
-        foreach ($expected as $k => $v) {
-            $this->assertEquals($v, $result[$k]);
-        }
-        $this->assertIsReadable($result['cafile']);
-    }
-
-    /**
-     * The PHP stream API returns ALL the headers for ALL the requests when
-     * there are redirects.
-     *
-     * @return void
-     */
-    public function testCreateResponseWithRedirects()
-    {
-        $this->markTestIncomplete();
-        $headers = [
-            'HTTP/1.1 302 Found',
-            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
-            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
-            'X-Powered-By: PHP/5.4.9',
-            'Location: http://localhost/cake3/tasks/second',
-            'Content-Length: 0',
-            'Connection: close',
-            'Content-Type: text/html; charset=UTF-8',
-            'Set-Cookie: first=value',
-            'HTTP/1.1 302 Found',
-            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
-            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
-            'X-Powered-By: PHP/5.4.9',
-            'Location: http://localhost/cake3/tasks/third',
-            'Content-Length: 0',
-            'Connection: close',
-            'Content-Type: text/html; charset=UTF-8',
-            'Set-Cookie: second=val',
-            'HTTP/1.1 200 OK',
-            'Date: Mon, 31 Dec 2012 16:53:16 GMT',
-            'Server: Apache/2.2.22 (Unix) DAV/2 PHP/5.4.9 mod_ssl/2.2.22 OpenSSL/0.9.8r',
-            'X-Powered-By: PHP/5.4.9',
-            'Content-Length: 22',
-            'Connection: close',
-            'Content-Type: text/html; charset=UTF-8',
-            'Set-Cookie: third=works',
-        ];
-        $content = 'This is the third page';
-
-        $responses = $this->stream->createResponses($headers, $content);
-        $this->assertCount(3, $responses);
-        $this->assertEquals('close', $responses[0]->getHeaderLine('Connection'));
-        $this->assertEquals('', (string)$responses[0]->getBody());
-        $this->assertEquals('', (string)$responses[1]->getBody());
-        $this->assertEquals($content, (string)$responses[2]->getBody());
-
-        $this->assertEquals(302, $responses[0]->getStatusCode());
-        $this->assertEquals(302, $responses[1]->getStatusCode());
-        $this->assertEquals(200, $responses[2]->getStatusCode());
-
-        $this->assertEquals('value', $responses[0]->getCookie('first'));
-        $this->assertNull($responses[0]->getCookie('second'));
-        $this->assertNull($responses[0]->getCookie('third'));
-
-        $this->assertNull($responses[1]->getCookie('first'));
-        $this->assertEquals('val', $responses[1]->getCookie('second'));
-        $this->assertNull($responses[1]->getCookie('third'));
-
-        $this->assertNull($responses[2]->getCookie('first'));
-        $this->assertNull($responses[2]->getCookie('second'));
-        $this->assertEquals('works', $responses[2]->getCookie('third'));
-    }
-
-    /**
-     * Test that no exception is radied when not timed out.
-     *
-     * @return void
-     */
-    public function testKeepDeadline()
-    {
-        $this->markTestIncomplete();
-        $request = new Request('http://dummy/?sleep');
-        $options = [
-            'timeout' => 5,
-        ];
-
-        $t = microtime(true);
-        $stream = new Stream();
-        $stream->send($request, $options);
-        $this->assertLessThan(5, microtime(true) - $t);
-    }
-
-    /**
-     * Test that an exception is raised when timed out.
-     *
-     * @return void
-     */
-    public function testMissDeadline()
-    {
-        $this->markTestIncomplete();
-        $this->expectException(\Cake\Http\Exception\HttpException::class);
-        $this->expectExceptionMessage('Connection timed out http://dummy/?sleep');
-        $request = new Request('http://dummy/?sleep');
-        $options = [
-            'timeout' => 2,
-        ];
-
-        $stream = new Stream();
-        $stream->send($request, $options);
+        $this->assertSame($expected, $result);
     }
 }

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -272,4 +272,34 @@ class CurlTest extends TestCase
         ];
         $this->assertSame($expected, $result);
     }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
+    public function testBuildOptionsCurlOptions()
+    {
+        $options = [
+            'curl' => [
+                CURLOPT_USERAGENT => 'Super-secret'
+            ]
+        ];
+        $request = new Request('http://localhost/things', 'GET');
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_HTTPGET => true,
+            CURLOPT_CAINFO => $this->caFile,
+            CURLOPT_USERAGENT => 'Super-secret'
+        ];
+        $this->assertSame($expected, $result);
+    }
 }

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -27,6 +27,8 @@ class CurlTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $this->skipIf(!extension_exists('curl'), 'Skipping as ext/curl is not installed.');
+
         $this->curl = new Curl();
         $this->caFile = CORE_PATH . 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -19,6 +19,7 @@ use Cake\Http\Client\Response;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * HTTP client test.
@@ -57,6 +58,19 @@ class ClientTest extends TestCase
         foreach ($expected as $key => $val) {
             $this->assertEquals($val, $result[$key]);
         }
+    }
+
+    /**
+     * testAdapterInstanceCheck
+     *
+     * @return void
+     */
+    public function testAdapterInstanceCheck()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
+
+        new Client(['adapter' => 'stdClass']);
     }
 
     /**


### PR DESCRIPTION
The stream based client has a few limitations around `fopen_url` settings, and proxy issues (#10841 ) that are not currently solvable. By adding a cURL based adapter we can default to using this extension which solves these problems and allows more feature support in the future.

### TODO

* [x] Verify results on timeout expiration.