### PR TITLE
Handle data attachments without warnings.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1833,7 +1833,7 @@ class Email implements JsonSerializable, Serializable
                     $name = basename($fileInfo['file']);
                 }
             }
-            if (!isset($fileInfo['mimetype']) && function_exists('mime_content_type')) {
+            if (!isset($fileInfo['mimetype']) && isset($fileInfo['file']) && function_exists('mime_content_type')) {
                 $fileInfo['mimetype'] = mime_content_type($fileInfo['file']);
             }
             if (!isset($fileInfo['mimetype'])) {

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -857,7 +857,7 @@ class EmailTest extends TestCase
      *
      * @return void
      */
-    public function testAttachments()
+    public function testSetAttachments()
     {
         $this->Email->setAttachments(CAKE . 'basics.php');
         $expected = [
@@ -889,6 +889,26 @@ class EmailTest extends TestCase
         $this->assertSame($expected, $this->Email->getAttachments());
         $this->expectException(\InvalidArgumentException::class);
         $this->Email->setAttachments([['nofile' => CAKE . 'basics.php', 'mimetype' => 'text/plain']]);
+    }
+
+    /**
+     * Test send() with no template and data string attachment and no mimetype
+     *
+     * @return void
+     */
+    public function testSetAttachmentDataNoMimetype()
+    {
+        $this->Email->setAttachments(['cake.icon.gif' => [
+            'data' => 'test',
+        ]]);
+        $result = $this->Email->getAttachments();
+        $expected = [
+            'cake.icon.gif' => [
+                'data' => base64_encode('test') . "\r\n",
+                'mimetype' => 'application/octet-stream'
+            ],
+        ];
+        $this->assertSame($expected, $this->Email->getAttachments());
     }
 
     /**
@@ -1317,7 +1337,6 @@ class EmailTest extends TestCase
      *
      * @return void
      */
-
     public function testSendNoTemplateWithDataStringAttachment()
     {
         $this->Email->setTransport('debug');


### PR DESCRIPTION
Don't attempt to detect mimetypes on 'data' attachments.

Refs #12297
