### PR TITLE
Use relative paths in phpcs configuration.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,7 +1,7 @@
 ---
 linters:
   phpcs:
-    standard: CakePHP
+    standard: ./phpcs.xml.dist
     extensions: 'php,ctp'
     fixer: true
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Core">
-    <config name="installed_paths" value="vendor/cakephp/cakephp-codesniffer,vendor/slevomat/coding-standard" />
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer,../../slevomat/coding-standard" />
 
     <rule ref="PSR12" >
         <!-- This exclude can be removed once phcs 3.3.1 is released -->


### PR DESCRIPTION
By using relative directory traversal both travis and stickler can find the coding standards we reference.
