### PR TITLE
Bugfix, activate bindingKey in a BelongsToMany Association

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -231,7 +231,7 @@ class BelongsToMany extends Association
         return $this->_foreignKey;
     }
 
-		/**
+    /**
      * Gets the name of the field representing name of the column in the current table, that will be used for matching the foreignKey. Defaults to the primary key.
      *
      * @return string
@@ -372,7 +372,7 @@ class BelongsToMany extends Association
             $target->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getTargetForeignKey(),
-								'bindingKey' => $this->getBindingKey(),
+                                'bindingKey' => $this->getBindingKey(),
                 'strategy' => $this->_strategy,
             ]);
         }
@@ -381,7 +381,7 @@ class BelongsToMany extends Association
                 'sourceTable' => $target,
                 'targetTable' => $source,
                 'foreignKey' => $this->getTargetForeignKey(),
-								'bindingKey' => $this->getBindingKey(),
+                                'bindingKey' => $this->getBindingKey(),
                 'targetForeignKey' => $this->getForeignKey(),
                 'through' => $junction,
                 'conditions' => $this->getConditions(),
@@ -411,7 +411,7 @@ class BelongsToMany extends Association
             $source->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getForeignKey(),
-								'bindingKey' => $this->getBindingKey(),
+                                'bindingKey' => $this->getBindingKey(),
                 'strategy' => $this->_strategy,
             ]);
         }
@@ -441,14 +441,14 @@ class BelongsToMany extends Association
         if (!$junction->hasAssociation($tAlias)) {
             $junction->belongsTo($tAlias, [
                 'foreignKey' => $this->getTargetForeignKey(),
-								'bindingKey' => $this->getBindingKey(),
+                                'bindingKey' => $this->getBindingKey(),
                 'targetTable' => $target
             ]);
         }
         if (!$junction->hasAssociation($sAlias)) {
             $junction->belongsTo($sAlias, [
                 'foreignKey' => $this->getForeignKey(),
-								'bindingKey' => $this->getBindingKey(),
+                                'bindingKey' => $this->getBindingKey(),
                 'targetTable' => $source
             ]);
         }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -231,6 +231,20 @@ class BelongsToMany extends Association
         return $this->_foreignKey;
     }
 
+		/**
+     * Gets the name of the field representing name of the column in the current table, that will be used for matching the foreignKey. Defaults to the primary key.
+     *
+     * @return string
+     */
+    public function getBindingKey()
+    {
+        if ($this->_bindingKey === null) {
+            $this->_bindingKey = $this->_modelKey($this->getSource()->getTable());
+        }
+
+        return $this->_foreignKey;
+    }
+
     /**
      * Sets the sort order in which target records should be returned.
      *
@@ -358,6 +372,7 @@ class BelongsToMany extends Association
             $target->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getTargetForeignKey(),
+								'bindingKey' => $this->getBindingKey(),
                 'strategy' => $this->_strategy,
             ]);
         }
@@ -366,6 +381,7 @@ class BelongsToMany extends Association
                 'sourceTable' => $target,
                 'targetTable' => $source,
                 'foreignKey' => $this->getTargetForeignKey(),
+								'bindingKey' => $this->getBindingKey(),
                 'targetForeignKey' => $this->getForeignKey(),
                 'through' => $junction,
                 'conditions' => $this->getConditions(),
@@ -395,6 +411,7 @@ class BelongsToMany extends Association
             $source->hasMany($junctionAlias, [
                 'targetTable' => $junction,
                 'foreignKey' => $this->getForeignKey(),
+								'bindingKey' => $this->getBindingKey(),
                 'strategy' => $this->_strategy,
             ]);
         }
@@ -424,12 +441,14 @@ class BelongsToMany extends Association
         if (!$junction->hasAssociation($tAlias)) {
             $junction->belongsTo($tAlias, [
                 'foreignKey' => $this->getTargetForeignKey(),
+								'bindingKey' => $this->getBindingKey(),
                 'targetTable' => $target
             ]);
         }
         if (!$junction->hasAssociation($sAlias)) {
             $junction->belongsTo($sAlias, [
                 'foreignKey' => $this->getForeignKey(),
+								'bindingKey' => $this->getBindingKey(),
                 'targetTable' => $source
             ]);
         }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -238,9 +238,9 @@ class BelongsToMany extends Association
      */
     public function getBindingKey()
     {
-				if ($this->_bindingKey === null) {
-						$this->_bindingKey = $this->getSource()->getPrimaryKey();
-				}
+        if ($this->_bindingKey === null) {
+                $this->_bindingKey = $this->getSource()->getPrimaryKey();
+        }
 
         return $this->_bindingKey;
     }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -238,11 +238,11 @@ class BelongsToMany extends Association
      */
     public function getBindingKey()
     {
-        if ($this->_bindingKey === null) {
-            $this->_bindingKey = $this->_modelKey($this->getSource()->getTable());
-        }
+				if ($this->_bindingKey === null) {
+						$this->_bindingKey = $this->getSource()->getPrimaryKey();
+				}
 
-        return $this->_foreignKey;
+        return $this->_bindingKey;
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -68,7 +68,7 @@ class BelongsToManyTest extends TestCase
         ]);
     }
 
-		/**
+    /**
      * Tests setBindingKey()
      *
      * @return void

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -68,6 +68,22 @@ class BelongsToManyTest extends TestCase
         ]);
     }
 
+		/**
+     * Tests setBindingKey()
+     *
+     * @return void
+     */
+    public function testSetBindingKey()
+    {
+        $assoc = new BelongsToMany('Test', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag
+        ]);
+        $this->assertEquals('id', $assoc->getBindingKey());
+        $this->assertSame($assoc, $assoc->setBindingKey('another_key'));
+        $this->assertEquals('another_key', $assoc->getBindingKey());
+    }
+
     /**
      * Tests setForeignKey()
      *


### PR DESCRIPTION
Enable bindingKey for BelongsToMany Associations.

Discussion link: [github.com/cakephp/cakephp/-397322875](https://github.com/cakephp/cakephp/-397322875)