### PR TITLE
Remove ORM annotations from Datasource package

### DIFF
--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -67,7 +67,7 @@ class QueryCacher
      * Load the cached results from the cache or run the query.
      *
      * @param object $query The query the cache read is for.
-     * @return \Cake\ORM\ResultSet|null Either the cached results or null.
+     * @return \Cake\Datasource\ResultSetInterface|null Either the cached results or null.
      */
     public function fetch($query)
     {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -28,7 +28,7 @@ trait QueryTrait
     /**
      * Instance of a table object this query is bound to
      *
-     * @var \Cake\ORM\Table|\Cake\Datasource\RepositoryInterface
+     * @var \Cake\Datasource\RepositoryInterface
      */
     protected $_repository;
 
@@ -87,8 +87,8 @@ trait QueryTrait
      * When called with a Table argument, the default table object will be set
      * and this query object will be returned for chaining.
      *
-     * @param \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table|null $table The default table object to use
-     * @return \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table|$this
+     * @param \Cake\Datasource\RepositoryInterface|null $table The default table object to use
+     * @return \Cake\Datasource\RepositoryInterface|$this
      */
     public function repository(RepositoryInterface $table = null)
     {
@@ -110,7 +110,7 @@ trait QueryTrait
      * Returns the default table object that will be used by this query,
      * that is, the table that will appear in the from clause.
      *
-     * @return \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table
+     * @return \Cake\Datasource\RepositoryInterface
      */
     public function getRepository()
     {
@@ -213,7 +213,7 @@ trait QueryTrait
      *
      * @deprecated 3.5.0 Use isEagerLoaded() for the getter part instead.
      * @param bool|null $value Whether or not to eager load.
-     * @return $this|\Cake\ORM\Query
+     * @return $this|bool
      */
     public function eagerLoaded($value = null)
     {
@@ -501,7 +501,7 @@ trait QueryTrait
      *  $query->getOptions(); // Returns ['doABarrelRoll' => true]
      * ```
      *
-     * @see \Cake\ORM\Query::applyOptions() to read about the options that will
+     * @see \Cake\Datasource\QueryInterface::applyOptions() to read about the options that will
      * be processed by this class and not returned by this function
      * @return array
      */

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -45,14 +45,9 @@ interface RepositoryInterface
      * Creates a new Query for this repository and applies some defaults based on the
      * type of search that was selected.
      *
-     * ### Model.beforeFind event
-     *
-     * Each find() will trigger a `Model.beforeFind` event for all attached
-     * listeners. Any listener can set a valid result set using $query
-     *
      * @param string $type the type of query to perform
      * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
-     * @return \Cake\ORM\Query
+     * @return \Cake\Datasource\QueryInterface
      */
     public function find($type = 'all', $options = []);
 
@@ -81,7 +76,7 @@ interface RepositoryInterface
     /**
      * Creates a new Query instance for this repository
      *
-     * @return \Cake\ORM\Query
+     * @return \Cake\Datasource\QueryInterface
      */
     public function query();
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1288,7 +1288,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a new Query for this repository and applies some defaults based on the
+     * type of search that was selected.
      *
      * ### Model.beforeFind event
      *
@@ -1340,6 +1341,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * Would invoke the `findPublished` method.
      *
+     * @param string $type the type of query to perform
+     * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
      * @return \Cake\ORM\Query The query builder
      */
     public function find($type = 'all', $options = [])
@@ -1746,7 +1749,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a new Query instance for a table.
+     *
+     * @return \Cake\ORM\Query
      */
     public function query()
     {


### PR DESCRIPTION
I found some annotated ORM typehints in Datasource package. Since Datasource does not depend on ORM, these should be removed.

Table typehints have been updated to point to the ORM Query implementation.