### PR TITLE
Remove unneeded View::$hasRendered flag.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -175,13 +175,6 @@ class View implements EventDispatcherInterface
     protected $theme;
 
     /**
-     * True when the view has been rendered.
-     *
-     * @var bool
-     */
-    protected $hasRendered = false;
-
-    /**
      * An instance of a \Cake\Http\ServerRequest object that contains information about the current request.
      * This object contains all the information about a request and several methods for reading
      * additional information about the request.
@@ -701,8 +694,6 @@ class View implements EventDispatcherInterface
             $this->layout = $defaultLayout;
         }
 
-        $this->hasRendered = true;
-
         return $this->Blocks->get('content');
     }
 
@@ -1101,17 +1092,6 @@ class View implements EventDispatcherInterface
         $helpers = $this->helpers();
 
         return $this->{$class} = $helpers->load($name, $config);
-    }
-
-    /**
-     * Check whether the view has been rendered.
-     *
-     * @return bool
-     * @since 3.7.0
-     */
-    public function hasRendered(): bool
-    {
-        return $this->hasRendered;
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -349,7 +349,6 @@ object(Cake\View\View) {
 	[protected] _ext => '.ctp'
 	[protected] subDir => ''
 	[protected] theme => null
-	[protected] hasRendered => false
 	[protected] request => object(Cake\Http\ServerRequest) {}
 	[protected] response => object(Cake\Http\Response) {}
 	[protected] elementCache => 'default'

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -2106,17 +2106,4 @@ TEXT;
         $layout = $this->View->getLayout();
         $this->assertSame($layout, 'foo');
     }
-
-    /**
-     * Test testHasRendered()
-     *
-     * @return void
-     */
-    public function testHasRendered()
-    {
-        $this->assertFalse($this->View->hasRendered());
-
-        $this->View->render('index');
-        $this->assertTrue($this->View->hasRendered());
-    }
 }


### PR DESCRIPTION
Calling View::render() multiple times should simply render again with given arguments and existing context.