### PR TITLE
4.x orm strict typing

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -248,7 +248,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * associated values for expressions
      * @return string
      */
-    public function sql(?ValueBinder $generator = null)
+    public function sql(?ValueBinder $generator = null): string
     {
         if (!$generator) {
             $generator = $this->getValueBinder();

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -52,7 +52,7 @@ interface RepositoryInterface
      * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
      * @return \Cake\Datasource\QueryInterface
      */
-    public function find($type = 'all', $options = []);
+    public function find(string $type = 'all', $options = []);
 
     /**
      * Returns a single record after finding it by its primary key, if no record is
@@ -74,7 +74,7 @@ interface RepositoryInterface
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\Datasource\RepositoryInterface::find()
      */
-    public function get($primaryKey, $options = []);
+    public function get($primaryKey, $options = []): EntityInterface;
 
     /**
      * Creates a new Query instance for this repository
@@ -164,7 +164,7 @@ interface RepositoryInterface
      * @param array $options A list of options for the object hydration.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function newEntity(?array $data = null, array $options = []);
+    public function newEntity(?array $data = null, array $options = []): EntityInterface;
 
     /**
      * Create a list of entities + associated entities from an array.
@@ -182,7 +182,7 @@ interface RepositoryInterface
      * @param array $options A list of options for the objects hydration.
      * @return \Cake\Datasource\EntityInterface[] An array of hydrated records.
      */
-    public function newEntities(array $data, array $options = []);
+    public function newEntities(array $data, array $options = []): array;
 
     /**
      * Merges the passed `$data` into `$entity` respecting the accessible
@@ -201,7 +201,7 @@ interface RepositoryInterface
      * @param array $options A list of options for the object hydration.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function patchEntity(EntityInterface $entity, array $data, array $options = []);
+    public function patchEntity(EntityInterface $entity, array $data, array $options = []): EntityInterface;
 
     /**
      * Merges each of the elements passed in `$data` into the entities
@@ -221,5 +221,5 @@ interface RepositoryInterface
      * @param array $options A list of options for the objects hydration.
      * @return \Cake\Datasource\EntityInterface[]
      */
-    public function patchEntities($entities, array $data, array $options = []);
+    public function patchEntities($entities, array $data, array $options = []): array;
 }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -25,6 +25,7 @@ use Cake\I18n\I18n;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Marshaller;
 use Cake\ORM\PropertyMarshalInterface;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
@@ -380,7 +381,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      *
      * {@inheritDoc}
      */
-    public function buildMarshalMap($marshaller, $map, $options)
+    public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
     {
         if (isset($options['translations']) && !$options['translations']) {
             return [];

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -58,7 +59,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      *
      * @param \Cake\ORM\Table|null $table The table this registry is attached to.
      */
-    public function __construct($table = null)
+    public function __construct(?Table $table = null)
     {
         if ($table !== null) {
             $this->setTable($table);
@@ -71,7 +72,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param \Cake\ORM\Table $table The table this registry is attached to.
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->_table = $table;
         $eventManager = $table->getEventManager();
@@ -87,7 +88,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return string|null Either the correct classname or null.
      * @since 3.5.7
      */
-    public static function className($class)
+    public static function className(string $class): ?string
     {
         $result = App::className($class, 'Model/Behavior', 'Behavior');
         if (!$result) {
@@ -167,7 +168,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return array A list of implemented finders and methods.
      * @throws \LogicException when duplicate methods are connected.
      */
-    protected function _getMethods(Behavior $instance, $class, $alias)
+    protected function _getMethods(Behavior $instance, string $class, string $alias): array
     {
         $finders = array_change_key_case($instance->implementedFinders());
         $methods = array_change_key_case($instance->implementedMethods());
@@ -212,7 +213,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param string $method The method to check for.
      * @return bool
      */
-    public function hasMethod($method)
+    public function hasMethod(string $method): bool
     {
         $method = strtolower($method);
 
@@ -228,7 +229,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param string $method The method to check for.
      * @return bool
      */
-    public function hasFinder($method)
+    public function hasFinder(string $method): bool
     {
         $method = strtolower($method);
 
@@ -243,7 +244,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return mixed The return value depends on the underlying behavior method.
      * @throws \BadMethodCallException When the method is unknown.
      */
-    public function call($method, array $args = [])
+    public function call(string $method, array $args = [])
     {
         $method = strtolower($method);
         if ($this->hasMethod($method) && $this->has($this->_methodMap[$method][0])) {
@@ -265,7 +266,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return mixed The return value depends on the underlying behavior method.
      * @throws \BadMethodCallException When the method is unknown.
      */
-    public function callFinder($type, array $args = [])
+    public function callFinder(string $type, array $args = [])
     {
         $type = strtolower($type);
 

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -126,7 +127,7 @@ class EagerLoadable
      * @param string $name The Association name.
      * @param array $config The list of properties to set.
      */
-    public function __construct($name, array $config = [])
+    public function __construct(string $name, array $config = [])
     {
         $this->_name = $name;
         $allowed = [
@@ -147,7 +148,7 @@ class EagerLoadable
      * @param \Cake\ORM\EagerLoadable $association The association to load.
      * @return void
      */
-    public function addAssociation($name, EagerLoadable $association)
+    public function addAssociation(string $name, EagerLoadable $association): void
     {
         $this->_associations[$name] = $association;
     }
@@ -157,7 +158,7 @@ class EagerLoadable
      *
      * @return array
      */
-    public function associations()
+    public function associations(): array
     {
         return $this->_associations;
     }
@@ -167,7 +168,7 @@ class EagerLoadable
      *
      * @return \Cake\ORM\Association|null
      */
-    public function instance()
+    public function instance(): ?Association
     {
         return $this->_instance;
     }
@@ -178,7 +179,7 @@ class EagerLoadable
      *
      * @return string|null
      */
-    public function aliasPath()
+    public function aliasPath(): ?string
     {
         return $this->_aliasPath;
     }
@@ -197,7 +198,7 @@ class EagerLoadable
      *
      * @return string|null
      */
-    public function propertyPath()
+    public function propertyPath(): ?string
     {
         return $this->_propertyPath;
     }
@@ -208,7 +209,7 @@ class EagerLoadable
      * @param bool $possible The value to set.
      * @return $this
      */
-    public function setCanBeJoined($possible)
+    public function setCanBeJoined(bool $possible): self
     {
         $this->_canBeJoined = (bool)$possible;
 
@@ -220,7 +221,7 @@ class EagerLoadable
      *
      * @return bool
      */
-    public function canBeJoined()
+    public function canBeJoined(): bool
     {
         return $this->_canBeJoined;
     }
@@ -232,7 +233,7 @@ class EagerLoadable
      * @param array $config The value to set.
      * @return $this
      */
-    public function setConfig(array $config)
+    public function setConfig(array $config): self
     {
         $this->_config = $config;
 
@@ -245,7 +246,7 @@ class EagerLoadable
      *
      * @return array
      */
-    public function getConfig()
+    public function getConfig(): array
     {
         return $this->_config;
     }
@@ -256,7 +257,7 @@ class EagerLoadable
      *
      * @return bool|null
      */
-    public function forMatching()
+    public function forMatching(): ?bool
     {
         return $this->_forMatching;
     }
@@ -275,7 +276,7 @@ class EagerLoadable
      *
      * @return string|null
      */
-    public function targetProperty()
+    public function targetProperty(): ?string
     {
         return $this->_targetProperty;
     }
@@ -286,7 +287,7 @@ class EagerLoadable
      *
      * @return array
      */
-    public function asContainArray()
+    public function asContainArray(): array
     {
         $associations = [];
         foreach ($this->_associations as $assoc) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -16,6 +17,7 @@ namespace Cake\ORM;
 
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Database\Statement\CallbackStatement;
+use Cake\Database\StatementInterface;
 use Cake\Datasource\QueryInterface;
 use Closure;
 use InvalidArgumentException;
@@ -130,7 +132,7 @@ class EagerLoader
      * @return array Containments.
      * @throws \InvalidArgumentException When using $queryBuilder with an array of $associations
      */
-    public function contain($associations, ?callable $queryBuilder = null)
+    public function contain($associations, ?callable $queryBuilder = null): array
     {
         if ($queryBuilder) {
             if (!is_string($associations)) {
@@ -163,7 +165,7 @@ class EagerLoader
      *
      * @return array Containments.
      */
-    public function getContain()
+    public function getContain(): array
     {
         return $this->_containments;
     }
@@ -176,7 +178,7 @@ class EagerLoader
      *
      * @return void
      */
-    public function clearContain()
+    public function clearContain(): void
     {
         $this->_containments = [];
         $this->_normalized = null;
@@ -190,7 +192,7 @@ class EagerLoader
      * @param bool $enable The value to set.
      * @return $this
      */
-    public function enableAutoFields($enable = true)
+    public function enableAutoFields(bool $enable = true): self
     {
         $this->_autoFields = (bool)$enable;
 
@@ -202,7 +204,7 @@ class EagerLoader
      *
      * @return bool The current value.
      */
-    public function isAutoFieldsEnabled()
+    public function isAutoFieldsEnabled(): bool
     {
         return $this->_autoFields;
     }
@@ -224,7 +226,7 @@ class EagerLoader
      * @param array $options Extra options for the association matching.
      * @return $this
      */
-    public function setMatching($assoc, ?callable $builder = null, $options = [])
+    public function setMatching(string $assoc, ?callable $builder = null, array $options = []): self
     {
         if ($this->_matching === null) {
             $this->_matching = new static();
@@ -258,7 +260,7 @@ class EagerLoader
      *
      * @return array The resulting containments array
      */
-    public function getMatching()
+    public function getMatching(): array
     {
         if ($this->_matching === null) {
             $this->_matching = new static();
@@ -283,7 +285,7 @@ class EagerLoader
      * will be normalized
      * @return array
      */
-    public function normalized(Table $repository)
+    public function normalized(Table $repository): array
     {
         if ($this->_normalized !== null || empty($this->_containments)) {
             return (array)$this->_normalized;
@@ -316,7 +318,7 @@ class EagerLoader
      * with the new one
      * @return array
      */
-    protected function _reformatContain($associations, $original)
+    protected function _reformatContain(array $associations, array $original): array
     {
         $result = $original;
 
@@ -394,7 +396,7 @@ class EagerLoader
      * per association in the containments array
      * @return void
      */
-    public function attachAssociations(Query $query, Table $repository, $includeFields)
+    public function attachAssociations(Query $query, Table $repository, bool $includeFields): void
     {
         if (empty($this->_containments) && $this->_matching === null) {
             return;
@@ -427,7 +429,7 @@ class EagerLoader
      * attached
      * @return array
      */
-    public function attachableAssociations(Table $repository)
+    public function attachableAssociations(Table $repository): array
     {
         $contain = $this->normalized($repository);
         $matching = $this->_matching ? $this->_matching->normalized($repository) : [];
@@ -445,7 +447,7 @@ class EagerLoader
      * to be loaded
      * @return \Cake\ORM\EagerLoadable[]
      */
-    public function externalAssociations(Table $repository)
+    public function externalAssociations(Table $repository): array
     {
         if ($this->_loadExternal) {
             return $this->_loadExternal;
@@ -470,7 +472,7 @@ class EagerLoader
      * @return \Cake\ORM\EagerLoadable Object with normalized associations
      * @throws \InvalidArgumentException When containments refer to associations that do not exist.
      */
-    protected function _normalizeContain(Table $parent, $alias, $options, $paths)
+    protected function _normalizeContain(Table $parent, string $alias, array $options, array $paths): EagerLoadable
     {
         $defaults = $this->_containOptions;
         $instance = $parent->getAssociation($alias);
@@ -523,7 +525,7 @@ class EagerLoader
      *
      * @return void
      */
-    protected function _fixStrategies()
+    protected function _fixStrategies(): void
     {
         foreach ($this->_aliasList as $aliases) {
             foreach ($aliases as $configs) {
@@ -547,7 +549,7 @@ class EagerLoader
      * @param \Cake\ORM\EagerLoadable $loadable The association config
      * @return void
      */
-    protected function _correctStrategy($loadable)
+    protected function _correctStrategy(EagerLoadable $loadable): void
     {
         $config = $loadable->getConfig();
         $currentStrategy = $config['strategy'] ??
@@ -570,7 +572,7 @@ class EagerLoader
      * @param array $matching list of associations that should be forcibly joined.
      * @return array
      */
-    protected function _resolveJoins($associations, $matching = [])
+    protected function _resolveJoins(array $associations, array $matching = []): array
     {
         $result = [];
         foreach ($matching as $table => $loadable) {
@@ -605,7 +607,7 @@ class EagerLoader
      * @param \Cake\Database\StatementInterface $statement The statement created after executing the $query
      * @return \Cake\Database\StatementInterface statement modified statement with extra loaders
      */
-    public function loadExternal($query, $statement)
+    public function loadExternal(Query $query, StatementInterface $statement): StatementInterface
     {
         $external = $this->externalAssociations($query->getRepository());
         if (empty($external)) {
@@ -657,7 +659,7 @@ class EagerLoader
      * will be normalized
      * @return array
      */
-    public function associationsMap($table)
+    public function associationsMap(Table $table): array
     {
         $map = [];
 
@@ -681,7 +683,7 @@ class EagerLoader
      * @param bool $matching Whether or not it is an association loaded through `matching()`.
      * @return array
      */
-    protected function _buildAssociationsMap($map, $level, $matching = false)
+    protected function _buildAssociationsMap(array $map, array $level, bool $matching = false): array
     {
         /* @var \Cake\ORM\EagerLoadable $meta */
         foreach ($level as $assoc => $meta) {
@@ -720,7 +722,7 @@ class EagerLoader
      * If not passed, the default property for the association will be used.
      * @return void
      */
-    public function addToJoinsMap($alias, Association $assoc, $asMatching = false, $targetProperty = null)
+    public function addToJoinsMap(string $alias, Association $assoc, bool $asMatching = false, ?string $targetProperty = null): void
     {
         $this->_joinsMap[$alias] = new EagerLoadable($alias, [
             'aliasPath' => $alias,
@@ -740,7 +742,7 @@ class EagerLoader
      * @param \Cake\Database\Statement\BufferedStatement $statement The statement to work on
      * @return array
      */
-    protected function _collectKeys($external, $query, $statement)
+    protected function _collectKeys(array $external, Query $query, $statement): array
     {
         $collectKeys = [];
         /* @var \Cake\ORM\EagerLoadable $meta */
@@ -782,7 +784,7 @@ class EagerLoader
      * @param array $collectKeys The keys to collect
      * @return array
      */
-    protected function _groupKeys($statement, $collectKeys)
+    protected function _groupKeys(BufferedStatement $statement, array $collectKeys): array
     {
         $keys = [];
         while ($result = $statement->fetch('assoc')) {

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -61,7 +62,7 @@ class PersistenceFailedException extends Exception
      * @param string|array $error Error message.
      * @return string
      */
-    protected function buildError($error)
+    protected function buildError($error): string
     {
         if (!is_array($error)) {
             return $error;
@@ -80,7 +81,7 @@ class PersistenceFailedException extends Exception
      *
      * @return \Cake\Datasource\EntityInterface
      */
-    public function getEntity()
+    public function getEntity(): EntityInterface
     {
         return $this->_entity;
     }

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -15,6 +16,7 @@
 namespace Cake\ORM;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Datasource\EntityInterface;
 
@@ -66,7 +68,7 @@ class LazyEagerLoader
      * @param \Cake\ORM\Table $source The table to use for fetching the top level entities
      * @return \Cake\ORM\Query
      */
-    protected function _getQuery($objects, $contain, $source)
+    protected function _getQuery(CollectionInterface $objects, array $contain, Table $source): Query
     {
         $primaryKey = $source->getPrimaryKey();
         $method = is_string($primaryKey) ? 'get' : 'extract';
@@ -112,7 +114,7 @@ class LazyEagerLoader
      * @param array $associations The name of the top level associations
      * @return array
      */
-    protected function _getPropertyMap($source, $associations)
+    protected function _getPropertyMap(Table $source, array $associations): array
     {
         $map = [];
         $container = $source->associations();
@@ -127,13 +129,13 @@ class LazyEagerLoader
      * Injects the results of the eager loader query into the original list of
      * entities.
      *
-     * @param array|\Traversable $objects The original list of entities
+     * @param iterable $objects The original list of entities
      * @param \Cake\Collection\CollectionInterface|\Cake\Database\Query $results The loaded results
      * @param array $associations The top level associations that were loaded
      * @param \Cake\ORM\Table $source The table where the entities came from
      * @return array
      */
-    protected function _injectResults($objects, $results, $associations, $source)
+    protected function _injectResults(iterable $objects, $results, array $associations, Table $source): array
     {
         $injected = [];
         $properties = $this->_getPropertyMap($source, $associations);

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -46,7 +47,7 @@ trait LocatorAwareTrait
      *
      * @return \Cake\ORM\Locator\LocatorInterface
      */
-    public function getTableLocator()
+    public function getTableLocator(): LocatorInterface
     {
         if (!$this->_tableLocator) {
             $this->_tableLocator = TableRegistry::getTableLocator();

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -28,7 +29,7 @@ interface LocatorInterface
      * @param string|null $alias Alias to get config for, null for complete config.
      * @return array The config data.
      */
-    public function getConfig($alias = null);
+    public function getConfig(?string $alias = null): array;
 
     /**
      * Stores a list of options to be used when instantiating an object
@@ -50,7 +51,7 @@ interface LocatorInterface
      * @param array $options The options you want to build the table with.
      * @return \Cake\ORM\Table
      */
-    public function get($alias, array $options = []);
+    public function get(string $alias, array $options = []): Table;
 
     /**
      * Check to see if an instance exists in the registry.
@@ -58,7 +59,7 @@ interface LocatorInterface
      * @param string $alias The alias to check for.
      * @return bool
      */
-    public function exists($alias);
+    public function exists(string $alias): bool;
 
     /**
      * Set an instance.
@@ -67,14 +68,14 @@ interface LocatorInterface
      * @param \Cake\ORM\Table $object The table to set.
      * @return \Cake\ORM\Table
      */
-    public function set($alias, Table $object);
+    public function set(string $alias, Table $object): Table;
 
     /**
      * Clears the registry of configuration and instances.
      *
      * @return void
      */
-    public function clear();
+    public function clear(): void;
 
     /**
      * Removes an instance from the registry.
@@ -82,5 +83,5 @@ interface LocatorInterface
      * @param string $alias The alias to remove.
      * @return void
      */
-    public function remove($alias);
+    public function remove(string $alias): void;
 }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -90,7 +91,7 @@ class TableLocator implements LocatorInterface
      * @param string|null $alias Alias to get config for, null for complete config.
      * @return array The config data.
      */
-    public function getConfig($alias = null)
+    public function getConfig(?string $alias = null): array
     {
         if ($alias === null) {
             return $this->_config;
@@ -135,7 +136,7 @@ class TableLocator implements LocatorInterface
      * @return \Cake\ORM\Table
      * @throws \RuntimeException When you try to configure an alias that already exists.
      */
-    public function get($alias, array $options = [])
+    public function get(string $alias, array $options = []): Table
     {
         if (isset($this->_instances[$alias])) {
             if (!empty($options) && $this->_options[$alias] !== $options) {
@@ -202,7 +203,7 @@ class TableLocator implements LocatorInterface
      * @param array $options Table options array.
      * @return string|null
      */
-    protected function _getClassName($alias, array $options = [])
+    protected function _getClassName(string $alias, array $options = []): ?string
     {
         if (empty($options['className'])) {
             $options['className'] = Inflector::camelize($alias);
@@ -217,7 +218,7 @@ class TableLocator implements LocatorInterface
      * @param array $options The alias to check for.
      * @return \Cake\ORM\Table
      */
-    protected function _create(array $options)
+    protected function _create(array $options): Table
     {
         return new $options['className']($options);
     }
@@ -225,7 +226,7 @@ class TableLocator implements LocatorInterface
     /**
      * {@inheritDoc}
      */
-    public function exists($alias)
+    public function exists(string $alias): bool
     {
         return isset($this->_instances[$alias]);
     }
@@ -233,7 +234,7 @@ class TableLocator implements LocatorInterface
     /**
      * {@inheritDoc}
      */
-    public function set($alias, Table $object)
+    public function set(string $alias, Table $object): Table
     {
         return $this->_instances[$alias] = $object;
     }
@@ -241,7 +242,7 @@ class TableLocator implements LocatorInterface
     /**
      * {@inheritDoc}
      */
-    public function clear()
+    public function clear(): void
     {
         $this->_instances = [];
         $this->_config = [];
@@ -256,7 +257,7 @@ class TableLocator implements LocatorInterface
      *
      * @return \Cake\ORM\Table[]
      */
-    public function genericInstances()
+    public function genericInstances(): array
     {
         return $this->_fallbacked;
     }
@@ -264,7 +265,7 @@ class TableLocator implements LocatorInterface
     /**
      * {@inheritDoc}
      */
-    public function remove($alias)
+    public function remove(string $alias): void
     {
         unset(
             $this->_instances[$alias],

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -287,7 +287,7 @@ class Marshaller
      * Create a new sub-marshaller and marshal the associated data.
      *
      * @param \Cake\ORM\Association $assoc The association to marshall
-     * @param array $value The data to hydrate
+     * @param mixed $value The data to hydrate. If not an array, this method will return null.
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
      */
@@ -701,7 +701,7 @@ class Marshaller
      *
      * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[] $original The original entity
      * @param \Cake\ORM\Association $assoc The association to merge
-     * @param array $value The data to hydrate
+     * @param mixed $value The array of data to hydrate. If not an array, this method will return null.
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
      */

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -62,7 +63,7 @@ class Marshaller
      * @throws \InvalidArgumentException When associations do not exist.
      * @return array
      */
-    protected function _buildPropertyMap($data, $options)
+    protected function _buildPropertyMap(array $data, array $options): array
     {
         $map = [];
         $schema = $this->_table->getSchema();
@@ -163,7 +164,7 @@ class Marshaller
      * @see \Cake\ORM\Table::newEntity()
      * @see \Cake\ORM\Entity::$_accessible
      */
-    public function one(array $data, array $options = [])
+    public function one(array $data, array $options = []): EntityInterface
     {
         list($data, $options) = $this->_prepareDataAndOptions($data, $options);
 
@@ -234,7 +235,7 @@ class Marshaller
      * @return array The list of validation errors.
      * @throws \RuntimeException If no validator can be created.
      */
-    protected function _validate($data, $options, $isNew)
+    protected function _validate(array $data, array $options, bool $isNew): array
     {
         if (!$options['validate']) {
             return [];
@@ -265,7 +266,7 @@ class Marshaller
      * @param array $options The options passed to this marshaller.
      * @return array An array containing prepared data and options.
      */
-    protected function _prepareDataAndOptions($data, $options)
+    protected function _prepareDataAndOptions(array $data, array $options): array
     {
         $options += ['validate' => true];
 
@@ -290,7 +291,7 @@ class Marshaller
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
      */
-    protected function _marshalAssociation($assoc, $value, $options)
+    protected function _marshalAssociation(Association $assoc, $value, array $options)
     {
         if (!is_array($value)) {
             return null;
@@ -340,7 +341,7 @@ class Marshaller
      * @see \Cake\ORM\Table::newEntities()
      * @see \Cake\ORM\Entity::$_accessible
      */
-    public function many(array $data, array $options = [])
+    public function many(array $data, array $options = []): array
     {
         $output = [];
         foreach ($data as $record) {
@@ -367,7 +368,7 @@ class Marshaller
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    protected function _belongsToMany(BelongsToMany $assoc, array $data, $options = [])
+    protected function _belongsToMany(BelongsToMany $assoc, array $data, array $options = []): array
     {
         $associated = $options['associated'] ?? [];
         $forceNew = $options['forceNew'] ?? false;
@@ -459,7 +460,7 @@ class Marshaller
      * @param array $ids The list of ids to load.
      * @return \Cake\Datasource\EntityInterface[] An array of entities.
      */
-    protected function _loadAssociatedByIds($assoc, $ids)
+    protected function _loadAssociatedByIds(Association $assoc, array $ids): array
     {
         if (empty($ids)) {
             return [];
@@ -520,7 +521,7 @@ class Marshaller
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Entity::$_accessible
      */
-    public function merge(EntityInterface $entity, array $data, array $options = [])
+    public function merge(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
         list($data, $options) = $this->_prepareDataAndOptions($data, $options);
 
@@ -624,7 +625,7 @@ class Marshaller
      * @return \Cake\Datasource\EntityInterface[]
      * @see \Cake\ORM\Entity::$_accessible
      */
-    public function mergeMany($entities, array $data, array $options = [])
+    public function mergeMany($entities, array $data, array $options = []): array
     {
         $primary = (array)$this->_table->getPrimaryKey();
 
@@ -662,7 +663,7 @@ class Marshaller
 
         $conditions = (new Collection($indexed))
             ->map(function ($data, $key) {
-                return explode(';', $key);
+                return explode(';', (string)$key);
             })
             ->filter(function ($keys) use ($primary) {
                 return count(array_filter($keys, 'strlen')) === count($primary);
@@ -704,7 +705,7 @@ class Marshaller
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
      */
-    protected function _mergeAssociation($original, $assoc, $value, $options)
+    protected function _mergeAssociation($original, Association $assoc, $value, array $options)
     {
         if (!$original) {
             return $this->_marshalAssociation($assoc, $value, $options);
@@ -736,7 +737,7 @@ class Marshaller
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface[]
      */
-    protected function _mergeBelongsToMany($original, $assoc, $value, $options)
+    protected function _mergeBelongsToMany($original, Association $assoc, $value, array $options): array
     {
         $associated = $options['associated'] ?? [];
 
@@ -766,7 +767,7 @@ class Marshaller
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface[] An array of entities
      */
-    protected function _mergeJoinData($original, $assoc, $value, $options)
+    protected function _mergeJoinData($original, BelongsToMany $assoc, array $value, array $options): array
     {
         $associated = $options['associated'] ?? [];
         $extra = [];

--- a/src/ORM/PropertyMarshalInterface.php
+++ b/src/ORM/PropertyMarshalInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -30,5 +31,5 @@ interface PropertyMarshalInterface
      * @param array $options The options array used in the marshalling call.
      * @return array A map of `[property => callable]` of additional properties to marshal.
      */
-    public function buildMarshalMap($marshaller, $map, $options);
+    public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array;
 }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -15,6 +15,7 @@
 namespace Cake\ORM;
 
 use ArrayObject;
+use Cake\Database\Connection;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\TypedResultInterface;
@@ -22,8 +23,10 @@ use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
+use Cake\Datasource\ResultSetInterface;
 use JsonSerializable;
 use RuntimeException;
+use Traversable;
 
 /**
  * Extends the base Query class to provide new methods related to association
@@ -110,7 +113,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Tracks whether or not the original query should include
      * fields from the top level table.
      *
-     * @var bool
+     * @var bool|null
      */
     protected $_autoFields;
 
@@ -159,7 +162,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct($connection, $table)
+    public function __construct(Connection $connection, Table $table)
     {
         parent::__construct($connection);
         $this->repository($table);
@@ -209,7 +212,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
-    public function select($fields = [], $overwrite = false)
+    public function select($fields = [], $overwrite = false): self
     {
         if ($fields instanceof Association) {
             $fields = $fields->getTarget();
@@ -237,7 +240,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @return Query
      * @throws \InvalidArgumentException If Association|Table is not passed in first argument
      */
-    public function selectAllExcept($table, array $excludedFields, $overwrite = false)
+    public function selectAllExcept($table, array $excludedFields, $overwrite = false): Query
     {
         if ($table instanceof Association) {
             $table = $table->getTarget();
@@ -264,7 +267,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\ORM\Table $table The table to pull types from
      * @return $this
      */
-    public function addDefaultTypes(Table $table)
+    public function addDefaultTypes(Table $table): self
     {
         $alias = $table->getAlias();
         $map = $table->getSchema()->typeMap();
@@ -284,7 +287,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\ORM\EagerLoader $instance The eager loader to use.
      * @return $this
      */
-    public function setEagerLoader(EagerLoader $instance)
+    public function setEagerLoader(EagerLoader $instance): self
     {
         $this->_eagerLoader = $instance;
 
@@ -296,7 +299,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return \Cake\ORM\EagerLoader
      */
-    public function getEagerLoader()
+    public function getEagerLoader(): EagerLoader
     {
         if ($this->_eagerLoader === null) {
             $this->_eagerLoader = new EagerLoader();
@@ -448,7 +451,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * @return array
      */
-    public function getContain()
+    public function getContain(): array
     {
         return $this->getEagerLoader()->getContain();
     }
@@ -458,7 +461,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return $this
      */
-    public function clearContain()
+    public function clearContain(): self
     {
         $this->getEagerLoader()->clearContain();
         $this->_dirty();
@@ -476,7 +479,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param array $associations The nested tree of associations to walk.
      * @return void
      */
-    protected function _addAssociationsToTypeMap($table, $typeMap, $associations)
+    protected function _addAssociationsToTypeMap(Table $table, TypeMap $typeMap, array $associations): void
     {
         foreach ($associations as $name => $nested) {
             if (!$table->hasAssociation($name)) {
@@ -544,7 +547,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function matching($assoc, ?callable $builder = null)
+    public function matching(string $assoc, ?callable $builder = null): self
     {
         $result = $this->getEagerLoader()->setMatching($assoc, $builder)->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
@@ -616,7 +619,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function leftJoinWith($assoc, ?callable $builder = null)
+    public function leftJoinWith(string $assoc, ?callable $builder = null): self
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -665,7 +668,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @return $this
      * @see \Cake\ORM\Query::matching()
      */
-    public function innerJoinWith($assoc, ?callable $builder = null)
+    public function innerJoinWith(string $assoc, ?callable $builder = null): self
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -729,7 +732,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function notMatching($assoc, ?callable $builder = null)
+    public function notMatching(string $assoc, ?callable $builder = null): self
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -826,7 +829,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return \Cake\ORM\Query
      */
-    public function cleanCopy()
+    public function cleanCopy(): Query
     {
         $clone = clone $this;
         $clone->setEagerLoader(clone $this->getEagerLoader());
@@ -879,7 +882,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return int
      */
-    protected function _performCount()
+    protected function _performCount(): int
     {
         $query = $this->cleanCopy();
         $counter = $this->_counter;
@@ -950,7 +953,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param callable|null $counter The counter value
      * @return $this
      */
-    public function counter($counter)
+    public function counter(?callable $counter): self
     {
         $this->_counter = $counter;
 
@@ -965,7 +968,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $enable Use a boolean to set the hydration mode.
      * @return $this
      */
-    public function enableHydration($enable = true)
+    public function enableHydration(bool $enable = true): self
     {
         $this->_dirty();
         $this->_hydrate = (bool)$enable;
@@ -978,7 +981,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return bool
      */
-    public function isHydrationEnabled()
+    public function isHydrationEnabled(): bool
     {
         return $this->_hydrate;
     }
@@ -989,7 +992,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @return $this
      * @throws \RuntimeException When you attempt to cache a non-select query.
      */
-    public function cache($key, $config = 'default')
+    public function cache(string $key, $config = 'default'): self
     {
         if ($this->_type !== 'select' && $this->_type !== null) {
             throw new RuntimeException('You cannot cache the results of non-select queries.');
@@ -1021,7 +1024,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return void
      */
-    public function triggerBeforeFind()
+    public function triggerBeforeFind(): void
     {
         if (!$this->_beforeFindFired && $this->_type === 'select') {
             $table = $this->getRepository();
@@ -1038,7 +1041,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * {@inheritDoc}
      */
-    public function sql(?ValueBinder $binder = null)
+    public function sql(?ValueBinder $binder = null): string
     {
         $this->triggerBeforeFind();
 
@@ -1052,9 +1055,9 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * This will also setup the correct statement class in order to eager load deep
      * associations.
      *
-     * @return \Cake\ORM\ResultSet
+     * @return \Cake\Datasource\ResultSetInterface
      */
-    protected function _execute()
+    protected function _execute(): ResultSetInterface
     {
         $this->triggerBeforeFind();
         if ($this->_results) {
@@ -1080,7 +1083,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @see \Cake\Database\Query::execute()
      * @return void
      */
-    protected function _transformQuery()
+    protected function _transformQuery(): void
     {
         if (!$this->_dirty || $this->_type !== 'select') {
             return;
@@ -1100,7 +1103,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return void
      */
-    protected function _addDefaultFields()
+    protected function _addDefaultFields(): void
     {
         $select = $this->clause('select');
         $this->_hasFields = true;
@@ -1120,7 +1123,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return void
      */
-    protected function _addDefaultSelectTypes()
+    protected function _addDefaultSelectTypes(): void
     {
         $typeMap = $this->getTypeMap()->getDefaults();
         $select = $this->clause('select');
@@ -1157,7 +1160,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return void
      */
-    protected function _dirty()
+    protected function _dirty(): void
     {
         $this->_results = null;
         $this->_resultsCount = null;
@@ -1210,7 +1213,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param array $types A map between columns & their datatypes.
      * @return $this
      */
-    public function insert(array $columns, array $types = [])
+    public function insert(array $columns, array $types = []): self
     {
         $table = $this->getRepository()->getTable();
         $this->into($table);
@@ -1260,7 +1263,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return \Cake\Datasource\ResultSetInterface The data to convert to JSON.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): ResultSetInterface
     {
         return $this->all();
     }
@@ -1274,7 +1277,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $value Set true to enable, false to disable.
      * @return $this
      */
-    public function enableAutoFields($value = true)
+    public function enableAutoFields(bool $value = true): self
     {
         $this->_autoFields = (bool)$value;
 
@@ -1287,9 +1290,9 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * By default calling select() will disable auto-fields. You can re-enable
      * auto-fields with enableAutoFields().
      *
-     * @return bool The current value.
+     * @return bool|null The current value.
      */
-    public function isAutoFieldsEnabled()
+    public function isAutoFieldsEnabled(): ?bool
     {
         return $this->_autoFields;
     }
@@ -1300,7 +1303,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Traversable $result Original results
      * @return \Cake\Datasource\ResultSetInterface
      */
-    protected function _decorateResults($result)
+    protected function _decorateResults(Traversable $result): ResultSetInterface
     {
         $result = $this->_applyDecorators($result);
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -17,6 +18,7 @@ namespace Cake\ORM;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
 use Cake\Database\Exception;
+use Cake\Database\StatementInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use SplFixedArray;
@@ -163,7 +165,7 @@ class ResultSet implements ResultSetInterface
      * @param \Cake\ORM\Query $query Query from where results come
      * @param \Cake\Database\StatementInterface $statement The statement to fetch from
      */
-    public function __construct($query, $statement)
+    public function __construct(Query $query, StatementInterface $statement)
     {
         $repository = $query->getRepository();
         $this->_statement = $statement;
@@ -202,7 +204,7 @@ class ResultSet implements ResultSetInterface
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->_index;
     }
@@ -214,7 +216,7 @@ class ResultSet implements ResultSetInterface
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_index++;
     }
@@ -227,7 +229,7 @@ class ResultSet implements ResultSetInterface
      * @throws \Cake\Database\Exception
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->_index === 0) {
             return;
@@ -248,7 +250,7 @@ class ResultSet implements ResultSetInterface
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->_useBuffering) {
             $valid = $this->_index < $this->_count;
@@ -300,7 +302,7 @@ class ResultSet implements ResultSetInterface
      *
      * @return string Serialized object
      */
-    public function serialize()
+    public function serialize(): string
     {
         if (!$this->_useBuffering) {
             $msg = 'You cannot serialize an un-buffered ResultSet. Use Query::bufferResults() to get a buffered ResultSet.';
@@ -366,7 +368,7 @@ class ResultSet implements ResultSetInterface
      * @param \Cake\ORM\Query $query The query from where to derive the associations
      * @return void
      */
-    protected function _calculateAssociationMap($query)
+    protected function _calculateAssociationMap(Query $query): void
     {
         $map = $query->getEagerLoader()->associationsMap($this->_defaultTable);
         $this->_matchingMap = (new Collection($map))
@@ -387,7 +389,7 @@ class ResultSet implements ResultSetInterface
      * @param \Cake\ORM\Query $query The query from where to derive the column map
      * @return void
      */
-    protected function _calculateColumnMap($query)
+    protected function _calculateColumnMap(Query $query): void
     {
         $map = [];
         foreach ($query->clause('select') as $key => $field) {
@@ -437,9 +439,9 @@ class ResultSet implements ResultSetInterface
      * Correctly nests results keys including those coming from associations
      *
      * @param array $row Array containing columns and values or false if there is no results
-     * @return array Results
+     * @return array|\Cake\Datasource\EntityInterface Results
      */
-    protected function _groupResult($row)
+    protected function _groupResult(array $row)
     {
         $defaultAlias = $this->_defaultAlias;
         $results = $presentAliases = [];

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -43,7 +44,7 @@ class RulesChecker extends BaseRulesChecker
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return callable
      */
-    public function isUnique(array $fields, $message = null)
+    public function isUnique(array $fields, $message = null): callable
     {
         $options = [];
         if (is_array($message)) {
@@ -89,7 +90,7 @@ class RulesChecker extends BaseRulesChecker
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return callable
      */
-    public function existsIn($field, $table, $message = null)
+    public function existsIn($field, $table, $message = null): callable
     {
         $options = [];
         if (is_array($message)) {
@@ -120,7 +121,7 @@ class RulesChecker extends BaseRulesChecker
      * @param string|null $message The error message to show in case the rule does not pass.
      * @return callable
      */
-    public function validCount($field, $count = 0, $operator = '>', $message = null)
+    public function validCount(string $field, int $count = 0, string $operator = '>', ?string $message = null): callable
     {
         if (!$message) {
             if ($this->_useI18n) {

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -66,7 +67,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param array $array Options array.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function parseArrayOptions($array)
+    public function parseArrayOptions(array $array): SaveOptionsBuilder
     {
         foreach ($array as $key => $value) {
             $this->{$key}($value);
@@ -81,7 +82,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param string|array $associated String or array of associations.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function associated($associated)
+    public function associated($associated): SaveOptionsBuilder
     {
         $associated = $this->_normalizeAssociations($associated);
         $this->_associated($this->_table, $associated);
@@ -97,7 +98,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param array $associations An associations array.
      * @return void
      */
-    protected function _associated(Table $table, array $associations)
+    protected function _associated(Table $table, array $associations): void
     {
         foreach ($associations as $key => $associated) {
             if (is_int($key)) {
@@ -120,7 +121,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param string $association Association name.
      * @return void
      */
-    protected function _checkAssociation(Table $table, $association)
+    protected function _checkAssociation(Table $table, string $association): void
     {
         if (!$table->associations()->has($association)) {
             throw new RuntimeException(sprintf('Table `%s` is not associated with `%s`', get_class($table), $association));
@@ -133,7 +134,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param bool $guard Guard the properties or not.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function guard($guard)
+    public function guard(bool $guard): SaveOptionsBuilder
     {
         $this->_options['guard'] = (bool)$guard;
 
@@ -146,7 +147,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param string $validate Name of the validation rule set to use.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function validate($validate)
+    public function validate(string $validate): SaveOptionsBuilder
     {
         $this->_table->getValidator($validate);
         $this->_options['validate'] = $validate;
@@ -160,7 +161,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param bool $checkExisting Guard the properties or not.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function checkExisting($checkExisting)
+    public function checkExisting(bool $checkExisting): SaveOptionsBuilder
     {
         $this->_options['checkExisting'] = (bool)$checkExisting;
 
@@ -173,7 +174,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param bool $checkRules Check the rules or not.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function checkRules($checkRules)
+    public function checkRules(bool $checkRules): SaveOptionsBuilder
     {
         $this->_options['checkRules'] = (bool)$checkRules;
 
@@ -186,7 +187,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param bool $atomic Atomic or not.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function atomic($atomic)
+    public function atomic(bool $atomic): SaveOptionsBuilder
     {
         $this->_options['atomic'] = (bool)$atomic;
 
@@ -196,7 +197,7 @@ class SaveOptionsBuilder extends ArrayObject
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->_options;
     }
@@ -208,7 +209,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @param mixed $value Option value.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function set($option, $value)
+    public function set(string $option, $value): SaveOptionsBuilder
     {
         if (method_exists($this, $option)) {
             return $this->{$option}($value);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -581,7 +581,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the display field.
      *
-     * @param string|array $fields Name to be used as display field.
+     * @param array $field Name to be used as display field.
      * @return $this
      */
     public function setDisplayField($field): self

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -581,7 +581,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the display field.
      *
-     * @param array $field Name to be used as display field.
+     * @param string|array $field Name to be used as display field.
      * @return $this
      */
     public function setDisplayField($field): self

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -17,6 +18,7 @@ namespace Cake\ORM;
 use ArrayObject;
 use BadMethodCallException;
 use Cake\Core\App;
+use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionInterface;
@@ -169,7 +171,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Connection instance
      *
-     * @var \Cake\Database\Connection
+     * @var \Cake\Database\Connection|null
      */
     protected $_connection;
 
@@ -190,7 +192,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * The name of the field that represents a human readable representation of a row
      *
-     * @var string
+     * @var string|array
      */
     protected $_displayField;
 
@@ -301,7 +303,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return string
      * @see \Cake\ORM\Locator\TableLocator::get()
      */
-    public static function defaultConnectionName()
+    public static function defaultConnectionName(): string
     {
         return 'default';
     }
@@ -324,7 +326,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $config Configuration options passed to the constructor
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
     }
 
@@ -334,7 +336,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $table Table name.
      * @return $this
      */
-    public function setTable($table)
+    public function setTable(string $table)
     {
         $this->_table = $table;
 
@@ -346,7 +348,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return string
      */
-    public function getTable()
+    public function getTable(): string
     {
         if ($this->_table === null) {
             $table = namespaceSplit(get_class($this));
@@ -397,7 +399,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $field The field to alias.
      * @return string The field prefixed with the table alias.
      */
-    public function aliasField($field)
+    public function aliasField(string $field): string
     {
         if (strpos($field, '.') !== false) {
             return $field;
@@ -412,7 +414,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $registryAlias The key used to access this object.
      * @return $this
      */
-    public function setRegistryAlias($registryAlias)
+    public function setRegistryAlias(string $registryAlias)
     {
         $this->_registryAlias = $registryAlias;
 
@@ -424,7 +426,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return string
      */
-    public function getRegistryAlias()
+    public function getRegistryAlias(): string
     {
         if ($this->_registryAlias === null) {
             $this->_registryAlias = $this->getAlias();
@@ -449,9 +451,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the connection instance.
      *
-     * @return \Cake\Database\Connection
+     * @return \Cake\Database\Connection|null
      */
-    public function getConnection()
+    public function getConnection(): ?Connection
     {
         return $this->_connection;
     }
@@ -461,7 +463,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\Database\Schema\TableSchema
      */
-    public function getSchema()
+    public function getSchema(): TableSchema
     {
         if ($this->_schema === null) {
             $this->_schema = $this->_initializeSchema(
@@ -524,7 +526,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param \Cake\Database\Schema\TableSchema $schema The table definition fetched from database.
      * @return \Cake\Database\Schema\TableSchema the altered schema
      */
-    protected function _initializeSchema(TableSchema $schema)
+    protected function _initializeSchema(TableSchema $schema): TableSchema
     {
         return $schema;
     }
@@ -579,12 +581,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the display field.
      *
-     * @param string $key Name to be used as display field.
+     * @param string|array $fields Name to be used as display field.
      * @return $this
      */
-    public function setDisplayField($key)
+    public function setDisplayField($field): self
     {
-        $this->_displayField = $key;
+        $this->_displayField = $field;
 
         return $this;
     }
@@ -592,7 +594,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the display field.
      *
-     * @return string
+     * @return string|array
      */
     public function getDisplayField()
     {
@@ -616,7 +618,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         if (!$this->_entityClass) {
             $default = Entity::class;
@@ -651,7 +653,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
      * @return $this
      */
-    public function setEntityClass($name)
+    public function setEntityClass(string $name): self
     {
         $class = App::className($name, 'Model/Entity');
         if (!$class) {
@@ -687,7 +689,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \RuntimeException If a behavior is being reloaded.
      * @see \Cake\ORM\Behavior
      */
-    public function addBehavior($name, array $options = [])
+    public function addBehavior(string $name, array $options = []): self
     {
         $this->_behaviors->load($name, $options);
 
@@ -710,7 +712,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return $this
      * @throws \RuntimeException If a behavior is being reloaded.
      */
-    public function addBehaviors(array $behaviors)
+    public function addBehaviors(array $behaviors): self
     {
         foreach ($behaviors as $name => $options) {
             if (is_int($name)) {
@@ -739,7 +741,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return $this
      * @see \Cake\ORM\Behavior
      */
-    public function removeBehavior($name)
+    public function removeBehavior(string $name)
     {
         $this->_behaviors->unload($name);
 
@@ -751,7 +753,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\ORM\BehaviorRegistry The BehaviorRegistry instance.
      */
-    public function behaviors()
+    public function behaviors(): BehaviorRegistry
     {
         return $this->_behaviors;
     }
@@ -763,7 +765,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\ORM\Behavior
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
-    public function getBehavior($name)
+    public function getBehavior(string $name): Behavior
     {
         /** @var \Cake\ORM\Behavior $behavior */
         $behavior = $this->_behaviors->get($name);
@@ -784,7 +786,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $name The behavior alias to check.
      * @return bool Whether or not the behavior exists.
      */
-    public function hasBehavior($name)
+    public function hasBehavior(string $name): bool
     {
         return $this->_behaviors->has($name);
     }
@@ -806,7 +808,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\ORM\Association The association.
      * @throws \InvalidArgumentException
      */
-    public function getAssociation($name)
+    public function getAssociation(string $name): Association
     {
         $association = $this->findAssociation($name);
         if (!$association) {
@@ -828,7 +830,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $name The alias used for the association.
      * @return bool
      */
-    public function hasAssociation($name)
+    public function hasAssociation(string $name): bool
     {
         return $this->findAssociation($name) !== null;
     }
@@ -845,7 +847,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $name The alias used for the association.
      * @return \Cake\ORM\Association|null Either the association or null.
      */
-    protected function findAssociation($name)
+    protected function findAssociation(string $name): ?Association
     {
         if (strpos($name, '.') === false) {
             return $this->_associations->get($name);
@@ -866,7 +868,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\ORM\AssociationCollection|\Cake\ORM\Association[] The collection of association objects.
      */
-    public function associations()
+    public function associations(): iterable
     {
         return $this->_associations;
     }
@@ -898,7 +900,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @see \Cake\ORM\Table::hasMany()
      * @see \Cake\ORM\Table::belongsToMany()
      */
-    public function addAssociations(array $params)
+    public function addAssociations(array $params): self
     {
         foreach ($params as $assocType => $tables) {
             foreach ($tables as $associated => $options) {
@@ -943,7 +945,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options list of options to configure the association definition
      * @return \Cake\ORM\Association\BelongsTo
      */
-    public function belongsTo($associated, array $options = [])
+    public function belongsTo(string $associated, array $options = []): BelongsTo
     {
         $options += ['sourceTable' => $this];
 
@@ -989,7 +991,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options list of options to configure the association definition
      * @return \Cake\ORM\Association\HasOne
      */
-    public function hasOne($associated, array $options = [])
+    public function hasOne(string $associated, array $options = []): HasOne
     {
         $options += ['sourceTable' => $this];
 
@@ -1041,7 +1043,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options list of options to configure the association definition
      * @return \Cake\ORM\Association\HasMany
      */
-    public function hasMany($associated, array $options = [])
+    public function hasMany(string $associated, array $options = []): HasMany
     {
         $options += ['sourceTable' => $this];
 
@@ -1095,7 +1097,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options list of options to configure the association definition
      * @return \Cake\ORM\Association\BelongsToMany
      */
-    public function belongsToMany($associated, array $options = [])
+    public function belongsToMany(string $associated, array $options = []): BelongsToMany
     {
         $options += ['sourceTable' => $this];
 
@@ -1163,7 +1165,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
      * @return \Cake\ORM\Query The query builder
      */
-    public function find($type = 'all', $options = [])
+    public function find(string $type = 'all', $options = []): Query
     {
         $query = $this->query();
         $query->select();
@@ -1181,7 +1183,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options to use for the find
      * @return \Cake\ORM\Query The query builder
      */
-    public function findAll(Query $query, array $options)
+    public function findAll(Query $query, array $options): Query
     {
         return $query;
     }
@@ -1243,7 +1245,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options for the find
      * @return \Cake\ORM\Query The query builder
      */
-    public function findList(Query $query, array $options)
+    public function findList(Query $query, array $options): Query
     {
         $options += [
             'keyField' => $this->getPrimaryKey(),
@@ -1306,7 +1308,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options to find with
      * @return \Cake\ORM\Query The query builder
      */
-    public function findThreaded(Query $query, array $options)
+    public function findThreaded(Query $query, array $options): Query
     {
         $options += [
             'keyField' => $this->getPrimaryKey(),
@@ -1335,7 +1337,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * the associated value
      * @return array
      */
-    protected function _setFieldMatchers($options, $keys)
+    protected function _setFieldMatchers(array $options, array $keys): array
     {
         foreach ($keys as $field) {
             if (!is_array($options[$field])) {
@@ -1375,7 +1377,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\Datasource\Exception\InvalidPrimaryKeyException When $primaryKey has an
      *      incorrect number of elements.
      */
-    public function get($primaryKey, $options = [])
+    public function get($primaryKey, $options = []): EntityInterface
     {
         $key = (array)$this->getPrimaryKey();
         $alias = $this->getAlias();
@@ -1426,7 +1428,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param bool $atomic Whether to execute the worker inside a database transaction.
      * @return mixed
      */
-    protected function _executeTransaction(callable $worker, $atomic = true)
+    protected function _executeTransaction(callable $worker, bool $atomic = true)
     {
         if ($atomic) {
             return $this->getConnection()->transactional(function () use ($worker) {
@@ -1444,7 +1446,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param bool $primary True if a primary was used.
      * @return bool Returns true if a transaction was committed.
      */
-    protected function _transactionCommitted($atomic, $primary)
+    protected function _transactionCommitted(bool $atomic, bool $primary): bool
     {
         return !$this->getConnection()->inTransaction() && ($atomic || (!$atomic && $primary));
     }
@@ -1482,7 +1484,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface An entity.
      */
-    public function findOrCreate($search, ?callable $callback = null, $options = [])
+    public function findOrCreate($search, ?callable $callback = null, $options = []): EntityInterface
     {
         $options = new ArrayObject($options + [
             'atomic' => true,
@@ -1511,7 +1513,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface An entity.
      */
-    protected function _processFindOrCreate($search, ?callable $callback = null, $options = [])
+    protected function _processFindOrCreate($search, ?callable $callback = null, $options = []): EntityInterface
     {
         if (is_callable($search)) {
             $query = $this->find();
@@ -1545,7 +1547,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array|\Cake\ORM\Query|string $search The criteria to find existing records by.
      * @return \Cake\ORM\Query
      */
-    protected function _getFindOrCreateQuery($search)
+    protected function _getFindOrCreateQuery($search): Query
     {
         if ($search instanceof Query) {
             return $search;
@@ -1559,7 +1561,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\ORM\Query
      */
-    public function query()
+    public function query(): Query
     {
         return new Query($this->getConnection(), $this);
     }
@@ -1744,7 +1746,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      * @see \Cake\ORM\Table::save()
      */
-    public function saveOrFail(EntityInterface $entity, $options = [])
+    public function saveOrFail(EntityInterface $entity, $options = []): EntityInterface
     {
         $saved = $this->save($entity, $options);
         if ($saved === false) {
@@ -1764,7 +1766,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction
      *   is aborted in the afterSave event.
      */
-    protected function _processSave($entity, $options)
+    protected function _processSave(EntityInterface $entity, ArrayObject $options)
     {
         $primaryColumns = (array)$this->getPrimaryKey();
 
@@ -1831,7 +1833,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction
      *   is aborted in the afterSave event.
      */
-    protected function _onSaveSuccess($entity, $options)
+    protected function _onSaveSuccess(EntityInterface $entity, ArrayObject $options): bool
     {
         $success = $this->_associations->saveChildren(
             $this,
@@ -1868,7 +1870,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \RuntimeException if not all the primary keys where supplied or could
      * be generated when the table has composite primary keys. Or when the table has no primary key.
      */
-    protected function _insert($entity, $data)
+    protected function _insert(EntityInterface $entity, array $data)
     {
         $primary = (array)$this->getPrimaryKey();
         if (empty($primary)) {
@@ -1944,7 +1946,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $primary The primary key columns to get a new ID for.
      * @return null|string|array Either null or the primary key value or a list of primary key values.
      */
-    protected function _newId($primary)
+    protected function _newId(array $primary)
     {
         if (!$primary || count((array)$primary) > 1) {
             return null;
@@ -1963,7 +1965,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\Datasource\EntityInterface|bool
      * @throws \InvalidArgumentException When primary key data is missing.
      */
-    protected function _update($entity, $data)
+    protected function _update(EntityInterface $entity, array $data)
     {
         $primaryColumns = (array)$this->getPrimaryKey();
         $primaryKey = $entity->extract($primaryColumns);
@@ -2012,10 +2014,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array|\ArrayAccess $options Options used when calling Table::save() for each entity.
      * @return bool|\Cake\Datasource\EntityInterface[]|\Cake\ORM\ResultSet False on failure, entities list on success.
      */
-    public function saveMany($entities, $options = [])
+    public function saveMany(iterable $entities, $options = [])
     {
         $isNew = [];
-        $cleanup = function ($entities) use (&$isNew) {
+        $cleanup = function ($entities) use (&$isNew): void {
             foreach ($entities as $key => $entity) {
                 if (isset($isNew[$key]) && $isNew[$key]) {
                     $entity->unsetProperty($this->getPrimaryKey());
@@ -2108,7 +2110,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\PersistenceFailedException
      * @see \Cake\ORM\Table::delete()
      */
-    public function deleteOrFail(EntityInterface $entity, $options = [])
+    public function deleteOrFail(EntityInterface $entity, $options = []): bool
     {
         $deleted = $this->delete($entity, $options);
         if ($deleted === false) {
@@ -2130,7 +2132,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * passed entity
      * @return bool success
      */
-    protected function _processDelete($entity, $options)
+    protected function _processDelete(EntityInterface $entity, ArrayObject $options): bool
     {
         if ($entity->isNew()) {
             return false;
@@ -2186,7 +2188,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return bool
      */
-    public function hasFinder($type)
+    public function hasFinder(string $type): bool
     {
         $finder = 'find' . $type;
 
@@ -2203,7 +2205,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\ORM\Query
      * @throws \BadMethodCallException
      */
-    public function callFinder($type, Query $query, array $options = [])
+    public function callFinder(string $type, Query $query, array $options = []): Query
     {
         $query->applyOptions($options);
         $options = $query->getOptions();
@@ -2230,7 +2232,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \BadMethodCallException when there are missing arguments, or when
      *  and & or are combined.
      */
-    protected function _dynamicFinder($method, $args)
+    protected function _dynamicFinder(string $method, array $args)
     {
         $method = Inflector::underscore($method);
         preg_match('/^find_([\w]+)_by_/', $method, $matches);
@@ -2353,7 +2355,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\ORM\Marshaller
      * @see \Cake\ORM\Marshaller
      */
-    public function marshaller()
+    public function marshaller(): Marshaller
     {
         return new Marshaller($this);
     }
@@ -2412,7 +2414,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
      */
-    public function newEntity(?array $data = null, array $options = [])
+    public function newEntity(?array $data = null, array $options = []): EntityInterface
     {
         if ($data === null) {
             $class = $this->getEntityClass();
@@ -2455,7 +2457,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
      */
-    public function newEntities(array $data, array $options = [])
+    public function newEntities(array $data, array $options = []): array
     {
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
@@ -2501,7 +2503,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * property will not be marked as dirty. This is an optimization to prevent unnecessary field
      * updates when persisting entities.
      */
-    public function patchEntity(EntityInterface $entity, array $data, array $options = [])
+    public function patchEntity(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
@@ -2536,7 +2538,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
      */
-    public function patchEntities($entities, array $data, array $options = [])
+    public function patchEntities($entities, array $data, array $options = []): array
     {
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
@@ -2580,7 +2582,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array|null $context Either the validation context or null.
      * @return bool True if the value is unique, or false if a non-scalar, non-unique value was given.
      */
-    public function validateUnique($value, array $options, ?array $context = null)
+    public function validateUnique($value, array $options, ?array $context = null): bool
     {
         if ($context === null) {
             $context = $options;
@@ -2666,7 +2668,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
      * @return \Cake\ORM\RulesChecker
      */
-    public function buildRules(RulesChecker $rules)
+    public function buildRules(RulesChecker $rules): RulesChecker
     {
         return $rules;
     }
@@ -2677,7 +2679,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options Options to parse by the builder.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function getSaveOptionsBuilder(array $options = [])
+    public function getSaveOptionsBuilder(array $options = []): SaveOptionsBuilder
     {
         return new SaveOptionsBuilder($this, $options);
     }
@@ -2720,7 +2722,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * {@inheritDoc}
      */
-    protected function validationMethodExists($method)
+    protected function validationMethodExists(string $method): bool
     {
         return method_exists($this, $method) || $this->behaviors()->hasMethod($method);
     }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -70,7 +71,7 @@ class TableRegistry
      * @return \Cake\ORM\Locator\LocatorInterface
      * @deprecated 3.5.0 Use getTableLocator()/setTableLocator() instead.
      */
-    public static function locator(?LocatorInterface $locator = null)
+    public static function locator(?LocatorInterface $locator = null): LocatorInterface
     {
         deprecationWarning(
             'TableRegistry::locator() is deprecated. ' .
@@ -88,7 +89,7 @@ class TableRegistry
      *
      * @return \Cake\ORM\Locator\LocatorInterface
      */
-    public static function getTableLocator()
+    public static function getTableLocator(): LocatorInterface
     {
         if (!static::$_locator) {
             static::$_locator = new static::$_defaultLocatorClass();
@@ -103,7 +104,7 @@ class TableRegistry
      * @param \Cake\ORM\Locator\LocatorInterface $tableLocator Instance of a locator to use.
      * @return void
      */
-    public static function setTableLocator(LocatorInterface $tableLocator)
+    public static function setTableLocator(LocatorInterface $tableLocator): void
     {
         static::$_locator = $tableLocator;
     }
@@ -117,7 +118,7 @@ class TableRegistry
      * @return array The config data.
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::getConfig()/setConfig() instead.
      */
-    public static function config($alias = null, $options = null)
+    public static function config(?string $alias = null, ?array $options = null): array
     {
         deprecationWarning(
             'TableRegistry::config() is deprecated. ' .
@@ -145,7 +146,7 @@ class TableRegistry
      * @return \Cake\ORM\Table
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::get() instead.
      */
-    public static function get($alias, array $options = [])
+    public static function get(string $alias, array $options = []): Table
     {
         return static::getTableLocator()->get($alias, $options);
     }
@@ -157,7 +158,7 @@ class TableRegistry
      * @return bool
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::exists() instead.
      */
-    public static function exists($alias)
+    public static function exists(string $alias): bool
     {
         return static::getTableLocator()->exists($alias);
     }
@@ -170,7 +171,7 @@ class TableRegistry
      * @return \Cake\ORM\Table
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::set() instead.
      */
-    public static function set($alias, Table $object)
+    public static function set(string $alias, Table $object): Table
     {
         return static::getTableLocator()->set($alias, $object);
     }
@@ -182,7 +183,7 @@ class TableRegistry
      * @return void
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::remove() instead.
      */
-    public static function remove($alias)
+    public static function remove(string $alias): void
     {
         static::getTableLocator()->remove($alias);
     }
@@ -193,7 +194,7 @@ class TableRegistry
      * @return void
      * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::clear() instead.
      */
-    public static function clear()
+    public static function clear(): void
     {
         static::getTableLocator()->clear();
     }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
  */
 class TestTable extends Table
 {
-    public function initialize(array $config = [])
+    public function initialize(array $config = []): void
     {
         $this->setSchema(['id' => ['type' => 'integer']]);
     }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
@@ -590,7 +591,7 @@ class CompositeKeyTest extends TestCase
         $table = $this->getTableLocator()->get('SiteAuthors');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['_addDefaultFields', 'execute'])
-            ->setConstructorArgs([null, $table])
+            ->setConstructorArgs([$table->getConnection(), $table])
             ->getMock();
 
         $items = new \Cake\Datasource\ResultSetDecorator([

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -922,9 +923,6 @@ class EntityTest extends TestCase
         $this->assertTrue($entity->isNew());
 
         $entity->isNew(true);
-        $this->assertTrue($entity->isNew());
-
-        $entity->isNew('derpy');
         $this->assertTrue($entity->isNew());
 
         $entity->isNew(false);

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -66,7 +66,7 @@ class GreedyCommentsTable extends Table
      * @param array $config Config data.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setTable('comments');
         $this->setAlias('Comments');
@@ -79,7 +79,7 @@ class GreedyCommentsTable extends Table
      * @param array $options find options
      * @return object
      */
-    public function find($type = 'all', $options = [])
+    public function find(string $type = 'all', $options = [])
     {
         if (empty($options['conditions'])) {
             $options['conditions'] = [];

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -78,9 +78,9 @@ class GreedyCommentsTable extends Table
      *
      * @param string $type Find type
      * @param array $options find options
-     * @return object
+     * @return \Cake\ORM\Query
      */
-    public function find(string $type = 'all', $options = [])
+    public function find(string $type = 'all', $options = []): Query
     {
         if (empty($options['conditions'])) {
             $options['conditions'] = [];

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -21,6 +21,7 @@ use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1884,7 +1884,7 @@ class QueryTest extends TestCase
             ->getMock();
         $query->select();
         $resultSet = $this->getMockbuilder('Cake\ORM\ResultSet')
-            ->setConstructorArgs([$query, null])
+            ->setConstructorArgs([$query, $this->getMockBuilder(StatementInterface::class)->getMock()])
             ->getMock();
         $query->expects($this->once())
             ->method('all')
@@ -1936,7 +1936,7 @@ class QueryTest extends TestCase
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
         $resultSet = $this->getMockBuilder('Cake\ORM\ResultSet')
-            ->setConstructorArgs([$query, null])
+            ->setConstructorArgs([$query, $this->getMockBuilder(StatementInterface::class)->getMock()])
             ->getMock();
 
         $query->expects($this->never())

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2582,7 +2582,7 @@ class TableTest extends TestCase
             ->getMock();
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([null, $table])
+            ->setConstructorArgs([$this->connection, $table])
             ->getMock();
         $statement = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')->getMock();
         $data = new Entity([
@@ -2729,7 +2729,7 @@ class TableTest extends TestCase
             ->getMock();
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([null, $table])
+            ->setConstructorArgs([$connection, $table])
             ->getMock();
         $table->expects($this->any())->method('getConnection')
             ->will($this->returnValue($connection));
@@ -2769,7 +2769,7 @@ class TableTest extends TestCase
             ->getMock();
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([null, $table])
+            ->setConstructorArgs([$connection, $table])
             ->getMock();
 
         $table->expects($this->any())->method('getConnection')
@@ -2953,7 +2953,7 @@ class TableTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['execute', 'addDefaultTypes', 'set'])
-            ->setConstructorArgs([null, $table])
+            ->setConstructorArgs([$this->connection, $table])
             ->getMock();
 
         $table->expects($this->once())->method('query')

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -33,7 +33,7 @@ class SecondaryPostsTable extends Table
     /**
      * @return string
      */
-    public static function defaultConnectionName()
+    public static function defaultConnectionName(): string
     {
         return 'secondary';
     }
@@ -361,7 +361,7 @@ class TestCaseTest extends TestCase
 
         $this->assertInstanceOf('TestApp\Model\Table\PostsTable', $Posts);
         $this->assertNull($Posts->save($entity));
-        $this->assertNull($Posts->getTable());
+        $this->assertSame('', $Posts->getTable());
 
         $Posts = $this->getMockForModel('Posts', ['save']);
         $Posts->expects($this->at(0))

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -63,7 +63,7 @@ class ContactsTable extends Table
      *
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setSchema($this->_schema);
     }
@@ -98,7 +98,7 @@ class ValidateUsersTable extends Table
      *
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setSchema($this->_schema);
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/CommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/CommentsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
@@ -21,7 +21,7 @@ use Cake\ORM\Table;
  */
 class TestPluginCommentsTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setTable('test_plugin_comments');
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP :  Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -19,7 +19,7 @@ use Cake\ORM\Table;
  */
 class ArticlesTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->belongsTo('Authors');
         $this->belongsToMany('Tags');

--- a/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
@@ -19,7 +19,7 @@ use Cake\ORM\Table;
  */
 class ArticlesTagsTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->belongsTo('Articles');
         $this->belongsTo('Tags');

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -20,7 +20,7 @@ use Cake\ORM\Table;
  */
 class AuthorsTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->hasMany('articles');
     }

--- a/tests/test_app/TestApp/Model/Table/CustomCookiesTable.php
+++ b/tests/test_app/TestApp/Model/Table/CustomCookiesTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright 2005-2013, Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -18,12 +18,12 @@ use Cake\ORM\Table;
  */
 class I18nTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setTable('custom_i18n_table');
     }
 
-    public static function defaultConnectionName()
+    public static function defaultConnectionName(): string
     {
         return 'custom_i18n_datasource';
     }

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP : Rapid Development Framework (https://cakephp.org)
  * Copyright 2005-2011, Cake Software Foundation, Inc.

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -26,7 +26,7 @@ class PaginatorPostsTable extends Table
      *
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->setTable('posts');
         $this->belongsTo('PaginatorAuthor', [

--- a/tests/test_app/TestApp/Model/Table/PostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PostsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Test App Posts Model
  *

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -19,7 +19,7 @@ use Cake\ORM\Table;
  */
 class TagsTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $this->belongsTo('Authors');
         $this->belongsToMany('Articles');


### PR DESCRIPTION
Refs #11935

Added type hints to all method (I hope) in ORM related files expect the ones mention below:
- Methods of `ORM\Query` which are inherited from `Datasource\Query`.
- Adding typehints to 1st and 3rd args of `Marshaller::_mergeAssociation()` as per it's docblock caused tests to fail. So either the tests or the doblocks need to be fixed.