### PR TITLE
Restrict phpstan to 0.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
 
   - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
-  - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:^0.9 && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src; fi
+  - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan:0.9.*" && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src; fi
 
 after_success:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
The new version of phpstan while great results in a bunch of errors/warnings we need to address. This gets us back to a passing build on master.
