### PR TITLE
Add typehint to helpers.

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -68,7 +68,7 @@ class Helper implements EventListenerInterface
     /**
      * The View instance this helper is attached to
      *
-     * @var \Cake\View\View|null
+     * @var \Cake\View\View
      */
     protected $_View;
 
@@ -123,7 +123,7 @@ class Helper implements EventListenerInterface
      *
      * @return \Cake\View\View The bound view instance.
      */
-    public function getView(): ?View
+    public function getView(): View
     {
         return $this->_View;
     }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -67,7 +68,7 @@ class Helper implements EventListenerInterface
     /**
      * The View instance this helper is attached to
      *
-     * @var \Cake\View\View
+     * @var \Cake\View\View|null
      */
     protected $_View;
 
@@ -122,7 +123,7 @@ class Helper implements EventListenerInterface
      *
      * @return \Cake\View\View The bound view instance.
      */
-    public function getView()
+    public function getView(): ?View
     {
         return $this->_View;
     }
@@ -153,11 +154,15 @@ class Helper implements EventListenerInterface
     /**
      * Returns a string read to be used in confirm()
      *
-     * @param string $message The message to clean
-     * @return mixed
+     * @param string|null $message The message to clean
+     * @return string
      */
     protected function _cleanConfirmMessage($message)
     {
+        if ($message === null) {
+            return '';
+        }
+
         return str_replace('\\\n', '\n', json_encode($message));
     }
 
@@ -169,7 +174,7 @@ class Helper implements EventListenerInterface
      * @param string $key the key to use for class.
      * @return array Array of options with $key set.
      */
-    public function addClass(array $options = [], $class = null, $key = 'class')
+    public function addClass(array $options = [], ?string $class = null, string $key = 'class'): array
     {
         if (isset($options[$key]) && is_array($options[$key])) {
             $options[$key][] = $class;
@@ -221,7 +226,7 @@ class Helper implements EventListenerInterface
      * @param array $config The configuration settings provided to this helper.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
     }
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -144,7 +145,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the index is out of bound
      */
-    public function insertAt($index, $title, $url = null, array $options = [])
+    public function insertAt(int $index, string $title, $url = null, array $options = [])
     {
         if (!isset($this->crumbs[$index])) {
             throw new LogicException(sprintf("No crumb could be found at index '%s'", $index));
@@ -173,7 +174,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the matching crumb can not be found
      */
-    public function insertBefore($matchingTitle, $title, $url = null, array $options = [])
+    public function insertBefore(string $matchingTitle, string $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
@@ -202,7 +203,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the matching crumb can not be found.
      */
-    public function insertAfter($matchingTitle, $title, $url = null, array $options = [])
+    public function insertAfter(string $matchingTitle, string $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
@@ -218,7 +219,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @return array
      */
-    public function getCrumbs()
+    public function getCrumbs(): array
     {
         return $this->crumbs;
     }
@@ -249,7 +250,7 @@ class BreadcrumbsHelper extends Helper
      * If you use the default for this option (empty), it will not render a separator.
      * @return string The breadcrumbs trail
      */
-    public function render(array $attributes = [], array $separator = [])
+    public function render(array $attributes = [], array $separator = []): string
     {
         if (!$this->crumbs) {
             return '';

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -68,7 +69,7 @@ class FlashHelper extends Helper
      *   in session.
      * @throws \UnexpectedValueException If value for flash settings key is not an array.
      */
-    public function render($key = 'flash', array $options = [])
+    public function render(string $key = 'flash', array $options = []): ?string
     {
         $session = $this->_View->getRequest()->getSession();
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -224,7 +224,7 @@ class FormHelper extends Helper
     /**
      * Locator for input widgets.
      *
-     * @var \Cake\View\Widget\WidgetLocator|null
+     * @var \Cake\View\Widget\WidgetLocator
      */
     protected $_locator;
 
@@ -306,7 +306,7 @@ class FormHelper extends Helper
      * @return \Cake\View\Widget\WidgetLocator Current locator instance
      * @since 3.6.0
      */
-    public function getWidgetLocator(): ?WidgetLocator
+    public function getWidgetLocator(): WidgetLocator
     {
         return $this->_locator;
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -223,7 +224,7 @@ class FormHelper extends Helper
     /**
      * Locator for input widgets.
      *
-     * @var \Cake\View\Widget\WidgetLocator
+     * @var \Cake\View\Widget\WidgetLocator|null
      */
     protected $_locator;
 
@@ -305,7 +306,7 @@ class FormHelper extends Helper
      * @return \Cake\View\Widget\WidgetLocator Current locator instance
      * @since 3.6.0
      */
-    public function getWidgetLocator()
+    public function getWidgetLocator(): ?WidgetLocator
     {
         return $this->_locator;
     }
@@ -331,7 +332,7 @@ class FormHelper extends Helper
      * @param array $contexts An array of context providers.
      * @return \Cake\View\Form\ContextFactory
      */
-    public function contextFactory(ContextFactory $instance = null, array $contexts = [])
+    public function contextFactory(?ContextFactory $instance = null, array $contexts = []): ContextFactory
     {
         if ($instance === null) {
             if ($this->_contextFactory === null) {
@@ -373,7 +374,7 @@ class FormHelper extends Helper
      * @return string An formatted opening FORM tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#Cake\View\Helper\FormHelper::create
      */
-    public function create($context = null, array $options = [])
+    public function create($context = null, array $options = []): string
     {
         $append = '';
 
@@ -570,7 +571,7 @@ class FormHelper extends Helper
      * @return string A closing FORM tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#closing-the-form
      */
-    public function end(array $secureAttributes = [])
+    public function end(array $secureAttributes = []): string
     {
         $out = '';
 
@@ -605,7 +606,7 @@ class FormHelper extends Helper
      * @return string A hidden input field with a security hash, or empty string when
      *   secured forms are not in use.
      */
-    public function secure(array $fields = [], array $secureAttributes = [])
+    public function secure(array $fields = [], array $secureAttributes = []): string
     {
         if (!$this->_View->getRequest()->getParam('_Token')) {
             return '';
@@ -655,7 +656,7 @@ class FormHelper extends Helper
      * @return array|null Either null, or the list of fields.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#working-with-securitycomponent
      */
-    public function unlockField($name = null)
+    public function unlockField(?string $name = null): ?array
     {
         if ($name === null) {
             return $this->_unlockedFields;
@@ -668,6 +669,8 @@ class FormHelper extends Helper
             unset($this->fields[$index]);
         }
         unset($this->fields[$name]);
+
+        return null;
     }
 
     /**
@@ -725,7 +728,7 @@ class FormHelper extends Helper
      * @return bool If there are errors this method returns true, else false.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#displaying-and-checking-errors
      */
-    public function isFieldError($field)
+    public function isFieldError(string $field): bool
     {
         return $this->_getContext()->hasError($field);
     }
@@ -747,7 +750,7 @@ class FormHelper extends Helper
      * @return string Formatted errors or ''.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#displaying-and-checking-errors
      */
-    public function error($field, $text = null, array $options = [])
+    public function error(string $field, $text = null, array $options = []): string
     {
         if (substr($field, -5) === '._ids') {
             $field = substr($field, 0, -5);
@@ -856,7 +859,7 @@ class FormHelper extends Helper
      * @return string The formatted LABEL element
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-labels
      */
-    public function label($fieldName, $text = null, array $options = [])
+    public function label(string $fieldName, ?string $text = null, array $options = []): string
     {
         if ($text === null) {
             $text = $fieldName;
@@ -924,7 +927,7 @@ class FormHelper extends Helper
      * @return string Completed form controls.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
      */
-    public function allControls(array $fields = [], array $options = [])
+    public function allControls(array $fields = [], array $options = []): string
     {
         $context = $this->_getContext();
 
@@ -960,7 +963,7 @@ class FormHelper extends Helper
      * @return string Completed form inputs.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
      */
-    public function controls(array $fields, array $options = [])
+    public function controls(array $fields, array $options = []): string
     {
         $fields = Hash::normalize($fields);
 
@@ -988,7 +991,7 @@ class FormHelper extends Helper
      *    to customize the legend text.
      * @return string Completed form inputs.
      */
-    public function fieldset($fields = '', array $options = [])
+    public function fieldset(string $fields = '', array $options = []): string
     {
         $fieldset = $legend = true;
         $context = $this->_getContext();
@@ -1057,7 +1060,7 @@ class FormHelper extends Helper
      * @return string Completed form widget.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-form-inputs
      */
-    public function control($fieldName, array $options = [])
+    public function control(string $fieldName, array $options = []): string
     {
         $options += [
             'type' => null,
@@ -1188,7 +1191,7 @@ class FormHelper extends Helper
      *
      * @param string $fieldName the field name
      * @param array $options The options for the input element
-     * @return string The generated input element
+     * @return string|array The generated input element
      */
     protected function _getInput($fieldName, $options)
     {
@@ -1502,7 +1505,7 @@ class FormHelper extends Helper
      * @return string|array An HTML text input element.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-checkboxes
      */
-    public function checkbox($fieldName, array $options = [])
+    public function checkbox(string $fieldName, array $options = [])
     {
         $options += ['hiddenField' => true, 'value' => 1];
 
@@ -1558,7 +1561,7 @@ class FormHelper extends Helper
      * @return string Completed radio widget set.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-radio-buttons
      */
-    public function radio($fieldName, $options = [], array $attributes = [])
+    public function radio(string $fieldName, $options = [], array $attributes = []): string
     {
         $attributes['options'] = $options;
         $attributes['idPrefix'] = $this->_idPrefix;
@@ -1633,7 +1636,7 @@ class FormHelper extends Helper
      * @return string A generated HTML text input element
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-textareas
      */
-    public function textarea($fieldName, array $options = [])
+    public function textarea(string $fieldName, array $options = []): string
     {
         $options = $this->_initInputField($fieldName, $options);
         unset($options['type']);
@@ -1649,7 +1652,7 @@ class FormHelper extends Helper
      * @return string A generated hidden input
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-hidden-inputs
      */
-    public function hidden($fieldName, array $options = [])
+    public function hidden(string $fieldName, array $options = []): string
     {
         $options += ['required' => false, 'secure' => true];
 
@@ -1678,7 +1681,7 @@ class FormHelper extends Helper
      * @return string A generated file input.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-file-inputs
      */
-    public function file($fieldName, array $options = [])
+    public function file(string $fieldName, array $options = []): string
     {
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);
@@ -1704,7 +1707,7 @@ class FormHelper extends Helper
      * @return string A HTML button tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-button-elements
      */
-    public function button($title, array $options = [])
+    public function button(string $title, array $options = []): string
     {
         $options += ['type' => 'submit', 'escape' => false, 'secure' => false, 'confirm' => null];
         $options['text'] = $title;
@@ -1739,7 +1742,7 @@ class FormHelper extends Helper
      * @return string A HTML button tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-standalone-buttons-and-post-links
      */
-    public function postButton($title, $url, array $options = [])
+    public function postButton(string $title, $url, array $options = []): string
     {
         $formOptions = ['url' => $url];
         if (isset($options['method'])) {
@@ -1792,7 +1795,7 @@ class FormHelper extends Helper
      * @return string An `<a />` element.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-standalone-buttons-and-post-links
      */
-    public function postLink($title, $url = null, array $options = [])
+    public function postLink(string $title, $url = null, array $options = []): string
     {
         $options += ['block' => null, 'confirm' => null];
 
@@ -1893,7 +1896,7 @@ class FormHelper extends Helper
      * @return string A HTML submit button
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-buttons-and-submit-elements
      */
-    public function submit($caption = null, array $options = [])
+    public function submit(?string $caption = null, array $options = []): string
     {
         if (!is_string($caption) && empty($caption)) {
             $caption = __d('cake', 'Submit');
@@ -2008,7 +2011,7 @@ class FormHelper extends Helper
      * @see \Cake\View\Helper\FormHelper::multiCheckbox() for creating multiple checkboxes.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-select-pickers
      */
-    public function select($fieldName, $options = [], array $attributes = [])
+    public function select(string $fieldName, $options = [], array $attributes = []): string
     {
         $attributes += [
             'disabled' => null,
@@ -2080,7 +2083,7 @@ class FormHelper extends Helper
      * @return string Formatted SELECT element
      * @see \Cake\View\Helper\FormHelper::select() for supported option formats.
      */
-    public function multiCheckbox($fieldName, $options, array $attributes = [])
+    public function multiCheckbox(string $fieldName, $options, array $attributes = []): string
     {
         $attributes += [
             'disabled' => null,
@@ -2149,7 +2152,7 @@ class FormHelper extends Helper
      * @return string A generated day select box.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-day-inputs
      */
-    public function day($fieldName = null, array $options = [])
+    public function day(?string $fieldName = null, array $options = []): string
     {
         $options = $this->_singleDatetime($options, 'day');
 
@@ -2182,7 +2185,7 @@ class FormHelper extends Helper
      * @return string Completed year select input
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-year-inputs
      */
-    public function year($fieldName, array $options = [])
+    public function year(string $fieldName, array $options = []): string
     {
         $options = $this->_singleDatetime($options, 'year');
 
@@ -2214,7 +2217,7 @@ class FormHelper extends Helper
      * @return string A generated month select dropdown.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-month-inputs
      */
-    public function month($fieldName, array $options = [])
+    public function month(string $fieldName, array $options = []): string
     {
         $options = $this->_singleDatetime($options, 'month');
 
@@ -2244,7 +2247,7 @@ class FormHelper extends Helper
      * @return string Completed hour select input
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-hour-inputs
      */
-    public function hour($fieldName, array $options = [])
+    public function hour(string $fieldName, array $options = []): string
     {
         $options += ['format' => 24];
         $options = $this->_singleDatetime($options, 'hour');
@@ -2279,7 +2282,7 @@ class FormHelper extends Helper
      * @return string Completed minute select input.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-minute-inputs
      */
-    public function minute($fieldName, array $options = [])
+    public function minute(string $fieldName, array $options = []): string
     {
         $options = $this->_singleDatetime($options, 'minute');
 
@@ -2307,7 +2310,7 @@ class FormHelper extends Helper
      * @return string Completed meridian select input
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-meridian-inputs
      */
-    public function meridian($fieldName, array $options = [])
+    public function meridian(string $fieldName, array $options = []): string
     {
         $options = $this->_singleDatetime($options, 'meridian');
 
@@ -2359,7 +2362,7 @@ class FormHelper extends Helper
      * @return string Generated set of select boxes for the date and time formats chosen.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#creating-date-and-time-inputs
      */
-    public function dateTime($fieldName, array $options = [])
+    public function dateTime(string $fieldName, array $options = []): string
     {
         $options += [
             'empty' => true,
@@ -2443,7 +2446,7 @@ class FormHelper extends Helper
             $val = new DateTime();
             $currentYear = $val->format('Y');
             if (isset($options['year']['end']) && $options['year']['end'] < $currentYear) {
-                $val->setDate($options['year']['end'], $val->format('n'), $val->format('j'));
+                $val->setDate((int)$options['year']['end'], (int)$val->format('n'), (int)$val->format('j'));
             }
             $options['val'] = $val;
         }
@@ -2465,7 +2468,7 @@ class FormHelper extends Helper
      * @return string Generated set of select boxes for time formats chosen.
      * @see \Cake\View\Helper\FormHelper::dateTime() for templating options.
      */
-    public function time($fieldName, array $options = [])
+    public function time(string $fieldName, array $options = []): string
     {
         $options += [
             'empty' => true,
@@ -2494,7 +2497,7 @@ class FormHelper extends Helper
      * @return string Generated set of select boxes for time formats chosen.
      * @see \Cake\View\Helper\FormHelper::dateTime() for templating options.
      */
-    public function date($fieldName, array $options = [])
+    public function date(string $fieldName, array $options = []): string
     {
         $options += [
             'empty' => true,
@@ -2604,7 +2607,7 @@ class FormHelper extends Helper
      * @param array $options The option set.
      * @return bool Whether or not the field is disabled.
      */
-    protected function _isDisabled(array $options)
+    protected function _isDisabled($options)
     {
         if (!isset($options['disabled'])) {
             return false;
@@ -2677,7 +2680,7 @@ class FormHelper extends Helper
      *   when the form context is the correct type.
      * @return void
      */
-    public function addContextProvider($type, callable $check)
+    public function addContextProvider(string $type, callable $check): void
     {
         $this->contextFactory()->addProvider($type, $check);
     }
@@ -2690,7 +2693,7 @@ class FormHelper extends Helper
      * @param \Cake\View\Form\ContextInterface|null $context Either the new context when setting, or null to get.
      * @return \Cake\View\Form\ContextInterface The context for the form.
      */
-    public function context($context = null)
+    public function context(?ContextInterface $context = null): ContextInterface
     {
         if ($context instanceof ContextInterface) {
             $this->_context = $context;
@@ -2730,7 +2733,7 @@ class FormHelper extends Helper
      *   name or an object implementing the WidgetInterface.
      * @return void
      */
-    public function addWidget($name, $spec)
+    public function addWidget(string $name, $spec): void
     {
         $this->_locator->add([$name => $spec]);
     }
@@ -2747,7 +2750,7 @@ class FormHelper extends Helper
      * @param array $data The data to render.
      * @return string
      */
-    public function widget($name, array $data = [])
+    public function widget(string $name, array $data = []): string
     {
         $secure = null;
         if (isset($data['secure'])) {
@@ -2772,7 +2775,7 @@ class FormHelper extends Helper
      *
      * @return void
      */
-    public function resetTemplates()
+    public function resetTemplates(): void
     {
         $this->setTemplates($this->_defaultConfig['templates']);
     }
@@ -2794,7 +2797,7 @@ class FormHelper extends Helper
      *
      * @return array List of value sources.
      */
-    public function getValueSources()
+    public function getValueSources(): array
     {
         return $this->_valueSources;
     }
@@ -2820,9 +2823,9 @@ class FormHelper extends Helper
      *
      * @param string $fieldname The fieldname to fetch the value for.
      * @param array|null $options The options containing default values.
-     * @return string|null Field value derived from sources or defaults.
+     * @return mixed Field value derived from sources or defaults.
      */
-    public function getSourceValue($fieldname, $options = [])
+    public function getSourceValue(string $fieldname, ?array $options = [])
     {
         $valueMap = [
             'data' => 'getData',

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -156,7 +157,7 @@ class HtmlHelper extends Helper
      * @return string|null Doctype string
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-doctype-tags
      */
-    public function docType($type = 'html5')
+    public function docType(string $type = 'html5'): ?string
     {
         if (isset($this->_docTypes[$type])) {
             return $this->_docTypes[$type];
@@ -205,7 +206,7 @@ class HtmlHelper extends Helper
      * @return string|null A completed `<link />` element, or null if the element was sent to a block.
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-meta-tags
      */
-    public function meta($type, $content = null, array $options = [])
+    public function meta($type, $content = null, array $options = []): ?string
     {
         if (!is_array($type)) {
             $types = [
@@ -272,6 +273,8 @@ class HtmlHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -282,10 +285,10 @@ class HtmlHelper extends Helper
      * @return string A meta tag containing the specified character set.
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-charset-tags
      */
-    public function charset($charset = null)
+    public function charset(?string $charset = null): string
     {
         if (empty($charset)) {
-            $charset = strtolower(Configure::read('App.encoding'));
+            $charset = strtolower((string)Configure::read('App.encoding'));
         }
 
         return $this->formatTemplate('charset', [
@@ -317,7 +320,7 @@ class HtmlHelper extends Helper
      * @return string An `<a />` element.
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-links
      */
-    public function link($title, $url = null, array $options = [])
+    public function link($title, $url = null, array $options = []): string
     {
         $escapeTitle = true;
         if ($url !== null) {
@@ -411,7 +414,7 @@ class HtmlHelper extends Helper
      * @return string|null CSS `<link />` or `<style />` tag, depending on the type of link.
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-css-files
      */
-    public function css($path, array $options = [])
+    public function css($path, array $options = []): ?string
     {
         $options += ['once' => true, 'block' => null, 'rel' => 'stylesheet'];
 
@@ -461,6 +464,8 @@ class HtmlHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -504,7 +509,7 @@ class HtmlHelper extends Helper
      *   or if $once is true and the file has been included before.
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-javascript-files
      */
-    public function script($url, array $options = [])
+    public function script($url, array $options = []): ?string
     {
         $defaults = ['block' => null, 'once' => true];
         $options += $defaults;
@@ -542,6 +547,8 @@ class HtmlHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -560,7 +567,7 @@ class HtmlHelper extends Helper
      * @return string|null String or null depending on the value of `$options['block']`
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-inline-javascript-blocks
      */
-    public function scriptBlock($script, array $options = [])
+    public function scriptBlock(string $script, array $options = []): ?string
     {
         $options += ['safe' => false, 'block' => null];
         if ($options['safe']) {
@@ -580,6 +587,8 @@ class HtmlHelper extends Helper
             $options['block'] = 'script';
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -598,7 +607,7 @@ class HtmlHelper extends Helper
      * @return void
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-inline-javascript-blocks
      */
-    public function scriptStart(array $options = [])
+    public function scriptStart(array $options = []): void
     {
         $this->_scriptBlockOptions = $options;
         ob_start();
@@ -612,7 +621,7 @@ class HtmlHelper extends Helper
      * @return string|null Depending on the settings of scriptStart() either a script tag or null
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-inline-javascript-blocks
      */
-    public function scriptEnd()
+    public function scriptEnd(): ?string
     {
         $buffer = ob_get_clean();
         $options = $this->_scriptBlockOptions;
@@ -638,7 +647,7 @@ class HtmlHelper extends Helper
      * @return string CSS styling data
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-css-programatically
      */
-    public function style(array $data, $oneLine = true)
+    public function style(array $data, bool $oneLine = true): string
     {
         $out = [];
         foreach ($data as $key => $value) {
@@ -682,7 +691,7 @@ class HtmlHelper extends Helper
      * @return string completed img tag
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-images
      */
-    public function image($path, array $options = [])
+    public function image($path, array $options = []): string
     {
         $path = $this->Url->image($path, $options);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
@@ -724,7 +733,7 @@ class HtmlHelper extends Helper
      * @return string Completed table headers
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-table-headings
      */
-    public function tableHeaders(array $names, array $trOptions = null, array $thOptions = null)
+    public function tableHeaders(array $names, array $trOptions = null, array $thOptions = null): string
     {
         $out = [];
         foreach ($names as $arg) {
@@ -756,7 +765,7 @@ class HtmlHelper extends Helper
      * @return string Formatted HTML
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-table-cells
      */
-    public function tableCells($data, $oddTrOptions = null, $evenTrOptions = null, $useCount = false, $continueOddEven = true)
+    public function tableCells($data, $oddTrOptions = null, $evenTrOptions = null, bool $useCount = false, bool $continueOddEven = true): string
     {
         if (empty($data[0]) || !is_array($data[0])) {
             $data = [$data];
@@ -797,7 +806,7 @@ class HtmlHelper extends Helper
      *
      * @param array $line Line data to render.
      * @param bool $useCount Renders the count into the row. Default is false.
-     * @return string[]
+     * @return array
      */
     protected function _renderCells($line, $useCount = false)
     {
@@ -833,7 +842,7 @@ class HtmlHelper extends Helper
      * @param array $options HTML attributes.
      * @return string
      */
-    public function tableRow($content, array $options = [])
+    public function tableRow(string $content, array $options = []): string
     {
         return $this->formatTemplate('tablerow', [
             'attrs' => $this->templater()->formatAttributes($options),
@@ -848,7 +857,7 @@ class HtmlHelper extends Helper
      * @param array $options HTML attributes.
      * @return string
      */
-    public function tableCell($content, array $options = [])
+    public function tableCell(string $content, array $options = []): string
     {
         return $this->formatTemplate('tablecell', [
             'attrs' => $this->templater()->formatAttributes($options),
@@ -869,7 +878,7 @@ class HtmlHelper extends Helper
      * @param array $options Additional HTML attributes of the DIV tag, see above.
      * @return string The formatted tag element
      */
-    public function tag($name, $text = null, array $options = [])
+    public function tag($name, ?string $text = null, array $options = []): string
     {
         if (empty($name)) {
             return $text;
@@ -904,7 +913,7 @@ class HtmlHelper extends Helper
      * @param array $options Additional HTML attributes of the DIV tag
      * @return string The formatted DIV element
      */
-    public function div($class = null, $text = null, array $options = [])
+    public function div(?string $class = null, ?string $text = null, array $options = []): string
     {
         if (!empty($class)) {
             $options['class'] = $class;
@@ -925,7 +934,7 @@ class HtmlHelper extends Helper
      * @param array $options Additional HTML attributes of the P tag
      * @return string The formatted P element
      */
-    public function para($class, $text, array $options = [])
+    public function para(string $class, ?string $text, array $options = []): string
     {
         if (!empty($options['escape'])) {
             $text = h($text);
@@ -1004,7 +1013,7 @@ class HtmlHelper extends Helper
      * @param array $options Array of HTML attributes, and special options above.
      * @return string Generated media element
      */
-    public function media($path, array $options = [])
+    public function media($path, array $options = []): string
     {
         $options += [
             'tag' => null,
@@ -1092,7 +1101,7 @@ class HtmlHelper extends Helper
      * @return string The nested list
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#creating-nested-lists
      */
-    public function nestedList(array $list, array $options = [], array $itemOptions = [])
+    public function nestedList(array $list, array $options = [], array $itemOptions = []): string
     {
         $options += ['tag' => 'ul'];
         $items = $this->_nestedListItem($list, $options, $itemOptions);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -806,7 +806,7 @@ class HtmlHelper extends Helper
      *
      * @param array $line Line data to render.
      * @param bool $useCount Renders the count into the row. Default is false.
-     * @return array
+     * @return string[]
      */
     protected function _renderCells($line, $useCount = false)
     {

--- a/src/View/Helper/IdGeneratorTrait.php
+++ b/src/View/Helper/IdGeneratorTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -115,7 +116,7 @@ class PaginatorHelper extends Helper
      * @param string|null $model Optional model name. Uses the default if none is specified.
      * @return array The array of paging parameters for the paginated resultset.
      */
-    public function params($model = null)
+    public function params(?string $model = null): array
     {
         $request = $this->_View->getRequest();
 
@@ -136,7 +137,7 @@ class PaginatorHelper extends Helper
      * @param string|null $model Optional model name. Uses the default if none is specified.
      * @return mixed Content of the requested param.
      */
-    public function param($key, $model = null)
+    public function param(string $key, ?string $model = null)
     {
         $params = $this->params($model);
         if (!isset($params[$key])) {
@@ -153,7 +154,7 @@ class PaginatorHelper extends Helper
      *   See PaginatorHelper::$options for list of keys.
      * @return void
      */
-    public function options(array $options = [])
+    public function options(array $options = []): void
     {
         $request = $this->_View->getRequest();
 
@@ -192,7 +193,7 @@ class PaginatorHelper extends Helper
      * @return int The current page number of the recordset.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
      */
-    public function current($model = null)
+    public function current(?string $model = null): int
     {
         $params = $this->params($model);
 
@@ -209,7 +210,7 @@ class PaginatorHelper extends Helper
      * @param string|null $model Optional model name. Uses the default if none is specified.
      * @return int The total pages for the recordset.
      */
-    public function total($model = null)
+    public function total(?string $model = null): int
     {
         $params = $this->params($model);
 
@@ -229,7 +230,7 @@ class PaginatorHelper extends Helper
      *  null if the results are not currently sorted.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-sort-links
      */
-    public function sortKey($model = null, array $options = [])
+    public function sortKey(?string $model = null, array $options = []): ?string
     {
         if (empty($options)) {
             $options = $this->params($model);
@@ -250,7 +251,7 @@ class PaginatorHelper extends Helper
      *  null if the results are not currently sorted.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-sort-links
      */
-    public function sortDir($model = null, array $options = [])
+    public function sortDir(?string $model = null, array $options = []): string
     {
         $dir = null;
 
@@ -350,7 +351,7 @@ class PaginatorHelper extends Helper
      * @return string A "previous" link or a disabled link.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function prev($title = '<< Previous', array $options = [])
+    public function prev(string $title = '<< Previous', array $options = []): string
     {
         $defaults = [
             'url' => [],
@@ -390,7 +391,7 @@ class PaginatorHelper extends Helper
      * @return string A "next" link or $disabledTitle text if the link is disabled.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function next($title = 'Next >>', array $options = [])
+    public function next(string $title = 'Next >>', array $options = []): string
     {
         $defaults = [
             'url' => [],
@@ -429,7 +430,7 @@ class PaginatorHelper extends Helper
      *  key the returned link will sort by 'desc'.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-sort-links
      */
-    public function sort($key, $title = null, array $options = [])
+    public function sort(string $key, $title = null, array $options = []): string
     {
         $options += ['url' => [], 'model' => null, 'escape' => true];
         $url = $options['url'];
@@ -506,7 +507,7 @@ class PaginatorHelper extends Helper
      * @return string By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#generating-pagination-urls
      */
-    public function generateUrl(array $options = [], $model = null, array $urlOptions = [])
+    public function generateUrl(array $options = [], ?string $model = null, array $urlOptions = []): string
     {
         $urlOptions += [
             'escape' => true,
@@ -523,7 +524,7 @@ class PaginatorHelper extends Helper
      * @param string|null $model Which model to paginate on
      * @return array An array of URL parameters
      */
-    public function generateUrlParams(array $options = [], $model = null)
+    public function generateUrlParams(array $options = [], ?string $model = null): array
     {
         $paging = $this->params($model);
         $paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
@@ -585,7 +586,7 @@ class PaginatorHelper extends Helper
      * @return bool True if the result set is not at the first page.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
      */
-    public function hasPrev($model = null)
+    public function hasPrev(?string $model = null): bool
     {
         return $this->_hasPage($model, 'prev');
     }
@@ -597,7 +598,7 @@ class PaginatorHelper extends Helper
      * @return bool True if the result set is not at the last page.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
      */
-    public function hasNext($model = null)
+    public function hasNext(?string $model = null): bool
     {
         return $this->_hasPage($model, 'next');
     }
@@ -611,7 +612,7 @@ class PaginatorHelper extends Helper
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#checking-the-pagination-state
      * @throws \InvalidArgumentException
      */
-    public function hasPage($page = 1, $model = null)
+    public function hasPage(int $page = 1, ?string $model = null): bool
     {
         if (!is_numeric($page)) {
             throw new InvalidArgumentException('First argument "page" has to be int. Note that argument order switched from 3.x to 4.x.');
@@ -645,7 +646,7 @@ class PaginatorHelper extends Helper
      * @param string|null $model Model name to set
      * @return string|null Model name or null if the pagination isn't initialized.
      */
-    public function defaultModel($model = null)
+    public function defaultModel(?string $model = null): ?string
     {
         if ($model !== null) {
             $this->_defaultModel = $model;
@@ -677,7 +678,7 @@ class PaginatorHelper extends Helper
      * @return string Counter string.
      * @link https://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-a-page-counter
      */
-    public function counter($format, array $options = [])
+    public function counter(string $format, array $options = []): string
     {
         $options += [
             'model' => $this->defaultModel(),
@@ -1127,7 +1128,7 @@ class PaginatorHelper extends Helper
      * @param array $options Array of options
      * @return string|null Meta links
      */
-    public function meta(array $options = [])
+    public function meta(array $options = []): ?string
     {
         $options += [
                 'model' => null,
@@ -1192,7 +1193,7 @@ class PaginatorHelper extends Helper
      * @param array $options Options for Select tag attributes like class, id or event
      * @return string html output.
      */
-    public function limitControl(array $limits = [], $default = null, array $options = [])
+    public function limitControl(array $limits = [], $default = null, array $options = []): ?string
     {
         $out = $this->Form->create(null, ['type' => 'get']);
 

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -65,7 +66,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return \Cake\I18n\Time
      */
-    public function fromString($dateString, $timezone = null)
+    public function fromString($dateString, $timezone = null): Time
     {
         return (new Time($dateString))->timezone($timezone);
     }
@@ -78,7 +79,7 @@ class TimeHelper extends Helper
      * @param string|null $locale Locale string.
      * @return string Formatted date string
      */
-    public function nice($dateString = null, $timezone = null, $locale = null)
+    public function nice($dateString = null, $timezone = null, ?string $locale = null): string
     {
         $timezone = $this->_getTimezone($timezone);
 
@@ -92,7 +93,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if the given datetime string is today.
      */
-    public function isToday($dateString, $timezone = null)
+    public function isToday($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isToday();
     }
@@ -104,7 +105,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if the given datetime string lies in the future.
      */
-    public function isFuture($dateString, $timezone = null)
+    public function isFuture($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isFuture();
     }
@@ -116,7 +117,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if the given datetime string lies in the past.
      */
-    public function isPast($dateString, $timezone = null)
+    public function isPast($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isPast();
     }
@@ -128,7 +129,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if datetime string is within current week
      */
-    public function isThisWeek($dateString, $timezone = null)
+    public function isThisWeek($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isThisWeek();
     }
@@ -140,7 +141,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if datetime string is within the current month
      */
-    public function isThisMonth($dateString, $timezone = null)
+    public function isThisMonth($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isThisMonth();
     }
@@ -152,7 +153,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if datetime string is within current year
      */
-    public function isThisYear($dateString, $timezone = null)
+    public function isThisYear($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isThisYear();
     }
@@ -165,7 +166,7 @@ class TimeHelper extends Helper
      * @return bool True if datetime string was yesterday
      *
      */
-    public function wasYesterday($dateString, $timezone = null)
+    public function wasYesterday($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isYesterday();
     }
@@ -177,7 +178,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if datetime string was yesterday
      */
-    public function isTomorrow($dateString, $timezone = null)
+    public function isTomorrow($dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isTomorrow();
     }
@@ -203,7 +204,7 @@ class TimeHelper extends Helper
      * @return string UNIX timestamp
      * @see \Cake\I18n\Time::toUnix()
      */
-    public function toUnix($dateString, $timezone = null)
+    public function toUnix($dateString, $timezone = null): string
     {
         return (new Time($dateString, $timezone))->toUnixString();
     }
@@ -216,7 +217,7 @@ class TimeHelper extends Helper
      * @return string Formatted date string
      * @see \Cake\I18n\Time::toAtom()
      */
-    public function toAtom($dateString, $timezone = null)
+    public function toAtom($dateString, $timezone = null): string
     {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
@@ -230,7 +231,7 @@ class TimeHelper extends Helper
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return string Formatted date string
      */
-    public function toRss($dateString, $timezone = null)
+    public function toRss($dateString, $timezone = null): string
     {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
@@ -253,7 +254,7 @@ class TimeHelper extends Helper
      * @return string Relative time string.
      * @see \Cake\I18n\Time::timeAgoInWords()
      */
-    public function timeAgoInWords($dateTime, array $options = [])
+    public function timeAgoInWords($dateTime, array $options = []): string
     {
         $element = null;
         $options += [
@@ -305,7 +306,7 @@ class TimeHelper extends Helper
      * @return bool
      * @see \Cake\I18n\Time::wasWithinLast()
      */
-    public function wasWithinLast($timeInterval, $dateString, $timezone = null)
+    public function wasWithinLast(string $timeInterval, $dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
@@ -320,7 +321,7 @@ class TimeHelper extends Helper
      * @return bool
      * @see \Cake\I18n\Time::wasWithinLast()
      */
-    public function isWithinNext($timeInterval, $dateString, $timezone = null)
+    public function isWithinNext(string $timeInterval, $dateString, $timezone = null): bool
     {
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
@@ -332,7 +333,7 @@ class TimeHelper extends Helper
      * @return string UNIX timestamp
      * @see \Cake\I18n\Time::gmt()
      */
-    public function gmt($string = null)
+    public function gmt($string = null): string
     {
         return (new Time($string))->toUnixString();
     }

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -40,7 +41,7 @@ class UrlHelper extends Helper
      * @param array $options Array of options.
      * @return string Full translated URL with base path.
      */
-    public function build($url = null, array $options = [])
+    public function build($url = null, array $options = []): string
     {
         $defaults = [
             'fullBase' => false,
@@ -75,7 +76,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function image($path, array $options = [])
+    public function image($path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.imageBaseUrl');
 
@@ -100,7 +101,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function css($path, array $options = [])
+    public function css($path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.cssBaseUrl');
         $ext = '.css';
@@ -126,7 +127,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function script($path, array $options = [])
+    public function script($path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.jsBaseUrl');
         $ext = '.js';
@@ -152,7 +153,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function assetUrl($path, array $options = [])
+    public function assetUrl($path, array $options = []): string
     {
         if (is_array($path)) {
             return $this->build($path, $options);
@@ -226,7 +227,7 @@ class UrlHelper extends Helper
      * @param bool|string $timestamp If set will overrule the value of `Asset.timestamp` in Configure.
      * @return string Path with a timestamp added, or not.
      */
-    public function assetTimestamp($path, $timestamp = null)
+    public function assetTimestamp($path, $timestamp = null): string
     {
         if ($timestamp === null) {
             $timestamp = Configure::read('Asset.timestamp');
@@ -262,7 +263,7 @@ class UrlHelper extends Helper
      * @param string $file The file to create a webroot path to.
      * @return string Web accessible path to file.
      */
-    public function webroot($file)
+    public function webroot($file): string
     {
         $request = $this->_View->getRequest();
 

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -90,7 +90,7 @@ class TextHelperTest extends TestCase
     public function testTextHelperProxyMethodCalls()
     {
         $methods = [
-            'stripLinks', 'excerpt', 'toList'
+            'stripLinks', 'toList'
         ];
         $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
             ->setMethods($methods)
@@ -100,6 +100,19 @@ class TextHelperTest extends TestCase
         foreach ($methods as $method) {
             $String->expects($this->at(0))->method($method);
             $Text->{$method}('who', 'what', 'when', 'where', 'how');
+        }
+
+        $methods = [
+            'excerpt'
+        ];
+        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+            ->setMethods($methods)
+            ->getMock();
+        $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
+        $Text->attach($String);
+        foreach ($methods as $method) {
+            $String->expects($this->at(0))->method($method);
+            $Text->{$method}('who', 'what');
         }
 
         $methods = [


### PR DESCRIPTION
Added typhints to all public methods of `View/Helper.php` and all files under `View/Helper/*`.

I skipped the 2 helpers `NumberHelper` and `TextHelper` which are basically proxies to utility classes and the tests started throws tons of errors when adding typhints to them.

Also an interesting thing I found is `HtmlHelper::tag()` takes `null` and `false` as values for 1st argument `$name` (there are tests for it) which seems quite weird to me. I would prefer changing it to only take string.