### PR TITLE
3.next - Deprecate the read side of join() and from()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -484,6 +484,8 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function from($tables = [], $overwrite = false)
     {
         if (empty($tables)) {
+            deprecationWarning('Using Query::from() to read state is deprecated. Use clause("from") instead.');
+
             return $this->_parts['from'];
         }
 
@@ -589,6 +591,8 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function join($tables = null, $types = [], $overwrite = false)
     {
         if ($tables === null) {
+            deprecationWarning('Using Query::join() to read state is deprecated. Use clause("join") instead.');
+
             return $this->_parts['join'];
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1129,7 +1129,7 @@ class BelongsToMany extends Association
     protected function _appendJunctionJoin($query, $conditions)
     {
         $name = $this->_junctionAssociationName();
-        $joins = $query->join();
+        $joins = $query->clause('join');
         $matching = [
             $name => [
                 'table' => $this->junction()->getTable(),

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4474,10 +4474,32 @@ class QueryTest extends TestCase
                 'type' => 'INNER',
                 'conditions' => ['articles.author_id = authors.id']
             ]]);
-        $this->assertArrayHasKey('authors', $query->join());
+        $this->assertArrayHasKey('authors', $query->clause('join'));
 
         $this->assertSame($query, $query->removeJoin('authors'));
-        $this->assertArrayNotHasKey('authors', $query->join());
+        $this->assertArrayNotHasKey('authors', $query->clause('join'));
+    }
+
+    /**
+     * Test join read mode
+     *
+     * @deprecated
+     * @return void
+     */
+    public function testJoinReadMode()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->select(['id', 'title'])
+            ->from('articles')
+            ->join(['authors' => [
+                'type' => 'INNER',
+                'conditions' => ['articles.author_id = authors.id']
+            ]]);
+
+        $this->deprecated(function () use ($query) {
+            $this->assertArrayHasKey('authors', $query->join());
+        });
     }
 
     /**


### PR DESCRIPTION
These methods were missed in previous get/set sweeps. Having mixed return types makes life harder as we add more typing.

Refs #12225