### PR TITLE
Load cakephp-plugins when searching paths.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -109,6 +109,8 @@ class PluginCollection implements Iterator, Countable
      */
     public function findPath($name)
     {
+        $this->loadConfig();
+
         $path = Configure::read('plugins.' . $name);
         if ($path) {
             return $path;

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -148,6 +148,28 @@ class PluginCollectionTest extends TestCase
         $this->assertEquals(TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS, $path);
     }
 
+    public function testFindPathLoadsConfigureData()
+    {
+        $configPath = ROOT . DS . 'cakephp-plugins.php';
+        $this->skipIf(file_exists($configPath), 'cakephp-plugins.php exists, skipping overwrite');
+        $file = <<<PHP
+<?php
+return [
+    'plugins' => [
+        'TestPlugin' => '/config/path'
+    ]
+];
+PHP;
+        file_put_contents($configPath, $file);
+
+        Configure::delete('plugins');
+        $plugins = new PluginCollection();
+        $path = $plugins->findPath('TestPlugin');
+        unlink($configPath);
+
+        $this->assertEquals('/config/path', $path);
+    }
+
     public function testFindPathConfigureData()
     {
         Configure::write('plugins', ['TestPlugin' => '/some/path']);


### PR DESCRIPTION
In test suites the plugins key is cleared, while the runtime loaded plugins are not for compatibility reasons. This requires us to re-load the configuration file to restore path information.

Refs #12288