### PR TITLE
Fix save many with exceptions

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2209,25 +2209,33 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function saveMany($entities, $options = [])
     {
         $isNew = [];
-
-        $return = $this->getConnection()->transactional(
-            function () use ($entities, $options, &$isNew) {
-                foreach ($entities as $key => $entity) {
-                    $isNew[$key] = $entity->isNew();
-                    if ($this->save($entity, $options) === false) {
-                        return false;
-                    }
-                }
-            }
-        );
-
-        if ($return === false) {
+        $cleanup = function ($entities) use (&$isNew) {
             foreach ($entities as $key => $entity) {
                 if (isset($isNew[$key]) && $isNew[$key]) {
                     $entity->unsetProperty($this->getPrimaryKey());
                     $entity->isNew(true);
                 }
             }
+        };
+
+        try {
+            $return = $this->getConnection()
+                ->transactional(function () use ($entities, $options, &$isNew) {
+                    foreach ($entities as $key => $entity) {
+                        $isNew[$key] = $entity->isNew();
+                        if ($this->save($entity, $options) === false) {
+                            return false;
+                        }
+                    }
+                });
+        } catch (\Exception $e) {
+            $cleanup($entities);
+
+            throw $e;
+        }
+
+        if ($return === false) {
+            $cleanup($entities);
 
             return false;
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3204,6 +3204,37 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test saveMany() with failed save due to an exception
+     *
+     * @return void
+     */
+    public function testSaveManyFailedWithException()
+    {
+        $table = $this->getTableLocator()
+            ->get('authors');
+        $entities = [
+            new Entity(['name' => 'mark']),
+            new Entity(['name' => 'jose'])
+        ];
+
+        $table->getEventManager()->on('Model.beforeSave', function (Event $event, Entity $entity) {
+           if ($entity->name === 'jose') {
+               throw new \Exception('Oh noes');
+           }
+        });
+
+        $this->expectException(\Exception::class);
+
+        try {
+            $table->saveMany($entities);
+        } finally {
+            foreach ($entities as $entity) {
+                $this->assertTrue($entity->isNew());
+            }
+        }
+    }
+
+    /**
      * Test simple delete.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3218,9 +3218,9 @@ class TableTest extends TestCase
         ];
 
         $table->getEventManager()->on('Model.beforeSave', function (Event $event, Entity $entity) {
-           if ($entity->name === 'jose') {
-               throw new \Exception('Oh noes');
-           }
+            if ($entity->name === 'jose') {
+                throw new \Exception('Oh noes');
+            }
         });
 
         $this->expectException(\Exception::class);


### PR DESCRIPTION
Encountered an issue with `saveMany()` when something causes an exception on `save()`. The code to revert the entity changes only ran if the transactional call returned false. However, if something caused an exception to be thrown (In our example it was a DB deadlock), any changed/saved entities are not reverted.

This obviously causes an entity that has a PK set, and is no longer marked as "new". If you attempt to retry that save (As recommended for deadlock resolution), entities with PKs set (but not actually persisted) might overwrite other rows from a different, successful transaction.

This change makes it so that the revert code will be run when exceptions are thrown as well.