### PR TITLE
Make TranslateBehavior use the same locator as AssociationCollection.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -108,6 +108,8 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
         if (isset($config['tableLocator'])) {
             $this->_tableLocator = $config['tableLocator'];
+        } else {
+            $this->_tableLocator = $table->associations()->getTableLocator();
         }
 
         parent::__construct($table, $config);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -18,6 +18,7 @@ use Cake\Collection\Collection;
 use Cake\I18n\I18n;
 use Cake\ORM\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
+use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 
@@ -1781,5 +1782,50 @@ class TranslateBehaviorTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $entity->getError('es'));
+    }
+
+    /**
+     * Test that the behavior uses associations' locator.
+     *
+     * @return void
+     */
+    public function testDefaultTableLocator()
+    {
+        $locator = new TableLocator();
+
+        $table = $locator->get('Articles');
+        $table->addBehavior('Translate', [
+            'fields' => ['title', 'body'],
+            'validator' => 'custom'
+        ]);
+
+        $behaviorLocator = $table->behaviors()->get('Translate')->getTableLocator();
+
+        $this->assertSame($locator, $behaviorLocator);
+        $this->assertSame($table->associations()->getTableLocator(), $behaviorLocator);
+        $this->assertNotSame($this->getTableLocator(), $behaviorLocator);
+    }
+
+    /**
+     * Test that the behavior uses a custom locator.
+     *
+     * @return void
+     */
+    public function testCustomTableLocator()
+    {
+        $locator = new TableLocator();
+
+        $table = $this->getTableLocator()->get('Articles');
+        $table->addBehavior('Translate', [
+            'fields' => ['title', 'body'],
+            'validator' => 'custom',
+            'tableLocator' => $locator,
+        ]);
+
+        $behaviorLocator = $table->behaviors()->get('Translate')->getTableLocator();
+
+        $this->assertSame($locator, $behaviorLocator);
+        $this->assertNotSame($table->associations()->getTableLocator(), $behaviorLocator);
+        $this->assertNotSame($this->getTableLocator(), $behaviorLocator);
     }
 }


### PR DESCRIPTION
`TranslateBehavior` should use the same `LocatorInterface` instance for creating it's associations as the one the table's `AssociationCollection` uses.