### PR TITLE
Add typehints to Mailer.

### DIFF
--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -23,7 +23,6 @@ use Cake\Core\InstanceConfigTrait;
  */
 abstract class AbstractTransport
 {
-
     use InstanceConfigTrait;
 
     /**
@@ -39,14 +38,14 @@ abstract class AbstractTransport
      * @param \Cake\Mailer\Email $email Email instance.
      * @return array
      */
-    abstract public function send(Email $email);
+    abstract public function send(Email $email): array;
 
     /**
      * Constructor
      *
      * @param array $config Configuration options.
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         $this->setConfig($config);
     }
@@ -58,7 +57,7 @@ abstract class AbstractTransport
      * @param string $eol End of line string.
      * @return string
      */
-    protected function _headersToString($headers, $eol = "\r\n")
+    protected function _headersToString(array $headers, string $eol = "\r\n"): string
     {
         $out = '';
         foreach ($headers as $key => $value) {

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -167,7 +167,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @var string
      */
-    protected $_domain;
+    protected $_domain = '';
 
     /**
      * The subject of the email
@@ -340,7 +340,7 @@ class Email implements JsonSerializable, Serializable
      * If null, filter_var() will be used. Use the emailPattern() method
      * to set a custom pattern.'
      *
-     * @var string
+     * @var string|null
      */
     protected $_emailPattern = self::EMAIL_PATTERN;
 
@@ -468,7 +468,7 @@ class Email implements JsonSerializable, Serializable
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setReadReceipt($email, $name = null)
+    public function setReadReceipt($email, ?string $name = null): self
     {
         return $this->_setEmailSingle('_readReceipt', $email, $name, 'Disposition-Notification-To requires only 1 email address.');
     }
@@ -478,7 +478,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getReadReceipt()
+    public function getReadReceipt(): array
     {
         return $this->_readReceipt;
     }
@@ -492,7 +492,7 @@ class Email implements JsonSerializable, Serializable
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setReturnPath($email, $name = null)
+    public function setReturnPath($email, ?string $name = null): self
     {
         return $this->_setEmailSingle('_returnPath', $email, $name, 'Return-Path requires only 1 email address.');
     }
@@ -502,7 +502,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getReturnPath()
+    public function getReturnPath(): array
     {
         return $this->_returnPath;
     }
@@ -515,7 +515,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function setTo($email, $name = null)
+    public function setTo($email, ?string $name = null): self
     {
         return $this->_setEmail('_to', $email, $name);
     }
@@ -538,7 +538,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function addTo($email, $name = null)
+    public function addTo($email, ?string $name = null): self
     {
         return $this->_addEmail('_to', $email, $name);
     }
@@ -551,7 +551,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function setCc($email, $name = null)
+    public function setCc($email, ?string $name = null): self
     {
         return $this->_setEmail('_cc', $email, $name);
     }
@@ -561,7 +561,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getCc()
+    public function getCc(): array
     {
         return $this->_cc;
     }
@@ -574,7 +574,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function addCc($email, $name = null)
+    public function addCc($email, ?string $name = null): self
     {
         return $this->_addEmail('_cc', $email, $name);
     }
@@ -587,7 +587,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function setBcc($email, $name = null)
+    public function setBcc($email, ?string $name = null): self
     {
         return $this->_setEmail('_bcc', $email, $name);
     }
@@ -597,7 +597,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getBcc()
+    public function getBcc(): array
     {
         return $this->_bcc;
     }
@@ -610,7 +610,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function addBcc($email, $name = null)
+    public function addBcc($email, ?string $name = null): self
     {
         return $this->_addEmail('_bcc', $email, $name);
     }
@@ -618,10 +618,10 @@ class Email implements JsonSerializable, Serializable
     /**
      * Charset setter.
      *
-     * @param string|null $charset Character set.
+     * @param string $charset Character set.
      * @return $this
      */
-    public function setCharset($charset)
+    public function setCharset(string $charset): self
     {
         $this->charset = $charset;
         if (!$this->headerCharset) {
@@ -636,7 +636,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string Charset
      */
-    public function getCharset()
+    public function getCharset(): string
     {
         return $this->charset;
     }
@@ -647,7 +647,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $charset Character set.
      * @return $this
      */
-    public function setHeaderCharset($charset)
+    public function setHeaderCharset(?string $charset): self
     {
         $this->headerCharset = $charset;
 
@@ -657,9 +657,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * HeaderCharset getter.
      *
-     * @return string Charset
+     * @return string|null Charset
      */
-    public function getHeaderCharset()
+    public function getHeaderCharset(): ?string
     {
         return $this->headerCharset;
     }
@@ -669,8 +669,9 @@ class Email implements JsonSerializable, Serializable
      *
      * @param string|null $encoding Encoding set.
      * @return $this
+     * @throws \InvalidArgumentException
      */
-    public function setTransferEncoding($encoding)
+    public function setTransferEncoding(?string $encoding): self
     {
         $encoding = strtolower($encoding);
         if (!in_array($encoding, $this->_transferEncodingAvailable)) {
@@ -691,7 +692,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string|null Encoding
      */
-    public function getTransferEncoding()
+    public function getTransferEncoding(): ?string
     {
         return $this->transferEncoding;
     }
@@ -703,7 +704,7 @@ class Email implements JsonSerializable, Serializable
      *   null to unset the pattern and make use of filter_var() instead.
      * @return $this
      */
-    public function setEmailPattern($regex)
+    public function setEmailPattern(?string $regex): self
     {
         $this->_emailPattern = $regex;
 
@@ -713,9 +714,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * EmailPattern setter/getter
      *
-     * @return string
+     * @return string|null
      */
-    public function getEmailPattern()
+    public function getEmailPattern(): ?string
     {
         return $this->_emailPattern;
     }
@@ -848,7 +849,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $subject Subject string.
      * @return $this
      */
-    public function setSubject($subject)
+    public function setSubject(string $subject): self
     {
         $this->_subject = $this->_encode($subject);
 
@@ -860,7 +861,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->_subject;
     }
@@ -870,7 +871,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string Original subject
      */
-    public function getOriginalSubject()
+    public function getOriginalSubject(): string
     {
         return $this->_decode($this->_subject);
     }
@@ -881,7 +882,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $headers Associative array containing headers to be set.
      * @return $this
      */
-    public function setHeaders(array $headers)
+    public function setHeaders(array $headers): self
     {
         $this->_headers = $headers;
 
@@ -894,7 +895,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $headers Headers to set.
      * @return $this
      */
-    public function addHeaders(array $headers)
+    public function addHeaders(array $headers): self
     {
         $this->_headers = array_merge($this->_headers, $headers);
 
@@ -918,7 +919,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $include List of headers.
      * @return array
      */
-    public function getHeaders(array $include = [])
+    public function getHeaders(array $include = []): array
     {
         if ($include == array_values($include)) {
             $include = array_fill_keys($include, true);
@@ -1028,7 +1029,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $template Template name or null to not use.
      * @return $this
      */
-    public function setTemplate($template)
+    public function setTemplate(?string $template): self
     {
         $this->viewBuilder()->setTemplate($template ?: '');
 
@@ -1040,7 +1041,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getTemplate()
+    public function getTemplate(): string
     {
         return $this->viewBuilder()->getTemplate();
     }
@@ -1051,7 +1052,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $layout Layout name or null to not use
      * @return $this
      */
-    public function setLayout($layout)
+    public function setLayout(?string $layout): self
     {
         $this->viewBuilder()->setLayout($layout ?: false);
 
@@ -1063,7 +1064,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getLayout()
+    public function getLayout(): string
     {
         return $this->viewBuilder()->getLayout();
     }
@@ -1074,7 +1075,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $viewClass View class name.
      * @return $this
      */
-    public function setViewRenderer($viewClass)
+    public function setViewRenderer(string $viewClass): self
     {
         $this->viewBuilder()->setClassName($viewClass);
 
@@ -1086,7 +1087,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getViewRenderer()
+    public function getViewRenderer(): string
     {
         return $this->viewBuilder()->getClassName();
     }
@@ -1097,7 +1098,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $viewVars Variables to set for view.
      * @return $this
      */
-    public function setViewVars($viewVars)
+    public function setViewVars(array $viewVars): self
     {
         $this->set($viewVars);
 
@@ -1109,7 +1110,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getViewVars()
+    public function getViewVars(): array
     {
         return $this->viewVars;
     }
@@ -1117,10 +1118,10 @@ class Email implements JsonSerializable, Serializable
     /**
      * Sets theme to use when rendering.
      *
-     * @param string $theme Theme name.
+     * @param string|null $theme Theme name.
      * @return $this
      */
-    public function setTheme($theme)
+    public function setTheme(?string $theme): self
     {
         $this->viewBuilder()->setTheme($theme);
 
@@ -1130,9 +1131,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * Gets theme to use when rendering.
      *
-     * @return string
+     * @return string|null
      */
-    public function getTheme()
+    public function getTheme(): ?string
     {
         return $this->viewBuilder()->getTheme();
     }
@@ -1143,7 +1144,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $helpers Helpers list.
      * @return $this
      */
-    public function setHelpers(array $helpers)
+    public function setHelpers(array $helpers): self
     {
         $this->viewBuilder()->setHelpers($helpers, false);
 
@@ -1155,7 +1156,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array
      */
-    public function getHelpers()
+    public function getHelpers(): array
     {
         return $this->viewBuilder()->getHelpers();
     }
@@ -1167,7 +1168,7 @@ class Email implements JsonSerializable, Serializable
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setEmailFormat($format)
+    public function setEmailFormat(string $format): self
     {
         if (!in_array($format, $this->_emailFormatAvailable)) {
             throw new InvalidArgumentException('Format not available.');
@@ -1182,7 +1183,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getEmailFormat()
+    public function getEmailFormat(): string
     {
         return $this->_emailFormat;
     }
@@ -1199,7 +1200,7 @@ class Email implements JsonSerializable, Serializable
      * @throws \LogicException When the chosen transport lacks a send method.
      * @throws \InvalidArgumentException When $name is neither a string nor an object.
      */
-    public function setTransport($name)
+    public function setTransport($name): self
     {
         if (is_string($name)) {
             $transport = $this->_constructTransport($name);
@@ -1222,9 +1223,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * Gets the transport.
      *
-     * @return \Cake\Mailer\AbstractTransport
+     * @return \Cake\Mailer\AbstractTransport|null
      */
-    public function getTransport()
+    public function getTransport(): ?AbstractTransport
     {
         return $this->_transport;
     }
@@ -1278,7 +1279,7 @@ class Email implements JsonSerializable, Serializable
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setMessageId($message)
+    public function setMessageId($message): self
     {
         if (is_bool($message)) {
             $this->_messageId = $message;
@@ -1310,7 +1311,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $domain Manually set the domain for CLI mailing.
      * @return $this
      */
-    public function setDomain($domain)
+    public function setDomain(string $domain): self
     {
         $this->_domain = $domain;
 
@@ -1322,7 +1323,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function getDomain()
+    public function getDomain(): string
     {
         return $this->_domain;
     }
@@ -1372,14 +1373,14 @@ class Email implements JsonSerializable, Serializable
      * The `contentDisposition` key allows you to disable the `Content-Disposition` header, this can improve
      * attachment compatibility with outlook email clients.
      *
-     * @param string|array $attachments String with the filename or array with filenames
+     * @param array $attachments Array of filenames.
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setAttachments($attachments)
+    public function setAttachments(array $attachments): self
     {
         $attach = [];
-        foreach ((array)$attachments as $name => $fileInfo) {
+        foreach ($attachments as $name => $fileInfo) {
             if (!is_array($fileInfo)) {
                 $fileInfo = ['file' => $fileInfo];
             }
@@ -1419,7 +1420,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array Array of attachments.
      */
-    public function getAttachments()
+    public function getAttachments(): array
     {
         return $this->_attachments;
     }
@@ -1427,12 +1428,12 @@ class Email implements JsonSerializable, Serializable
     /**
      * Add attachments
      *
-     * @param string|array $attachments String with the filename or array with filenames
+     * @param array $attachments Array of filenames.
      * @return $this
      * @throws \InvalidArgumentException
      * @see \Cake\Mailer\Email::setAttachments()
      */
-    public function addAttachments($attachments)
+    public function addAttachments(array $attachments): self
     {
         $current = $this->_attachments;
         $this->setAttachments($attachments);
@@ -1447,7 +1448,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $type Use MESSAGE_* constants or null to return the full message as array
      * @return string|array String if type is given, array if type is null
      */
-    public function message($type = null)
+    public function message(?string $type = null)
     {
         switch ($type) {
             case static::MESSAGE_HTML:
@@ -1465,7 +1466,7 @@ class Email implements JsonSerializable, Serializable
      * @param int|null $priority 1 (highest) to 5 (lowest)
      * @return $this
      */
-    public function setPriority($priority)
+    public function setPriority(?int $priority): self
     {
         $this->_priority = $priority;
 
@@ -1475,9 +1476,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * Gets priority.
      *
-     * @return int
+     * @return int|null
      */
-    public function getPriority()
+    public function getPriority(): ?int
     {
         return $this->_priority;
     }
@@ -1503,7 +1504,7 @@ class Email implements JsonSerializable, Serializable
      * @return void
      * @throws \BadMethodCallException When modifying an existing configuration.
      */
-    public static function setConfigTransport($key, $config = null)
+    public static function setConfigTransport($key, $config = null): void
     {
         if (is_array($key)) {
             foreach ($key as $name => $settings) {
@@ -1536,7 +1537,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $key The configuration name to read.
      * @return array|null Transport config.
      */
-    public static function getConfigTransport($key)
+    public static function getConfigTransport(string $key): ?array
     {
         return isset(static::$_transportConfig[$key]) ? static::$_transportConfig[$key] : null;
     }
@@ -1546,7 +1547,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return array Array of configurations.
      */
-    public static function configuredTransport()
+    public static function configuredTransport(): array
     {
         return array_keys(static::$_transportConfig);
     }
@@ -1557,7 +1558,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $key The transport name to remove.
      * @return void
      */
-    public static function dropTransport($key)
+    public static function dropTransport($key): void
     {
         unset(static::$_transportConfig[$key]);
     }
@@ -1569,11 +1570,8 @@ class Email implements JsonSerializable, Serializable
      *    an array with config.
      * @return $this
      */
-    public function setProfile($config)
+    public function setProfile($config): self
     {
-        if (!is_array($config)) {
-            $config = $config;
-        }
         $this->_applyConfig($config);
 
         return $this;
@@ -1582,9 +1580,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * Gets the configuration profile to use for this instance.
      *
-     * @return string|array
+     * @return array
      */
-    public function getProfile()
+    public function getProfile(): array
     {
         return $this->_profile;
     }
@@ -1596,7 +1594,7 @@ class Email implements JsonSerializable, Serializable
      * @return array
      * @throws \BadMethodCallException
      */
-    public function send($content = null)
+    public function send($content = null): array
     {
         if (empty($this->_from)) {
             throw new BadMethodCallException('From is not specified.');
@@ -1673,7 +1671,7 @@ class Email implements JsonSerializable, Serializable
      * @return static Instance of Cake\Mailer\Email
      * @throws \InvalidArgumentException
      */
-    public static function deliver($to = null, $subject = null, $message = null, $config = 'default', $send = true)
+    public static function deliver($to = null, ?string $subject = null, $message = null, $config = 'default', bool $send = true): Email
     {
         $class = __CLASS__;
 
@@ -1765,7 +1763,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return $this
      */
-    public function reset()
+    public function reset(): self
     {
         $this->_to = [];
         $this->_from = [];
@@ -2268,7 +2266,7 @@ class Email implements JsonSerializable, Serializable
      * @return array Serializable array of configuration properties.
      * @throws \Exception When a view var object can not be properly serialized.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $properties = [
             '_to', '_from', '_sender', '_replyTo', '_cc', '_bcc', '_subject',
@@ -2302,6 +2300,7 @@ class Email implements JsonSerializable, Serializable
      * @param mixed $item Reference to the view var value.
      * @param string $key View var key.
      * @return void
+     * @throws \RuntimeException
      */
     protected function _checkViewVars(&$item, $key)
     {
@@ -2328,7 +2327,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $config Email configuration array.
      * @return $this Configured email instance.
      */
-    public function createFromArray($config)
+    public function createFromArray(array $config): self
     {
         if (isset($config['viewConfig'])) {
             $this->viewBuilder()->createFromArray($config['viewConfig']);
@@ -2347,7 +2346,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         $array = $this->jsonSerialize();
         array_walk_recursive($array, function (&$item, $key) {
@@ -2365,7 +2364,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $data Serialized string.
      * @return static Configured email instance.
      */
-    public function unserialize($data)
+    public function unserialize($data): self
     {
         return $this->createFromArray(unserialize($data));
     }

--- a/src/Mailer/Exception/MissingMailerException.php
+++ b/src/Mailer/Exception/MissingMailerException.php
@@ -21,6 +21,8 @@ use Cake\Core\Exception\Exception;
  */
 class MissingMailerException extends Exception
 {
-
+    /**
+     * {@inheritDoc}
+     */
     protected $_messageTemplate = 'Mailer class "%s" could not be found.';
 }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -15,6 +15,7 @@ namespace Cake\Mailer;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventListenerInterface;
 use Cake\Mailer\Exception\MissingActionException;
+use Cake\View\ViewBuilder;
 
 /**
  * Mailer base class.
@@ -137,7 +138,6 @@ use Cake\Mailer\Exception\MissingActionException;
  */
 abstract class Mailer implements EventListenerInterface
 {
-
     use ModelAwareTrait;
 
     /**
@@ -167,7 +167,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @param \Cake\Mailer\Email|null $email Email instance.
      */
-    public function __construct(Email $email = null)
+    public function __construct(?Email $email = null)
     {
         if ($email === null) {
             $email = new Email();
@@ -182,7 +182,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         if (!static::$name) {
             static::$name = str_replace(
@@ -200,7 +200,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @return \Cake\View\ViewBuilder
      */
-    public function viewBuilder()
+    public function viewBuilder(): ViewBuilder
     {
         return $this->_email->viewBuilder();
     }
@@ -212,7 +212,7 @@ abstract class Mailer implements EventListenerInterface
      * @param array $args Method arguments
      * @return $this|mixed
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         $result = $this->_email->$method(...$args);
         if (strpos($method, 'get') === 0) {
@@ -229,7 +229,7 @@ abstract class Mailer implements EventListenerInterface
      * @param mixed $value View variable value.
      * @return $this
      */
-    public function set($key, $value = null)
+    public function set($key, $value = null): self
     {
         $this->_email->setViewVars(is_string($key) ? [$key => $value] : $key);
 
@@ -246,7 +246,7 @@ abstract class Mailer implements EventListenerInterface
      * @throws \Cake\Mailer\Exception\MissingActionException
      * @throws \BadMethodCallException
      */
-    public function send($action, $args = [], $headers = [])
+    public function send(string $action, array $args = [], array $headers = []): array
     {
         try {
             if (!method_exists($this, $action)) {
@@ -276,7 +276,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @return $this
      */
-    protected function reset()
+    protected function reset(): self
     {
         $this->_email = clone $this->_clonedEmail;
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -212,7 +212,7 @@ abstract class Mailer implements EventListenerInterface
      * @param array $args Method arguments
      * @return $this|mixed
      */
-    public function __call(string $method, array $args)
+    public function __call($method, $args)
     {
         $result = $this->_email->$method(...$args);
         if (strpos($method, 'get') === 0) {

--- a/src/Mailer/MailerAwareTrait.php
+++ b/src/Mailer/MailerAwareTrait.php
@@ -26,7 +26,6 @@ use Cake\Mailer\Exception\MissingMailerException;
  */
 trait MailerAwareTrait
 {
-
     /**
      * Returns a mailer instance.
      *
@@ -35,7 +34,7 @@ trait MailerAwareTrait
      * @return \Cake\Mailer\Mailer
      * @throws \Cake\Mailer\Exception\MissingMailerException if undefined mailer class.
      */
-    protected function getMailer($name, Email $email = null)
+    protected function getMailer(string $name, ?Email $email = null): Mailer
     {
         if ($email === null) {
             $email = new Email();

--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -32,7 +32,7 @@ class DebugTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Cake Email
      * @return array
      */
-    public function send(Email $email)
+    public function send(Email $email): array
     {
         $headers = $email->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject']);
         $headers = $this->_headersToString($headers);

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -32,7 +32,7 @@ class MailTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Cake Email
      * @return array
      */
-    public function send(Email $email)
+    public function send(Email $email): array
     {
         $eol = PHP_EOL;
         if (isset($this->_config['eol'])) {
@@ -70,7 +70,7 @@ class MailTransport extends AbstractTransport
      * @throws \Cake\Network\Exception\SocketException if mail could not be sent
      * @return void
      */
-    protected function _mail($to, $subject, $message, $headers, $params = null)
+    protected function _mail(string $to, string $subject, string $message, string $headers, ?string $params = null): void
     {
         //@codingStandardsIgnoreStart
         if (!@mail($to, $subject, $message, $headers, $params)) {

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -25,7 +25,6 @@ use Exception;
  */
 class SmtpTransport extends AbstractTransport
 {
-
     /**
      * Default config for this class
      *
@@ -86,7 +85,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return void
      */
-    public function connect()
+    public function connect(): void
     {
         if (!$this->connected()) {
             $this->_connect();
@@ -99,7 +98,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return bool
      */
-    public function connected()
+    public function connected(): bool
     {
         return $this->_socket !== null && $this->_socket->connected;
     }
@@ -112,7 +111,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return void
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         if ($this->connected()) {
             $this->_disconnect();
@@ -144,7 +143,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return array
      */
-    public function getLastResponse()
+    public function getLastResponse(): array
     {
         return $this->_lastResponse;
     }
@@ -156,7 +155,7 @@ class SmtpTransport extends AbstractTransport
      * @return array
      * @throws \Cake\Network\Exception\SocketException
      */
-    public function send(Email $email)
+    public function send(Email $email): array
     {
         if (!$this->connected()) {
             $this->_connect();
@@ -181,7 +180,7 @@ class SmtpTransport extends AbstractTransport
      * @param array $responseLines Response lines to parse.
      * @return void
      */
-    protected function _bufferResponseLines(array $responseLines)
+    protected function _bufferResponseLines(array $responseLines): void
     {
         $response = [];
         foreach ($responseLines as $responseLine) {
@@ -201,7 +200,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _connect()
+    protected function _connect(): void
     {
         $this->_generateSocket();
         if (!$this->_socket->connect()) {
@@ -244,7 +243,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _auth()
+    protected function _auth(): void
     {
         if (isset($this->_config['username'], $this->_config['password'])) {
             $replyCode = (string)$this->_smtpSend('AUTH LOGIN', '334|500|502|504');
@@ -273,7 +272,7 @@ class SmtpTransport extends AbstractTransport
      * @param string $email The email address to send with the command.
      * @return string
      */
-    protected function _prepareFromCmd($email)
+    protected function _prepareFromCmd(string $email): string
     {
         return 'MAIL FROM:<' . $email . '>';
     }
@@ -284,7 +283,7 @@ class SmtpTransport extends AbstractTransport
      * @param string $email The email address to send with the command.
      * @return string
      */
-    protected function _prepareRcptCmd($email)
+    protected function _prepareRcptCmd(string $email): string
     {
         return 'RCPT TO:<' . $email . '>';
     }
@@ -295,7 +294,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Email instance
      * @return array
      */
-    protected function _prepareFromAddress($email)
+    protected function _prepareFromAddress(Email $email): array
     {
         $from = $email->getReturnPath();
         if (empty($from)) {
@@ -311,7 +310,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Email instance
      * @return array
      */
-    protected function _prepareRecipientAddresses($email)
+    protected function _prepareRecipientAddresses(Email $email): array
     {
         $to = $email->getTo();
         $cc = $email->getCc();
@@ -326,7 +325,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Email instance
      * @return array
      */
-    protected function _prepareMessageHeaders($email)
+    protected function _prepareMessageHeaders(Email $email): array
     {
         return $email->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject', 'returnPath']);
     }
@@ -337,7 +336,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Email $email Email instance
      * @return string
      */
-    protected function _prepareMessage($email)
+    protected function _prepareMessage(Email $email): string
     {
         $lines = $email->message();
         $messages = [];
@@ -355,11 +354,11 @@ class SmtpTransport extends AbstractTransport
     /**
      * Send emails
      *
-     * @return void
      * @param \Cake\Mailer\Email $email Cake Email
      * @throws \Cake\Network\Exception\SocketException
+     * @return void
      */
-    protected function _sendRcpt($email)
+    protected function _sendRcpt(Email $email): void
     {
         $from = $this->_prepareFromAddress($email);
         $this->_smtpSend($this->_prepareFromCmd(key($from)));
@@ -377,7 +376,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _sendData($email)
+    protected function _sendData(Email $email): void
     {
         $this->_smtpSend('DATA', '354');
 
@@ -394,7 +393,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _disconnect()
+    protected function _disconnect(): void
     {
         $this->_smtpSend('QUIT', false);
         $this->_socket->disconnect();
@@ -406,7 +405,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _generateSocket()
+    protected function _generateSocket(): void
     {
         $this->_socket = new Socket($this->_config);
     }
@@ -419,7 +418,7 @@ class SmtpTransport extends AbstractTransport
      * @return string|null The matched code, or null if nothing matched
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _smtpSend($data, $checkCode = '250')
+    protected function _smtpSend(?string $data, ?string $checkCode = '250'): ?string
     {
         $this->_lastResponse = [];
 
@@ -456,5 +455,7 @@ class SmtpTransport extends AbstractTransport
             }
             throw new SocketException(sprintf('SMTP Error: %s', $response));
         }
+
+        return null;
     }
 }

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -418,7 +418,7 @@ class SmtpTransport extends AbstractTransport
      * @return string|null The matched code, or null if nothing matched
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _smtpSend(?string $data, ?string $checkCode = '250'): ?string
+    protected function _smtpSend(?string $data, $checkCode = '250'): ?string
     {
         $this->_lastResponse = [];
 

--- a/src/TestSuite/TestEmailTransport.php
+++ b/src/TestSuite/TestEmailTransport.php
@@ -22,23 +22,28 @@ use Cake\Mailer\Email;
  *
  * Set this as the email transport to capture emails for later assertions
  *
- * @see Cake\TestSuite\EmailTrait
+ * @see \Cake\TestSuite\EmailTrait
  */
 class TestEmailTransport extends AbstractTransport
 {
+    /**
+     * @var array
+     */
     private static $emails = [];
 
     /**
      * Stores email for later assertions
      *
-     * @param Email $email Email
-     * @return bool
+     * @param \Cake\Mailer\Email $email Email
+     * @return array
      */
-    public function send(Email $email)
+    public function send(Email $email): array
     {
         static::$emails[] = $email;
 
-        return true;
+        return [
+             'result' => 'Success'
+        ];
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -42,6 +42,8 @@ class TestEmail extends Email
     /**
      * Wrap to protected method
      *
+     * @param string $text
+     * @param int $length
      * @return array
      */
     public function wrap($text, $length = Email::LINE_LENGTH_MUST)
@@ -859,7 +861,7 @@ class EmailTest extends TestCase
      */
     public function testSetAttachments()
     {
-        $this->Email->setAttachments(CAKE . 'basics.php');
+        $this->Email->setAttachments([CAKE . 'basics.php']);
         $expected = [
             'basics.php' => [
                 'file' => CAKE . 'basics.php',
@@ -874,7 +876,7 @@ class EmailTest extends TestCase
         $this->Email->setAttachments([
             ['file' => CAKE . 'basics.php', 'mimetype' => 'text/plain']
         ]);
-        $this->Email->addAttachments(CORE_PATH . 'config' . DS . 'bootstrap.php');
+        $this->Email->addAttachments([CORE_PATH . 'config' . DS . 'bootstrap.php']);
         $this->Email->addAttachments([CORE_PATH . 'config' . DS . 'bootstrap.php']);
         $this->Email->addAttachments([
             'other.txt' => CORE_PATH . 'config' . DS . 'bootstrap.php',
@@ -987,8 +989,7 @@ class EmailTest extends TestCase
             'className' => 'Debug',
             'log' => true
         ];
-        $result = Email::setConfigTransport('debug', $settings);
-        $this->assertNull($result, 'No return.');
+        Email::setConfigTransport('debug', $settings);
 
         $result = Email::getConfigTransport('debug');
         $this->assertEquals($settings, $result);
@@ -1587,6 +1588,8 @@ class EmailTest extends TestCase
         $this->Email->setSubject('My title');
         $this->Email->setProfile(['log' => 'debug']);
         $result = $this->Email->send($message);
+
+        $this->assertNotEmpty($result);
     }
 
     /**
@@ -2132,7 +2135,7 @@ class EmailTest extends TestCase
 
         $this->Email->reset();
         $this->assertSame([], $this->Email->getTo());
-        $this->assertFalse($this->Email->getTheme());
+        $this->assertSame('', $this->Email->getTheme());
         $this->assertSame(Email::EMAIL_PATTERN, $this->Email->getEmailPattern());
     }
 
@@ -2359,7 +2362,7 @@ class EmailTest extends TestCase
         $this->assertEquals('html', $result);
 
         $this->expectException(\InvalidArgumentException::class);
-        $result = $this->Email->setEmailFormat('invalid');
+        $this->Email->setEmailFormat('invalid');
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -42,7 +42,7 @@ class SmtpTestTransport extends SmtpTransport
      *
      * @return void
      */
-    protected function _generateSocket()
+    protected function _generateSocket(): void
     {
     }
 
@@ -50,7 +50,7 @@ class SmtpTestTransport extends SmtpTransport
      * Magic function to call protected methods
      *
      * @param string $method
-     * @param string $args
+     * @param array $args
      * @return mixed
      */
     public function __call($method, $args)
@@ -66,6 +66,15 @@ class SmtpTestTransport extends SmtpTransport
  */
 class SmtpTransportTest extends TestCase
 {
+    /**
+     * @var \Cake\Test\TestCase\Mailer\Transport\SmtpTestTransport
+     */
+    protected $SmtpTransport;
+
+    /**
+     * @var \Cake\Network\Socket|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $socket;
 
     /**
      * Setup
@@ -384,6 +393,7 @@ class SmtpTransportTest extends TestCase
         $email = $this->getMockBuilder('Cake\Mailer\Email')
             ->setMethods(['message'])
             ->getMock();
+        /** @var \Cake\Mailer\Email $email */
         $email->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $email->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $email->setTo('cake@cakephp.org', 'CakePHP');

--- a/tests/test_app/TestApp/Mailer/TestMailer.php
+++ b/tests/test_app/TestApp/Mailer/TestMailer.php
@@ -27,7 +27,7 @@ class TestMailer extends Mailer
         return $this->_email;
     }
 
-    public function reset()
+    protected function reset(): Mailer
     {
         $this->template = $this->viewBuilder()->getTemplate();
 


### PR DESCRIPTION
Some doc blocks were incorrect as well.

Maybe we can also get rid of some |null things in favor of just string in the neat future.