### PR TITLE
MultiCheckboxWidget should use checkboxWrapper, not radioWrapper.

### DIFF
--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -191,7 +191,7 @@ class MultiCheckboxWidget implements WidgetInterface
             )
         ]);
 
-        if ($checkbox['label'] === false && strpos($this->_templates->get('radioWrapper'), '{{input}}') === false) {
+        if ($checkbox['label'] === false && strpos($this->_templates->get('checkboxWrapper'), '{{input}}') === false) {
             $label = $input;
         } else {
             $labelAttrs = [

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -370,6 +370,77 @@ class MultiCheckboxWidgetTest extends TestCase
     }
 
     /**
+     * Test label = false with checkboxWrapper option.
+     *
+     * @return void
+     */
+    public function testNoLabelWithCheckboxWrapperOption()
+    {
+        $data = [
+            'label' => false,
+            'name' => 'test',
+            'options' => [
+                1 => 'A',
+                2 => 'B',
+            ],
+        ];
+
+        $label = new LabelWidget($this->templates);
+        $input = new MultiCheckboxWidget($this->templates, $label);
+        $result = $input->render($data, $this->context);
+        $expected = [
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => 1,
+                'id' => 'test-1',
+            ]],
+            ['label' => ['for' => 'test-1']],
+            'A',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => '2',
+                'id' => 'test-2',
+            ]],
+            ['label' => ['for' => 'test-2']],
+            'B',
+            '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $templates = [
+            'checkboxWrapper' => '<div class="checkbox">{{label}}</div>',
+        ];
+        $this->templates->add($templates);
+        $result = $input->render($data, $this->context);
+        $expected = [
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => 1,
+                'id' => 'test-1',
+            ]],
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => '2',
+                'id' => 'test-2',
+            ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test render with groupings.
      *
      * @return void


### PR DESCRIPTION
The current code seems incorrect to me, as MultiCheckboxWidget checks radioWrapper not checkboxWrapper. But I am not sure whether my fix is correct or not, as values of 'options' are not rendered when 'label' => false and 'checkboxWrapper' doesn't contain '{{input}}'. Is this correct?