### PR TITLE
Add missing versions to deprecation notices.

### DIFF
--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Cache\Engine;
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.6.0 Add backwards compat alias.
 class_alias('Cake\Cache\Engine\ApcuEngine', 'Cake\Cache\Engine\ApcEngine');
 
 deprecationWarning('Use Cake\Cache\Engine\ApcuEngine instead of Cake\Cache\Engine\ApcEngine.');

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias
+// @deprecated 3.4.0 Load new class and alias
 class_exists('Cake\Database\Schema\TableSchema');
 deprecationWarning('Use Cake\Database\Schema\TableSchema instead of Cake\Database\Schema\Table.');

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -868,5 +868,5 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Database\Schema\TableSchema', 'Cake\Database\Schema\Table');

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -18,6 +18,8 @@ use Cake\Datasource\SchemaInterface;
 
 /**
  * An interface used by database TableSchema objects.
+ *
+ * Deprecated 3.5.0: Use Cake\Database\TableSchemaAwareInterface instead.
  */
 interface TableSchemaInterface extends SchemaInterface
 {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -610,5 +610,5 @@ class Client
         return new $class($this, $options);
     }
 }
-// @deprecated Backwards compatibility with earler 3.x versions.
+// @deprecated 3.4.0 Backwards compatibility with earler 3.x versions.
 class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -330,5 +330,5 @@ class Stream
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -73,5 +73,5 @@ class Basic
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -144,5 +144,5 @@ class Digest
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -364,5 +364,5 @@ class Oauth
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -117,5 +117,5 @@ class CookieCollection extends BaseCollection
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -263,5 +263,5 @@ class FormData implements Countable
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -222,5 +222,5 @@ class FormDataPart
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');

--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -200,5 +200,5 @@ class Message
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -283,5 +283,5 @@ class Request extends Message implements RequestInterface
     }
 }
 
-// @deprecated Add backwards compact alias.
+// @deprecated 3.4.0 Add backwards compact alias.
 class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -669,5 +669,5 @@ class Response extends Message implements ResponseInterface
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2816,5 +2816,5 @@ class Response implements ResponseInterface
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\Response', 'Cake\Network\Response');

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -2446,5 +2446,5 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     }
 }
 
-// @deprecated Add backwards compat alias.
+// @deprecated 3.4.0 Add backwards compat alias.
 class_alias('Cake\Http\ServerRequest', 'Cake\Network\Request');

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backwards compatibility alias
+// @deprecated 3.6.0 Backwards compatibility alias
 class_alias('Cake\Http\CorsBuilder', 'Cake\Network\CorsBuilder');
 deprecationWarning('Use Cake\Http\CorsBuilder instead of Cake\Network\CorsBuilder.');

--- a/src/Network/Email/AbstractTransport.php
+++ b/src/Network/Email/AbstractTransport.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility with 2.x, 3.0.x
+// @deprecated 3.5.0 Backward compatibility with 2.x, 3.0.x
 class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport');
 deprecationWarning('Use Cake\Mailer\AbstractTransport instead of Cake\Network\Email\AbstractTransport.');

--- a/src/Network/Email/DebugTransport.php
+++ b/src/Network/Email/DebugTransport.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility with 2.x, 3.0.x
+// @deprecated 3.5.0 Backward compatibility with 2.x, 3.0.x
 class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport');
 deprecationWarning('Use Cake\Mailer\Transport\DebugTransport instead of Cake\Network\Email\DebugTransport.');

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility with 2.x, 3.0.x
+// @deprecated 3.5.0 Backward compatibility with 2.x, 3.0.x
 class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
 deprecationWarning('Use Cake\Mailer\Email instead of Cake\Network\Email\Email.');

--- a/src/Network/Email/MailTransport.php
+++ b/src/Network/Email/MailTransport.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility with 2.x, 3.0.x
+// @deprecated 3.5.0 Backward compatibility with 2.x, 3.0.x
 class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
 deprecationWarning('Use Cake\Mailer\Transport\MailTransport instead of Cake\Network\Email\MailTransport.');

--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility with 2.x, 3.0.x
+// @deprecated 3.5.0 Backward compatibility with 2.x, 3.0.x
 class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
 deprecationWarning('Use Cake\Mailer\Transport\SmtpTransport instead of Cake\Network\Email\SmtpTransport.');

--- a/src/Network/Exception/BadRequestException.php
+++ b/src/Network/Exception/BadRequestException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\BadRequestException', 'Cake\Network\Exception\BadRequestException');
 deprecationWarning('Use Cake\Http\Exception\BadRequestException instead of Cake\Network\Exception\BadRequestException.');

--- a/src/Network/Exception/ConflictException.php
+++ b/src/Network/Exception/ConflictException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\ConflictException', 'Cake\Network\Exception\ConflictException');
 deprecationWarning('Use Cake\Http\Exception\ConflictException instead of Cake\Network\Exception\ConflictException.');

--- a/src/Network/Exception/ForbiddenException.php
+++ b/src/Network/Exception/ForbiddenException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\ForbiddenException', 'Cake\Network\Exception\ForbiddenException');
 deprecationWarning('Use Cake\Http\Exception\ForbiddenException instead of Cake\Network\Exception\ForbiddenException.');

--- a/src/Network/Exception/GoneException.php
+++ b/src/Network/Exception/GoneException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\GoneException', 'Cake\Network\Exception\GoneException');
 deprecationWarning('Use Cake\Http\Exception\GoneException instead of Cake\Network\Exception\GoneException.');

--- a/src/Network/Exception/HttpException.php
+++ b/src/Network/Exception/HttpException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\HttpException', 'Cake\Network\Exception\HttpException');
 deprecationWarning('Use Cake\Http\Exception\HttpException instead of Cake\Network\Exception\HttpException.');

--- a/src/Network/Exception/InternalErrorException.php
+++ b/src/Network/Exception/InternalErrorException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\InternalErrorException', 'Cake\Network\Exception\InternalErrorException');
 deprecationWarning('Use Cake\Http\Exception\InternalErrorException instead of Cake\Network\Exception\InternalErrorException.');

--- a/src/Network/Exception/InvalidCsrfTokenException.php
+++ b/src/Network/Exception/InvalidCsrfTokenException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\InvalidCsrfTokenException', 'Cake\Network\Exception\InvalidCsrfTokenException');
 deprecationWarning('Use Cake\Http\Exception\InvalidCsrfTokenException instead of Cake\Network\Exception\InvalidCsrfTokenException.');

--- a/src/Network/Exception/MethodNotAllowedException.php
+++ b/src/Network/Exception/MethodNotAllowedException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\MethodNotAllowedException', 'Cake\Network\Exception\MethodNotAllowedException');
 deprecationWarning('Use Cake\Http\Exception\MethodNotAllowedException instead of Cake\Network\Exception\MethodNotAllowedException.');

--- a/src/Network/Exception/NotAcceptableException.php
+++ b/src/Network/Exception/NotAcceptableException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\NotAcceptableException', 'Cake\Network\Exception\NotAcceptableException');
 deprecationWarning('Use Cake\Http\Exception\NotAcceptableException instead of Cake\Network\Exception\NotAcceptableException.');

--- a/src/Network/Exception/NotFoundException.php
+++ b/src/Network/Exception/NotFoundException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\NotFoundException', 'Cake\Network\Exception\NotFoundException');
 deprecationWarning('Use Cake\Http\Exception\NotFoundException instead of Cake\Network\Exception\NotFoundException.');

--- a/src/Network/Exception/NotImplementedException.php
+++ b/src/Network/Exception/NotImplementedException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\NotImplementedException', 'Cake\Network\Exception\NotImplementedException');
 deprecationWarning('Use Cake\Http\Exception\NotImplementedException instead of Cake\Network\Exception\NotImplementedException.');

--- a/src/Network/Exception/ServiceUnavailableException.php
+++ b/src/Network/Exception/ServiceUnavailableException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\ServiceUnavailableException', 'Cake\Network\Exception\ServiceUnavailableException');
 deprecationWarning('Use Cake\Http\Exception\ServiceUnavailableException instead of Cake\Network\Exception\ServiceUnavailableException.');

--- a/src/Network/Exception/UnauthorizedException.php
+++ b/src/Network/Exception/UnauthorizedException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\UnauthorizedException', 'Cake\Network\Exception\UnauthorizedException');
 deprecationWarning('Use Cake\Http\Exception\UnauthorizedException instead of Cake\Network\Exception\UnauthorizedException.');

--- a/src/Network/Exception/UnavailableForLegalReasonsException.php
+++ b/src/Network/Exception/UnavailableForLegalReasonsException.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backward compatibility alias
+// @deprecated 3.6.0 Backward compatibility alias
 class_alias('Cake\Http\Exception\UnavailableForLegalReasonsException', 'Cake\Network\Exception\UnavailableForLegalReasonsException');
 deprecationWarning('Use Cake\Http\Exception\UnavailableForLegalReasonsException instead of Cake\Network\Exception\UnavailableForLegalReasonsException.');

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Adapter\Stream');
 deprecationWarning('Use Cake\Http\Client\Adapter\Stream instead of Cake\Network\Http\Adapter\Stream.');

--- a/src/Network/Http/Auth/Basic.php
+++ b/src/Network/Http/Auth/Basic.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Auth\Basic');
 deprecationWarning('Use Cake\Http\Client\Auth\Basic instead of Cake\Network\Http\Auth\Basic.');

--- a/src/Network/Http/Auth/Digest.php
+++ b/src/Network/Http/Auth/Digest.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Auth\Digest');
 deprecationWarning('Use Cake\Http\Client\Auth\Digest instead of Cake\Network\Http\Auth\Digest.');

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Auth\Oauth');
 deprecationWarning('Use Cake\Http\Client\Auth\Oauth instead of Cake\Network\Http\Auth\Oauth.');

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client');
 deprecationWarning('Use Cake\Http\Client instead of Cake\Network\Http\Client.');

--- a/src/Network/Http/CookieCollection.php
+++ b/src/Network/Http/CookieCollection.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\CookieCollection');
 deprecationWarning('Use Cake\Http\Client\CookieCollection instead of Cake\Network\Http\CookieCollection.');

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\FormData');
 deprecationWarning('Use Cake\Http\Client\FormData instead of Cake\Network\Http\FormData.');

--- a/src/Network/Http/FormData/Part.php
+++ b/src/Network/Http/FormData/Part.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\FormDataPart');
 deprecationWarning('Use Cake\Http\Client\FormDataPart instead of Cake\Network\Http\FormData\Part.');

--- a/src/Network/Http/Message.php
+++ b/src/Network/Http/Message.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Message');
 deprecationWarning('Use Cake\Http\Client\Message instead of Cake\Network\Http\Message.');

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Request');
 deprecationWarning('Use Cake\Http\Client\Request instead of Cake\Network\Http\Request.');

--- a/src/Network/Http/Response.php
+++ b/src/Network/Http/Response.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias.
+// @deprecated 3.4.0 Load new class and alias.
 class_exists('Cake\Http\Client\Response');
 deprecationWarning('Use Cake\Http\Client\Response instead of Cake\Network\Http\Response.');

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias
+// @deprecated 3.4.0 Load new class and alias
 class_exists('Cake\Http\ServerRequest');
 deprecationWarning('Use Cake\Http\ServerRequest instead of Cake\Network\Request.');

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Load new class and alias
+// @deprecated 3.4.0 Load new class and alias
 class_exists('Cake\Http\Response');
 deprecationWarning('Use Cake\Http\Response instead of Cake\Network\Response.');

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backwards compatibility alias
+// @deprecated 3.6.0 Backwards compatibility alias
 class_alias('Cake\Http\Session', 'Cake\Network\Session');
 deprecationWarning('Use Cake\Http\Session instead of Cake\Network\Session.');

--- a/src/Network/Session/CacheSession.php
+++ b/src/Network/Session/CacheSession.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backwards compatibility alias
+// @deprecated 3.6.0 Backwards compatibility alias
 class_alias('Cake\Http\Session\CacheSession', 'Cake\Network\Session\CacheSession');
 deprecationWarning('Use Cake\Http\Session\CacheSession instead of Cake\Network\Session\CacheSession.');

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -1,4 +1,4 @@
 <?php
-// @deprecated Backwards compatibility alias
+// @deprecated 3.6.0 Backwards compatibility alias
 class_alias('Cake\Http\Session\DatabaseSession', 'Cake\Network\Session\DatabaseSession');
 deprecationWarning('Use Cake\Http\Session\DatabaseSession instead of Cake\Network\Session\DatabaseSession.');

--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -1,5 +1,5 @@
 <?php
-// @deprecated Backward compatibility with 2.x series
+// @deprecated 3.5.0 Backward compatibility with 2.x series
 if (PHP_VERSION_ID < 70000) {
     class_alias('Cake\Utility\Text', 'Cake\Utility\String');
     deprecationWarning('Use Cake\Utility\Text instead of Cake\Utility\String.');

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -12,7 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-// @deprecated Add backwards compat alias.
+// @deprecated 3.6.0 Add backwards compat alias.
 class_alias('Cake\View\Widget\WidgetLocator', 'Cake\View\Widget\WidgetRegistry');
 
 deprecationWarning('Use Cake\View\Widget\WidgetLocator instead of Cake\View\Widget\WidgetRegistry.');


### PR DESCRIPTION
This is a painfully missing info when trying to upgrade plugins and ecosystem tooling for new majors.
If you keep 3.5 compatibility, for example, you easily risk killing the whole plugin by upgrading too high.

So having the version numbers here help to find the right things to upgrade as per minimum version support in composer.json.