### PR TITLE
Use cleaner api for Plugin loaded info.

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Core;
 
-use ArgumentCountError;
 use DirectoryIterator;
 
 /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Core;
 
-use Cake\Core\Exception\MissingPluginException;
+use ArgumentCountError;
 use DirectoryIterator;
 
 /**
@@ -285,23 +285,22 @@ class Plugin
     }
 
     /**
-     * Check whether or not a plugin is loaded.
+     * Returns true if the plugin $plugin is already loaded.
      *
-     * @param string $plugin The name of the plugin to check.
+     * @param string $plugin Plugin name.
      * @return bool
      */
-    public static function isLoaded($plugin)
+    public static function isLoaded(string $plugin): bool
     {
         return static::getCollection()->has($plugin);
     }
 
     /**
-     * Return a list of loaded plugins.
+     * Returns a list of all loaded plugins.
      *
-     * @return bool|array Boolean true if $plugin is already loaded.
-     *   If $plugin is null, returns a list of plugins that have been loaded
+     * @return array
      */
-    public static function loaded()
+    public static function loaded(): array
     {
         $names = [];
         foreach (static::getCollection() as $plugin) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1285,7 +1285,7 @@ class View implements EventDispatcherInterface
     {
         $plugin = null;
         list($first, $second) = pluginSplit($name);
-        if (Plugin::isLoaded($first) === true) {
+        if ($first && Plugin::isLoaded($first)) {
             $name = $second;
             $plugin = $first;
         }


### PR DESCRIPTION
We need a cleaner API here.
These "god-getters" of both scalar and multiple depending on first arg are a bad idea.
They prevent typehinting, they also correctly make PHPStan and tooling complain a lot here.
You are forced to cast everywhere in code in current 3.x.

This would fix it with a clear message in case you didnt adjust code.

What do you think?
Then I can adjust the tests.