### PR TITLE
Fixes #12376 bindTranslation restore fields

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -344,7 +344,7 @@ class TranslateBehavior extends ModelBehavior {
 	public function afterFind(Model $Model, $results, $primary = false) {
 		$Model->virtualFields = $this->runtime[$Model->alias]['virtualFields'];
 
-		$this->runtime[$Model->alias]['virtualFields'] = $this->runtime[$Model->alias]['fields'] = array();
+		$this->runtime[$Model->alias]['virtualFields'] = array();
 		if (!empty($this->runtime[$Model->alias]['restoreFields'])) {
 			$this->runtime[$Model->alias]['fields'] = $this->runtime[$Model->alias]['restoreFields'];
 			unset($this->runtime[$Model->alias]['restoreFields']);

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -1144,6 +1144,16 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->bindTranslation($translations);
 
 		$result = $TestModel->find('first');
+		$TestModel->find('first', array(
+			'fields' => array(
+				'TranslatedItem.title',
+			),
+		));
+		$TestModel->find('first', array(
+			'fields' => array(
+				'TranslatedItem.title',
+			),
+		));
 		$this->assertArrayHasKey('Title', $result);
 		$this->assertArrayHasKey('content', $result['Title'][0]);
 		$this->assertArrayNotHasKey('title', $result);


### PR DESCRIPTION
This fixes https://github.com/cakephp/cakephp/issues/12376
Makes sure that bindTranslation() when called with $reset = true, restores the fields to their original value and not empty array.

@markstory maybe add some comments about why the 2 extra finds are there?