### PR TITLE
Check if no alias was created before in phpunit initalization

### DIFF
--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -4,14 +4,14 @@ if (class_exists('PHPUnit_Runner_Version')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
 
-	if (!class_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
-		class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
-		class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
-		class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
-		class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
-		class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
-		class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
-		class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
-		class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
-	}
+    if (!class_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
+        class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
+        class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
+        class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+        class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
+        class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
+        class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
+        class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
+        class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
+    }
 }

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -4,12 +4,14 @@ if (class_exists('PHPUnit_Runner_Version')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
 
-    class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
-    class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
-    class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
-    class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
-    class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
-    class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
-    class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
-    class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
+	if (!class_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
+		class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
+		class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
+		class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+		class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
+		class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
+		class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
+		class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
+		class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
+	}
 }


### PR DESCRIPTION
Some packages, for example codeception create reverse aliases and this cause exception(https://github.com/Codeception/Codeception/commit/503f1fe4f54b131c0617cba076b7b945b97a02c2#diff-b38cfe53d6f105ad2685aa4bc6f020de). It is good practice to check if aliases not created before