### PR TITLE
Fix typo on Table save() function documentation demo

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1866,7 +1866,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * ```
      * // Only save the comments association
-     * $articles->save($entity, ['associated' => ['Comments']);
+     * $articles->save($entity, ['associated' => ['Comments']]);
      *
      * // Save the company, the employees and related addresses for each of them.
      * // For employees do not check the entity rules


### PR DESCRIPTION
Fix typo on Table save() function documentation demo