### PR TITLE
Add typehinting to Configure class. Cleaner API.

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -78,10 +78,10 @@ class Configure
      * @param string|array $config The key to write, can be a dot notation value.
      * Alternatively can be an array containing key(s) and value(s).
      * @param mixed $value Value to set for var
-     * @return bool True if write was successful
+     * @return void
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#writing-configuration-data
      */
-    public static function write($config, $value = null)
+    public static function write($config, $value = null): void
     {
         if (!is_array($config)) {
             $config = [$config => $value];
@@ -99,8 +99,6 @@ class Configure
                 ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
         }
-
-        return true;
     }
 
     /**
@@ -118,7 +116,7 @@ class Configure
      * @return mixed Value stored in configure, or null.
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#reading-configuration-data
      */
-    public static function read($var = null, $default = null)
+    public static function read(?string $var = null, $default = null)
     {
         if ($var === null) {
             return static::$_values;
@@ -133,7 +131,7 @@ class Configure
      * @param string $var Variable name to check for
      * @return bool True if variable is there
      */
-    public static function check($var)
+    public static function check(string $var): bool
     {
         if (empty($var)) {
             return false;
@@ -161,7 +159,7 @@ class Configure
      * @throws \RuntimeException if the requested configuration is not set.
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#reading-configuration-data
      */
-    public static function readOrFail($var)
+    public static function readOrFail(string $var)
     {
         if (static::check($var) === false) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
@@ -183,7 +181,7 @@ class Configure
      * @return void
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#deleting-configuration-data
      */
-    public static function delete($var)
+    public static function delete(string $var): void
     {
         static::$_values = Hash::remove(static::$_values, $var);
     }
@@ -201,7 +199,7 @@ class Configure
      * @throws \RuntimeException if the requested configuration is not set.
      * @since 3.6.0
      */
-    public static function consumeOrFail($var)
+    public static function consumeOrFail(string $var)
     {
         if (static::check($var) === false) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
@@ -219,7 +217,7 @@ class Configure
      * @param string $var The key to read and remove.
      * @return array|string|null
      */
-    public static function consume($var)
+    public static function consume(string $var)
     {
         if (strpos($var, '.') === false) {
             if (!isset(static::$_values[$var])) {
@@ -252,19 +250,9 @@ class Configure
      * @param \Cake\Core\Configure\ConfigEngineInterface $engine The engine to append.
      * @return void
      */
-    public static function config($name, ConfigEngineInterface $engine)
+    public static function config(string $name, ConfigEngineInterface $engine): void
     {
         static::$_engines[$name] = $engine;
-    }
-
-    /**
-     * Gets the names of the configured Engine objects.
-     *
-     * @return array|bool Array of the configured Engine objects, bool for specific name.
-     */
-    public static function configured()
-    {
-        return array_keys(static::$_engines);
     }
 
     /**
@@ -273,11 +261,20 @@ class Configure
      * @param string $name Engine name.
      * @return bool
      */
-    public static function isConfigured($name)
+    public static function isConfigured(string $name): bool
     {
         return isset(static::$_engines[$name]);
     }
 
+    /**
+     * Gets the names of the configured Engine objects.
+     *
+     * @return array
+     */
+    public static function configured(): array
+    {
+        return array_keys(static::$_engines);
+    }
     /**
      * Remove a configured engine. This will unset the engine
      * and make any future attempts to use it cause an Exception.
@@ -285,7 +282,7 @@ class Configure
      * @param string $name Name of the engine to drop.
      * @return bool Success
      */
-    public static function drop($name)
+    public static function drop(string $name): bool
     {
         if (!isset(static::$_engines[$name])) {
             return false;
@@ -321,7 +318,7 @@ class Configure
      * @return bool False if file not found, true if load successful.
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#reading-and-writing-configuration-files
      */
-    public static function load($key, $config = 'default', $merge = true)
+    public static function load(string $key, string $config = 'default', bool $merge = true): bool
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
@@ -333,7 +330,9 @@ class Configure
             $values = Hash::merge(static::$_values, $values);
         }
 
-        return static::write($values);
+        static::write($values);
+
+        return true;
     }
 
     /**
@@ -365,7 +364,7 @@ class Configure
      * @return bool Success
      * @throws \Cake\Core\Exception\Exception if the adapter does not implement a `dump` method.
      */
-    public static function dump($key, $config = 'default', $keys = [])
+    public static function dump(string $key, string $config = 'default', array $keys = []): bool
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
@@ -384,13 +383,13 @@ class Configure
      * Will create new PhpConfig for default if not configured yet.
      *
      * @param string $config The name of the configured adapter
-     * @return \Cake\Core\Configure\ConfigEngineInterface|false Engine instance or false
+     * @return \Cake\Core\Configure\ConfigEngineInterface Engine instance or null
      */
-    protected static function _getEngine($config)
+    protected static function _getEngine(string $config)
     {
         if (!isset(static::$_engines[$config])) {
             if ($config !== 'default') {
-                return false;
+                return null;
             }
             static::config($config, new PhpConfig());
         }
@@ -408,7 +407,7 @@ class Configure
      *
      * @return string Current version of CakePHP
      */
-    public static function version()
+    public static function version(): string
     {
         if (!isset(static::$_values['Cake']['version'])) {
             $config = require CORE_PATH . 'config/config.php';
@@ -428,7 +427,7 @@ class Configure
      * @param array|null $data Either an array of data to store, or leave empty to store all values.
      * @return bool Success
      */
-    public static function store($name, $cacheConfig = 'default', $data = null)
+    public static function store(string $name, string $cacheConfig = 'default', array $data = null): bool
     {
         if ($data === null) {
             $data = static::$_values;
@@ -445,11 +444,13 @@ class Configure
      * @param string $cacheConfig Name of the Cache configuration to read from.
      * @return bool Success.
      */
-    public static function restore($name, $cacheConfig = 'default')
+    public static function restore(string $name, string $cacheConfig = 'default'): bool
     {
         $values = Cache::read($name, $cacheConfig);
         if ($values) {
-            return static::write($values);
+            static::write($values);
+
+            return true;
         }
 
         return false;
@@ -458,12 +459,10 @@ class Configure
     /**
      * Clear all values stored in Configure.
      *
-     * @return bool success.
+     * @return void
      */
-    public static function clear()
+    public static function clear(): void
     {
         static::$_values = [];
-
-        return true;
     }
 }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -78,10 +78,10 @@ class Configure
      * @param string|array $config The key to write, can be a dot notation value.
      * Alternatively can be an array containing key(s) and value(s).
      * @param mixed $value Value to set for var
-     * @return void
+     * @return bool
      * @link https://book.cakephp.org/3.0/en/development/configuration.html#writing-configuration-data
      */
-    public static function write($config, $value = null): void
+    public static function write($config, $value = null): bool
     {
         if (!is_array($config)) {
             $config = [$config => $value];
@@ -99,6 +99,8 @@ class Configure
                 ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
         }
+
+        return true;
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -135,11 +135,11 @@ class ConfigureTest extends TestCase
      */
     public function testWrite()
     {
-        Configure::write('SomeName.someKey', 'myvalue');
+        $this->assertTrue(Configure::write('SomeName.someKey', 'myvalue'));
         $result = Configure::read('SomeName.someKey');
         $this->assertEquals('myvalue', $result);
 
-        Configure::write('SomeName.someKey', null);
+        $this->assertTrue(Configure::write('SomeName.someKey', null));
         $result = Configure::read('SomeName.someKey');
         $this->assertNull($result);
 

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -135,19 +135,16 @@ class ConfigureTest extends TestCase
      */
     public function testWrite()
     {
-        $writeResult = Configure::write('SomeName.someKey', 'myvalue');
-        $this->assertTrue($writeResult);
+        Configure::write('SomeName.someKey', 'myvalue');
         $result = Configure::read('SomeName.someKey');
         $this->assertEquals('myvalue', $result);
 
-        $writeResult = Configure::write('SomeName.someKey', null);
-        $this->assertTrue($writeResult);
+        Configure::write('SomeName.someKey', null);
         $result = Configure::read('SomeName.someKey');
         $this->assertNull($result);
 
         $expected = ['One' => ['Two' => ['Three' => ['Four' => ['Five' => 'cool']]]]];
-        $writeResult = Configure::write('Key', $expected);
-        $this->assertTrue($writeResult);
+        Configure::write('Key', $expected);
 
         $result = Configure::read('Key');
         $this->assertEquals($expected, $result);
@@ -238,16 +235,16 @@ class ConfigureTest extends TestCase
      */
     public function testCheckingSavedEmpty()
     {
-        $this->assertTrue(Configure::write('ConfigureTestCase', 0));
+        Configure::write('ConfigureTestCase', 0);
         $this->assertTrue(Configure::check('ConfigureTestCase'));
 
-        $this->assertTrue(Configure::write('ConfigureTestCase', '0'));
+        Configure::write('ConfigureTestCase', '0');
         $this->assertTrue(Configure::check('ConfigureTestCase'));
 
-        $this->assertTrue(Configure::write('ConfigureTestCase', false));
+        Configure::write('ConfigureTestCase', false);
         $this->assertTrue(Configure::check('ConfigureTestCase'));
 
-        $this->assertTrue(Configure::write('ConfigureTestCase', null));
+        Configure::write('ConfigureTestCase', null);
         $this->assertFalse(Configure::check('ConfigureTestCase'));
     }
 
@@ -258,11 +255,11 @@ class ConfigureTest extends TestCase
      */
     public function testCheckKeyWithSpaces()
     {
-        $this->assertTrue(Configure::write('Configure Test', 'test'));
+        Configure::write('Configure Test', 'test');
         $this->assertTrue(Configure::check('Configure Test'));
         Configure::delete('Configure Test');
 
-        $this->assertTrue(Configure::write('Configure Test.Test Case', 'test'));
+        Configure::write('Configure Test.Test Case', 'test');
         $this->assertTrue(Configure::check('Configure Test.Test Case'));
     }
 
@@ -274,7 +271,6 @@ class ConfigureTest extends TestCase
     public function testCheckEmpty()
     {
         $this->assertFalse(Configure::check(''));
-        $this->assertFalse(Configure::check(null));
     }
 
     /**
@@ -500,7 +496,7 @@ class ConfigureTest extends TestCase
     public function testClear()
     {
         Configure::write('test', 'value');
-        $this->assertTrue(Configure::clear());
+        Configure::clear();
         $this->assertNull(Configure::read('debug'));
         $this->assertNull(Configure::read('test'));
     }
@@ -587,9 +583,6 @@ class ConfigureTest extends TestCase
         Configure::write('Test', ['key' => 'value', 'key2' => 'value2']);
 
         $result = Configure::consume('');
-        $this->assertNull($result);
-
-        $result = Configure::consume(null);
         $this->assertNull($result);
     }
 


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/12321

- Cleaner API for all configured() vs specific isConfigured() with a clear migration exception.
- void for write and clear (since they always return true and are effectively void), such writing methods should always throw an exception instead, that is way cleaner than silently returning false.
- added typehints where possible

If the API sounds good, I can adjust the tests here and provide a docs migration update.