### PR TITLE
Sanitize User Input through Environment Variables

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -228,7 +228,7 @@ if (!function_exists('env')) {
         }
 
         if ($val !== null) {
-            return $val;
+            return filter_var($val, FILTER_SANITIZE_STRING);
         }
 
         switch ($key) {


### PR DESCRIPTION
I recognized that cakephp is returning the variables from the server environment direct and without sanitizing. I'm not sure if that a good idea. Perhaps I'm acting far too cautiously, but in my opinion you should filter the input at least with the filter_var function.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.