### PR TITLE
Remove hints on controller hook methods.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -777,12 +777,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * or perform logic that needs to happen before each controller action.
      *
      * @param \Cake\Event\EventInterface $event An Event instance
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      * @link https://book.cakephp.org/3.0/en/controllers.html#request-life-cycle-callbacks
      */
-    public function beforeFilter(EventInterface $event): ?Response
+    public function beforeFilter(EventInterface $event)
     {
-        return null;
     }
 
     /**
@@ -790,12 +789,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * to perform logic or set view variables that are required on every request.
      *
      * @param \Cake\Event\EventInterface $event An Event instance
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      * @link https://book.cakephp.org/3.0/en/controllers.html#request-life-cycle-callbacks
      */
-    public function beforeRender(EventInterface $event): ?Response
+    public function beforeRender(EventInterface $event)
     {
-        return null;
     }
 
     /**
@@ -811,23 +809,21 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @param string|array $url A string or array-based URL pointing to another location within the app,
      *     or an absolute URL
      * @param \Cake\Http\Response $response The response object.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      * @link https://book.cakephp.org/3.0/en/controllers.html#request-life-cycle-callbacks
      */
-    public function beforeRedirect(EventInterface $event, $url, Response $response): ?Response
+    public function beforeRedirect(EventInterface $event, $url, Response $response)
     {
-        return null;
     }
 
     /**
      * Called after the controller action is run and rendered.
      *
      * @param \Cake\Event\EventInterface $event An Event instance
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      * @link https://book.cakephp.org/3.0/en/controllers.html#request-life-cycle-callbacks
      */
-    public function afterFilter(EventInterface $event): ?Response
+    public function afterFilter(EventInterface $event)
     {
-        return null;
     }
 }

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -16,7 +16,6 @@ declare(strict_types = 1);
 namespace Cake\Controller;
 
 use Cake\Event\EventInterface;
-use Cake\Http\Response;
 
 /**
  * Error Handling Controller

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -39,12 +39,10 @@ class ErrorController extends Controller
      * beforeRender callback.
      *
      * @param \Cake\Event\EventInterface $event Event.
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      */
-    public function beforeRender(EventInterface $event): ?Response
+    public function beforeRender(EventInterface $event)
     {
         $this->viewBuilder()->setTemplatePath('Error');
-
-        return null;
     }
 }

--- a/tests/test_app/TestApp/Controller/Admin/ErrorController.php
+++ b/tests/test_app/TestApp/Controller/Admin/ErrorController.php
@@ -38,12 +38,10 @@ class ErrorController extends Controller
      * beforeRender callback.
      *
      * @param \Cake\Event\Event $event Event.
-     * @return Cake\Http\Response|null
+     * @return Cake\Http\Response|null|void
      */
-    public function beforeRender(EventInterface $event): ?Response
+    public function beforeRender(EventInterface $event)
     {
         $this->viewBuilder()->setTemplatePath('Error');
-
-        return null;
     }
 }

--- a/tests/test_app/TestApp/Controller/Admin/ErrorController.php
+++ b/tests/test_app/TestApp/Controller/Admin/ErrorController.php
@@ -15,7 +15,6 @@ namespace TestApp\Controller\Admin;
 
 use Cake\Controller\Controller;
 use Cake\Event\EventInterface;
-use Cake\Http\Response;
 
 /**
  * Error Handling Controller

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -16,7 +16,6 @@ namespace TestApp\Controller;
 
 use Cake\Event\EventInterface;
 use Cake\Http\Cookie\Cookie;
-use Cake\Http\Response;
 
 /**
  * PostsController class

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -33,15 +33,13 @@ class PostsController extends AppController
     /**
      * beforeFilter
      *
-     * @return \Cake\Http\Response|null
+     * @return \Cake\Http\Response|null|void
      */
-    public function beforeFilter(EventInterface $event): ?Response
+    public function beforeFilter(EventInterface $event)
     {
         if ($this->request->getParam('action') !== 'securePost') {
             $this->getEventManager()->off($this->Security);
         }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
These hints don't fully capture the possible return types. Having to explicitly return `null` seems like an annoyance for end users and doesn't allow us to make CakePHP any more typesafe as we still have to handle null|Response everywhere.

Refs #11935