### PR TITLE
Fix match() not enabling multibyte patterns.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -742,7 +742,7 @@ class Route
         // check patterns for routed params
         if (!empty($this->options)) {
             foreach ($this->options as $key => $pattern) {
-                if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#', $url[$key])) {
+                if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', $url[$key])) {
                     return false;
                 }
             }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -505,7 +505,7 @@ class RouteTest extends TestCase
      *
      * @return void
      */
-    public function testRouteCompilingWithUnicodePatterns()
+    public function testCompileWithUnicodePatterns()
     {
         $route = new Route(
             '/test/:slug',
@@ -1050,36 +1050,23 @@ class RouteTest extends TestCase
     }
 
     /**
-     * Test that match() pulls out extra arguments as query string params.
+     * Test that match() with multibyte pattern
      *
      * @return void
      */
-    public function testMatchExtractQueryStringArgs()
+    public function testMatchWithMultibytePattern()
     {
-        $route = new Route('/:controller/:action/*');
+        $route = new Route(
+            '/articles/:action/:id',
+            ['controller' => 'Articles'],
+            ['multibytePattern' => true, 'id' => '\pL+']
+        );
         $result = $route->match([
-            'controller' => 'posts',
-            'action' => 'index',
-            'page' => 1
+            'controller' => 'Articles',
+            'action' => 'view',
+            'id' => "\xC4\x81"
         ]);
-        $this->assertEquals('/posts/index?page=1', $result);
-
-        $result = $route->match([
-            'controller' => 'posts',
-            'action' => 'index',
-            'page' => 0
-        ]);
-        $this->assertEquals('/posts/index?page=0', $result);
-
-        $result = $route->match([
-            'controller' => 'posts',
-            'action' => 'index',
-            1,
-            'page' => 1,
-            'dir' => 'desc',
-            'order' => 'title'
-        ]);
-        $this->assertEquals('/posts/index/1?page=1&dir=desc&order=title', $result);
+        $this->assertEquals("/articles/view/\xC4\x81", $result);
     }
 
     /**


### PR DESCRIPTION
When matching parameter values in reverse routing we should use unicode patterns to make unicode life easier.

Refs #12314