### PR TITLE
Use setDirty(field) as true by default as the name suggest.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -805,10 +805,10 @@ trait EntityTrait
      *
      * @param string $property the field to set or check status for
      * @param bool $isDirty true means the property was changed, false means
-     * it was not changed
+     * it was not changed. Defaults to true.
      * @return $this
      */
-    public function setDirty($property, $isDirty)
+    public function setDirty($property, $isDirty = true)
     {
         if ($isDirty === false) {
             unset($this->_dirty[$property]);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -812,7 +812,7 @@ class EntityTest extends TestCase
         ], ['markClean' => true]);
 
         $this->assertFalse($entity->isDirty());
-        $this->assertSame($entity, $entity->setDirty('title', true));
+        $this->assertSame($entity, $entity->setDirty('title'));
         $this->assertSame($entity, $entity->setDirty('id', false));
 
         $entity->setErrors(['title' => ['badness']]);


### PR DESCRIPTION
When we split the methods, this small oversight has been left.
I guess from the implicit meaning of the method name it is clear that the default of setDirty() should be setting it to dirty. As such we can add this default.
It is BC.

I used it as 

    $releaseElement->setDirty('branch');

and was wondering why the 2nd argument here was required.