### PR TITLE
Don't blow up client operations when we get invalid cookies.

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -381,15 +381,19 @@ class CookieCollection implements IteratorAggregate, Countable
                 $expires = null;
             }
 
-            $cookies[] = new Cookie(
-                $name,
-                $cookie['value'],
-                $expires,
-                $cookie['path'],
-                $cookie['domain'],
-                $cookie['secure'],
-                $cookie['httponly']
-            );
+            try {
+                $cookies[] = new Cookie(
+                    $name,
+                    $cookie['value'],
+                    $expires,
+                    $cookie['path'],
+                    $cookie['domain'],
+                    $cookie['secure'],
+                    $cookie['httponly']
+                );
+            } catch (Exception $e) {
+                // Don't blow up on invalid cookies
+            }
         }
 
         return $cookies;

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -264,6 +264,23 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test adding cookies from a response ignores empty headers
+     *
+     * @return void
+     */
+    public function testAddFromResponseIgnoreEmpty()
+    {
+        $collection = new CookieCollection();
+        $request = new ServerRequest([
+            'url' => '/app'
+        ]);
+        $response = (new Response())
+            ->withAddedHeader('Set-Cookie', '');
+        $new = $collection->addFromResponse($response, $request);
+        $this->assertCount(0, $new, 'no cookies parsed');
+    }
+
+    /**
      * Test adding cookies from a response ignores expired cookies
      *
      * @return void


### PR DESCRIPTION
The internet is a dangerous place for http clients. Ignore more varieties of invalid cookies.

Refs #12311