### PR TITLE
Casting all integration test data to string

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -672,7 +672,7 @@ abstract class IntegrationTestCase extends TestCase
     {
         foreach ($data as $key => $value) {
             if (is_scalar($value)) {
-                $data[$key] = (string)$value;
+                $data[$key] = $value === false ? '0' : (string)$value;
 
                 continue;
             }

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -679,9 +679,11 @@ abstract class IntegrationTestCase extends TestCase
 
             if (is_array($value)) {
                 $looksLikeFile = isset($value['error']) && isset($value['tmp_name']) && isset($value['size']);
-                if (!$looksLikeFile) {
-                    $data[$key] = $this->_castToString($value);
+                if ($looksLikeFile) {
+                    continue;
                 }
+
+                $data[$key] = $this->_castToString($value);
             }
         }
 

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -605,7 +605,8 @@ abstract class IntegrationTestCase extends TestCase
             $props['input'] = $data;
         }
         if (!isset($props['input'])) {
-            $props['post'] = $this->_addTokens($tokenUrl, $data);
+            $data = $this->_addTokens($tokenUrl, $data);
+            $props['post'] = $this->_castToString($data);
         }
         $props['cookies'] = $this->_cookie;
 
@@ -654,6 +655,33 @@ abstract class IntegrationTestCase extends TestCase
             }
             if (!isset($data['_csrfToken'])) {
                 $data['_csrfToken'] = $this->_cookie['csrfToken'];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Recursively casts all data to string as that is how data would be POSTed in
+     * the real world
+     *
+     * @param array $data POST data
+     * @return array
+     */
+    protected function _castToString($data)
+    {
+        foreach ($data as $key => $value) {
+            if (is_scalar($value)) {
+                $data[$key] = (string)$value;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $looksLikeFile = isset($value['error']) && isset($value['tmp_name']) && isset($value['size']);
+                if (!$looksLikeFile) {
+                    $data[$key] = $this->_castToString($value);
+                }
             }
         }
 

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -79,6 +79,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
             'title' => 'Blog Post',
             'status' => 1,
             'published' => true,
+            'not_published' => false,
             'comments' => [
                 [
                     'body' => 'Comment',
@@ -119,6 +120,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $request = $this->_buildRequest('/posts/add', 'POST', $data);
         $this->assertInternalType('string', $request['post']['status']);
         $this->assertInternalType('string', $request['post']['published']);
+        $this->assertSame('0', $request['post']['not_published']);
         $this->assertInternalType('string', $request['post']['comments'][0]['status']);
         $this->assertInternalType('integer', $request['post']['file']['error']);
         $this->assertInternalType('integer', $request['post']['file']['size']);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -23,6 +23,7 @@ use Cake\Routing\Route\InflectedRoute;
 use Cake\TestSuite\IntegrationTestCase;
 use Cake\Test\Fixture\AssertIntegrationTestCase;
 use Cake\Utility\Security;
+use Zend\Diactoros\UploadedFile;
 
 /**
  * Self test of the IntegrationTestCase
@@ -65,6 +66,67 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         DispatcherFactory::add('ControllerFactory');
 
         $this->useHttpServer(false);
+    }
+
+    /**
+     * Tests that all data that used by the request is cast to strings
+     *
+     * @return void
+     */
+    public function testDataCastToString()
+    {
+        $data = [
+            'title' => 'Blog Post',
+            'status' => 1,
+            'published' => true,
+            'comments' => [
+                [
+                    'body' => 'Comment',
+                    'status' => 1,
+                ]
+            ],
+            'file' => [
+                'tmp_name' => __FILE__,
+                'size' => 42,
+                'error' => 0,
+                'type' => 'text/plain',
+                'name' => 'Uploaded file'
+            ],
+            'pictures' => [
+                'name' => [
+                    ['file' => 'a-file.png'],
+                    ['file' => 'a-moose.png']
+                ],
+                'type' => [
+                    ['file' => 'image/png'],
+                    ['file' => 'image/jpg']
+                ],
+                'tmp_name' => [
+                    ['file' => __FILE__],
+                    ['file' => __FILE__]
+                ],
+                'error' => [
+                    ['file' => 0],
+                    ['file' => 0]
+                ],
+                'size' => [
+                    ['file' => 17188],
+                    ['file' => 2010]
+                ],
+            ],
+            'upload' => new UploadedFile(__FILE__, 42, 0)
+        ];
+        $request = $this->_buildRequest('/posts/add', 'POST', $data);
+        $this->assertInternalType('string', $request['post']['status']);
+        $this->assertInternalType('string', $request['post']['published']);
+        $this->assertInternalType('string', $request['post']['comments'][0]['status']);
+        $this->assertInternalType('integer', $request['post']['file']['error']);
+        $this->assertInternalType('integer', $request['post']['file']['size']);
+        $this->assertInternalType('integer', $request['post']['pictures']['error'][0]['file']);
+        $this->assertInternalType('integer', $request['post']['pictures']['error'][1]['file']);
+        $this->assertInternalType('integer', $request['post']['pictures']['size'][0]['file']);
+        $this->assertInternalType('integer', $request['post']['pictures']['size'][1]['file']);
+        $this->assertInstanceOf(UploadedFile::class, $request['post']['upload']);
     }
 
     /**


### PR DESCRIPTION
This fixes a bug where data passed to methods in IntegrationTestCase were directly passed to the request. In an actual HTTP context everything is passed as a string. This fix prevents false tests such as this:

```php
// controller action
public function add()
{
    if ($this->request->getData('status') === 1) {
        // do stuff
        // this would never be reached in a true HTTP context
    }
}

// test case
public function testAdd()
{
    $this->post('/action', [
        'status' => 1
    ]);
    // assert did stuff
}
```

This leaves file arrays alone as they are created by PHP and have `int` values on certain keys. It also leaves classes alone so testing with things like `UploadedFile` is still possible.

I can PR against 3.next as well to help prevent extra merge work if you'd like.