### PR TITLE
Fix `BreadcrumbsHelper` property annotation.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -56,7 +56,7 @@ use RuntimeException;
  * `plugins/SuperHot/Template/Posts/index.ctp`. If a theme template
  * is not found for the current action the default app template file is used.
  *
- * @property \Cake\View\Helper\BreadCrumbsHelper $BreadCrumbs
+ * @property \Cake\View\Helper\BreadcrumbsHelper $Breadcrumbs
  * @property \Cake\View\Helper\FlashHelper $Flash
  * @property \Cake\View\Helper\FormHelper $Form
  * @property \Cake\View\Helper\HtmlHelper $Html


### PR DESCRIPTION
The actual classname uses a lowercase `c`.