### PR TITLE
Deprecate logQueries()

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -120,7 +120,7 @@ class Connection implements ConnectionInterface
         $this->setDriver($driver, $config);
 
         if (!empty($config['log'])) {
-            $this->logQueries($config['log']);
+            $this->enableQueryLogging($config['log']);
         }
     }
 
@@ -847,13 +847,42 @@ class Connection implements ConnectionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 3.7.0 Use enableQueryLogging() and isQueryLoggingEnabled() instead.
      */
     public function logQueries($enable = null)
     {
+        deprecationWarning(
+            'Connection::logQueries() is deprecated. ' .
+            'Use enableQueryLogging() and isQueryLoggingEnabled() instead.'
+        );
         if ($enable === null) {
             return $this->_logQueries;
         }
         $this->_logQueries = $enable;
+    }
+
+    /**
+     * Enable/disable query logging
+     *
+     * @param bool $value Enable/disable query logging
+     * @return $this
+     */
+    public function enableQueryLogging($value)
+    {
+        $this->_logQueries = (bool)$value;
+
+        return $this;
+    }
+
+    /**
+     * Check if query logging is enabled.
+     *
+     * @return bool
+     */
+    public function isQueryLoggingEnabled()
+    {
+        return $this->_logQueries;
     }
 
     /**

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -25,6 +25,8 @@ namespace Cake\Datasource;
  * @method \Cake\Database\Query newQuery()
  * @method \Cake\Database\StatementInterface prepare($sql)
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = [])
+ * @method $this enableQueryLogging($value)
+ * @method bool isQueryLoggingEnabled(value)
  * @method string quote($value, $type = null)
  */
 interface ConnectionInterface

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -26,7 +26,7 @@ namespace Cake\Datasource;
  * @method \Cake\Database\StatementInterface prepare($sql)
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = [])
  * @method $this enableQueryLogging($value)
- * @method bool isQueryLoggingEnabled(value)
+ * @method bool isQueryLoggingEnabled()
  * @method string quote($value, $type = null)
  */
 interface ConnectionInterface

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -906,13 +906,13 @@ class ConnectionTest extends TestCase
     public function testLoggerDecorator()
     {
         $logger = new QueryLogger;
-        $this->connection->logQueries(true);
+        $this->connection->enableQueryLogging(true);
         $this->connection->setLogger($logger);
         $st = $this->connection->prepare('SELECT 1');
         $this->assertInstanceOf(LoggingStatement::class, $st);
         $this->assertSame($logger, $st->getLogger());
 
-        $this->connection->logQueries(false);
+        $this->connection->enableQueryLogging(false);
         $st = $this->connection->prepare('SELECT 1');
         $this->assertNotInstanceOf('\Cake\Database\Log\LoggingStatement', $st);
     }
@@ -920,15 +920,32 @@ class ConnectionTest extends TestCase
     /**
      * test logQueries method
      *
+     * @deprecated
      * @return void
      */
     public function testLogQueries()
     {
-        $this->connection->logQueries(true);
-        $this->assertTrue($this->connection->logQueries());
+        $this->deprecated(function () {
+            $this->connection->logQueries(true);
+            $this->assertTrue($this->connection->logQueries());
 
-        $this->connection->logQueries(false);
-        $this->assertFalse($this->connection->logQueries());
+            $this->connection->logQueries(false);
+            $this->assertFalse($this->connection->logQueries());
+        });
+    }
+
+    /**
+     * test enableQueryLogging method
+     *
+     * @return void
+     */
+    public function testEnableQueryLogging()
+    {
+        $this->connection->enableQueryLogging(true);
+        $this->assertTrue($this->connection->isQueryLoggingEnabled());
+
+        $this->connection->enableQueryLogging(false);
+        $this->assertFalse($this->connection->isQueryLoggingEnabled());
     }
 
     /**
@@ -960,7 +977,7 @@ class ConnectionTest extends TestCase
             ->setMethods(['connect'])
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->logQueries(true);
+        $connection->enableQueryLogging(true);
 
         $driver = $this->getMockFormDriver();
         $connection->setDriver($driver);
@@ -1004,7 +1021,7 @@ class ConnectionTest extends TestCase
                 $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'COMMIT')
             ));
-        $connection->logQueries(true);
+        $connection->enableQueryLogging(true);
         $connection->begin();
         $connection->commit();
     }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -71,8 +71,8 @@ class FixtureManagerTest extends TestCase
     public function testLogSchemaWithDebug()
     {
         $db = ConnectionManager::get('test');
-        $restore = $db->logQueries();
-        $db->logQueries(true);
+        $restore = $db->isQueryLoggingEnabled();
+        $db->enableQueryLogging(true);
 
         $this->manager->setDebug(true);
         $buffer = new ConsoleOutput();
@@ -90,7 +90,7 @@ class FixtureManagerTest extends TestCase
         $this->manager->load($test);
         $this->manager->shutdown();
 
-        $db->logQueries($restore);
+        $db->enableQueryLogging($restore);
         $this->assertContains('CREATE TABLE', implode('', $buffer->messages()));
     }
 
@@ -103,8 +103,8 @@ class FixtureManagerTest extends TestCase
     public function testResetDbIfTableExists()
     {
         $db = ConnectionManager::get('test');
-        $restore = $db->logQueries();
-        $db->logQueries(true);
+        $restore = $db->isQueryLoggingEnabled();
+        $db->enableQueryLogging(true);
 
         $this->manager->setDebug(true);
         $buffer = new ConsoleOutput();
@@ -128,7 +128,7 @@ class FixtureManagerTest extends TestCase
         $this->manager->fixturize($test);
         $this->manager->load($test);
 
-        $db->logQueries($restore);
+        $db->enableQueryLogging($restore);
         $this->assertContains('DROP TABLE', implode('', $buffer->messages()));
     }
 


### PR DESCRIPTION
This is a combined get/set that we missed earlier. Add new methods that follow convention of other bool setters. I've included shims for connection implementations that don't implement the new method. I'm hoping to make fewer fatal errors in elasticsearch and other plugins when our users upgrade to 3.7

Refs #12343