### PR TITLE
More secure default for redirects.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -676,10 +676,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Returns the referring URL for this request.
      *
      * @param string|array|null $default Default URL to use if HTTP_REFERER cannot be read from headers
-     * @param bool $local If true, restrict referring URLs to local server
+     * @param bool $local If false, do not restrict referring URLs to local server. Careful with trusting external sources.
      * @return string Referring URL
      */
-    public function referer($default = null, $local = false)
+    public function referer($default = null, $local = true)
     {
         if (!$this->request) {
             return Router::url($default, !$local);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -551,7 +551,7 @@ class ControllerTest extends TestCase
             ->will($this->returnValue('/posts/index'));
 
         $Controller = new Controller($request);
-        $result = $Controller->referer(null, true);
+        $result = $Controller->referer();
         $this->assertEquals('/posts/index', $result);
 
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')
@@ -573,11 +573,11 @@ class ControllerTest extends TestCase
             ->will($this->returnValue('http://localhost/posts/index'));
 
         $Controller = new Controller($request);
-        $result = $Controller->referer();
+        $result = $Controller->referer(null, false);
         $this->assertEquals('http://localhost/posts/index', $result);
 
         $Controller = new Controller(null);
-        $result = $Controller->referer();
+        $result = $Controller->referer(null, false);
         $this->assertEquals('/', $result);
     }
 


### PR DESCRIPTION
Lots of people just have this in their post action code:
```php
return $this->redirect($this->referer(['action' => 'index']));
```

I also found a few of those in my code/apps.

Now that has a few security issues out of the box. You can spoof the referrer to an external untrusted source and maybe exploit the site here.
So I think the sane default should be server internal, and only explicitly set it to allow external URLs.

What do you think?

refs https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet