### PR TITLE
4.x - Add typehints to console classes.

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -38,7 +39,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function setCommandCollection(CommandCollection $commands)
+    public function setCommandCollection(CommandCollection $commands): void
     {
         $this->commands = $commands;
     }
@@ -50,7 +51,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         if (!$args->getOption('xml')) {
             $io->out('<info>Current Paths:</info>', 2);
@@ -82,7 +83,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      * @param \ArrayIterator $commands The command collection to output.
      * @return void
      */
-    protected function asText($io, $commands)
+    protected function asText($io, $commands): void
     {
         $invert = [];
         foreach ($commands as $name => $class) {
@@ -121,7 +122,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      * @param \ArrayIterator $commands The command collection to output
      * @return void
      */
-    protected function asXml($io, $commands)
+    protected function asXml($io, $commands): void
     {
         $shells = new SimpleXMLElement('<shells></shells>');
         foreach ($commands as $name => $class) {
@@ -141,7 +142,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to build
      * @return \Cake\Console\ConsoleOptionParser
      */
-    protected function buildOptionParser(ConsoleOptionParser $parser)
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
             'Get the list of available shells for this application.'

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -31,7 +32,7 @@ class VersionCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out(Configure::version());
 

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -61,7 +62,7 @@ class Arguments
      *
      * @return string[]
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->args;
     }
@@ -72,7 +73,7 @@ class Arguments
      * @param int $index The argument index to access.
      * @return string|null The argument value or null
      */
-    public function getArgumentAt($index)
+    public function getArgumentAt(int $index)
     {
         if ($this->hasArgumentAt($index)) {
             return $this->args[$index];
@@ -87,7 +88,7 @@ class Arguments
      * @param int $index The argument index to check.
      * @return bool
      */
-    public function hasArgumentAt($index)
+    public function hasArgumentAt(int $index): bool
     {
         return isset($this->args[$index]);
     }
@@ -98,7 +99,7 @@ class Arguments
      * @param string $name The argument name to check.
      * @return bool
      */
-    public function hasArgument($name)
+    public function hasArgument(string $name): bool
     {
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false) {
@@ -114,7 +115,7 @@ class Arguments
      * @param string $name The argument name to check.
      * @return string|null
      */
-    public function getArgument($name)
+    public function getArgument(string $name)
     {
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false) {
@@ -129,7 +130,7 @@ class Arguments
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -140,7 +141,7 @@ class Arguments
      * @param string $name The name of the option to check.
      * @return string|int|bool|null The option value or null.
      */
-    public function getOption($name)
+    public function getOption(string $name)
     {
         if (isset($this->options[$name])) {
             return $this->options[$name];
@@ -155,7 +156,7 @@ class Arguments
      * @param string $name The name of the option to check.
      * @return bool
      */
-    public function hasOption($name)
+    public function hasOption(string $name): bool
     {
         return isset($this->options[$name]);
     }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -76,7 +77,7 @@ class Command
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setName($name)
+    public function setName(string $name): self
     {
         if (strpos($name, ' ') < 1) {
             throw new InvalidArgumentException(
@@ -93,7 +94,7 @@ class Command
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -106,7 +107,7 @@ class Command
      * @return \Cake\Console\ConsoleOptionParser
      * @throws \RuntimeException When the parser is invalid
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         list($root, $name) = explode(' ', $this->name, 2);
         $parser = new ConsoleOptionParser($name);
@@ -144,7 +145,7 @@ class Command
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
     }
 
@@ -155,7 +156,7 @@ class Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null Exit code or null for success.
      */
-    public function run(array $argv, ConsoleIo $io)
+    public function run(array $argv, ConsoleIo $io): ?int
     {
         $this->initialize();
 
@@ -191,7 +192,7 @@ class Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return void
      */
-    protected function displayHelp(ConsoleOptionParser $parser, Arguments $args, ConsoleIo $io)
+    protected function displayHelp(ConsoleOptionParser $parser, Arguments $args, ConsoleIo $io): void
     {
         $format = 'text';
         if ($args->getArgumentAt(0) === 'xml') {
@@ -209,7 +210,7 @@ class Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return void
      */
-    protected function setOutputLevel(Arguments $args, ConsoleIo $io)
+    protected function setOutputLevel(Arguments $args, ConsoleIo $io): void
     {
         $io->setLoggers(ConsoleIo::NORMAL);
         if ($args->getOption('quiet')) {
@@ -241,7 +242,7 @@ class Command
      * @throws \Cake\Console\Exception\StopException
      * @return void
      */
-    public function abort($code = self::CODE_ERROR)
+    public function abort($code = self::CODE_ERROR): void
     {
         throw new StopException('Command aborted', $code);
     }

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -54,7 +55,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string|\Cake\Console\Shell|\Cake\Console\Command $command The command to map.
      * @return $this
      */
-    public function add($name, $command)
+    public function add(string $name, $command): self
     {
         // Once we have a new Command class this should check
         // against that interface.
@@ -77,7 +78,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @return $this
      * @see \Cake\Console\CommandCollection::add()
      */
-    public function addMany(array $commands)
+    public function addMany(array $commands): self
     {
         foreach ($commands as $name => $class) {
             $this->add($name, $class);
@@ -92,7 +93,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string $name The named shell.
      * @return $this
      */
-    public function remove($name)
+    public function remove(string $name): self
     {
         unset($this->commands[$name]);
 
@@ -105,7 +106,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string $name The named shell.
      * @return bool
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return isset($this->commands[$name]);
     }
@@ -114,10 +115,10 @@ class CommandCollection implements IteratorAggregate, Countable
      * Get the target for a command.
      *
      * @param string $name The named shell.
-     * @return string|\Cake\Console\Shell Either the shell class or an instance.
+     * @return string|\Cake\Console\Command Either the command class or an instance.
      * @throws \InvalidArgumentException when unknown commands are fetched.
      */
-    public function get($name)
+    public function get(string $name)
     {
         if (!$this->has($name)) {
             throw new InvalidArgumentException("The $name is not a known command name.");
@@ -143,7 +144,7 @@ class CommandCollection implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->commands);
     }
@@ -159,7 +160,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string $plugin The plugin to scan.
      * @return array Discovered plugin commands.
      */
-    public function discoverPlugin($plugin)
+    public function discoverPlugin($plugin): array
     {
         $scanner = new CommandScanner();
         $shells = $scanner->scanPlugin($plugin);
@@ -173,7 +174,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param array $input The results of a CommandScanner operation.
      * @return array A flat map of command names => class names.
      */
-    protected function resolveNames(array $input)
+    protected function resolveNames(array $input): array
     {
         $out = [];
         foreach ($input as $info) {
@@ -210,7 +211,7 @@ class CommandCollection implements IteratorAggregate, Countable
      *
      * @return array An array of command names and their classes.
      */
-    public function autoDiscover()
+    public function autoDiscover(): array
     {
         $scanner = new CommandScanner();
 

--- a/src/Console/CommandCollectionAwareInterface.php
+++ b/src/Console/CommandCollectionAwareInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -27,5 +28,5 @@ interface CommandCollectionAwareInterface
      * @param \Cake\Console\CommandCollection $commands The commands to use.
      * @return void
      */
-    public function setCommandCollection(CommandCollection $commands);
+    public function setCommandCollection(CommandCollection $commands): void;
 }

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/src/Console/CommandFactoryInterface.php
+++ b/src/Console/CommandFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -103,7 +104,7 @@ class CommandRunner implements EventDispatcherInterface
      * @param array $aliases The map of aliases to replace.
      * @return $this
      */
-    public function setAliases(array $aliases)
+    public function setAliases(array $aliases): self
     {
         $this->aliases = $aliases;
 
@@ -125,7 +126,7 @@ class CommandRunner implements EventDispatcherInterface
      * @return int The exit code of the command.
      * @throws \RuntimeException
      */
-    public function run(array $argv, ConsoleIo $io = null)
+    public function run(array $argv, ConsoleIo $io = null): int
     {
         $this->bootstrap();
 
@@ -180,7 +181,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @return void
      */
-    protected function bootstrap()
+    protected function bootstrap(): void
     {
         $this->app->bootstrap();
         if ($this->app instanceof PluginApplicationInterface) {
@@ -213,7 +214,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @return \Cake\Event\EventManagerInterface
      */
-    public function getEventManager()
+    public function getEventManager(): EventManagerInterface
     {
         if ($this->app instanceof PluginApplicationInterface) {
             return $this->app->getEventManager();
@@ -276,10 +277,10 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @param \Cake\Console\CommandCollection $commands The command collection to check.
      * @param \Cake\Console\ConsoleIo $io ConsoleIo object for errors.
-     * @param string $name The name from the CLI args.
+     * @param string|null $name The name from the CLI args.
      * @return string The resolved name.
      */
-    protected function resolveName($commands, $io, $name)
+    protected function resolveName(CommandCollection $commands, ConsoleIo $io, ?string $name): string
     {
         if (!$name) {
             $io->err('<error>No command provided. Choose one of the available commands.</error>', 2);
@@ -306,7 +307,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @param \Cake\Console\Shell $shell The shell to run.
      * @param array $argv The CLI arguments to invoke.
-     * @return int Exit code
+     * @return int|bool|null Exit code
      */
     protected function runShell(Shell $shell, array $argv)
     {
@@ -343,7 +344,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @return void
      */
-    protected function loadRoutes()
+    protected function loadRoutes(): void
     {
         $builder = Router::createRouteBuilder('/');
 

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
@@ -33,7 +34,7 @@ class CommandScanner
      *
      * @return array A list of command metadata.
      */
-    public function scanCore()
+    public function scanCore(): array
     {
         $coreShells = $this->scanDir(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Shell' . DIRECTORY_SEPARATOR,
@@ -56,7 +57,7 @@ class CommandScanner
      *
      * @return array A list of command metadata.
      */
-    public function scanApp()
+    public function scanApp(): array
     {
         $appNamespace = Configure::read('App.namespace');
         $appShells = $this->scanDir(
@@ -81,7 +82,7 @@ class CommandScanner
      * @param string $plugin The named plugin.
      * @return array A list of command metadata.
      */
-    public function scanPlugin($plugin)
+    public function scanPlugin(string $plugin): array
     {
         if (!Plugin::loaded($plugin)) {
             return [];
@@ -106,7 +107,7 @@ class CommandScanner
      * @param array $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
      */
-    protected function scanDir($path, $namespace, $prefix, array $hide)
+    protected function scanDir(string $path, string $namespace, string $prefix, array $hide): array
     {
         $dir = new Folder($path);
         $contents = $dir->read(true, true);

--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -63,7 +64,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
      * @throws \Exception When renderer class not found
      * @see https://secure.php.net/manual/en/function.set-exception-handler.php
      */
-    public function handleException(Exception $exception)
+    public function handleException(Exception $exception): void
     {
         $this->_displayException($exception);
         $this->_logException($exception);
@@ -78,7 +79,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
      * @param \Exception $exception The exception to handle
      * @return void
      */
-    protected function _displayException($exception)
+    protected function _displayException($exception): void
     {
         $errorName = 'Exception:';
         if ($exception instanceof FatalErrorException) {
@@ -130,7 +131,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
      * @param int $code The exit code.
      * @return void
      */
-    protected function _stop($code)
+    protected function _stop($code): void
     {
         exit($code);
     }

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -43,7 +43,7 @@ class ConsoleInput
      *
      * @param string $handle The location of the stream to use as input.
      */
-    public function __construct($handle = 'php://stdin')
+    public function __construct(string $handle = 'php://stdin')
     {
         $this->_canReadline = (extension_loaded('readline') && $handle === 'php://stdin');
         $this->_input = fopen($handle, 'rb');
@@ -52,9 +52,9 @@ class ConsoleInput
     /**
      * Read a value from the stream
      *
-     * @return mixed The value of the stream
+     * @return string The value of the stream
      */
-    public function read()
+    public function read(): string
     {
         if ($this->_canReadline) {
             $line = readline('');
@@ -74,7 +74,7 @@ class ConsoleInput
      * @param int $timeout An optional time to wait for data
      * @return bool True for data available, false otherwise
      */
-    public function dataAvailable($timeout = 0)
+    public function dataAvailable(int $timeout = 0): bool
     {
         $readFds = [$this->_input];
         $readyFds = stream_select($readFds, $writeFds, $errorFds, $timeout);

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -81,7 +81,7 @@ class ConsoleInputArgument
      *
      * @return string Value of this->_name.
      */
-    public function name()
+    public function name(): string
     {
         return $this->_name;
     }
@@ -92,7 +92,7 @@ class ConsoleInputArgument
      * @param \Cake\Console\ConsoleInputArgument $argument ConsoleInputArgument to compare to.
      * @return bool
      */
-    public function isEqualTo(ConsoleInputArgument $argument)
+    public function isEqualTo(ConsoleInputArgument $argument): bool
     {
         return $this->usage() === $argument->usage();
     }
@@ -103,7 +103,7 @@ class ConsoleInputArgument
      * @param int $width The width to make the name of the option.
      * @return string
      */
-    public function help($width = 0)
+    public function help(int $width = 0): string
     {
         $name = $this->_name;
         if (strlen($name) < $width) {
@@ -125,7 +125,7 @@ class ConsoleInputArgument
      *
      * @return string
      */
-    public function usage()
+    public function usage(): string
     {
         $name = $this->_name;
         if ($this->_choices) {
@@ -144,7 +144,7 @@ class ConsoleInputArgument
      *
      * @return bool
      */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return (bool)$this->_required;
     }
@@ -156,7 +156,7 @@ class ConsoleInputArgument
      * @return bool
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    public function validChoice($value)
+    public function validChoice(string $value): bool
     {
         if (empty($this->_choices)) {
             return true;
@@ -181,7 +181,7 @@ class ConsoleInputArgument
      * @param \SimpleXMLElement $parent The parent element.
      * @return \SimpleXMLElement The parent with this argument appended.
      */
-    public function xml(SimpleXMLElement $parent)
+    public function xml(SimpleXMLElement $parent): SimpleXmlElement
     {
         $option = $parent->addChild('argument');
         $option->addAttribute('name', $this->_name);

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -121,7 +121,7 @@ class ConsoleInputOption
      *
      * @return string Value of this->_name.
      */
-    public function name()
+    public function name(): string
     {
         return $this->_name;
     }
@@ -131,9 +131,9 @@ class ConsoleInputOption
      *
      * @return string Value of this->_short.
      */
-    public function short()
+    public function short(): string
     {
-        return $this->_short;
+        return (string)$this->_short;
     }
 
     /**
@@ -142,7 +142,7 @@ class ConsoleInputOption
      * @param int $width The width to make the name of the option.
      * @return string
      */
-    public function help($width = 0)
+    public function help(int $width = 0): string
     {
         $default = $short = '';
         if ($this->_default && $this->_default !== true) {
@@ -167,7 +167,7 @@ class ConsoleInputOption
      *
      * @return string
      */
-    public function usage()
+    public function usage(): string
     {
         $name = (strlen($this->_short) > 0) ? ('-' . $this->_short) : ('--' . $this->_name);
         $default = '';
@@ -196,7 +196,7 @@ class ConsoleInputOption
      *
      * @return bool
      */
-    public function isBoolean()
+    public function isBoolean(): bool
     {
         return (bool)$this->_boolean;
     }
@@ -206,7 +206,7 @@ class ConsoleInputOption
      *
      * @return bool
      */
-    public function acceptsMultiple()
+    public function acceptsMultiple(): bool
     {
         return (bool)$this->_multiple;
     }
@@ -218,7 +218,7 @@ class ConsoleInputOption
      * @return bool
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    public function validChoice($value)
+    public function validChoice($value): bool
     {
         if (empty($this->_choices)) {
             return true;
@@ -243,7 +243,7 @@ class ConsoleInputOption
      * @param \SimpleXMLElement $parent The parent element.
      * @return \SimpleXMLElement The parent with this option appended.
      */
-    public function xml(SimpleXMLElement $parent)
+    public function xml(SimpleXMLElement $parent): SimpleXmlElement
     {
         $option = $parent->addChild('option');
         $option->addAttribute('name', '--' . $this->_name);

--- a/src/Console/ConsoleInputSubcommand.php
+++ b/src/Console/ConsoleInputSubcommand.php
@@ -78,7 +78,7 @@ class ConsoleInputSubcommand
      *
      * @return string Value of this->_name.
      */
-    public function name()
+    public function name(): string
     {
         return $this->_name;
     }
@@ -88,7 +88,7 @@ class ConsoleInputSubcommand
      *
      * @return string
      */
-    public function getRawHelp()
+    public function getRawHelp(): string
     {
         return $this->_help;
     }
@@ -99,7 +99,7 @@ class ConsoleInputSubcommand
      * @param int $width The width to make the name of the subcommand.
      * @return string
      */
-    public function help($width = 0)
+    public function help(int $width = 0): string
     {
         $name = $this->_name;
         if (strlen($name) < $width) {
@@ -129,7 +129,7 @@ class ConsoleInputSubcommand
      * @param \SimpleXMLElement $parent The parent element.
      * @return \SimpleXMLElement The parent with this subcommand appended.
      */
-    public function xml(SimpleXMLElement $parent)
+    public function xml(SimpleXMLElement $parent): SimpleXmlElement
     {
         $command = $parent->addChild('command');
         $command->addAttribute('name', $this->_name);

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -124,7 +125,7 @@ class ConsoleIo
      * @param null|int $level The current output level.
      * @return int The current output level.
      */
-    public function level($level = null)
+    public function level(?int $level = null): int
     {
         if ($level !== null) {
             $this->_level = $level;
@@ -140,7 +141,7 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function verbose($message, $newlines = 1)
+    public function verbose($message, int $newlines = 1)
     {
         return $this->out($message, $newlines, self::VERBOSE);
     }
@@ -152,7 +153,7 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function quiet($message, $newlines = 1)
+    public function quiet($message, int $newlines = 1)
     {
         return $this->out($message, $newlines, self::QUIET);
     }
@@ -173,7 +174,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function out($message = '', $newlines = 1, $level = ConsoleIo::NORMAL)
+    public function out($message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL)
     {
         if ($level <= $this->_level) {
             $this->_lastWritten = (int)$this->_out->write($message, $newlines);
@@ -193,7 +194,7 @@ class ConsoleIo
      * @return int|bool The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
-    public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function info($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         $messageType = 'info';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -209,7 +210,7 @@ class ConsoleIo
      * @return int|bool The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
      */
-    public function warning($message = null, $newlines = 1)
+    public function warning($message = null, int $newlines = 1)
     {
         $messageType = 'warning';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -225,7 +226,7 @@ class ConsoleIo
      * @return int|bool The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
      */
-    public function error($message = null, $newlines = 1)
+    public function error($message = null, int $newlines = 1)
     {
         $messageType = 'error';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -242,7 +243,7 @@ class ConsoleIo
      * @return int|bool The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
-    public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function success($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         $messageType = 'success';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -257,7 +258,7 @@ class ConsoleIo
      * @param string|array $message The message to wrap.
      * @return array|string The message wrapped with the given message type.
      */
-    protected function wrapMessageWithType($messageType, $message)
+    protected function wrapMessageWithType(string $messageType, $message)
     {
         if (is_array($message)) {
             foreach ($message as $k => $v) {
@@ -284,7 +285,7 @@ class ConsoleIo
      *    length of the last message output.
      * @return void
      */
-    public function overwrite($message, $newlines = 1, $size = null)
+    public function overwrite($message, int $newlines = 1, ?int $size = null)
     {
         $size = $size ?: $this->_lastWritten;
 
@@ -318,7 +319,7 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stderr.
      */
-    public function err($message = '', $newlines = 1)
+    public function err($message = '', int $newlines = 1)
     {
         return $this->_err->write($message, $newlines);
     }
@@ -329,7 +330,7 @@ class ConsoleIo
      * @param int $multiplier Number of times the linefeed sequence should be repeated
      * @return string
      */
-    public function nl($multiplier = 1)
+    public function nl(int $multiplier = 1): string
     {
         return str_repeat(ConsoleOutput::LF, $multiplier);
     }
@@ -341,7 +342,7 @@ class ConsoleIo
      * @param int $width Width of the line, defaults to 79
      * @return void
      */
-    public function hr($newlines = 0, $width = 79)
+    public function hr(int $newlines = 0, int $width = 79): void
     {
         $this->out(null, $newlines);
         $this->out(str_repeat('-', $width));
@@ -367,7 +368,7 @@ class ConsoleIo
      * @return void
      * @see \Cake\Console\ConsoleOutput::setOutputAs()
      */
-    public function setOutputAs($mode)
+    public function setOutputAs(int $mode): void
     {
         $this->_out->setOutputAs($mode);
     }
@@ -395,7 +396,7 @@ class ConsoleIo
      * @param string|null $default Default input value.
      * @return mixed Either the default value, or the user-provided input.
      */
-    public function askChoice($prompt, $options, $default = null)
+    public function askChoice(string $prompt, $options, $default = null)
     {
         if ($options && is_string($options)) {
             if (strpos($options, ',')) {
@@ -429,7 +430,7 @@ class ConsoleIo
      * @param string|null $default Default input value. Pass null to omit.
      * @return string Either the default value, or the user-provided input.
      */
-    protected function _getInput($prompt, $options, $default)
+    protected function _getInput(string $prompt, $options, $default): string
     {
         $optionsText = '';
         if (isset($options)) {
@@ -464,7 +465,7 @@ class ConsoleIo
      *   QUIET disables notice, info and debug logs.
      * @return void
      */
-    public function setLoggers($enable)
+    public function setLoggers($enable): void
     {
         Log::drop('stdout');
         Log::drop('stderr');
@@ -499,7 +500,7 @@ class ConsoleIo
      * @param array $settings Configuration data for the helper.
      * @return \Cake\Console\Helper The created helper instance.
      */
-    public function helper($name, array $settings = [])
+    public function helper(string $name, array $settings = [])
     {
         $name = ucfirst($name);
 
@@ -524,7 +525,7 @@ class ConsoleIo
      * @throws \Cake\Console\Exception\StopException When `q` is given as an answer
      *   to whether or not a file should be overwritten.
      */
-    public function createFile($path, $contents, $forceOverwrite = false)
+    public function createFile(string $path, string $contents, bool $forceOverwrite = false): bool
     {
         $path = str_replace(
             DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR,

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -153,11 +153,11 @@ class ConsoleOptionParser
     /**
      * Construct an OptionParser so you can define its behavior
      *
-     * @param string|null $command The command name this parser is for. The command name is used for generating help.
+     * @param string $command The command name this parser is for. The command name is used for generating help.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set. Setting
      *  this to false will prevent the addition of `--verbose` & `--quiet` options.
      */
-    public function __construct($command = null, $defaultOptions = true)
+    public function __construct(string $command = '', bool $defaultOptions = true)
     {
         $this->setCommand($command);
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -79,7 +80,7 @@ class ConsoleOptionParser
      * @see \Cake\Console\ConsoleOptionParser::description()
      * @var string
      */
-    protected $_description;
+    protected $_description = '';
 
     /**
      * Epilog text - displays after options when help is generated
@@ -87,7 +88,7 @@ class ConsoleOptionParser
      * @see \Cake\Console\ConsoleOptionParser::epilog()
      * @var string
      */
-    protected $_epilog;
+    protected $_epilog = '';
 
     /**
      * Option definitions.
@@ -214,7 +215,7 @@ class ConsoleOptionParser
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
      * @return static
      */
-    public static function buildFromArray($spec, $defaultOptions = true)
+    public static function buildFromArray(array $spec, bool $defaultOptions = true)
     {
         $parser = new static($spec['command'], $defaultOptions);
         if (!empty($spec['arguments'])) {
@@ -241,7 +242,7 @@ class ConsoleOptionParser
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $result = [
             'command' => $this->_command,
@@ -291,7 +292,7 @@ class ConsoleOptionParser
      * @param string $text The text to set.
      * @return $this
      */
-    public function setCommand($text)
+    public function setCommand(string $text): self
     {
         $this->_command = Inflector::underscore($text);
 
@@ -303,7 +304,7 @@ class ConsoleOptionParser
      *
      * @return string The value of the command.
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         return $this->_command;
     }
@@ -315,7 +316,7 @@ class ConsoleOptionParser
      *   text will be imploded with "\n".
      * @return $this
      */
-    public function setDescription($text)
+    public function setDescription($text): self
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -330,7 +331,7 @@ class ConsoleOptionParser
      *
      * @return string The value of the description
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->_description;
     }
@@ -343,7 +344,7 @@ class ConsoleOptionParser
      *   be imploded with "\n".
      * @return $this
      */
-    public function setEpilog($text)
+    public function setEpilog($text): self
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -358,7 +359,7 @@ class ConsoleOptionParser
      *
      * @return string The value of the epilog.
      */
-    public function getEpilog()
+    public function getEpilog(): string
     {
         return $this->_epilog;
     }
@@ -369,7 +370,7 @@ class ConsoleOptionParser
      * @param bool $value Whether or not to sort subcommands
      * @return $this
      */
-    public function enableSubcommandSort($value = true)
+    public function enableSubcommandSort(bool $value = true): self
     {
         $this->_subcommandSort = (bool)$value;
 
@@ -381,7 +382,7 @@ class ConsoleOptionParser
      *
      * @return bool
      */
-    public function isSubcommandSortEnabled()
+    public function isSubcommandSortEnabled(): bool
     {
         return $this->_subcommandSort;
     }
@@ -410,7 +411,7 @@ class ConsoleOptionParser
      * @param array $options An array of parameters that define the behavior of the option
      * @return $this
      */
-    public function addOption($name, array $options = [])
+    public function addOption($name, array $options = []): self
     {
         if ($name instanceof ConsoleInputOption) {
             $option = $name;
@@ -443,7 +444,7 @@ class ConsoleOptionParser
      * @param string $name The option name to remove.
      * @return $this
      */
-    public function removeOption($name)
+    public function removeOption(string $name): self
     {
         unset($this->_options[$name]);
 
@@ -667,7 +668,7 @@ class ConsoleOptionParser
      * @return array [$params, $args]
      * @throws \Cake\Console\Exception\ConsoleException When an invalid parameter is encountered.
      */
-    public function parse($argv)
+    public function parse(array $argv): array
     {
         $command = isset($argv[0]) ? Inflector::underscore($argv[0]) : null;
         if (isset($this->_subcommands[$command])) {
@@ -679,6 +680,7 @@ class ConsoleOptionParser
         $params = $args = [];
         $this->_tokens = $argv;
         while (($token = array_shift($this->_tokens)) !== null) {
+            $token = (string)$token;
             if (isset($this->_subcommands[$token])) {
                 continue;
             }
@@ -725,7 +727,7 @@ class ConsoleOptionParser
      * @param int $width The width to format user content to. Defaults to 72
      * @return string Generated help.
      */
-    public function help($subcommand = null, $format = 'text', $width = 72)
+    public function help(?string $subcommand = null, string $format = 'text', int $width = 72): string
     {
         if ($subcommand === null) {
             $formatter = new HelpFormatter($this);
@@ -763,7 +765,7 @@ class ConsoleOptionParser
      * @param string $name The root command name
      * @return $this
      */
-    public function setRootName($name)
+    public function setRootName(string $name): self
     {
         $this->rootName = (string)$name;
 
@@ -777,7 +779,7 @@ class ConsoleOptionParser
      * @param string $command Unknown command name trying to be dispatched.
      * @return string The message to be displayed in the console.
      */
-    protected function getCommandError($command)
+    protected function getCommandError(string $command): string
     {
         $rootCommand = $this->getCommand();
         $subcommands = array_keys((array)$this->subcommands());
@@ -814,7 +816,7 @@ class ConsoleOptionParser
      * @param string $option Unknown option name trying to be used.
      * @return string The message to be displayed in the console.
      */
-    protected function getOptionError($option)
+    protected function getOptionError(string $option): string
     {
         $availableOptions = array_keys($this->_options);
         $bestGuess = $this->findClosestItem($option, $availableOptions);
@@ -844,7 +846,7 @@ class ConsoleOptionParser
      * @param string $option Unknown short option name trying to be used.
      * @return string The message to be displayed in the console.
      */
-    protected function getShortOptionError($option)
+    protected function getShortOptionError(string $option): string
     {
         $out = [sprintf('Unknown short option `%s`', $option)];
         $out[] = '';
@@ -866,7 +868,7 @@ class ConsoleOptionParser
      * @param array $haystack List of items available for the type $needle belongs to.
      * @return string|null The closest name to the item submitted by the user.
      */
-    protected function findClosestItem($needle, $haystack)
+    protected function findClosestItem(string $needle, array $haystack): ?string
     {
         $bestGuess = null;
         foreach ($haystack as $item) {
@@ -899,7 +901,7 @@ class ConsoleOptionParser
      * @param array $params The params to append the parsed value into
      * @return array Params with $option added in.
      */
-    protected function _parseLongOption($option, $params)
+    protected function _parseLongOption(string $option, array $params): array
     {
         $name = substr($option, 2);
         if (strpos($name, '=') !== false) {
@@ -920,7 +922,7 @@ class ConsoleOptionParser
      * @return array Params with $option added in.
      * @throws \Cake\Console\Exception\ConsoleException When unknown short options are encountered.
      */
-    protected function _parseShortOption($option, $params)
+    protected function _parseShortOption(string $option, array $params): array
     {
         $key = substr($option, 1);
         if (strlen($key) > 1) {
@@ -946,7 +948,7 @@ class ConsoleOptionParser
      * @return array Params with $option added in.
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    protected function _parseOption($name, $params)
+    protected function _parseOption(string $name, array $params): array
     {
         if (!isset($this->_options[$name])) {
             throw new ConsoleException($this->getOptionError($name));
@@ -982,7 +984,7 @@ class ConsoleOptionParser
      * @param string $name The name of the option.
      * @return bool
      */
-    protected function _optionExists($name)
+    protected function _optionExists(string $name): bool
     {
         if (substr($name, 0, 2) === '--') {
             return isset($this->_options[substr($name, 2)]);
@@ -1003,7 +1005,7 @@ class ConsoleOptionParser
      * @return array Args
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    protected function _parseArg($argument, $args)
+    protected function _parseArg(string $argument, array $args): array
     {
         if (empty($this->_args)) {
             $args[] = $argument;
@@ -1027,7 +1029,7 @@ class ConsoleOptionParser
      *
      * @return string next token or ''
      */
-    protected function _nextToken()
+    protected function _nextToken(): string
     {
         return isset($this->_tokens[0]) ? $this->_tokens[0] : '';
     }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -160,7 +161,7 @@ class ConsoleOutput
      *
      * @param string $stream The identifier of the stream to write output to.
      */
-    public function __construct($stream = 'php://stdout')
+    public function __construct(string $stream = 'php://stdout')
     {
         $this->_output = fopen($stream, 'wb');
 
@@ -179,7 +180,7 @@ class ConsoleOutput
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to output.
      */
-    public function write($message, $newlines = 1)
+    public function write($message, int $newlines = 1)
     {
         if (is_array($message)) {
             $message = implode(static::LF, $message);
@@ -194,7 +195,7 @@ class ConsoleOutput
      * @param string $text Text with styling tags.
      * @return string String with color codes added.
      */
-    public function styleText($text)
+    public function styleText(string $text): string
     {
         if ($this->_outputAs == static::RAW) {
             return $text;
@@ -218,7 +219,7 @@ class ConsoleOutput
      * @param array $matches An array of matches to replace.
      * @return string
      */
-    protected function _replaceTags($matches)
+    protected function _replaceTags(array $matches): string
     {
         $style = $this->styles($matches['tag']);
         if (empty($style)) {
@@ -248,7 +249,7 @@ class ConsoleOutput
      * @param string $message Message to write.
      * @return int|bool The number of bytes returned from writing to output.
      */
-    protected function _write($message)
+    protected function _write(string $message)
     {
         return fwrite($this->_output, $message);
     }
@@ -309,7 +310,7 @@ class ConsoleOutput
      *
      * @return int
      */
-    public function getOutputAs()
+    public function getOutputAs(): int
     {
         return $this->_outputAs;
     }
@@ -321,7 +322,7 @@ class ConsoleOutput
      * @return void
      * @throws \InvalidArgumentException in case of a not supported output type.
      */
-    public function setOutputAs($type)
+    public function setOutputAs(int $type): void
     {
         if (!in_array($type, [self::RAW, self::PLAIN, self::COLOR], true)) {
             throw new InvalidArgumentException(sprintf('Invalid output type "%s".', $type));

--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/Exception/MissingHelperException.php
+++ b/src/Console/Exception/MissingHelperException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/Exception/MissingShellException.php
+++ b/src/Console/Exception/MissingShellException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/Exception/MissingShellMethodException.php
+++ b/src/Console/Exception/MissingShellMethodException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/Exception/MissingTaskException.php
+++ b/src/Console/Exception/MissingTaskException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -73,15 +74,10 @@ class HelpFormatter
      *
      * @param string $alias The alias
      * @return void
-     * @throws \Cake\Console\Exception\ConsoleException When alias is not a string.
      */
-    public function setAlias($alias)
+    public function setAlias(string $alias): void
     {
-        if (is_string($alias)) {
-            $this->_alias = $alias;
-        } else {
-            throw new ConsoleException('Alias must be of type string.');
-        }
+        $this->_alias = $alias;
     }
 
     /**
@@ -164,7 +160,7 @@ class HelpFormatter
      *
      * @return string
      */
-    protected function _generateUsage()
+    protected function _generateUsage(): string
     {
         $usage = [$this->_alias . ' ' . $this->_parser->getCommand()];
         $subcommands = $this->_parser->subcommands();
@@ -197,7 +193,7 @@ class HelpFormatter
      * @param array $collection The collection to find a max length of.
      * @return int
      */
-    protected function _getMaxLength($collection)
+    protected function _getMaxLength(array $collection): int
     {
         $max = 0;
         foreach ($collection as $item) {
@@ -213,7 +209,7 @@ class HelpFormatter
      * @param bool $string Return the SimpleXml object or a string. Defaults to true.
      * @return string|\SimpleXMLElement See $string
      */
-    public function xml($string = true)
+    public function xml(bool $string = true)
     {
         $parser = $this->_parser;
         $xml = new SimpleXMLElement('<shell></shell>');

--- a/src/Console/Helper.php
+++ b/src/Console/Helper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -38,7 +39,7 @@ class HelperRegistry extends ObjectRegistry
      * @param \Cake\Console\ConsoleIo $io An io instance.
      * @return void
      */
-    public function setIo(ConsoleIo $io)
+    public function setIo(ConsoleIo $io): void
     {
         $this->_io = $io;
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -208,9 +209,9 @@ class Shell
      * @param string $name The name of the root command.
      * @return $this
      */
-    public function setRootName($name)
+    public function setRootName(string $name): self
     {
-        $this->rootName = (string)$name;
+        $this->rootName = $name;
 
         return $this;
     }
@@ -220,7 +221,7 @@ class Shell
      *
      * @return \Cake\Console\ConsoleIo The current ConsoleIo object.
      */
-    public function getIo()
+    public function getIo(): ConsoleIo
     {
         return $this->_io;
     }
@@ -231,7 +232,7 @@ class Shell
      * @param \Cake\Console\ConsoleIo $io The ConsoleIo object to use.
      * @return void
      */
-    public function setIo(ConsoleIo $io)
+    public function setIo(ConsoleIo $io): void
     {
         $this->_io = $io;
     }
@@ -280,7 +281,7 @@ class Shell
      *
      * @return bool
      */
-    public function loadTasks()
+    public function loadTasks(): bool
     {
         if ($this->tasks === true || empty($this->tasks) || empty($this->Tasks)) {
             return true;
@@ -299,11 +300,11 @@ class Shell
      * @throws \RuntimeException
      * @return void
      */
-    protected function _validateTasks()
+    protected function _validateTasks(): void
     {
         foreach ($this->_taskMap as $taskName => $task) {
             $class = App::className($task['class'], 'Shell/Task', 'Task');
-            if (!class_exists($class)) {
+            if ($class === false || !class_exists($class)) {
                 throw new RuntimeException(sprintf(
                     'Task `%s` not found. Maybe you made a typo or a plugin is missing or not loaded?',
                     $taskName
@@ -319,7 +320,7 @@ class Shell
      * @return bool Success
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#shell-tasks
      */
-    public function hasTask($task)
+    public function hasTask(string $task): bool
     {
         return isset($this->_taskMap[Inflector::camelize($task)]);
     }
@@ -331,7 +332,7 @@ class Shell
      * @return bool
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#shell-tasks
      */
-    public function hasMethod($name)
+    public function hasMethod(string $name): bool
     {
         try {
             $method = new ReflectionMethod($this, $name);
@@ -387,7 +388,7 @@ class Shell
      * @return int The cli command exit code. 0 is success.
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#invoking-other-shells-from-your-shell
      */
-    public function dispatchShell()
+    public function dispatchShell(): int
     {
         list($args, $extra) = $this->parseDispatchArguments(func_get_args());
 
@@ -407,7 +408,7 @@ class Shell
      * @return array First value has to be an array of the command arguments.
      * Second value has to be an array of extra parameter to pass on to the dispatcher
      */
-    public function parseDispatchArguments($args)
+    public function parseDispatchArguments(array $args): array
     {
         $extra = [];
 
@@ -460,7 +461,7 @@ class Shell
      * @return int|bool|null
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#the-cakephp-console
      */
-    public function runCommand($argv, $autoMethod = false, $extra = [])
+    public function runCommand(array $argv, bool $autoMethod = false, array $extra = [])
     {
         $command = isset($argv[0]) ? Inflector::underscore($argv[0]) : null;
         $this->OptionParser = $this->getOptionParser();
@@ -498,7 +499,7 @@ class Shell
             return $this->$method(...$this->args);
         }
 
-        if ($this->hasTask($command) && isset($subcommands[$command])) {
+        if ($command && $this->hasTask($command) && isset($subcommands[$command])) {
             $this->startup();
             array_shift($argv);
 
@@ -526,7 +527,7 @@ class Shell
      *
      * @return void
      */
-    protected function _setOutputLevel()
+    protected function _setOutputLevel(): void
     {
         $this->_io->setLoggers(ConsoleIo::NORMAL);
         if (!empty($this->params['quiet'])) {
@@ -545,7 +546,7 @@ class Shell
      * @param string $command The command to get help for.
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    protected function _displayHelp($command)
+    protected function _displayHelp(string $command)
     {
         $format = 'text';
         if (!empty($this->args[0]) && $this->args[0] === 'xml') {
@@ -584,7 +585,7 @@ class Shell
      * @param string $name The task to get.
      * @return \Cake\Console\Shell Object of Task
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         if (empty($this->{$name}) && in_array($name, $this->taskNames)) {
             $properties = $this->_taskMap[$name];
@@ -604,7 +605,7 @@ class Shell
      * @param string $name The name of the parameter to get.
      * @return string|bool|null Value. Will return null if it doesn't exist.
      */
-    public function param($name)
+    public function param(string $name)
     {
         if (!isset($this->params[$name])) {
             return null;
@@ -622,7 +623,7 @@ class Shell
      * @return mixed Either the default value, or the user-provided input.
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::in
      */
-    public function in($prompt, $options = null, $default = null)
+    public function in(string $prompt, $options = null, $default = null)
     {
         if (!$this->interactive) {
             return $default;
@@ -650,7 +651,7 @@ class Shell
      * @see \Cake\Utility\Text::wrap()
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::wrapText
      */
-    public function wrapText($text, $options = [])
+    public function wrapText(string $text, array $options = [])
     {
         return Text::wrap($text, $options);
     }
@@ -662,7 +663,7 @@ class Shell
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function verbose($message, $newlines = 1)
+    public function verbose($message, int $newlines = 1)
     {
         return $this->_io->verbose($message, $newlines);
     }
@@ -674,7 +675,7 @@ class Shell
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function quiet($message, $newlines = 1)
+    public function quiet($message, int $newlines = 1)
     {
         return $this->_io->quiet($message, $newlines);
     }
@@ -696,7 +697,7 @@ class Shell
      * @return int|bool The number of bytes returned from writing to stdout.
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
-    public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function out($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         return $this->_io->out($message, $newlines, $level);
     }
@@ -709,7 +710,7 @@ class Shell
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stderr.
      */
-    public function err($message = null, $newlines = 1)
+    public function err($message = null, int $newlines = 1)
     {
         return $this->_io->error($message, $newlines);
     }
@@ -723,7 +724,7 @@ class Shell
      * @return int|bool The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
-    public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function info($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         return $this->_io->info($message, $newlines, $level);
     }
@@ -736,7 +737,7 @@ class Shell
      * @return int|bool The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
      */
-    public function warn($message = null, $newlines = 1)
+    public function warn($message = null, int $newlines = 1)
     {
         return $this->_io->warning($message, $newlines);
     }
@@ -750,7 +751,7 @@ class Shell
      * @return int|bool The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
-    public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function success($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         return $this->_io->success($message, $newlines, $level);
     }
@@ -762,7 +763,7 @@ class Shell
      * @return string
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::nl
      */
-    public function nl($multiplier = 1)
+    public function nl(int $multiplier = 1)
     {
         return $this->_io->nl($multiplier);
     }
@@ -775,7 +776,7 @@ class Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::hr
      */
-    public function hr($newlines = 0, $width = 63)
+    public function hr(int $newlines = 0, int $width = 63)
     {
         $this->_io->hr($newlines, $width);
     }
@@ -790,7 +791,7 @@ class Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
      */
-    public function abort($message, $exitCode = self::CODE_ERROR)
+    public function abort(string $message, int $exitCode = self::CODE_ERROR): void
     {
         $this->_io->err('<error>' . $message . '</error>');
         throw new StopException($message, $exitCode);
@@ -821,7 +822,7 @@ class Shell
      * @return bool Success
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#creating-files
      */
-    public function createFile($path, $contents)
+    public function createFile(string $path, string $contents): bool
     {
         $path = str_replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $path);
 
@@ -882,7 +883,7 @@ class Shell
      * @return string short path
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::shortPath
      */
-    public function shortPath($file)
+    public function shortPath(string $file): string
     {
         $shortPath = str_replace(ROOT, null, $file);
         $shortPath = str_replace('..' . DIRECTORY_SEPARATOR, '', $shortPath);
@@ -901,7 +902,7 @@ class Shell
      * @param array $settings Configuration data for the helper.
      * @return \Cake\Console\Helper The created helper instance.
      */
-    public function helper($name, array $settings = [])
+    public function helper(string $name, array $settings = [])
     {
         return $this->_io->helper($name, $settings);
     }
@@ -914,7 +915,7 @@ class Shell
      * @throws \Cake\Console\Exception\StopException
      * @return void
      */
-    protected function _stop($status = self::CODE_SUCCESS)
+    protected function _stop(int $status = self::CODE_SUCCESS): void
     {
         throw new StopException('Halting error reached', $status);
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -651,7 +651,7 @@ class Shell
      * @see \Cake\Utility\Text::wrap()
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::wrapText
      */
-    public function wrapText(string $text, array $options = [])
+    public function wrapText(string $text, $options = [])
     {
         return Text::wrap($text, $options);
     }
@@ -911,7 +911,7 @@ class Shell
      * Stop execution of the current script.
      * Raises a StopException to try and halt the execution.
      *
-     * @param int|string $status see https://secure.php.net/exit for values
+     * @param int $status see https://secure.php.net/exit for values
      * @throws \Cake\Console\Exception\StopException
      * @return void
      */

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -96,7 +97,7 @@ class ShellDispatcher
      * @param string|null $original The original full name for the shell.
      * @return string|false The aliased class name, or false if the alias does not exist
      */
-    public static function alias($short, $original = null)
+    public static function alias(string $short, ?string $original = null)
     {
         $short = Inflector::camelize($short);
         if ($original) {
@@ -111,7 +112,7 @@ class ShellDispatcher
      *
      * @return void
      */
-    public static function resetAliases()
+    public static function resetAliases(): void
     {
         static::$_aliases = [];
     }
@@ -123,7 +124,7 @@ class ShellDispatcher
      * @param array $extra Extra parameters
      * @return int The exit code of the shell process.
      */
-    public static function run($argv, $extra = [])
+    public static function run(array $argv, array $extra = []): int
     {
         $dispatcher = new ShellDispatcher($argv);
 
@@ -136,7 +137,7 @@ class ShellDispatcher
      * @return void
      * @throws \Cake\Core\Exception\Exception
      */
-    protected function _initEnvironment()
+    protected function _initEnvironment(): void
     {
         if (!$this->_bootstrap()) {
             $message = "Unable to load CakePHP core.\nMake sure Cake exists in " . CAKE_CORE_INCLUDE_PATH;
@@ -157,7 +158,7 @@ class ShellDispatcher
      *
      * @return bool Success.
      */
-    protected function _bootstrap()
+    protected function _bootstrap(): bool
     {
         if (!Configure::read('App.fullBaseUrl')) {
             Configure::write('App.fullBaseUrl', 'http://localhost');
@@ -178,7 +179,7 @@ class ShellDispatcher
      * - `requested` : if used, will prevent the Shell welcome message to be displayed
      * @return int The cli command exit code. 0 is success.
      */
-    public function dispatch($extra = [])
+    public function dispatch(array $extra = []): int
     {
         try {
             $result = $this->_dispatch($extra);
@@ -205,7 +206,7 @@ class ShellDispatcher
      * @return bool|int|null
      * @throws \Cake\Console\Exception\MissingShellMethodException
      */
-    protected function _dispatch($extra = [])
+    protected function _dispatch(array $extra = [])
     {
         $shell = $this->shiftArgs();
 
@@ -240,7 +241,7 @@ class ShellDispatcher
      *
      * @return array the resultant list of aliases
      */
-    public function addShortPluginAliases()
+    public function addShortPluginAliases(): array
     {
         $plugins = Plugin::loaded();
 
@@ -317,7 +318,7 @@ class ShellDispatcher
      * @return \Cake\Console\Shell A shell instance.
      * @throws \Cake\Console\Exception\MissingShellException when errors are encountered.
      */
-    public function findShell($shell)
+    public function findShell(string $shell)
     {
         $className = $this->_shellExists($shell);
         if (!$className) {
@@ -340,7 +341,7 @@ class ShellDispatcher
      * @param string $shell Optionally the name of a plugin or alias
      * @return string Shell name with plugin prefix
      */
-    protected function _handleAlias($shell)
+    protected function _handleAlias(string $shell): string
     {
         $aliased = static::alias($shell);
         if ($aliased) {
@@ -358,10 +359,10 @@ class ShellDispatcher
      * @param string $shell The shell name to look for.
      * @return string|bool Either the classname or false.
      */
-    protected function _shellExists($shell)
+    protected function _shellExists(string $shell)
     {
         $class = App::className($shell, 'Shell', 'Shell');
-        if (class_exists($class)) {
+        if ($class && class_exists($class)) {
             return $class;
         }
 
@@ -379,7 +380,7 @@ class ShellDispatcher
     {
         list($plugin) = pluginSplit($shortName);
         $instance = new $className();
-        $instance->plugin = trim($plugin, '.');
+        $instance->plugin = trim((string)$plugin, '.');
 
         return $instance;
     }
@@ -399,7 +400,7 @@ class ShellDispatcher
      *
      * @return void
      */
-    public function help()
+    public function help(): void
     {
         trigger_error(
             'Console help cannot be generated from Shell classes anymore. ' .
@@ -413,7 +414,7 @@ class ShellDispatcher
      *
      * @return void
      */
-    public function version()
+    public function version(): void
     {
         trigger_error(
             'Version information cannot be generated from Shell classes anymore. ' .

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/TestSuite/Stub/ConsoleOutput.php
+++ b/src/TestSuite/Stub/ConsoleOutput.php
@@ -46,7 +46,7 @@ class ConsoleOutput extends ConsoleOutputBase
      * @param int $newlines Number of newlines to append
      * @return void
      */
-    public function write($message, $newlines = 1)
+    public function write($message, int $newlines = 1)
     {
         foreach ((array)$message as $line) {
             $this->_out[] = $line;
@@ -64,7 +64,7 @@ class ConsoleOutput extends ConsoleOutputBase
      *
      * @return array
      */
-    public function messages()
+    public function messages(): array
     {
         return $this->_out;
     }

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -101,23 +102,6 @@ class CommandTest extends TestCase
         $parser = $command->getOptionParser();
         $this->assertInstanceOf(ConsoleOptionParser::class, $parser);
         $this->assertSame('routes show', $parser->getCommand());
-    }
-
-    /**
-     * Test option parser fetching
-     *
-     * @expectedException RuntimeException
-     * @return void
-     */
-    public function testGetOptionParserInvalid()
-    {
-        $command = $this->getMockBuilder(Command::class)
-            ->setMethods(['buildOptionParser'])
-            ->getMock();
-        $command->expects($this->once())
-            ->method('buildOptionParser')
-            ->will($this->returnValue(null));
-        $command->getOptionParser();
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -284,8 +285,6 @@ class ConsoleIoTest extends TestCase
             $newLine = "\r\n";
         }
         $this->assertEquals($this->io->nl(), $newLine);
-        $this->assertEquals($this->io->nl(true), $newLine);
-        $this->assertEquals('', $this->io->nl(false));
         $this->assertEquals($this->io->nl(2), $newLine . $newLine);
         $this->assertEquals($this->io->nl(1), $newLine);
     }
@@ -307,12 +306,7 @@ class ConsoleIoTest extends TestCase
         $this->out->expects($this->at(4))->method('write')->with($bar, 1);
         $this->out->expects($this->at(5))->method('write')->with('', true);
 
-        $this->out->expects($this->at(6))->method('write')->with('', 2);
-        $this->out->expects($this->at(7))->method('write')->with($bar, 1);
-        $this->out->expects($this->at(8))->method('write')->with('', 2);
-
         $this->io->hr();
-        $this->io->hr(true);
         $this->io->hr(2);
     }
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * ConsoleOutputTest file
  *
@@ -60,7 +61,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with('Some output');
 
-        $this->output->write('Some output', false);
+        $this->output->write('Some output', 0);
     }
 
     /**
@@ -146,7 +147,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mError:\033[0m Something bad");
 
-        $this->output->write('<error>Error:</error> Something bad', false);
+        $this->output->write('<error>Error:</error> Something bad', 0);
     }
 
     /**
@@ -159,7 +160,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with('<red> Something bad');
 
-        $this->output->write('<red> Something bad', false);
+        $this->output->write('<red> Something bad', 0);
     }
 
     /**
@@ -179,7 +180,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with("\033[35;46;5;4mAnnoy:\033[0m Something bad");
 
-        $this->output->write('<annoying>Annoy:</annoying> Something bad', false);
+        $this->output->write('<annoying>Annoy:</annoying> Something bad', 0);
     }
 
     /**
@@ -192,7 +193,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with('<not_there>Error:</not_there> Something bad');
 
-        $this->output->write('<not_there>Error:</not_there> Something bad', false);
+        $this->output->write('<not_there>Error:</not_there> Something bad', 0);
     }
 
     /**
@@ -205,7 +206,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
 
-        $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', false);
+        $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', 0);
     }
 
     /**
@@ -218,7 +219,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
 
-        $this->output->write('<error>Bad</error> <error>Warning</error> Regular', false);
+        $this->output->write('<error>Bad</error> <error>Warning</error> Regular', 0);
     }
 
     /**
@@ -232,7 +233,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with('<error>Bad</error> Regular');
 
-        $this->output->write('<error>Bad</error> Regular', false);
+        $this->output->write('<error>Bad</error> Regular', 0);
     }
 
     /**
@@ -247,18 +248,7 @@ class ConsoleOutputTest extends TestCase
         $this->output->expects($this->once())->method('_write')
             ->with('Bad Regular');
 
-        $this->output->write('<error>Bad</error> Regular', false);
-    }
-
-    /**
-     * test set wrong type.
-     *
-     */
-    public function testSetOutputWrongType()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid output type "Foo".');
-        $this->output->setOutputAs('Foo');
+        $this->output->write('<error>Bad</error> Regular', 0);
     }
 
     /**
@@ -269,9 +259,10 @@ class ConsoleOutputTest extends TestCase
     public function testSetOutputAsPlainSelectiveTagRemoval()
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())
+            ->method('_write')
             ->with('Bad Regular <b>Left</b> <i>behind</i> <name>');
 
-        $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', false);
+        $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', 0);
     }
 }

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * HelpFormatterTest file
  *
@@ -306,20 +307,6 @@ xml;
         $result = $formatter->text();
         $expected = 'foo mycommand [-h]';
         $this->assertContains($expected, $result);
-    }
-
-    /**
-     * Tests that setting a none string help alias triggers an exception
-     *
-     * @return void
-     */
-    public function testWithNoneStringHelpAlias()
-    {
-        $this->expectException(\Cake\Console\Exception\ConsoleException::class);
-        $this->expectExceptionMessage('Alias must be of type string.');
-        $parser = new ConsoleOptionParser('mycommand', false);
-        $formatter = new HelpFormatter($parser);
-        $formatter->setAlias(['foo']);
     }
 
     /**

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -1042,8 +1043,10 @@ TEXT;
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->disableOriginalConstructor()
             ->getMock();
-
         $parser->expects($this->once())->method('help');
+        $parser->method('parse')
+            ->will($this->returnValue([[], []]));
+
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->never())->method('hr');
@@ -1071,8 +1074,10 @@ TEXT;
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->disableOriginalConstructor()
             ->getMock();
-
         $parser->expects($this->once())->method('help');
+        $parser->method('parse')
+            ->will($this->returnValue([[], []]));
+
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->_io->expects($this->exactly(2))->method('err');

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -51,7 +51,7 @@ class ShellTestShell extends Shell
      * @param int $status
      * @return void
      */
-    protected function _stop($status = Shell::CODE_SUCCESS): void
+    protected function _stop(int $status = Shell::CODE_SUCCESS): void
     {
         $this->stopped = $status;
     }

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -51,7 +51,7 @@ class ShellTestShell extends Shell
      * @param int $status
      * @return void
      */
-    protected function _stop($status = Shell::CODE_SUCCESS)
+    protected function _stop($status = Shell::CODE_SUCCESS): void
     {
         $this->stopped = $status;
     }

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -30,7 +30,7 @@ class TestingDispatchShell extends Shell
         $this->out('<info>Welcome to CakePHP Console</info>');
     }
 
-    public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function out($message = null, int $newlines = 1, int $level = Shell::NORMAL)
     {
         echo $message . "\n";
     }


### PR DESCRIPTION
Fix various typing related failures/errors and add strict_types to all classes and test case files.

I opted to not add types to commonly used hook methods on `Shell` and `Command` because I thought they would cause unnecessary noise/breakage in applications as they upgrade for effectively no value. I'm happy to reconsider that position though.

I was able to remove a few tests as I see no value in ensuring that PHP's TypeErrors work anymore.

Refs #11935 