### PR TITLE
Don't set testNow on all the things.

### DIFF
--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -33,7 +33,6 @@ class TimeTest extends TestCase
     {
         parent::setUp();
         $this->now = Time::getTestNow();
-        $this->frozenNow = FrozenTime::getTestNow();
         $this->locale = Time::getDefaultLocale();
         Time::setDefaultLocale('en_US');
         FrozenTime::setDefaultLocale('en_US');
@@ -52,7 +51,6 @@ class TimeTest extends TestCase
         Time::resetToStringFormat();
         Time::setJsonEncodeFormat("yyyy-MM-dd'T'HH:mm:ssxxx");
 
-        FrozenTime::setTestNow($this->frozenNow);
         FrozenTime::setDefaultLocale($this->locale);
         FrozenTime::resetToStringFormat();
         FrozenTime::setJsonEncodeFormat("yyyy-MM-dd'T'HH:mm:ssxxx");
@@ -682,7 +680,7 @@ class TimeTest extends TestCase
      */
     public function testDiffForHumansAbsolute($class)
     {
-        $class::setTestNow(new $class('2015-12-12 10:10:10'));
+        Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year', $time->diffForHumans(null, ['absolute' => true]));
 
@@ -701,7 +699,7 @@ class TimeTest extends TestCase
      */
     public function testDiffForHumansNow($class)
     {
-        $class::setTestNow(new $class('2015-12-12 10:10:10'));
+        Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year ago', $time->diffForHumans());
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -126,9 +126,6 @@ Log::setConfig([
 ]);
 
 Chronos::setTestNow(Chronos::now());
-MutableDateTime::setTestNow(MutableDateTime::now());
-Date::setTestNow(Date::now());
-MutableDate::setTestNow(MutableDate::now());
 
 ini_set('intl.default_locale', 'en_US');
 ini_set('session.gc_divisor', '1');


### PR DESCRIPTION
With new chronos we don't need to modify all 4 classes as the testNow is shared. This will require the fixes from cakephp/chronos#174 as well.