### PR TITLE
Add array typehinting in method signatures.

### DIFF
--- a/src/Console/Helper.php
+++ b/src/Console/Helper.php
@@ -59,5 +59,5 @@ abstract class Helper
      * @param array $args The arguments for the helper.
      * @return void
      */
-    abstract public function output($args);
+    abstract public function output(array $args);
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -291,7 +291,7 @@ class Debugger
      * @return mixed Formatted stack trace.
      * @link https://book.cakephp.org/3.0/en/development/debugging.html#generating-stack-traces
      */
-    public static function formatTrace($backtrace, $options = [])
+    public static function formatTrace($backtrace, array $options = [])
     {
         if ($backtrace instanceof Exception) {
             $backtrace = $backtrace->getTrace();

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -387,7 +387,7 @@ class Client
      * @param array $options Additional options to use.
      * @return \Cake\Http\Client\Response
      */
-    public function send(Request $request, $options = [])
+    public function send(Request $request, array $options = [])
     {
         $redirects = 0;
         if (isset($options['redirect'])) {
@@ -444,7 +444,7 @@ class Client
      * @param array $options The config options stored with Client::config()
      * @return string A complete url with scheme, port, host, and path.
      */
-    public function buildUrl($url, $query = [], $options = [])
+    public function buildUrl($url, $query = [], array $options = [])
     {
         if (empty($options) && empty($query)) {
             return $url;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1125,7 +1125,7 @@ class Response implements ResponseInterface
      * @return static
      * @since 3.6.0
      */
-    public function withAddedLink($url, $options = [])
+    public function withAddedLink($url, array $options = [])
     {
         $params = [];
         foreach ($options as $key => $option) {
@@ -1283,7 +1283,7 @@ class Response implements ResponseInterface
      * @param array $options An array of cookie options.
      * @return static
      */
-    public function withExpiredCookie($name, $options = [])
+    public function withExpiredCookie($name, array $options = [])
     {
         if ($name instanceof CookieInterface) {
             $cookie = $name->withExpired();

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -68,7 +68,7 @@ class ProgressHelper extends Helper
      * @param array $args The arguments/options to use when outputing the progress bar.
      * @return void
      */
-    public function output($args)
+    public function output(array $args)
     {
         $args += ['callback' => null];
         if (isset($args[0])) {

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -39,7 +39,7 @@ class TableHelper extends Helper
      * @param array $rows The rows on which the columns width will be calculated on.
      * @return array
      */
-    protected function _calculateWidths($rows)
+    protected function _calculateWidths(array $rows)
     {
         $widths = [];
         foreach ($rows as $line) {
@@ -60,7 +60,7 @@ class TableHelper extends Helper
      * @param array $widths The widths of each column to output.
      * @return void
      */
-    protected function _rowSeparator($widths)
+    protected function _rowSeparator(array $widths)
     {
         $out = '';
         foreach ($widths as $column) {
@@ -78,7 +78,7 @@ class TableHelper extends Helper
      * @param array $options Options to be passed.
      * @return void
      */
-    protected function _render(array $row, $widths, $options = [])
+    protected function _render(array $row, array $widths, array $options = [])
     {
         if (count($row) === 0) {
             return;

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -105,7 +105,7 @@ class TableHelper extends Helper
      * @param array $rows The data to render out.
      * @return void
      */
-    public function output($rows)
+    public function output(array $rows)
     {
         if (!is_array($rows) || count($rows) === 0) {
             return;

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -166,7 +166,7 @@ class ArrayContext implements ContextInterface
      *      context's schema should be used if it's not explicitly provided.
      * @return mixed
      */
-    public function val($field, $options = [])
+    public function val($field, array $options = [])
     {
         $options += [
             'default' => null,

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -227,7 +227,7 @@ class EntityContext implements ContextInterface
      *     schema should be used if it's not explicitly provided.
      * @return mixed The value of the field or null on a miss.
      */
-    public function val($field, $options = [])
+    public function val($field, array $options = [])
     {
         $options += [
             'default' => null,

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -82,7 +82,7 @@ class FormContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
-    public function val($field, $options = [])
+    public function val($field, array $options = [])
     {
         $options += [
             'default' => null,

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -168,7 +168,7 @@ class ClientTest extends TestCase
     {
         $http = new Client();
 
-        $result = $http->buildUrl($url, $query, $opts);
+        $result = $http->buildUrl($url, $query, (array)$opts);
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/Helper/ExampleHelper.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/Helper/ExampleHelper.php
@@ -5,7 +5,7 @@ use Cake\Console\Helper;
 
 class ExampleHelper extends Helper
 {
-    public function output($args)
+    public function output(array $args)
     {
         $this->_io->out('Plugins work!');
     }

--- a/tests/test_app/TestApp/Command/Helper/CommandHelper.php
+++ b/tests/test_app/TestApp/Command/Helper/CommandHelper.php
@@ -5,7 +5,7 @@ use Cake\Console\Helper;
 
 class CommandHelper extends Helper
 {
-    public function output($args)
+    public function output(array $args)
     {
         $this->_io->out('I am helping ' . implode(' ', $args));
     }

--- a/tests/test_app/TestApp/Shell/Helper/SimpleHelper.php
+++ b/tests/test_app/TestApp/Shell/Helper/SimpleHelper.php
@@ -5,7 +5,7 @@ use Cake\Console\Helper;
 
 class SimpleHelper extends Helper
 {
-    public function output($args)
+    public function output(array $args)
     {
         $this->_io->out('It works!' . implode(' ', $args));
     }


### PR DESCRIPTION
Lets see what the test say

A bit cleaner API when declaring the array signatures as such via typehint.