### PR TITLE
Normalize string namespaces to non prefix slash.

### DIFF
--- a/tests/PHPStan/TableFindByPropertyMethodReflection.php
+++ b/tests/PHPStan/TableFindByPropertyMethodReflection.php
@@ -66,6 +66,6 @@ class TableFindByPropertyMethodReflection implements MethodReflection
 
     public function getReturnType(): Type
     {
-        return new ObjectType('\Cake\ORM\Query');
+        return new ObjectType('Cake\ORM\Query');
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -897,7 +897,7 @@ class ConnectionTest extends TestCase
 
         $this->connection->enableQueryLogging(false);
         $st = $this->connection->prepare('SELECT 1');
-        $this->assertNotInstanceOf('\Cake\Database\Log\LoggingStatement', $st);
+        $this->assertNotInstanceOf('Cake\Database\Log\LoggingStatement', $st);
     }
 
     /**
@@ -942,7 +942,7 @@ class ConnectionTest extends TestCase
         $this->connection->setLogger($logger);
         $logger->expects($this->once())->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT 1')
             ));
         $this->connection->log('SELECT 1');
@@ -969,12 +969,12 @@ class ConnectionTest extends TestCase
         $connection->setLogger($logger);
         $logger->expects($this->at(0))->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'BEGIN')
             ));
         $logger->expects($this->at(1))->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'ROLLBACK')
             ));
 
@@ -1001,7 +1001,7 @@ class ConnectionTest extends TestCase
 
         $logger->expects($this->at(1))->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'COMMIT')
             ));
         $connection->enableQueryLogging(true);

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -150,7 +150,7 @@ class PostgresTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $connection = $this
-            ->getMockBuilder('\Cake\Database\Connection')
+            ->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['connect'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -254,7 +254,7 @@ class SqlserverTest extends TestCase
             ->method('_version')
             ->will($this->returnValue(12));
 
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
@@ -305,7 +305,7 @@ class SqlserverTest extends TestCase
             ->method('_version')
             ->will($this->returnValue(8));
 
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
@@ -363,7 +363,7 @@ class SqlserverTest extends TestCase
             ->setMethods(['_connect', 'getConnection'])
             ->setConstructorArgs([[]])
             ->getMock();
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -48,7 +48,7 @@ class QueryExpressionTest extends TestCase
     public function testAndOrCalls()
     {
         $expr = new QueryExpression();
-        $expected = '\Cake\Database\Expression\QueryExpression';
+        $expected = 'Cake\Database\Expression\QueryExpression';
         $this->assertInstanceOf($expected, $expr->and([]));
         $this->assertInstanceOf($expected, $expr->or([]));
     }

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -31,11 +31,11 @@ class LoggingStatementTest extends TestCase
     {
         $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('rowCount')->will($this->returnValue(3));
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT bar FROM foo'),
                 $this->attributeEqualTo('took', 5, 200),
                 $this->attributeEqualTo('numRows', 3),
@@ -56,11 +56,11 @@ class LoggingStatementTest extends TestCase
     {
         $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('rowCount')->will($this->returnValue(4));
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT bar FROM foo'),
                 $this->attributeEqualTo('took', 5, 200),
                 $this->attributeEqualTo('numRows', 4),
@@ -81,11 +81,11 @@ class LoggingStatementTest extends TestCase
     {
         $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->any())->method('rowCount')->will($this->returnValue(4));
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->at(0))
             ->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT bar FROM foo'),
                 $this->attributeEqualTo('took', 5, 200),
                 $this->attributeEqualTo('numRows', 4),
@@ -94,7 +94,7 @@ class LoggingStatementTest extends TestCase
         $logger->expects($this->at(1))
             ->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT bar FROM foo'),
                 $this->attributeEqualTo('took', 5, 200),
                 $this->attributeEqualTo('numRows', 4),
@@ -103,7 +103,7 @@ class LoggingStatementTest extends TestCase
         $date = new \DateTime('2013-01-01');
         $inner->expects($this->at(0))->method('bindValue')->with('a', 1);
         $inner->expects($this->at(1))->method('bindValue')->with('b', $date);
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
         $st->setLogger($logger);
@@ -127,11 +127,11 @@ class LoggingStatementTest extends TestCase
         $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('execute')
             ->will($this->throwException($exception));
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(
-                $this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
+                $this->isInstanceOf('Cake\Database\Log\LoggedQuery'),
                 $this->attributeEqualTo('query', 'SELECT bar FROM foo'),
                 $this->attributeEqualTo('took', 5, 200),
                 $this->attributeEqualTo('params', []),
@@ -150,7 +150,7 @@ class LoggingStatementTest extends TestCase
      */
     public function testSetAndGetLogger()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $st = new LoggingStatement();
         $this->assertNull($st->getLogger());
         $st->setLogger($logger);

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -53,7 +53,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolation()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
             ->getMock();
         $query = new LoggedQuery;
@@ -73,7 +73,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolationNotNamed()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
             ->getMock();
         $query = new LoggedQuery;
@@ -93,7 +93,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolationDuplicate()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
             ->getMock();
         $query = new LoggedQuery;
@@ -113,7 +113,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolationNamed()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
             ->getMock();
         $query = new LoggedQuery;
@@ -133,7 +133,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolationSpecialChars()
     {
-        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
             ->getMock();
         $query = new LoggedQuery;
@@ -159,13 +159,13 @@ class QueryLoggerTest extends TestCase
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
         $query->params = ['string', '3', null];
 
-        $engine = $this->getMockBuilder('\Cake\Log\Engine\BaseLog')
+        $engine = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
             ->setMethods(['log'])
             ->setConstructorArgs(['scopes' => ['queriesLog']])
             ->getMock();
         Log::engine('queryLoggerTest');
 
-        $engine2 = $this->getMockBuilder('\Cake\Log\Engine\BaseLog')
+        $engine2 = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
             ->setMethods(['log'])
             ->setConstructorArgs(['scopes' => ['foo']])
             ->getMock();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1371,8 +1371,8 @@ class QueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->where([
-                'id' => '\Cake\Error\Debugger::dump',
-                'title' => ['\Cake\Error\Debugger', 'dump'],
+                'id' => 'Cake\Error\Debugger::dump',
+                'title' => ['Cake\Error\Debugger', 'dump'],
                 'author_id' => function ($exp) {
                     return 1;
                 },
@@ -4416,7 +4416,7 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection);
 
-        $this->assertInstanceOf('\Cake\Database\ValueBinder', $query->getValueBinder());
+        $this->assertInstanceOf('Cake\Database\ValueBinder', $query->getValueBinder());
     }
 
     /**

--- a/tests/TestCase/Database/Statement/StatementDecoratorTest.php
+++ b/tests/TestCase/Database/Statement/StatementDecoratorTest.php
@@ -31,7 +31,7 @@ class StatementDecoratorTest extends TestCase
     public function testLastInsertId()
     {
         $statement = $this->getMockBuilder('\PDOStatement')->getMock();
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($statement, $driver);
 
         $driver->expects($this->once())->method('lastInsertId')
@@ -49,7 +49,7 @@ class StatementDecoratorTest extends TestCase
     public function testLastInsertIdWithReturning()
     {
         $internal = $this->getMockBuilder('\PDOStatement')->getMock();
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($internal, $driver);
 
         $internal->expects($this->once())->method('columnCount')
@@ -70,7 +70,7 @@ class StatementDecoratorTest extends TestCase
     public function testNoDoubleExecution()
     {
         $inner = $this->getMockBuilder('\PDOStatement')->getMock();
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($inner, $driver);
 
         $inner->expects($this->once())->method('execute');

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -189,7 +189,7 @@ class TypeFactoryTest extends TestCase
         );
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $this->assertSame($integer, $type->toPHP($integer, $driver));
         $this->assertSame($integer, $type->toPHP('' . $integer, $driver));
         $this->assertSame(3, $type->toPHP(3.57, $driver));
@@ -204,7 +204,7 @@ class TypeFactoryTest extends TestCase
     {
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $this->assertEquals(PDO::PARAM_INT, $type->toStatement($integer, $driver));
     }
 
@@ -216,7 +216,7 @@ class TypeFactoryTest extends TestCase
     public function testDecimalToPHP()
     {
         $type = TypeFactory::build('decimal');
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
 
         $this->assertSame(3.14159, $type->toPHP('3.14159', $driver));
         $this->assertSame(3.14159, $type->toPHP(3.14159, $driver));
@@ -232,7 +232,7 @@ class TypeFactoryTest extends TestCase
     {
         $type = TypeFactory::build('decimal');
         $string = '12.55';
-        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $this->assertEquals(PDO::PARAM_STR, $type->toStatement($string, $driver));
     }
 

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -665,7 +665,7 @@ class EventManagerTest extends TestCase
         $manager->dispatch($event2);
 
         $result = $manager->getEventList();
-        $this->assertInstanceOf('\Cake\Event\EventList', $result);
+        $this->assertInstanceOf('Cake\Event\EventList', $result);
         $this->assertCount(2, $result);
         $this->assertEquals($result[0], $event);
         $this->assertEquals($result[1], $event2);

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2842,7 +2842,7 @@ HTML;
     {
         Email::dropTransport('default');
 
-        $mock = $this->getMockBuilder('\Cake\Mailer\AbstractTransport')->getMock();
+        $mock = $this->getMockBuilder('Cake\Mailer\AbstractTransport')->getMock();
         $config = ['from' => 'tester@example.org', 'transport' => 'default'];
 
         Email::setConfig('default', $config);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -500,7 +500,7 @@ class BelongsToManyTest extends TestCase
     public function testLinkSuccessWithMocks()
     {
         $connection = ConnectionManager::get('test');
-        $joint = $this->getMockBuilder('\Cake\ORM\Table')
+        $joint = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['save', 'getPrimaryKey'])
             ->setConstructorArgs([['alias' => 'ArticlesTags', 'connection' => $connection]])
             ->getMock();
@@ -857,7 +857,7 @@ class BelongsToManyTest extends TestCase
             ->setMethods(['table'])
             ->getMock();
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association\BelongsToMany')
             ->setMethods(['_saveTarget', 'replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();
@@ -886,7 +886,7 @@ class BelongsToManyTest extends TestCase
             ->setMethods(['table'])
             ->getMock();
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association\BelongsToMany')
             ->setMethods(['_saveTarget', 'replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();
@@ -918,7 +918,7 @@ class BelongsToManyTest extends TestCase
             ->setMethods(['table'])
             ->getMock();
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association\BelongsToMany')
             ->setMethods(['replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();
@@ -948,7 +948,7 @@ class BelongsToManyTest extends TestCase
             ->setMethods(['table'])
             ->getMock();
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association\BelongsToMany')
             ->setMethods(['replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -376,8 +376,8 @@ class BelongsToTest extends TestCase
         $association = new BelongsTo('Companies', $config);
         $listener->expects($this->once())->method('__invoke')
             ->with(
-                $this->isInstanceOf('\Cake\Event\Event'),
-                $this->isInstanceOf('\Cake\ORM\Query'),
+                $this->isInstanceOf('Cake\Event\Event'),
+                $this->isInstanceOf('Cake\ORM\Query'),
                 $this->isInstanceOf('\ArrayObject'),
                 false
             );
@@ -405,8 +405,8 @@ class BelongsToTest extends TestCase
         $options = new \ArrayObject(['something' => 'more']);
         $listener->expects($this->once())->method('__invoke')
             ->with(
-                $this->isInstanceOf('\Cake\Event\Event'),
-                $this->isInstanceOf('\Cake\ORM\Query'),
+                $this->isInstanceOf('Cake\Event\Event'),
+                $this->isInstanceOf('Cake\ORM\Query'),
                 $options,
                 false
             );

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -167,7 +167,7 @@ class HasOneTest extends TestCase
         $this->user->setPrimaryKey(['id', 'site_id']);
         $association = new HasOne('Profiles', $config);
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['join', 'select'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -197,7 +197,7 @@ class HasOneTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['join', 'select'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -286,8 +286,8 @@ class HasOneTest extends TestCase
         $this->listenerCalled = false;
         $this->profile->getEventManager()->on('Model.beforeFind', function ($event, $query, $options, $primary) {
             $this->listenerCalled = true;
-            $this->assertInstanceOf('\Cake\Event\Event', $event);
-            $this->assertInstanceOf('\Cake\ORM\Query', $query);
+            $this->assertInstanceOf('Cake\Event\Event', $event);
+            $this->assertInstanceOf('Cake\ORM\Query', $query);
             $this->assertInstanceOf('\ArrayObject', $options);
             $this->assertFalse($primary);
         });
@@ -315,8 +315,8 @@ class HasOneTest extends TestCase
             'Model.beforeFind',
             function ($event, $query, $options, $primary) use ($opts) {
                 $this->listenerCalled = true;
-                $this->assertInstanceOf('\Cake\Event\Event', $event);
-                $this->assertInstanceOf('\Cake\ORM\Query', $query);
+                $this->assertInstanceOf('Cake\Event\Event', $event);
+                $this->assertInstanceOf('Cake\ORM\Query', $query);
                 $this->assertEquals($options, $opts);
                 $this->assertFalse($primary);
             }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -55,14 +55,14 @@ class AssociationTest extends TestCase
         parent::setUp();
         $this->source = new TestTable;
         $config = [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
             'foreignKey' => 'a_key',
             'conditions' => ['field' => 'value'],
             'dependent' => true,
             'sourceTable' => $this->source,
             'joinType' => 'INNER',
         ];
-        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+        $this->association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -150,7 +150,7 @@ class AssociationTest extends TestCase
      */
     public function testClassName()
     {
-        $this->assertEquals('\Cake\Test\TestCase\ORM\TestTable', $this->association->className());
+        $this->assertEquals('Cake\Test\TestCase\ORM\TestTable', $this->association->className());
     }
 
     /**
@@ -163,7 +163,7 @@ class AssociationTest extends TestCase
         $config = [
             'className' => 'Test',
         ];
-        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+        $this->association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -186,9 +186,9 @@ class AssociationTest extends TestCase
         $this->getTableLocator()->get('Test');
 
         $config = [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
         ];
-        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+        $this->association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -207,14 +207,14 @@ class AssociationTest extends TestCase
     public function testTargetTableDescendant()
     {
         $this->getTableLocator()->get('Test', [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
         ]);
-        $className = '\Cake\ORM\Table';
+        $className = 'Cake\ORM\Table';
 
         $config = [
             'className' => $className,
         ];
-        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+        $this->association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -352,7 +352,7 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
         ];
 
-        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+        $this->association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
                 'requiresKeys',
@@ -441,7 +441,7 @@ class AssociationTest extends TestCase
         $this->source->setSchema(['foo' => ['type' => 'string']]);
 
         $config = [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
             'foreignKey' => 'a_key',
             'conditions' => ['field' => 'value'],
             'dependent' => true,
@@ -449,7 +449,7 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
             'propertyName' => 'foo',
         ];
-        $association = $this->getMockBuilder('\Cake\ORM\Association')
+        $association = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -507,7 +507,7 @@ class AssociationTest extends TestCase
     public function testFinderInConstructor()
     {
         $config = [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
             'foreignKey' => 'a_key',
             'conditions' => ['field' => 'value'],
             'dependent' => true,
@@ -515,7 +515,7 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
             'finder' => 'published',
         ];
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
                 'requiresKeys',
@@ -549,10 +549,10 @@ class AssociationTest extends TestCase
     {
         $locator = $this->getMockBuilder('Cake\ORM\Locator\LocatorInterface')->getMock();
         $config = [
-            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'className' => 'Cake\Test\TestCase\ORM\TestTable',
             'tableLocator' => $locator,
         ];
-        $assoc = $this->getMockBuilder('\Cake\ORM\Association')
+        $assoc = $this->getMockBuilder('Cake\ORM\Association')
             ->setMethods([
                 'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
                 'requiresKeys',

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -588,7 +588,7 @@ class CompositeKeyTest extends TestCase
     public function testFindThreadedCompositeKeys()
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['_addDefaultFields', 'execute'])
             ->setConstructorArgs([null, $table])
             ->getMock();

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -157,7 +157,7 @@ class EagerLoaderTest extends TestCase
             ],
         ];
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['join'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
@@ -496,7 +496,7 @@ class EagerLoaderTest extends TestCase
             ],
         ];
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['join'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -161,7 +161,7 @@ class EntityTest extends TestCase
      */
     public function testSetOneParamWithSetter()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())->method('_setName')
@@ -182,7 +182,7 @@ class EntityTest extends TestCase
      */
     public function testMultipleWithSetter()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setName', '_setStuff'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -212,7 +212,7 @@ class EntityTest extends TestCase
      */
     public function testBypassSetters()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setName', '_setStuff'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -237,7 +237,7 @@ class EntityTest extends TestCase
      */
     public function testConstructor()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -261,7 +261,7 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithGuard()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -290,7 +290,7 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGetters()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())
@@ -311,7 +311,7 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGettersAfterSet()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())
@@ -335,7 +335,7 @@ class EntityTest extends TestCase
      */
     public function testGetCacheClearedByUnset()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())->method('_getName')
@@ -356,7 +356,7 @@ class EntityTest extends TestCase
      */
     public function testGetCamelCasedProperties()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getListIdName'])
             ->getMock();
         $entity->expects($this->any())->method('_getListIdName')
@@ -389,7 +389,7 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetter()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())->method('_setName')
@@ -410,7 +410,7 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetterTitleCase()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())
@@ -432,7 +432,7 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetter()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->once())->method('_getName')
@@ -453,7 +453,7 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetterTitleCase()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->once())
@@ -499,7 +499,7 @@ class EntityTest extends TestCase
         $this->assertFalse($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getThings'])
             ->getMock();
         $entity->expects($this->once())->method('_getThings')
@@ -570,7 +570,7 @@ class EntityTest extends TestCase
      */
     public function testMagicUnset()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['unsetProperty'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -600,7 +600,7 @@ class EntityTest extends TestCase
      */
     public function testGetArrayAccess()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['get'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -624,7 +624,7 @@ class EntityTest extends TestCase
      */
     public function testSetArrayAccess()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['set'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -650,7 +650,7 @@ class EntityTest extends TestCase
      */
     public function testUnsetArrayAccess()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['unsetProperty'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -668,10 +668,10 @@ class EntityTest extends TestCase
      */
     public function testMethodCache()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setFoo', '_getBar'])
             ->getMock();
-        $entity2 = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity2 = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_setBar'])
             ->getMock();
         $entity->expects($this->once())->method('_setFoo');
@@ -690,7 +690,7 @@ class EntityTest extends TestCase
      */
     public function testSetGetLongPropertyNames()
     {
-        $entity = $this->getMockBUilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBUilder('Cake\ORM\Entity')
             ->setMethods(['_getVeryLongProperty', '_setVeryLongProperty'])
             ->getMock();
         $entity->expects($this->once())->method('_getVeryLongProperty');
@@ -938,14 +938,14 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithClean()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->never())->method('clean');
         $entity->__construct(['a' => 'b', 'c' => 'd']);
 
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -960,14 +960,14 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithMarkNew()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['isNew', 'clean'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->never())->method('clean');
         $entity->__construct(['a' => 'b', 'c' => 'd']);
 
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['isNew'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1049,7 +1049,7 @@ class EntityTest extends TestCase
      */
     public function testToArrayWithAccessor()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -1126,7 +1126,7 @@ class EntityTest extends TestCase
      */
     public function testToArrayVirtualProperties()
     {
-        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+        $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
         $entity->setAccess('*', true);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -240,10 +240,10 @@ class TableLocatorTest extends TestCase
     public function testGetWithConfigClassName()
     {
         $this->_locator->setConfig('MyUsersTableAlias', [
-            'className' => '\Cake\Test\TestCase\ORM\Locator\MyUsersTable',
+            'className' => 'Cake\Test\TestCase\ORM\Locator\MyUsersTable',
         ]);
         $result = $this->_locator->get('MyUsersTableAlias');
-        $this->assertInstanceOf('\Cake\Test\TestCase\ORM\Locator\MyUsersTable', $result, 'Should use getConfig() data className option.');
+        $this->assertInstanceOf('Cake\Test\TestCase\ORM\Locator\MyUsersTable', $result, 'Should use getConfig() data className option.');
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1440,7 +1440,7 @@ class QueryTest extends TestCase
      */
     public function testHydrateCustomObject()
     {
-        $class = $this->getMockClass('\Cake\ORM\Entity', ['fakeMethod']);
+        $class = $this->getMockClass('Cake\ORM\Entity', ['fakeMethod']);
         $table = $this->getTableLocator()->get('articles', [
             'table' => 'articles',
             'entityClass' => '\\' . $class,
@@ -1469,8 +1469,8 @@ class QueryTest extends TestCase
      */
     public function testHydrateHasManyCustomEntity()
     {
-        $authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
-        $articleEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
+        $authorEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
+        $articleEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
         $table = $this->getTableLocator()->get('authors', [
             'entityClass' => '\\' . $authorEntity,
         ]);
@@ -1510,7 +1510,7 @@ class QueryTest extends TestCase
      */
     public function testHydrateBelongsToCustomEntity()
     {
-        $authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
+        $authorEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
         $table = $this->getTableLocator()->get('articles');
         $this->getTableLocator()->get('authors', [
             'entityClass' => '\\' . $authorEntity,
@@ -1848,7 +1848,7 @@ class QueryTest extends TestCase
      */
     public function testClearContain()
     {
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['all'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
@@ -1878,12 +1878,12 @@ class QueryTest extends TestCase
      */
     public function testCollectionProxy($method, $arg, $return)
     {
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['all'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
         $query->select();
-        $resultSet = $this->getMockbuilder('\Cake\ORM\ResultSet')
+        $resultSet = $this->getMockbuilder('Cake\ORM\ResultSet')
             ->setConstructorArgs([$query, null])
             ->getMock();
         $query->expects($this->once())
@@ -1931,11 +1931,11 @@ class QueryTest extends TestCase
      */
     public function testCacheReadIntegration()
     {
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
-        $resultSet = $this->getMockBuilder('\Cake\ORM\ResultSet')
+        $resultSet = $this->getMockBuilder('Cake\ORM\ResultSet')
             ->setConstructorArgs([$query, null])
             ->getMock();
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -142,7 +142,7 @@ class TableTest extends TestCase
         $table = new UsersTable;
         $this->assertEquals('users', $table->getTable());
 
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingsTable')
             ->getMock();
@@ -174,7 +174,7 @@ class TableTest extends TestCase
         $table = new UsersTable;
         $this->assertEquals('Users', $table->getAlias());
 
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingTable')
             ->getMock();
@@ -1173,12 +1173,12 @@ class TableTest extends TestCase
      */
     public function testStackingFinders()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['find', 'findList'])
             ->disableOriginalConstructor()
             ->getMock();
         $params = [$this->connection, $table];
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['addDefaultTypes'])
             ->setConstructorArgs($params)
             ->getMock();
@@ -1392,7 +1392,7 @@ class TableTest extends TestCase
      */
     public function testTableClassInApp()
     {
-        $class = $this->getMockClass('\Cake\ORM\Entity');
+        $class = $this->getMockClass('Cake\ORM\Entity');
 
         if (!class_exists('TestApp\Model\Entity\TestUser')) {
             class_alias($class, 'TestApp\Model\Entity\TestUser');
@@ -1410,7 +1410,7 @@ class TableTest extends TestCase
      */
     public function testEntityClassInflection()
     {
-        $class = $this->getMockClass('\Cake\ORM\Entity');
+        $class = $this->getMockClass('Cake\ORM\Entity');
 
         if (!class_exists('TestApp\Model\Entity\CustomCookie')) {
             class_alias($class, 'TestApp\Model\Entity\CustomCookie');
@@ -1428,7 +1428,7 @@ class TableTest extends TestCase
      */
     public function testTableClassInPlugin()
     {
-        $class = $this->getMockClass('\Cake\ORM\Entity');
+        $class = $this->getMockClass('Cake\ORM\Entity');
 
         if (!class_exists('MyPlugin\Model\Entity\SuperUser')) {
             class_alias($class, 'MyPlugin\Model\Entity\SuperUser');
@@ -1476,7 +1476,7 @@ class TableTest extends TestCase
     public function testSetEntityClass()
     {
         $table = new Table;
-        $class = '\\' . $this->getMockClass('\Cake\ORM\Entity');
+        $class = '\\' . $this->getMockClass('Cake\ORM\Entity');
         $this->assertSame($table, $table->setEntityClass($class));
         $this->assertEquals($class, $table->getEntityClass());
     }
@@ -2576,15 +2576,15 @@ class TableTest extends TestCase
      */
     public function testAfterSaveNotCalled()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
             ->setConstructorArgs([null, $table])
             ->getMock();
-        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
+        $statement = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')->getMock();
         $data = new Entity([
             'username' => 'superuser',
             'created' => new Time('2013-10-10 00:00'),
@@ -2685,13 +2685,13 @@ class TableTest extends TestCase
     {
         $config = ConnectionManager::getConfig('test');
 
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['begin', 'commit', 'inTransaction'])
             ->setConstructorArgs([$config])
             ->getMock();
         $connection->setDriver($this->connection->getDriver());
 
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['getConnection'])
             ->setConstructorArgs([['table' => 'users']])
             ->getMock();
@@ -2718,16 +2718,16 @@ class TableTest extends TestCase
     public function testAtomicSaveRollback()
     {
         $this->expectException(\PDOException::class);
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['begin', 'rollback'])
             ->setConstructorArgs([ConnectionManager::getConfig('test')])
             ->getMock();
         $connection->setDriver(ConnectionManager::get('test')->getDriver());
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query', 'getConnection'])
             ->setConstructorArgs([['table' => 'users']])
             ->getMock();
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
             ->setConstructorArgs([null, $table])
             ->getMock();
@@ -2758,16 +2758,16 @@ class TableTest extends TestCase
      */
     public function testAtomicSaveRollbackOnFailure()
     {
-        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['begin', 'rollback'])
             ->setConstructorArgs([ConnectionManager::getConfig('test')])
             ->getMock();
         $connection->setDriver(ConnectionManager::get('test')->getDriver());
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query', 'getConnection', 'exists'])
             ->setConstructorArgs([['table' => 'users']])
             ->getMock();
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
             ->setConstructorArgs([null, $table])
             ->getMock();
@@ -2778,7 +2778,7 @@ class TableTest extends TestCase
         $table->expects($this->once())->method('query')
             ->will($this->returnValue($query));
 
-        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
+        $statement = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')->getMock();
         $statement->expects($this->once())
             ->method('rowCount')
             ->will($this->returnValue(0));
@@ -2924,7 +2924,7 @@ class TableTest extends TestCase
      */
     public function testSaveUpdateWithHint()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['exists'])
             ->setConstructorArgs([['table' => 'users', 'connection' => ConnectionManager::get('test')]])
             ->getMock();
@@ -2946,12 +2946,12 @@ class TableTest extends TestCase
      */
     public function testSaveUpdatePrimaryKeyNotModified()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes', 'set'])
             ->setConstructorArgs([null, $table])
             ->getMock();
@@ -2959,7 +2959,7 @@ class TableTest extends TestCase
         $table->expects($this->once())->method('query')
             ->will($this->returnValue($query));
 
-        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
+        $statement = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')->getMock();
         $statement->expects($this->once())
             ->method('errorCode')
             ->will($this->returnValue('00000'));
@@ -2988,7 +2988,7 @@ class TableTest extends TestCase
      */
     public function testUpdateNoChange()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
@@ -3026,7 +3026,7 @@ class TableTest extends TestCase
     public function testUpdateNoPrimaryButOtherKeys()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
@@ -3539,7 +3539,7 @@ class TableTest extends TestCase
      */
     public function testValidationWithDefiner()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['validationForOtherStuff'])
             ->getMock();
         $table->expects($this->once())->method('validationForOtherStuff')
@@ -3559,7 +3559,7 @@ class TableTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The Cake\ORM\Table::validationBad() validation method must return an instance of Cake\Validation\Validator.');
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['validationBad'])
             ->getMock();
         $table->expects($this->once())
@@ -4241,7 +4241,7 @@ class TableTest extends TestCase
      */
     public function testSaveCleanEntity()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_processSave'])
             ->getMock();
         $entity = new Entity(
@@ -4285,15 +4285,15 @@ class TableTest extends TestCase
      */
     public function testSaveDeepAssociationOptions()
     {
-        $articles = $this->getMockBuilder('\Cake\ORM\Table')
+        $articles = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_insert'])
             ->setConstructorArgs([['table' => 'articles', 'connection' => $this->connection]])
             ->getMock();
-        $authors = $this->getMockBuilder('\Cake\ORM\Table')
+        $authors = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
-        $supervisors = $this->getMockBuilder('\Cake\ORM\Table')
+        $supervisors = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_insert', 'validate'])
             ->setConstructorArgs([[
                 'table' => 'authors',
@@ -4301,7 +4301,7 @@ class TableTest extends TestCase
                 'connection' => $this->connection,
             ]])
             ->getMock();
-        $tags = $this->getMockBuilder('\Cake\ORM\Table')
+        $tags = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_insert'])
             ->setConstructorArgs([['table' => 'tags', 'connection' => $this->connection]])
             ->getMock();
@@ -5575,7 +5575,7 @@ class TableTest extends TestCase
      */
     public function testSimplifiedFind()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['callFinder'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
@@ -5607,7 +5607,7 @@ class TableTest extends TestCase
      */
     public function testGet($options)
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['callFinder', 'query'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
@@ -5619,7 +5619,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
@@ -5657,7 +5657,7 @@ class TableTest extends TestCase
      */
     public function testGetWithCustomFinder($options)
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['callFinder', 'query'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
@@ -5669,7 +5669,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
@@ -5716,7 +5716,7 @@ class TableTest extends TestCase
      */
     public function testGetWithCache($options, $cacheKey, $cacheConfig)
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
+        $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['callFinder', 'query'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
@@ -5729,7 +5729,7 @@ class TableTest extends TestCase
             ->getMock();
         $table->setTable('table_name');
 
-        $query = $this->getMockBuilder('\Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -437,7 +437,7 @@ class TestCaseTest extends TestCase
         $Mock = $this->getMockForModel(
             'Table',
             ['save'],
-            ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
+            ['alias' => 'Comments', 'className' => 'Cake\ORM\Table']
         );
 
         $result = $this->getTableLocator()->get('Comments');

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -46,7 +46,7 @@ class RulesProviderTest extends TestCase
      */
     public function testCustomObject()
     {
-        $mock = $this->getMockBuilder('\Cake\Validation\Validator')
+        $mock = $this->getMockBuilder('Cake\Validation\Validator')
             ->setMethods(['field'])
             ->getMock();
         $mock->expects($this->once())

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -121,7 +121,7 @@ class HelperTest extends TestCase
      */
     public function testThatHelperHelpersAreNotAttached()
     {
-        $events = $this->getMockBuilder('\Cake\Event\EventManager')->getMock();
+        $events = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $this->View->setEventManager($events);
 
         $events->expects($this->never())


### PR DESCRIPTION
Normalizing to what we use everywhere for strings: no slash-prefix.
Hopefully, using a sniffer we can soon transform them all into actual ::class usage.