### PR TITLE
Add typehints to shell hook methods.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -131,7 +131,7 @@ class Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */
-    protected function buildOptionParser(ConsoleOptionParser $parser)
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         return $parser;
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -244,7 +244,7 @@ class Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Cake\Console\ConsoleOptionParser::initialize
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->loadTasks();
     }
@@ -259,7 +259,7 @@ class Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Cake\Console\ConsoleOptionParser::startup
      */
-    public function startup()
+    public function startup(): void
     {
         if (!$this->param('requested')) {
             $this->_welcome();
@@ -569,7 +569,7 @@ class Shell
      * @return \Cake\Console\ConsoleOptionParser
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
         $parser = new ConsoleOptionParser($name);
@@ -762,7 +762,7 @@ class Shell
      * @return string
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::nl
      */
-    public function nl(int $multiplier = 1)
+    public function nl(int $multiplier = 1): string
     {
         return $this->_io->nl($multiplier);
     }
@@ -775,7 +775,7 @@ class Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::hr
      */
-    public function hr(int $newlines = 0, int $width = 63)
+    public function hr(int $newlines = 0, int $width = 63): void
     {
         $this->_io->hr($newlines, $width);
     }
@@ -901,7 +901,7 @@ class Shell
      * @param array $settings Configuration data for the helper.
      * @return \Cake\Console\Helper The created helper instance.
      */
-    public function helper(string $name, array $settings = [])
+    public function helper(string $name, array $settings = []): Helper
     {
         return $this->_io->helper($name, $settings);
     }

--- a/src/Shell/CacheShell.php
+++ b/src/Shell/CacheShell.php
@@ -17,6 +17,7 @@ namespace Cake\Shell;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\ApcuEngine;
 use Cake\Cache\Engine\WincacheEngine;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use InvalidArgumentException;
 
@@ -34,7 +35,7 @@ class CacheShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->addSubcommand('list_prefixes', [
@@ -70,7 +71,7 @@ class CacheShell extends Shell
      * @throws \Cake\Console\Exception\StopException
      * @return void
      */
-    public function clear($prefix = null)
+    public function clear($prefix = null): void
     {
         try {
             $engine = Cache::engine($prefix);

--- a/src/Shell/CompletionShell.php
+++ b/src/Shell/CompletionShell.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 
 /**
@@ -35,7 +36,7 @@ class CompletionShell extends Shell
      *
      * @return void
      */
-    public function startup()
+    public function startup(): void
     {
     }
 
@@ -112,7 +113,7 @@ class CompletionShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
@@ -129,7 +130,7 @@ class I18nShell extends Shell
      * @return \Cake\Console\ConsoleOptionParser
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $initParser = [

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
 
@@ -53,7 +54,7 @@ class PluginShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Exception\MissingRouteException;
@@ -110,7 +111,7 @@ class RoutesShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->setDescription(

--- a/src/Shell/SchemaCacheShell.php
+++ b/src/Shell/SchemaCacheShell.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Database\SchemaCache;
 use Cake\Datasource\ConnectionManager;
@@ -91,7 +92,7 @@ class SchemaCacheShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->addSubcommand('clear', [

--- a/src/Shell/ServerShell.php
+++ b/src/Shell/ServerShell.php
@@ -15,6 +15,7 @@
 
 namespace Cake\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 
@@ -75,7 +76,7 @@ class ServerShell extends Shell
      * @return void
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#hook-methods
      */
-    public function startup()
+    public function startup(): void
     {
         if ($this->param('host')) {
             $this->_host = $this->param('host');
@@ -154,7 +155,7 @@ class ServerShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/Task/AssetsTask.php
+++ b/src/Shell/Task/AssetsTask.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell\Task;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
@@ -314,7 +315,7 @@ class AssetsTask extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell\Task;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Plugin;
@@ -307,7 +308,7 @@ class ExtractTask extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->setDescription(

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell\Task;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Filesystem\File;
 
@@ -133,7 +134,7 @@ class LoadTask extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell\Task;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Filesystem\File;
 
@@ -123,7 +124,7 @@ class UnloadTask extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/tests/test_app/TestApp/Shell/IntegrationShell.php
+++ b/tests/test_app/TestApp/Shell/IntegrationShell.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * IntegrationShell file
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -30,7 +28,7 @@ class IntegrationShell extends Shell
      *
      * @return ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = new ConsoleOptionParser();
         $argAndOptionParser = (new ConsoleOptionParser())

--- a/tests/test_app/TestApp/Shell/Task/SampleTask.php
+++ b/tests/test_app/TestApp/Shell/Task/SampleTask.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * SampleTask file
- *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
@@ -15,11 +13,12 @@
  */
 namespace TestApp\Shell\Task;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 
 class SampleTask extends Shell
 {
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->addOption('sample', [


### PR DESCRIPTION
I left these off in a previous pass as we were undecided on how to treat hook methods. I've added hints where I could. clear() is a notably problematic method in Shell as several classes overload it with a different signature.

Refs #11935