### PR TITLE
4.x: Remove more deprecations, cleaner typehinting for Paginator.

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -19,6 +19,7 @@ use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
 use Cake\View\View;
+use RuntimeException;
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -613,13 +614,18 @@ class PaginatorHelper extends Helper
     /**
      * Returns true if the given result set has the page number given by $page
      *
-     * @param string|null $model Optional model name. Uses the default if none is specified.
      * @param int $page The page number - if not set defaults to 1.
+     * @param string|null $model Optional model name. Uses the default if none is specified.
      * @return bool True if the given result set has the specified page number.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
+     * @throws \RuntimeException
      */
-    public function hasPage($model = null, $page = 1)
+    public function hasPage($page = 1, $model = null)
     {
+        if (!is_numeric($page)) {
+            throw new RuntimeException('First argument "page" has to be int. Note that argument order switched from 3.x to 4.x.');
+        }
+
         $paging = $this->params($model);
         if ($paging === []) {
             return false;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -671,26 +671,25 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * Returns a counter string for the paged result set
+     * Returns a counter string for the paged result set.
      *
      * ### Options
      *
      * - `model` The model to use, defaults to PaginatorHelper::defaultModel();
-     * - `format` The format string you want to use, defaults to 'pages' Which generates output like '1 of 5'
+     *
+     * @param string $format The format string you want to use, defaults to 'pages' Which generates output like '1 of 5'
      *    set to 'range' to generate output like '1 - 3 of 13'. Can also be set to a custom string, containing
      *    the following placeholders `{{page}}`, `{{pages}}`, `{{current}}`, `{{count}}`, `{{model}}`, `{{start}}`, `{{end}}` and any
      *    custom content you would like.
-     *
      * @param array $options Options for the counter string. See #options for list of keys.
      *   If string it will be used as format.
      * @return string Counter string.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-a-page-counter
      */
-    public function counter(array $options = [])
+    public function counter($format, array $options = [])
     {
         $options += [
             'model' => $this->defaultModel(),
-            'format' => 'pages',
         ];
 
         $paging = $this->params($options['model']);
@@ -698,14 +697,14 @@ class PaginatorHelper extends Helper
             $paging['pageCount'] = 1;
         }
 
-        switch ($options['format']) {
+        switch ($format) {
             case 'range':
             case 'pages':
-                $template = 'counter' . ucfirst($options['format']);
+                $template = 'counter' . ucfirst($format);
                 break;
             default:
                 $template = 'counterCustom';
-                $this->templater()->add([$template => $options['format']]);
+                $this->templater()->add([$template => $format]);
         }
         $map = array_map([$this->Number, 'format'], [
             'page' => $paging['page'],

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -19,7 +19,7 @@ use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
 use Cake\View\View;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -618,12 +618,12 @@ class PaginatorHelper extends Helper
      * @param string|null $model Optional model name. Uses the default if none is specified.
      * @return bool True if the given result set has the specified page number.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     public function hasPage($page = 1, $model = null)
     {
         if (!is_numeric($page)) {
-            throw new RuntimeException('First argument "page" has to be int. Note that argument order switched from 3.x to 4.x.');
+            throw new InvalidArgumentException('First argument "page" has to be int. Note that argument order switched from 3.x to 4.x.');
         }
 
         $paging = $this->params($model);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -223,7 +223,7 @@ class PaginatorHelper extends Helper
      * Gets the current key by which the recordset is sorted
      *
      * @param string|null $model Optional model name. Uses the default if none is specified.
-     * @param array $options Options for pagination links. See #options for list of keys.
+     * @param array $options Options for pagination links.
      * @return string|null The name of the key by which the recordset is being sorted, or
      *  null if the results are not currently sorted.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-sort-links
@@ -244,7 +244,7 @@ class PaginatorHelper extends Helper
      * Gets the current direction the recordset is sorted
      *
      * @param string|null $model Optional model name. Uses the default if none is specified.
-     * @param array $options Options for pagination links. See #options for list of keys.
+     * @param array $options Options for pagination links.
      * @return string The direction by which the recordset is being sorted, or
      *  null if the results are not currently sorted.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-sort-links
@@ -620,10 +620,6 @@ class PaginatorHelper extends Helper
      */
     public function hasPage($model = null, $page = 1)
     {
-        if (is_numeric($model)) {
-            $page = $model;
-            $model = null;
-        }
         $paging = $this->params($model);
         if ($paging === []) {
             return false;
@@ -679,17 +675,13 @@ class PaginatorHelper extends Helper
      *    the following placeholders `{{page}}`, `{{pages}}`, `{{current}}`, `{{count}}`, `{{model}}`, `{{start}}`, `{{end}}` and any
      *    custom content you would like.
      *
-     * @param string|array $options Options for the counter string. See #options for list of keys.
+     * @param array $options Options for the counter string. See #options for list of keys.
      *   If string it will be used as format.
      * @return string Counter string.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-a-page-counter
      */
-    public function counter($options = [])
+    public function counter(array $options = [])
     {
-        if (is_string($options)) {
-            $options = ['format' => $options];
-        }
-
         $options += [
             'model' => $this->defaultModel(),
             'format' => 'pages',
@@ -1208,7 +1200,7 @@ class PaginatorHelper extends Helper
     {
         $out = $this->Form->create(null, ['type' => 'get']);
 
-        if (empty($default) || !is_numeric($default)) {
+        if (empty($default)) {
             $default = $this->param('perPage');
         }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2824,16 +2824,16 @@ class PaginatorHelperTest extends TestCase
      */
     public function testHasPage()
     {
-        $result = $this->Paginator->hasPage('Article', 15);
+        $result = $this->Paginator->hasPage(15, 'Article');
         $this->assertFalse($result);
 
-        $result = $this->Paginator->hasPage('UndefinedModel', 2);
+        $result = $this->Paginator->hasPage(2, 'UndefinedModel');
         $this->assertFalse($result);
 
-        $result = $this->Paginator->hasPage('Article', 2);
+        $result = $this->Paginator->hasPage(2, 'Article');
         $this->assertTrue($result);
 
-        $result = $this->Paginator->hasPage(null, 2);
+        $result = $this->Paginator->hasPage(2);
         $this->assertTrue($result);
     }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2763,7 +2763,7 @@ class PaginatorHelperTest extends TestCase
 
         $expected = 'Page 1 of 5, showing 3 records out of 13 total, starting on record 1, ';
         $expected .= 'ending on 3';
-        $result = $this->Paginator->counter($input);
+        $result = $this->Paginator->counter(['format' => $input]);
         $this->assertEquals($expected, $result);
 
         $result = $this->Paginator->counter(['format' => 'pages']);
@@ -2774,7 +2774,7 @@ class PaginatorHelperTest extends TestCase
         $expected = '1 - 3 of 13';
         $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->counter('Showing {{page}} of {{pages}} {{model}}');
+        $result = $this->Paginator->counter(['format' => 'Showing {{page}} of {{pages}} {{model}}']);
         $this->assertEquals('Showing 1 of 5 clients', $result);
     }
 
@@ -2807,13 +2807,13 @@ class PaginatorHelperTest extends TestCase
 
         $expected = 'Page 1,523 of 1,600, showing 3,000 records out of 4,800,001 total, ';
         $expected .= 'starting on record 4,566,001, ending on 4,569,001';
-        $result = $this->Paginator->counter($input);
+        $result = $this->Paginator->counter(['format' => $input]);
         $this->assertEquals($expected, $result);
 
         I18n::setLocale('de-DE');
         $expected = 'Page 1.523 of 1.600, showing 3.000 records out of 4.800.001 total, ';
         $expected .= 'starting on record 4.566.001, ending on 4.569.001';
-        $result = $this->Paginator->counter($input);
+        $result = $this->Paginator->counter(['format' => $input]);
         $this->assertEquals($expected, $result);
     }
 
@@ -2833,7 +2833,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->hasPage('Article', 2);
         $this->assertTrue($result);
 
-        $result = $this->Paginator->hasPage(2);
+        $result = $this->Paginator->hasPage(null, 2);
         $this->assertTrue($result);
     }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2763,18 +2763,18 @@ class PaginatorHelperTest extends TestCase
 
         $expected = 'Page 1 of 5, showing 3 records out of 13 total, starting on record 1, ';
         $expected .= 'ending on 3';
-        $result = $this->Paginator->counter(['format' => $input]);
+        $result = $this->Paginator->counter($input);
         $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->counter(['format' => 'pages']);
+        $result = $this->Paginator->counter('pages');
         $expected = '1 of 5';
         $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->counter(['format' => 'range']);
+        $result = $this->Paginator->counter('range');
         $expected = '1 - 3 of 13';
         $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->counter(['format' => 'Showing {{page}} of {{pages}} {{model}}']);
+        $result = $this->Paginator->counter('Showing {{page}} of {{pages}} {{model}}');
         $this->assertEquals('Showing 1 of 5 clients', $result);
     }
 
@@ -2807,13 +2807,13 @@ class PaginatorHelperTest extends TestCase
 
         $expected = 'Page 1,523 of 1,600, showing 3,000 records out of 4,800,001 total, ';
         $expected .= 'starting on record 4,566,001, ending on 4,569,001';
-        $result = $this->Paginator->counter(['format' => $input]);
+        $result = $this->Paginator->counter($input);
         $this->assertEquals($expected, $result);
 
         I18n::setLocale('de-DE');
         $expected = 'Page 1.523 of 1.600, showing 3.000 records out of 4.800.001 total, ';
         $expected .= 'starting on record 4.566.001, ending on 4.569.001';
-        $result = $this->Paginator->counter(['format' => $input]);
+        $result = $this->Paginator->counter($input);
         $this->assertEquals($expected, $result);
     }
 
@@ -2967,7 +2967,7 @@ class PaginatorHelperTest extends TestCase
             ]
         ]));
 
-        $result = $this->Paginator->counter(['format' => 'pages']);
+        $result = $this->Paginator->counter('pages');
         $expected = '0 of 1';
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/12224

Resolves one of the cleanup tasks of https://github.com/cakephp/cakephp/wiki/4.0-Roadmap