### PR TITLE
Micro-opt and return type fix.

### DIFF
--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -60,8 +60,9 @@ trait FileConfigTrait
             return $file;
         }
 
-        if (is_file(realpath($file))) {
-            return realpath($file);
+        $realPath = realpath($file);
+        if ($realPath !== false && is_file($realPath)) {
+            return $realPath;
         }
 
         throw new Exception(sprintf('Could not load configuration file: %s', $file));


### PR DESCRIPTION
While looking closer into return types, this issue came up:

realpath() can return string|false

So 
- a) dont call method twice
- b) dont call next method if already false