### PR TITLE
Deprecated View::uuid() as it's unused in core.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -198,7 +198,7 @@ class View implements EventDispatcherInterface
      * List of generated DOM UUIDs.
      *
      * @var array
-     * @deprecated 3.7.0 The property is unused and will be removed in 4.0.0.
+     * @deprecated 3.7.0 The property is deprecated and will be removed in 4.0.0.
      */
     public $uuids = [];
 
@@ -1143,9 +1143,12 @@ class View implements EventDispatcherInterface
      * @param string $object Type of object, i.e. 'form' or 'link'
      * @param string $url The object's target URL
      * @return string
+     * @deprecated 3.7.0 This method is deprecated and will be removed in 4.0.0.
      */
     public function uuid($object, $url)
     {
+        deprecationWarning('View::uuid() is deprecated and will be removed in 4.0.0.');
+
         $c = 1;
         $url = Router::url($url);
         $hash = $object . substr(md5($object . $url), 0, 10);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -858,15 +858,17 @@ class ViewTest extends TestCase
      */
     public function testUUIDGeneration()
     {
-        Router::connect('/:controller', ['action' => 'index']);
-        $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
-        $this->assertEquals('form5988016017', $result);
+        $this->deprecated(function () {
+            Router::connect('/:controller', ['action' => 'index']);
+            $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
+            $this->assertEquals('form5988016017', $result);
 
-        $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
-        $this->assertEquals('formc3dc6be854', $result);
+            $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
+            $this->assertEquals('formc3dc6be854', $result);
 
-        $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
-        $this->assertEquals('form28f92cc87f', $result);
+            $result = $this->View->uuid('form', ['controller' => 'posts', 'action' => 'index']);
+            $this->assertEquals('form28f92cc87f', $result);
+        });
     }
 
     /**


### PR DESCRIPTION
I missed out deprecating `View::uuid()` in earlier PR. I don't see any usage of it in the core, probably a relic of 2.x days.