### PR TITLE
FileEngine Compression

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -67,7 +67,8 @@ class FileEngine extends CacheEngine
         'path' => null,
         'prefix' => 'cake_',
         'probability' => 100,
-        'serialize' => true
+        'serialize' => true,
+        'compression' => false,
     ];
 
     /**
@@ -149,6 +150,10 @@ class FileEngine extends CacheEngine
             }
         }
 
+        if ($this->_config['compression']) {
+            $data = gzcompress($data, 3);
+        }
+
         $duration = $this->_config['duration'];
         $expires = time() + $duration;
         $contents = implode([$expires, $lineBreak, $data, $lineBreak]);
@@ -210,6 +215,13 @@ class FileEngine extends CacheEngine
 
         if ($this->_config['lock']) {
             $this->_File->flock(LOCK_UN);
+        }
+
+        if ($this->_config['compression']) {
+            // check if previous cache was compressed and uncompress it
+            if (($uncompressed = @gzuncompress($data)) !== false) {
+                $data = $uncompressed;
+            }
         }
 
         $data = trim($data);

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -641,4 +641,32 @@ class FileEngineTest extends TestCase
         $result = Cache::add('test_add_key', 'test data 2', 'file_test');
         $this->assertFalse($result);
     }
+
+    /**
+     * Test reading and writing to the compressed cache.
+     *
+     * @return void
+     * @expectedException \PHPUnit\Framework\Error\Error
+     */
+    public function testReadAndwriteCompressed()
+    {
+        $this->_configCache(['compression' => true]);
+
+        $result = Cache::read('test', 'file_test');
+        $this->assertFalse($result);
+
+        $data = 'this is a test of the emergency broadcasting system';
+        $result = Cache::write('test', $data,'file_test');
+        $this->assertFileExists(TMP . 'tests/cake_test');
+
+        $result = Cache::read('test', 'file_test');
+        $expecting = $data;
+        $this->assertEquals($expecting, $result);
+
+        // read without compression
+        $this->_configCache(['compression' => false]);
+        $result = Cache::read('test', 'file_test');
+
+        Cache::delete('test', 'file_test');
+    }
 }

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -656,7 +656,7 @@ class FileEngineTest extends TestCase
         $this->assertFalse($result);
 
         $data = 'this is a test of the emergency broadcasting system';
-        $result = Cache::write('test', $data,'file_test');
+        $result = Cache::write('test', $data, 'file_test');
         $this->assertFileExists(TMP . 'tests/cake_test');
 
         $result = Cache::read('test', 'file_test');


### PR DESCRIPTION
Cache FileEngine compress files before write.
from 50% to 90% file size saved