### PR TITLE
Enable `_ids` to work when updating has many associations

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -753,6 +753,17 @@ class Marshaller
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
         }
 
+        if ($assoc->type() === Association::ONE_TO_MANY) {
+            $hasIds = array_key_exists('_ids', $value);
+            $onlyIds = array_key_exists('onlyIds', $options) && $options['onlyIds'];
+            if ($hasIds && is_array($value['_ids'])) {
+                return $this->_loadAssociatedByIds($assoc, $value['_ids']);
+            }
+            if ($hasIds || $onlyIds) {
+                return [];
+            }
+        }
+
         return $marshaller->mergeMany($original, $value, (array)$options);
     }
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1816,7 +1816,6 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
     }
 
-
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * will not generate conflicting queries when associations are automatically selected

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1732,6 +1732,57 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Tests that merging data to a hasMany association with _ids works.
+     *
+     * @return void
+     */
+    public function testMergeHasManyEntitiesFromIds()
+    {
+        $entity = $this->articles->get(1, ['contain' => ['Comments']]);
+        $this->assertNotEmpty($entity->comments);
+
+        $marshall = new Marshaller($this->articles);
+        $data = ['comments' => ['_ids' => [1, 2, 3]]];
+        $result = $marshall->merge($entity, $data, ['associated' => ['Comments']]);
+
+        $this->assertCount(3, $result->comments);
+        $this->assertTrue($result->isDirty('comments'), 'Updated prop should be dirty');
+        $this->assertInstanceOf(Entity::class, $result->comments[0]);
+        $this->assertEquals(1, $result->comments[0]->id);
+        $this->assertInstanceOf(Entity::class, $result->comments[1]);
+        $this->assertEquals(2, $result->comments[1]->id);
+        $this->assertInstanceOf(Entity::class, $result->comments[2]);
+        $this->assertEquals(3, $result->comments[2]->id);
+    }
+
+    /**
+     * Tests that merging data to a hasMany association using onlyIds restricts operations.
+     *
+     * @return void
+     */
+    public function testMergeHasManyEntitiesFromIdsOnlyIds()
+    {
+        $entity = $this->articles->get(1, ['contain' => ['Comments']]);
+        $this->assertNotEmpty($entity->comments);
+
+        $marshall = new Marshaller($this->articles);
+        $data = [
+            'comments' => [
+                '_ids' => [1],
+                [
+                    'comment' => 'Nope'
+                ]
+            ]
+        ];
+        $result = $marshall->merge($entity, $data, ['associated' => ['Comments' => ['onlyIds' => true]]]);
+
+        $this->assertCount(1, $result->comments);
+        $this->assertTrue($result->isDirty('comments'), 'Updated prop should be dirty');
+        $this->assertInstanceOf(Entity::class, $result->comments[0]);
+        $this->assertNotEquals('Nope', $result->comments[0]);
+    }
+
+    /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * will just overwrite the data
      *
@@ -1764,6 +1815,7 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Entity', $result->tags[1]);
         $this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
     }
+
 
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids


### PR DESCRIPTION
Previously the `_ids` key could only be used to update hasMany associations if the association property *was not* populated. Now you can use `_ids` to overwrite existing association data. This makes hasMany associations consistent with belongs to many.

Refs #12373
