### PR TITLE
Stick to normal php min versioning.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "source": "https://github.com/cakephp/cakephp"
     },
     "require": {
-        "php": ">=7.1.0,<7.3.0",
+        "php": ">=7.1.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "cakephp/chronos": "^1.0.1",


### PR DESCRIPTION
We should stick to normal PHP min versioning.
The minors in PHP usually are rather compatible, and restricting here only creates hazzle later on.

IDEs also dont like this much, as I had to discover.