### PR TITLE
Fix/improve PSR-7 Uploaded file validation support

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -775,13 +775,15 @@ class Validation
     /**
      * Checks that value has a valid file extension.
      *
-     * @param string|array $check Value to check
+     * @param string|array|\Psr\Http\Message\UploadedFileInterface $check Value to check
      * @param array $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
      * @return bool Success
      */
     public static function extension($check, $extensions = ['gif', 'jpeg', 'png', 'jpg'])
     {
-        if (is_array($check)) {
+        if ($check instanceof UploadedFileInterface) {
+            return static::extension($check->getClientFilename(), $extensions);
+        } elseif (is_array($check)) {
             $check = isset($check['name']) ? $check['name'] : array_shift($check);
 
             return static::extension($check, $extensions);
@@ -1258,7 +1260,7 @@ class Validation
      * - `optional` - Whether or not this file is optional. Defaults to false.
      *   If true a missing file will pass the validator regardless of other constraints.
      *
-     * @param array $file The uploaded file data from PHP.
+     * @param array|\Psr\Http\Message\UploadedFileInterface $file The uploaded file data from PHP.
      * @param array $options An array of options for the validation.
      * @return bool
      */
@@ -1310,7 +1312,7 @@ class Validation
     /**
      * Validates the size of an uploaded image.
      *
-     * @param array $file The uploaded file data from PHP.
+     * @param array|\Psr\Http\Message\UploadedFileInterface  $file The uploaded file data from PHP.
      * @param array $options Options to validate width and height.
      * @return bool
      */
@@ -1320,11 +1322,7 @@ class Validation
             throw new InvalidArgumentException('Invalid image size validation parameters! Missing `width` and / or `height`.');
         }
 
-        if ($file instanceof UploadedFileInterface) {
-            $file = $file->getStream()->getContents();
-        } elseif (is_array($file) && isset($file['tmp_name'])) {
-            $file = $file['tmp_name'];
-        }
+        $file = static::getFilename($file);
 
         list($width, $height) = getimagesize($file);
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -783,7 +783,8 @@ class Validation
     {
         if ($check instanceof UploadedFileInterface) {
             return static::extension($check->getClientFilename(), $extensions);
-        } elseif (is_array($check)) {
+        }
+        if (is_array($check)) {
             $check = isset($check['name']) ? $check['name'] : array_shift($check);
 
             return static::extension($check, $extensions);

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2337,6 +2337,20 @@ class ValidationTest extends TestCase
     }
 
     /**
+     * Test extension with a PSR7 object
+     */
+    public function testExtensionPsr7()
+    {
+        $file = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
+
+        $upload = new UploadedFile($file, 5308, UPLOAD_ERR_OK, 'extension.jpeg', 'image/jpeg');
+        $this->assertTrue(Validation::extension($upload));
+
+        $upload = new UploadedFile($file, 163, UPLOAD_ERR_OK, 'no_php_extension', 'text/plain');
+        $this->assertFalse(Validation::extension($upload));
+    }
+
+    /**
      * testMoney method
      *
      * @return void
@@ -3114,6 +3128,22 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::imageSize($upload, [
             'width' => [Validation::COMPARE_LESS_OR_EQUAL, 299],
             'height' => [Validation::COMPARE_GREATER_OR_EQUAL, 300],
+        ]));
+    }
+
+    /**
+     * Test imageSize with a PSR7 object
+     *
+     * @return void
+     */
+    public function testImageSizePsr7()
+    {
+        $image = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
+        $upload = new UploadedFile($image, 5308, UPLOAD_ERR_OK, 'test.jpg', 'image/jpeg');
+
+        $this->assertTrue(Validation::imageSize($upload, [
+            'width' => [Validation::COMPARE_GREATER, 100],
+            'height' => [Validation::COMPARE_GREATER, 100],
         ]));
     }
 


### PR DESCRIPTION
`imageSize()` wasn't working, and since `extension()` supports file uploads, it might be worth adding PSR-7 support.