### PR TITLE
Don't lowercase cookie names in the id

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -200,9 +200,7 @@ class Cookie implements CookieInterface
      */
     public function getId()
     {
-        $name = mb_strtolower($this->name);
-
-        return "{$name};{$this->domain};{$this->path}";
+        return "{$this->name};{$this->domain};{$this->path}";
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -553,7 +553,7 @@ class CookieTest extends TestCase
         $this->assertEquals('cakephp;;', $cookie->getId());
 
         $cookie = new Cookie('CAKEPHP', 'cakephp-rocks');
-        $this->assertEquals('cakephp;;', $cookie->getId());
+        $this->assertEquals('CAKEPHP;;', $cookie->getId());
 
         $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
         $this->assertEquals('test;example.com;/path', $cookie->getId());


### PR DESCRIPTION
Cookie names are supposed to be case sensitive as per the RFC which doesn't include them as case-insensitive. All major browsers also treat cookies as case-sensitive.

Refs #12220
