### PR TITLE
Show deprecated warning only if session handler found in Network/Session namespace

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -257,8 +257,10 @@ class Session
         $className = App::className($class, 'Http/Session');
 
         if (!$className) {
-            deprecationWarning('Session adapters should be moved to the Http/Session namespace.');
             $className = App::className($class, 'Network/Session');
+            if ($className) {
+                deprecationWarning('Session adapters should be moved to the Http/Session namespace.');
+            }
         }
         if (!$className) {
             throw new InvalidArgumentException(

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -534,13 +534,10 @@ class SessionTest extends TestCase
      */
     public function testBadEngine()
     {
-        // Not actually deprecated, but we need to supress the deprecation warning.
-        $this->deprecated(function () {
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
-            $session = new Session();
-            $session->engine('Derp');
-        });
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
+        $session = new Session();
+        $session->engine('Derp');
     }
 
     /**


### PR DESCRIPTION
If session engine was set to invalid name, it threw deprecated warning + not found errors.

Emit deprecated warning only if session handler found in Network/Session namespace

