### PR TITLE
Convert command objects to class name strings for HelpCommand output.

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -86,6 +86,9 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     {
         $invert = [];
         foreach ($commands as $name => $class) {
+            if (is_object($class)) {
+                $class = get_class($class);
+            }
             if (!isset($invert[$class])) {
                 $invert[$class] = [];
             }
@@ -93,6 +96,9 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
         }
 
         foreach ($commands as $name => $class) {
+            if (is_object($class)) {
+                $class = get_class($class);
+            }
             if (count($invert[$class]) == 1) {
                 $io->out('- ' . $name);
             }
@@ -125,6 +131,9 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     {
         $shells = new SimpleXMLElement('<shells></shells>');
         foreach ($commands as $name => $class) {
+            if (is_object($class)) {
+                $class = get_class($class);
+            }
             $shell = $shells->addChild('shell');
             $shell->addAttribute('name', $name);
             $shell->addAttribute('call_as', $name);

--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -76,6 +76,7 @@ class HelpCommandTest extends ConsoleIntegrationTestCase
         $this->assertOutputContains('- test_plugin.sample', 'Long plugin name');
         $this->assertOutputContains('- routes', 'core shell');
         $this->assertOutputContains('- example', 'short plugin name');
+        $this->assertOutputContains('- abort', 'command object');
         $this->assertOutputContains('To run a command', 'more info present');
         $this->assertOutputContains('To get help', 'more info present');
     }

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -29,7 +29,7 @@ class Application extends BaseApplication
     public function console($commands)
     {
         return $commands
-            ->add('abort_command', AbortCommand::class)
+            ->add('abort_command', new AbortCommand())
             ->addMany($commands->autoDiscover());
     }
 


### PR DESCRIPTION
An attempt to fix #12262