### PR TITLE
Corrected annotation for Debugger::exportVar() method.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -486,7 +486,7 @@ class Debugger
      * This is done to protect database credentials, which could be accidentally
      * shown in an error message if CakePHP is deployed in development mode.
      *
-     * @param string $var Variable to convert.
+     * @param mixed $var Variable to convert.
      * @param int $depth The depth to output to. Defaults to 3.
      * @return string Variable as a formatted string
      */


### PR DESCRIPTION
`Debugger::exportVar()` in fact accepts any variables, not only strings. See annotations for `_export()` function in the same class.
