### PR TITLE
Remove recent deprecations from 3.x

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -458,16 +458,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      *  passed as an array of strings, array of expression objects, or a single string. See
      *  the examples above for the valid call types.
      * @param bool $overwrite whether to reset tables with passed list or not
-     * @return $this|array
+     * @return $this
      */
     public function from($tables = [], $overwrite = false)
     {
-        if (empty($tables)) {
-            deprecationWarning('Using Query::from() to read state is deprecated. Use clause("from") instead.');
-
-            return $this->_parts['from'];
-        }
-
         $tables = (array)$tables;
 
         if ($overwrite) {
@@ -565,16 +559,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset joins with passed list or not
      * @see \Cake\Database\Type
-     * @return $this|array
+     * @return $this
      */
     public function join($tables = null, $types = [], $overwrite = false)
     {
-        if ($tables === null) {
-            deprecationWarning('Using Query::join() to read state is deprecated. Use clause("join") instead.');
-
-            return $this->_parts['join'];
-        }
-
         if (is_string($tables) || isset($tables['table'])) {
             $tables = [$tables];
         }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -561,41 +561,17 @@ class RouteBuilder
      * the current RouteBuilder instance.
      *
      * @param string $name The plugin name
-     * @param string $file The routes file to load. Defaults to `routes.php`. This parameter
-     *   is deprecated and will be removed in 4.0
      * @return void
      * @throws \Cake\Core\Exception\MissingPluginException When the plugin has not been loaded.
      * @throws \InvalidArgumentException When the plugin does not have a routes file.
      */
-    public function loadPlugin($name, $file = 'routes.php')
+    public function loadPlugin($name)
     {
         $plugins = Plugin::getCollection();
         if (!$plugins->has($name)) {
             throw new MissingPluginException(['plugin' => $name]);
         }
         $plugin = $plugins->get($name);
-
-        // @deprecated This block should be removed in 4.0
-        if ($file !== 'routes.php') {
-            deprecationWarning(
-                'Loading plugin routes now uses the routes() hook method on the plugin class. ' .
-                'Loading non-standard files will be removed in 4.0'
-            );
-
-            $path = $plugin->getConfigPath() . DIRECTORY_SEPARATOR . $file;
-            if (!file_exists($path)) {
-                throw new InvalidArgumentException(sprintf(
-                    'Cannot load routes for the plugin named %s. The %s file does not exist.',
-                    $name,
-                    $path
-                ));
-            }
-
-            $routes = $this;
-            include $path;
-
-            return;
-        }
         $plugin->routes($this);
 
         // Disable the routes hook to prevent duplicate route issues.

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4278,28 +4278,6 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Test join read mode
-     *
-     * @deprecated
-     * @return void
-     */
-    public function testJoinReadMode()
-    {
-        $this->loadFixtures('Articles');
-        $query = new Query($this->connection);
-        $query->select(['id', 'title'])
-            ->from('articles')
-            ->join(['authors' => [
-                'type' => 'INNER',
-                'conditions' => ['articles.author_id = authors.id']
-            ]]);
-
-        $this->deprecated(function () use ($query) {
-            $this->assertArrayHasKey('authors', $query->join());
-        });
-    }
-
-    /**
      * Tests that types in the type map are used in the
      * specific comparison functions when using a callable
      *

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -1174,22 +1174,6 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
-     * Test loading routes from a missing file
-     *
-     * @return void
-     */
-    public function testLoadPluginBadFile()
-    {
-        $this->deprecated(function () {
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('Cannot load routes for the plugin named TestPlugin.');
-            Plugin::load('TestPlugin');
-            $routes = new RouteBuilder($this->collection, '/');
-            $routes->loadPlugin('TestPlugin', 'nope.php');
-        });
-    }
-
-    /**
      * Test loading routes with success
      *
      * @return void


### PR DESCRIPTION
I did a merge with 3.next and some new deprecated things need to be cleared out.