### PR TITLE
Don't strip off `/` when it is the entire path.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -308,7 +308,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      */
     protected function _setConfig($config)
     {
-        if (!empty($config['url']) && $config['url'][0] === '/') {
+        if (strlen($config['url']) > 1 && $config['url'][0] === '/') {
             $config['url'] = substr($config['url'], 1);
         }
 

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -159,6 +159,22 @@ class ServerRequestTest extends TestCase
     }
 
     /**
+     * Test constructing with a string url.
+     *
+     * @deprecated
+     * @return void
+     */
+    public function testConstructStringUrlIgnoreServer()
+    {
+        $_SERVER['REQUEST_URI'] = '/some/other/path';
+
+        $request = new ServerRequest('/articles/view/1');
+        $this->assertEquals('/articles/view/1', $request->getUri()->getPath());
+
+        $request = new ServerRequest('/');
+        $this->assertEquals('/', $request->getUri()->getPath());
+    }
+    /**
      * Test that querystring args provided in the URL string are parsed.
      *
      * @return void


### PR DESCRIPTION
Only remove `/` from URLs that are longer. Removing the `/` when it is the only part of the path results in the created Uri object not having its path reset.

Refs #12389
