### PR TITLE
4.x - Add type hints to database package

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -567,7 +568,7 @@ class Connection implements ConnectionInterface
     /**
      * Creates a new save point for nested transactions.
      *
-     * @param string $name The save point name.
+     * @param string|int $name The save point name.
      * @return void
      */
     public function createSavePoint($name)
@@ -578,7 +579,7 @@ class Connection implements ConnectionInterface
     /**
      * Releases a save point by its name.
      *
-     * @param string $name The save point name.
+     * @param string|int $name The save point name.
      * @return void
      */
     public function releaseSavePoint($name)
@@ -589,7 +590,7 @@ class Connection implements ConnectionInterface
     /**
      * Rollback a save point by its name.
      *
-     * @param string $name The save point name.
+     * @param string|int $name The save point name.
      * @return void
      */
     public function rollbackSavepoint($name)

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -109,7 +109,7 @@ class Connection implements ConnectionInterface
      *
      * @param array $config configuration for connecting to database
      */
-    public function __construct($config)
+    public function __construct(array $config)
     {
         $this->_config = $config;
 
@@ -190,7 +190,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Cake\Core\Retry\CommandRetry The retry wrapper
      */
-    public function getDisconnectRetry()
+    public function getDisconnectRetry(): CommandRetry
     {
         return new CommandRetry(new ReconnectStrategy($this));
     }
@@ -200,7 +200,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Cake\Database\Driver
      */
-    public function getDriver()
+    public function getDriver(): Driver
     {
         return $this->_driver;
     }
@@ -211,7 +211,7 @@ class Connection implements ConnectionInterface
      * @throws \Cake\Database\Exception\MissingConnectionException if credentials are invalid.
      * @return bool true, if the connection was already established or the attempt was successful.
      */
-    public function connect()
+    public function connect(): bool
     {
         try {
             return $this->_driver->connect();
@@ -225,7 +225,7 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->_driver->disconnect();
     }
@@ -235,7 +235,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
         return $this->_driver->isConnected();
     }
@@ -246,7 +246,7 @@ class Connection implements ConnectionInterface
      * @param string|\Cake\Database\Query $sql The SQL to convert into a prepared statement.
      * @return \Cake\Database\StatementInterface
      */
-    public function prepare($sql)
+    public function prepare($sql): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($sql) {
             $statement = $this->_driver->prepare($sql);
@@ -268,7 +268,7 @@ class Connection implements ConnectionInterface
      * @param array $types list or associative array of types to be used for casting values in query
      * @return \Cake\Database\StatementInterface executed statement
      */
-    public function execute($query, array $params = [], array $types = [])
+    public function execute(string $query, array $params = [], array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($query, $params, $types) {
             if (!empty($params)) {
@@ -291,7 +291,7 @@ class Connection implements ConnectionInterface
      * @param \Cake\Database\ValueBinder $generator The placeholder generator to use
      * @return string
      */
-    public function compileQuery(Query $query, ValueBinder $generator)
+    public function compileQuery(Query $query, ValueBinder $generator): string
     {
         return $this->getDriver()->compileQuery($query, $generator)[1];
     }
@@ -303,7 +303,7 @@ class Connection implements ConnectionInterface
      * @param \Cake\Database\Query $query The query to be executed
      * @return \Cake\Database\StatementInterface executed statement
      */
-    public function run(Query $query)
+    public function run(Query $query): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($query) {
             $statement = $this->prepare($query);
@@ -320,7 +320,7 @@ class Connection implements ConnectionInterface
      * @param string $sql The SQL query to execute.
      * @return \Cake\Database\StatementInterface
      */
-    public function query($sql)
+    public function query(string $sql): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($sql) {
             $statement = $this->prepare($sql);
@@ -335,7 +335,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Cake\Database\Query
      */
-    public function newQuery()
+    public function newQuery(): Query
     {
         return new Query($this);
     }
@@ -358,7 +358,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Cake\Database\Schema\Collection
      */
-    public function getSchemaCollection()
+    public function getSchemaCollection(): SchemaCollection
     {
         if ($this->_schemaCollection !== null) {
             return $this->_schemaCollection;
@@ -379,7 +379,7 @@ class Connection implements ConnectionInterface
      * @param array $types list of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
-    public function insert($table, array $data, array $types = [])
+    public function insert(string $table, array $data, array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($table, $data, $types) {
             $columns = array_keys($data);
@@ -400,7 +400,7 @@ class Connection implements ConnectionInterface
      * @param array $types list of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
-    public function update($table, array $data, array $conditions = [], $types = [])
+    public function update(string $table, array $data, array $conditions = [], array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($table, $data, $conditions, $types) {
             return $this->newQuery()->update($table)
@@ -418,7 +418,7 @@ class Connection implements ConnectionInterface
      * @param array $types list of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
-    public function delete($table, $conditions = [], $types = [])
+    public function delete(string $table, array $conditions = [], array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($table, $conditions, $types) {
             return $this->newQuery()->delete($table)
@@ -432,14 +432,14 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    public function begin()
+    public function begin(): void
     {
         if (!$this->_transactionStarted) {
             if ($this->_logQueries) {
                 $this->log('BEGIN');
             }
 
-            $this->getDisconnectRetry()->run(function () {
+            $this->getDisconnectRetry()->run(function (): void {
                 $this->_driver->beginTransaction();
             });
 
@@ -461,7 +461,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool true on success, false otherwise
      */
-    public function commit()
+    public function commit(): bool
     {
         if (!$this->_transactionStarted) {
             return false;
@@ -498,7 +498,7 @@ class Connection implements ConnectionInterface
      * beginning of it. Defaults to false if using savepoints, or true if not.
      * @return bool
      */
-    public function rollback($toBeginning = null)
+    public function rollback(?bool $toBeginning = null): bool
     {
         if (!$this->_transactionStarted) {
             return false;
@@ -544,7 +544,7 @@ class Connection implements ConnectionInterface
      * @param bool $enable Whether or not save points should be used.
      * @return $this
      */
-    public function enableSavePoints($enable)
+    public function enableSavePoints(bool $enable)
     {
         if ($enable === false) {
             $this->_useSavePoints = false;
@@ -560,7 +560,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool true if enabled, false otherwise
      */
-    public function isSavePointsEnabled()
+    public function isSavePointsEnabled(): bool
     {
         return $this->_useSavePoints;
     }
@@ -571,7 +571,7 @@ class Connection implements ConnectionInterface
      * @param string|int $name The save point name.
      * @return void
      */
-    public function createSavePoint($name)
+    public function createSavePoint($name): void
     {
         $this->execute($this->_driver->savePointSQL($name))->closeCursor();
     }
@@ -582,7 +582,7 @@ class Connection implements ConnectionInterface
      * @param string|int $name The save point name.
      * @return void
      */
-    public function releaseSavePoint($name)
+    public function releaseSavePoint($name): void
     {
         $this->execute($this->_driver->releaseSavePointSQL($name))->closeCursor();
     }
@@ -593,7 +593,7 @@ class Connection implements ConnectionInterface
      * @param string|int $name The save point name.
      * @return void
      */
-    public function rollbackSavepoint($name)
+    public function rollbackSavepoint($name): void
     {
         $this->execute($this->_driver->rollbackSavePointSQL($name))->closeCursor();
     }
@@ -603,9 +603,9 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    public function disableForeignKeys()
+    public function disableForeignKeys(): void
     {
-        $this->getDisconnectRetry()->run(function () {
+        $this->getDisconnectRetry()->run(function (): void {
             $this->execute($this->_driver->disableForeignKeySQL())->closeCursor();
         });
     }
@@ -615,9 +615,9 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    public function enableForeignKeys()
+    public function enableForeignKeys(): void
     {
-        $this->getDisconnectRetry()->run(function () {
+        $this->getDisconnectRetry()->run(function (): void {
             $this->execute($this->_driver->enableForeignKeySQL())->closeCursor();
         });
     }
@@ -628,7 +628,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool true if driver supports dynamic constraints
      */
-    public function supportsDynamicConstraints()
+    public function supportsDynamicConstraints(): bool
     {
         return $this->_driver->supportsDynamicConstraints();
     }
@@ -676,7 +676,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool
      */
-    protected function wasNestedTransactionRolledback()
+    protected function wasNestedTransactionRolledback(): bool
     {
         return $this->nestedTransactionRollbackException instanceof NestedTransactionRollbackException;
     }
@@ -715,7 +715,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool True if a transaction is running else false.
      */
-    public function inTransaction()
+    public function inTransaction(): bool
     {
         return $this->_transactionStarted;
     }
@@ -727,7 +727,7 @@ class Connection implements ConnectionInterface
      * @param string|null $type Type to be used for determining kind of quoting to perform
      * @return string Quoted value
      */
-    public function quote($value, $type = null)
+    public function quote($value, $type = null): string
     {
         list($value, $type) = $this->cast($value, $type);
 
@@ -739,7 +739,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool
      */
-    public function supportsQuoting()
+    public function supportsQuoting(): bool
     {
         return $this->_driver->supportsQuoting();
     }
@@ -751,7 +751,7 @@ class Connection implements ConnectionInterface
      * @param string $identifier The identifier to quote.
      * @return string
      */
-    public function quoteIdentifier($identifier)
+    public function quoteIdentifier(string $identifier): string
     {
         return $this->_driver->quoteIdentifier($identifier);
     }
@@ -765,7 +765,7 @@ class Connection implements ConnectionInterface
      *   true to use `_cake_model_` or the name of the cache config to use.
      * @return void
      */
-    public function cacheMetadata($cache)
+    public function cacheMetadata($cache): void
     {
         $this->_schemaCollection = null;
         $this->_config['cacheMetadata'] = $cache;
@@ -777,7 +777,7 @@ class Connection implements ConnectionInterface
      * @param bool $value Enable/disable query logging
      * @return $this
      */
-    public function enableQueryLogging($value): ConnectionInterface
+    public function enableQueryLogging(bool $value): ConnectionInterface
     {
         $this->_logQueries = (bool)$value;
 
@@ -789,7 +789,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool
      */
-    public function isQueryLoggingEnabled()
+    public function isQueryLoggingEnabled(): bool
     {
         return $this->_logQueries;
     }
@@ -797,7 +797,7 @@ class Connection implements ConnectionInterface
     /**
      * Sets a logger
      *
-     * @param \Cake\Database\Log\QueryLogger $logger Logger object
+     * @param \Cake\Database\Log\QueryLogger|null $logger Logger object
      * @return $this
      */
     public function setLogger($logger)
@@ -827,7 +827,7 @@ class Connection implements ConnectionInterface
      * @param string $sql string to be logged
      * @return void
      */
-    public function log($sql)
+    public function log(string $sql): void
     {
         $query = new LoggedQuery();
         $query->query = $sql;
@@ -841,7 +841,7 @@ class Connection implements ConnectionInterface
      * @param \Cake\Database\StatementInterface $statement the instance to be decorated
      * @return \Cake\Database\Log\LoggingStatement
      */
-    protected function _newLogger(StatementInterface $statement)
+    protected function _newLogger(StatementInterface $statement): LoggingStatement
     {
         $log = new LoggingStatement($statement, $this->_driver);
         $log->setLogger($this->getLogger());
@@ -855,7 +855,7 @@ class Connection implements ConnectionInterface
      *
      * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         $secrets = [
             'password' => '*****',

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -120,7 +120,7 @@ class Connection implements ConnectionInterface
         $this->setDriver($driver, $config);
 
         if (!empty($config['log'])) {
-            $this->enableQueryLogging($config['log']);
+            $this->enableQueryLogging((bool)$config['log']);
         }
     }
 
@@ -779,7 +779,7 @@ class Connection implements ConnectionInterface
      */
     public function enableQueryLogging(bool $value): ConnectionInterface
     {
-        $this->_logQueries = (bool)$value;
+        $this->_logQueries = $value;
 
         return $this;
     }

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database\Dialect;
 
+use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Schema\MysqlSchema;
 use Cake\Database\SqlDialectTrait;
 
@@ -54,9 +55,9 @@ trait MysqlDialectTrait
      * Used by Cake\Database\Schema package to reflect schema and
      * generate schema.
      *
-     * @return \Cake\Database\Schema\MysqlSchema
+     * @return \Cake\Database\Schema\BaseSchema
      */
-    public function schemaDialect()
+    public function schemaDialect(): BaseSchema
     {
         if (!$this->_schemaDialect) {
             $this->_schemaDialect = new MysqlSchema($this);

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Dialect;
 
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Schema\PostgresSchema;
 use Cake\Database\SqlDialectTrait;
 
@@ -162,9 +163,9 @@ trait PostgresDialectTrait
      * Used by Cake\Database\Schema package to reflect schema and
      * generate schema.
      *
-     * @return \Cake\Database\Schema\PostgresSchema
+     * @return \Cake\Database\Schema\BaseSchema
      */
-    public function schemaDialect()
+    public function schemaDialect(): BaseSchema
     {
         if (!$this->_schemaDialect) {
             $this->_schemaDialect = new PostgresSchema($this);

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Database\Dialect;
 
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\QueryCompiler;
+use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Schema\SqliteSchema;
 use Cake\Database\SqlDialectTrait;
 use Cake\Database\SqliteCompiler;
@@ -162,9 +164,9 @@ trait SqliteDialectTrait
      * Used by Cake\Database\Schema package to reflect schema and
      * generate schema.
      *
-     * @return \Cake\Database\Schema\SqliteSchema
+     * @return \Cake\Database\Schema\BaseSchema
      */
-    public function schemaDialect()
+    public function schemaDialect(): BaseSchema
     {
         if (!$this->_schemaDialect) {
             $this->_schemaDialect = new SqliteSchema($this);
@@ -194,7 +196,7 @@ trait SqliteDialectTrait
      *
      * @return \Cake\Database\SqliteCompiler
      */
-    public function newCompiler()
+    public function newCompiler(): QueryCompiler
     {
         return new SqliteCompiler();
     }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -19,6 +19,8 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\UnaryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
+use Cake\Database\QueryCompiler;
+use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Schema\SqlserverSchema;
 use Cake\Database\SqlDialectTrait;
 use Cake\Database\SqlserverCompiler;
@@ -69,7 +71,7 @@ trait SqlserverDialectTrait
             $query->order($query->newExpr()->add('(SELECT NULL)'));
         }
 
-        if ($this->_version() < 11 && $offset !== null) {
+        if ($this->version() < 11 && $offset !== null) {
             return $this->_pagingSubquery($query, $limit, $offset);
         }
 
@@ -81,8 +83,7 @@ trait SqlserverDialectTrait
      *
      * @return int
      */
-    // @codingStandardsIgnoreLine
-    public function _version()
+    protected function version()
     {
         $this->connect();
 
@@ -324,9 +325,9 @@ trait SqlserverDialectTrait
      * Used by Cake\Schema package to reflect schema and
      * generate schema.
      *
-     * @return \Cake\Database\Schema\SqlserverSchema
+     * @return \Cake\Database\Schema\BaseSchema
      */
-    public function schemaDialect()
+    public function schemaDialect(): BaseSchema
     {
         return new SqlserverSchema($this);
     }
@@ -369,7 +370,7 @@ trait SqlserverDialectTrait
      *
      * @return \Cake\Database\SqlserverCompiler
      */
-    public function newCompiler()
+    public function newCompiler(): QueryCompiler
     {
         return new SqlserverCompiler();
     }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -335,10 +335,10 @@ trait SqlserverDialectTrait
     /**
      * Returns a SQL snippet for creating a new transaction savepoint
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function savePointSQL(string $name): string
+    public function savePointSQL($name): string
     {
         return 'SAVE TRANSACTION t' . $name;
     }
@@ -346,10 +346,10 @@ trait SqlserverDialectTrait
     /**
      * Returns a SQL snippet for releasing a previously created save point
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function releaseSavePointSQL(string $name): string
+    public function releaseSavePointSQL($name): string
     {
         return 'COMMIT TRANSACTION t' . $name;
     }
@@ -357,10 +357,10 @@ trait SqlserverDialectTrait
     /**
      * Returns a SQL snippet for rollbacking a previously created save point
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function rollbackSavePointSQL(string $name): string
+    public function rollbackSavePointSQL($name): string
     {
         return 'ROLLBACK TRANSACTION t' . $name;
     }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -192,17 +192,17 @@ abstract class Driver implements DriverInterface
     /**
      * {@inheritDoc}
      */
-    abstract public function releaseSavePointSQL(string $name): string;
+    abstract public function releaseSavePointSQL($name): string;
 
     /**
      * {@inheritDoc}
      */
-    abstract public function savePointSQL(string $name): string;
+    abstract public function savePointSQL($name): string;
 
     /**
      * {@inheritDoc}
      */
-    abstract public function rollbackSavePointSQL(string $name): string;
+    abstract public function rollbackSavePointSQL($name): string;
 
     /**
      * {@inheritDoc}

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Statement\PDOStatement;
 use InvalidArgumentException;
 use PDO;
@@ -62,7 +63,7 @@ abstract class Driver implements DriverInterface
      * @param array $config The configuration for the driver.
      * @throws \InvalidArgumentException
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         if (empty($config['username']) && !empty($config['login'])) {
             throw new InvalidArgumentException(
@@ -83,7 +84,7 @@ abstract class Driver implements DriverInterface
      * @param array $config configuration to be used for creating connection
      * @return bool true on success
      */
-    protected function _connect($dsn, array $config)
+    protected function _connect(string $dsn, array $config): bool
     {
         $connection = new PDO(
             $dsn,
@@ -251,12 +252,12 @@ abstract class Driver implements DriverInterface
     /**
      * {@inheritDoc}
      */
-    abstract public function queryTranslator(string $type);
+    abstract public function queryTranslator(string $type): callable;
 
     /**
      * {@inheritDoc}
      */
-    abstract public function schemaDialect();
+    abstract public function schemaDialect(): BaseSchema;
 
     /**
      * {@inheritDoc}
@@ -363,7 +364,7 @@ abstract class Driver implements DriverInterface
     /**
      * {@inheritDoc}
      */
-    public function newCompiler()
+    public function newCompiler(): QueryCompiler
     {
         return new QueryCompiler();
     }
@@ -382,7 +383,7 @@ abstract class Driver implements DriverInterface
      *
      * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return [
             'connected' => $this->_connection !== null,

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -90,26 +90,26 @@ interface DriverInterface
     /**
      * Get the SQL for releasing a save point.
      *
-     * @param string $name The table name.
+     * @param string|int $name The table name.
      * @return string
      */
-    public function releaseSavePointSQL(string $name): string;
+    public function releaseSavePointSQL($name): string;
 
     /**
      * Get the SQL for creating a save point.
      *
-     * @param string $name The table name.
+     * @param string|int $name The table name.
      * @return string
      */
-    public function savePointSQL(string $name): string;
+    public function savePointSQL($name): string;
 
     /**
      * Get the SQL for rollingback a save point.
      *
-     * @param string $name The table name.
+     * @param string|int $name The table name.
      * @return string
      */
-    public function rollbackSavePointSQL(string $name): string;
+    public function rollbackSavePointSQL($name): string;
 
     /**
      * Get the SQL for disabling foreign keys.

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Schema\BaseSchema;
+
 /**
  * Interface for database driver.
  */
@@ -37,14 +39,14 @@ interface DriverInterface
     /**
      * Returns correct connection resource or object that is internally used.
      *
-     * @return object Connection object used internally.
+     * @return mixed Connection object used internally.
      */
     public function getConnection();
 
     /**
      * Set the internal connection object.
      *
-     * @param object $connection The connection instance.
+     * @param mixed $connection The connection instance.
      * @return $this
      */
     public function setConnection($connection);
@@ -163,7 +165,7 @@ interface DriverInterface
      * (select, insert, update, delete).
      * @return callable
      */
-    public function queryTranslator(string $type);
+    public function queryTranslator(string $type): callable;
 
     /**
      * Get the schema dialect.
@@ -176,7 +178,7 @@ interface DriverInterface
      *
      * @return \Cake\Database\Schema\BaseSchema
      */
-    public function schemaDialect();
+    public function schemaDialect(): BaseSchema;
 
     /**
      * Quotes a database identifier (a column name, table name, etc..) to
@@ -251,5 +253,5 @@ interface DriverInterface
      *
      * @return \Cake\Database\QueryCompiler
      */
-    public function newCompiler();
+    public function newCompiler(): QueryCompiler;
 }

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/Exception/NestedTransactionRollbackException.php
+++ b/src/Database/Exception/NestedTransactionRollbackException.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Exception;
 
 use Cake\Core\Exception\Exception;
+use Throwable;
 
 /**
  * Class NestedTransactionRollbackException
@@ -26,9 +27,9 @@ class NestedTransactionRollbackException extends Exception
      *
      * @param string|null $message If no message is given a default meesage will be used.
      * @param int $code Status code, defaults to 500.
-     * @param \Exception|null $previous the previous exception.
+     * @param \Throwable|null $previous the previous exception.
      */
-    public function __construct(?string $message = null, int $code = 500, ?\Exception $previous = null)
+    public function __construct(?string $message = null, int $code = 500, ?Throwable $previous = null)
     {
         if ($message === null) {
             $message = 'Cannot commit transaction - rollback() has been already called in the nested transaction';

--- a/src/Database/Exception/NestedTransactionRollbackException.php
+++ b/src/Database/Exception/NestedTransactionRollbackException.php
@@ -28,7 +28,7 @@ class NestedTransactionRollbackException extends Exception
      * @param int $code Status code, defaults to 500.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($message = null, $code = 500, $previous = null)
+    public function __construct(?string $message = null, int $code = 500, ?\Exception $previous = null)
     {
         if ($message === null) {
             $message = 'Cannot commit transaction - rollback() has been already called in the nested transaction';

--- a/src/Database/Exception/NestedTransactionRollbackException.php
+++ b/src/Database/Exception/NestedTransactionRollbackException.php
@@ -26,10 +26,10 @@ class NestedTransactionRollbackException extends Exception
      * Constructor
      *
      * @param string|null $message If no message is given a default meesage will be used.
-     * @param int $code Status code, defaults to 500.
+     * @param int|null $code Status code, defaults to 500.
      * @param \Throwable|null $previous the previous exception.
      */
-    public function __construct(?string $message = null, int $code = 500, ?Throwable $previous = null)
+    public function __construct(?string $message = null, ?int $code = 500, ?Throwable $previous = null)
     {
         if ($message === null) {
             $message = 'Cannot commit transaction - rollback() has been already called in the nested transaction';

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -102,7 +102,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
      * {@inheritDoc}
      *
      */
-    public function traverse(callable $callable)
+    public function traverse(callable $callable): void
     {
         foreach ([$this->_field, $this->_from, $this->_to] as $part) {
             if ($part instanceof ExpressionInterface) {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -231,7 +231,7 @@ class CaseExpression implements ExpressionInterface
      * {@inheritDoc}
      *
      */
-    public function traverse(callable $visitor)
+    public function traverse(callable $visitor): void
     {
         foreach (['_conditions', '_values'] as $part) {
             foreach ($this->{$part} as $c) {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -167,7 +167,7 @@ class Comparison implements ExpressionInterface, FieldInterface
      * {@inheritDoc}
      *
      */
-    public function traverse(callable $callable)
+    public function traverse(callable $callable): void
     {
         if ($this->_field instanceof ExpressionInterface) {
             $callable($this->_field);

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -47,7 +47,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     /**
      * {@inheritDoc}
      */
-    public function sql(ValueBinder $generator)
+    public function sql(ValueBinder $generator): string
     {
         $field = $this->_field;
         if ($field instanceof ExpressionInterface) {
@@ -60,7 +60,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     /**
      * {@inheritDoc}
      */
-    public function traverse(callable $visitor)
+    public function traverse(callable $visitor): void
     {
         if ($this->_field instanceof ExpressionInterface) {
             $visitor($this->_field);

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -94,7 +94,7 @@ class UnaryExpression implements ExpressionInterface
      * {@inheritDoc}
      *
      */
-    public function traverse(callable $callable)
+    public function traverse(callable $callable): void
     {
         if ($this->_value instanceof ExpressionInterface) {
             $callable($this->_value);

--- a/src/Database/ExpressionInterface.php
+++ b/src/Database/ExpressionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/ExpressionInterface.php
+++ b/src/Database/ExpressionInterface.php
@@ -26,7 +26,7 @@ interface ExpressionInterface
      * @param \Cake\Database\ValueBinder $generator Placeholder generator object
      * @return string
      */
-    public function sql(ValueBinder $generator);
+    public function sql(ValueBinder $generator): string;
 
     /**
      * Iterates over each part of the expression recursively for every
@@ -35,7 +35,7 @@ interface ExpressionInterface
      * being iterated.
      *
      * @param callable $visitor The callable to apply to all nodes.
-     * @return void
+     * @return $this
      */
     public function traverse(callable $visitor);
 }

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -119,7 +119,7 @@ class FieldTypeConverter
      * @param array $row The array with the fields to be casted
      * @return array
      */
-    public function __invoke($row)
+    public function __invoke(array $row): array
     {
         if (!empty($this->_typeMap)) {
             foreach ($this->_typeMap as $field => $type) {

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -34,7 +34,7 @@ class FunctionsBuilder
      * @param string $return The return type of the function expression
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    protected function _build($name, $params = [], $types = [], $return = 'string')
+    protected function _build(string $name, array $params = [], array $types = [], string $return = 'string'): FunctionExpression
     {
         return new FunctionExpression($name, $params, $types, $return);
     }
@@ -49,7 +49,7 @@ class FunctionsBuilder
      * @param string $return The return type for the function
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    protected function _literalArgumentFunction($name, $expression, $types = [], $return = 'string')
+    protected function _literalArgumentFunction(string $name, $expression, $types = [], $return = 'string'): FunctionExpression
     {
         if (!is_string($expression)) {
             $expression = [$expression];
@@ -65,7 +65,7 @@ class FunctionsBuilder
      *
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function rand()
+    public function rand(): FunctionExpression
     {
         return $this->_build('RAND', [], [], 'float');
     }
@@ -77,7 +77,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function sum($expression, $types = [])
+    public function sum($expression, $types = []): FunctionExpression
     {
         $returnType = 'float';
         if (current($types) === 'integer') {
@@ -94,7 +94,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function avg($expression, $types = [])
+    public function avg($expression, $types = []): FunctionExpression
     {
         return $this->_literalArgumentFunction('AVG', $expression, $types, 'float');
     }
@@ -106,7 +106,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function max($expression, $types = [])
+    public function max($expression, $types = []): FunctionExpression
     {
         return $this->_literalArgumentFunction('MAX', $expression, $types, current($types) ?: 'string');
     }
@@ -118,7 +118,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function min($expression, $types = [])
+    public function min($expression, $types = []): FunctionExpression
     {
         return $this->_literalArgumentFunction('MIN', $expression, $types, current($types) ?: 'string');
     }
@@ -130,7 +130,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function count($expression, $types = [])
+    public function count($expression, $types = []): FunctionExpression
     {
         return $this->_literalArgumentFunction('COUNT', $expression, $types, 'integer');
     }
@@ -142,7 +142,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function concat($args, $types = [])
+    public function concat(array $args, array $types = []): FunctionExpression
     {
         return $this->_build('CONCAT', $args, $types, 'string');
     }
@@ -154,7 +154,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function coalesce($args, $types = [])
+    public function coalesce(array $args, array $types = []): FunctionExpression
     {
         return $this->_build('COALESCE', $args, $types, current($types) ?: 'string');
     }
@@ -167,7 +167,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function dateDiff($args, $types = [])
+    public function dateDiff(array $args, array $types = []): FunctionExpression
     {
         return $this->_build('DATEDIFF', $args, $types, 'integer');
     }
@@ -180,7 +180,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function datePart($part, $expression, $types = [])
+    public function datePart(string $part, string $expression, array $types = []): FunctionExpression
     {
         return $this->extract($part, $expression);
     }
@@ -193,7 +193,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function extract($part, $expression, $types = [])
+    public function extract(string $part, string $expression, array $types = []): FunctionExpression
     {
         $expression = $this->_literalArgumentFunction('EXTRACT', $expression, $types, 'integer');
         $expression->setConjunction(' FROM')->add([$part => 'literal'], [], true);
@@ -205,12 +205,12 @@ class FunctionsBuilder
      * Add the time unit to the date expression
      *
      * @param string $expression Expression to obtain the date part from.
-     * @param string $value Value to be added. Use negative to substract.
+     * @param string|int $value Value to be added. Use negative to substract.
      * @param string $unit Unit of the value e.g. hour or day.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function dateAdd($expression, $value, $unit, $types = [])
+    public function dateAdd(string $expression, $value, string $unit, array $types = []): FunctionExpression
     {
         if (!is_numeric($value)) {
             $value = 0;
@@ -230,7 +230,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function dayOfWeek($expression, $types = [])
+    public function dayOfWeek($expression, $types = []): FunctionExpression
     {
         return $this->_literalArgumentFunction('DAYOFWEEK', $expression, $types, 'integer');
     }
@@ -243,7 +243,7 @@ class FunctionsBuilder
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function weekday($expression, $types = [])
+    public function weekday($expression, $types = []): FunctionExpression
     {
         return $this->dayOfWeek($expression, $types);
     }
@@ -256,7 +256,7 @@ class FunctionsBuilder
      * @param string $type (datetime|date|time)
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function now($type = 'datetime')
+    public function now(string $type = 'datetime'): FunctionExpression
     {
         if ($type === 'datetime') {
             return $this->_build('NOW')->setReturnType('datetime');
@@ -278,7 +278,7 @@ class FunctionsBuilder
      * params, and the third one the return type of the function
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function __call($name, $args)
+    public function __call(string $name, array $args): FunctionExpression
     {
         switch (count($args)) {
             case 0:

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -181,7 +181,7 @@ class IdentifierQuoter
         $table = $this->_driver->quoteIdentifier($table);
         foreach ($columns as &$column) {
             if (is_scalar($column)) {
-                $column = $this->_driver->quoteIdentifier($column);
+                $column = $this->_driver->quoteIdentifier((string)$column);
             }
         }
         $query->insert($columns)->into($table);

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -50,10 +50,10 @@ class IdentifierQuoter
      * @param \Cake\Database\Query $query The query to have its identifiers quoted
      * @return \Cake\Database\Query
      */
-    public function quote(Query $query)
+    public function quote(Query $query): Query
     {
         $binder = $query->getValueBinder();
-        $query->setValueBinder(false);
+        $query->setValueBinder(null);
 
         if ($query->type() === 'insert') {
             $this->_quoteInsert($query);
@@ -75,7 +75,7 @@ class IdentifierQuoter
      * @param \Cake\Database\ExpressionInterface $expression The expression object to walk and quote.
      * @return void
      */
-    public function quoteExpression($expression)
+    public function quoteExpression(ExpressionInterface $expression): void
     {
         if ($expression instanceof FieldInterface) {
             $this->_quoteComparison($expression);
@@ -102,7 +102,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Query $query The query to quote.
      * @return void
      */
-    protected function _quoteParts($query)
+    protected function _quoteParts(Query $query): void
     {
         foreach (['distinct', 'select', 'from', 'group'] as $part) {
             $contents = $query->clause($part);
@@ -130,7 +130,7 @@ class IdentifierQuoter
      * @param array $part the part of the query to quote
      * @return array
      */
-    protected function _basicQuoter($part)
+    protected function _basicQuoter(array $part): array
     {
         $result = [];
         foreach ((array)$part as $alias => $value) {
@@ -149,7 +149,7 @@ class IdentifierQuoter
      * @param array $joins The joins to quote.
      * @return array
      */
-    protected function _quoteJoins($joins)
+    protected function _quoteJoins(array $joins): array
     {
         $result = [];
         foreach ($joins as $value) {
@@ -175,7 +175,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Query $query The insert query to quote.
      * @return void
      */
-    protected function _quoteInsert($query)
+    protected function _quoteInsert(Query $query): void
     {
         list($table, $columns) = $query->clause('insert');
         $table = $this->_driver->quoteIdentifier($table);
@@ -193,7 +193,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Query $query The update query to quote.
      * @return void
      */
-    protected function _quoteUpdate($query)
+    protected function _quoteUpdate(Query $query): void
     {
         $table = $query->clause('update')[0];
 
@@ -208,7 +208,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\FieldInterface $expression The expression to quote.
      * @return void
      */
-    protected function _quoteComparison(FieldInterface $expression)
+    protected function _quoteComparison(FieldInterface $expression): void
     {
         $field = $expression->getField();
         if (is_string($field)) {
@@ -233,7 +233,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\OrderByExpression $expression The expression to quote.
      * @return void
      */
-    protected function _quoteOrderBy(OrderByExpression $expression)
+    protected function _quoteOrderBy(OrderByExpression $expression): void
     {
         $expression->iterateParts(function ($part, &$field) {
             if (is_string($field)) {
@@ -255,7 +255,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\IdentifierExpression $expression The identifiers to quote.
      * @return void
      */
-    protected function _quoteIdentifierExpression(IdentifierExpression $expression)
+    protected function _quoteIdentifierExpression(IdentifierExpression $expression): void
     {
         $expression->setIdentifier(
             $this->_driver->quoteIdentifier($expression->getIdentifier())

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -62,7 +62,7 @@ class LoggedQuery
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return "duration={$this->took} rows={$this->numRows} {$this->query}";
     }

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -71,11 +71,11 @@ class LoggingStatement extends StatementDecorator
      * to the logging system.
      *
      * @param \Cake\Database\Log\LoggedQuery $query The query to log.
-     * @param array $params List of values to be bound to query.
+     * @param array|null $params List of values to be bound to query.
      * @param float $startTime The microtime when the query was executed.
      * @return void
      */
-    protected function _log($query, $params, $startTime)
+    protected function _log(LoggedQuery $query, ?array $params, float $startTime): void
     {
         $query->took = round((microtime(true) - $startTime) * 1000, 0);
         $query->params = $params ?: $this->_compiledParams;
@@ -110,7 +110,7 @@ class LoggingStatement extends StatementDecorator
      * @param \Cake\Database\Log\QueryLogger $logger Logger object
      * @return void
      */
-    public function setLogger($logger)
+    public function setLogger(QueryLogger $logger): void
     {
         $this->_logger = $logger;
     }
@@ -118,9 +118,9 @@ class LoggingStatement extends StatementDecorator
     /**
      * Gets the logger object
      *
-     * @return \Cake\Database\Log\QueryLogger logger instance
+     * @return \Cake\Database\Log\QueryLogger|null logger instance
      */
-    public function getLogger()
+    public function getLogger(): ?QueryLogger
     {
         return $this->_logger;
     }

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -45,7 +45,7 @@ class QueryLogger
      * @param \Cake\Database\Log\LoggedQuery $query to be written in log
      * @return void
      */
-    protected function _log(\Cake\Database\Log\LoggedQuery $query): void
+    protected function _log(LoggedQuery $query): void
     {
         Log::write('debug', $query, ['queriesLog']);
     }
@@ -57,7 +57,7 @@ class QueryLogger
      * @param \Cake\Database\Log\LoggedQuery $query The query to log
      * @return string
      */
-    protected function _interpolate(\Cake\Database\Log\LoggedQuery $query): string
+    protected function _interpolate(LoggedQuery $query): string
     {
         $params = array_map(function ($p) {
             if ($p === null) {

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -30,7 +30,7 @@ class QueryLogger
      * @param \Cake\Database\Log\LoggedQuery $query to be written in log
      * @return void
      */
-    public function log(LoggedQuery $query)
+    public function log(LoggedQuery $query): void
     {
         if (!empty($query->params)) {
             $query->query = $this->_interpolate($query);
@@ -45,7 +45,7 @@ class QueryLogger
      * @param \Cake\Database\Log\LoggedQuery $query to be written in log
      * @return void
      */
-    protected function _log($query)
+    protected function _log(\Cake\Database\Log\LoggedQuery $query): void
     {
         Log::write('debug', $query, ['queriesLog']);
     }
@@ -57,7 +57,7 @@ class QueryLogger
      * @param \Cake\Database\Log\LoggedQuery $query The query to log
      * @return string
      */
-    protected function _interpolate($query)
+    protected function _interpolate(\Cake\Database\Log\LoggedQuery $query): string
     {
         $params = array_map(function ($p) {
             if ($p === null) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -299,7 +299,40 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The callback will receive 2 parameters, the first one is the value of the query
      * part that is being iterated and the second the name of such part.
      *
-     * ### Example:
+     * ### Example
+     * ```
+     * $query->select(['title'])->from('articles')->traverse(function ($value, $clause) {
+     *     if ($clause === 'select') {
+     *         var_dump($value);
+     *     }
+     * });
+     * ```
+     *
+     * @param callable $visitor A function or callable to be executed for each part
+     * @return $this
+     */
+    public function traverse(callable $visitor)
+    {
+        $parts = array_keys($this->_parts);
+        foreach ($parts as $name) {
+            $visitor($this->_parts[$name], $name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Will iterate over the provided parts.
+     *
+     * Traversing functions can aggregate results using variables in the closure
+     * or instance variables. This method can be used to traverse a subset of
+     * query parts in order to render a SQL query.
+     *
+     * The callback will receive 2 parameters, the first one is the value of the query
+     * part that is being iterated and the second the name of such part.
+     *
+     * ### Example
+     *
      * ```
      * $query->select(['title'])->from('articles')->traverse(function ($value, $clause) {
      *     if ($clause === 'select') {
@@ -309,12 +342,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * @param callable $visitor A function or callable to be executed for each part
+     * @param array $parts The list of query parts to traverse
      * @return $this
      */
-    public function traverse(callable $visitor)
+    public function traverseParts(callable $visitor, array $parts)
     {
-        $partList = "_{$this->type()}Parts";
-        $parts = $this->{$partList} ?? array_keys($this->_parts);
         foreach ($parts as $name) {
             $visitor($this->_parts[$name], $name);
         }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -44,6 +44,37 @@ class QueryCompiler
     ];
 
     /**
+     * The list of query clauses to traverse for generating a SELECT statement
+     *
+     * @var array
+     */
+    protected $_selectParts = [
+        'select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit',
+        'offset', 'union', 'epilog',
+    ];
+
+    /**
+     * The list of query clauses to traverse for generating an UPDATE statement
+     *
+     * @var array
+     */
+    protected $_updateParts = ['update', 'set', 'where', 'epilog'];
+
+    /**
+     * The list of query clauses to traverse for generating a DELETE statement
+     *
+     * @var array
+     */
+    protected $_deleteParts = ['delete', 'modifier', 'from', 'where', 'epilog'];
+
+    /**
+     * The list of query clauses to traverse for generating an INSERT statement
+     *
+     * @var array
+     */
+    protected $_insertParts = ['insert', 'values', 'epilog'];
+
+    /**
      * Indicate whether or not this query dialect supports ordered unions.
      *
      * Overridden in subclasses.
@@ -63,7 +94,11 @@ class QueryCompiler
     public function compile(Query $query, ValueBinder $generator): string
     {
         $sql = '';
-        $query->traverse($this->_sqlCompiler($sql, $query, $generator));
+        $type = $query->type();
+        $query->traverseParts(
+            $this->_sqlCompiler($sql, $query, $generator),
+            $this->{"_{$type}Parts"}
+        );
 
         // Propagate bound parameters from sub-queries if the
         // placeholders can be found in the SQL statement.

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -95,7 +95,7 @@ class ReconnectStrategy implements RetryStrategyInterface
      *
      * @return bool Whether or not the connection was re-established
      */
-    protected function reconnect()
+    protected function reconnect(): bool
     {
         if ($this->connection->inTransaction()) {
             // It is not safe to blindly reconnect in the middle of a transaction

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -50,7 +50,7 @@ class SchemaCache
      * @param string|null $name The name of the table to build cache data for.
      * @return array Returns a list build table caches
      */
-    public function build($name = null)
+    public function build(?string $name = null): array
     {
         $tables = [$name];
         if (empty($name)) {
@@ -70,7 +70,7 @@ class SchemaCache
      * @param string|null $name The name of the table to clear cache data for.
      * @return array Returns a list of cleared table caches
      */
-    public function clear($name = null)
+    public function clear(?string $name = null): array
     {
         $tables = [$name];
         if (empty($name)) {

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -88,7 +88,7 @@ trait SqlDialectTrait
      * (select, insert, update, delete)
      * @return callable
      */
-    public function queryTranslator(string $type)
+    public function queryTranslator(string $type): callable
     {
         return function ($query) use ($type) {
             if ($this->isAutoQuotingEnabled()) {
@@ -121,7 +121,7 @@ trait SqlDialectTrait
      *
      * @return array
      */
-    protected function _expressionTranslators()
+    protected function _expressionTranslators(): array
     {
         return [];
     }
@@ -132,7 +132,7 @@ trait SqlDialectTrait
      * @param \Cake\Database\Query $query The query to translate
      * @return \Cake\Database\Query The modified query
      */
-    protected function _selectQueryTranslator($query)
+    protected function _selectQueryTranslator(Query $query): Query
     {
         return $this->_transformDistinct($query);
     }
@@ -144,7 +144,7 @@ trait SqlDialectTrait
      * @param \Cake\Database\Query $query The query to be transformed
      * @return \Cake\Database\Query
      */
-    protected function _transformDistinct($query)
+    protected function _transformDistinct(Query $query): Query
     {
         if (is_array($query->clause('distinct'))) {
             $query->group($query->clause('distinct'), true);
@@ -166,7 +166,7 @@ trait SqlDialectTrait
      * @param \Cake\Database\Query $query The query to translate
      * @return \Cake\Database\Query The modified query
      */
-    protected function _deleteQueryTranslator($query)
+    protected function _deleteQueryTranslator(Query $query): Query
     {
         $hadAlias = false;
         $tables = [];
@@ -198,7 +198,7 @@ trait SqlDialectTrait
      * @param \Cake\Database\Query $query The query to translate
      * @return \Cake\Database\Query The modified query
      */
-    protected function _updateQueryTranslator($query)
+    protected function _updateQueryTranslator(Query $query): Query
     {
         return $this->_removeAliasesFromConditions($query);
     }
@@ -211,7 +211,7 @@ trait SqlDialectTrait
      * @throws \RuntimeException In case the processed query contains any joins, as removing
      *  aliases from the conditions can break references to the joined tables.
      */
-    protected function _removeAliasesFromConditions($query)
+    protected function _removeAliasesFromConditions(Query $query): Query
     {
         if ($query->clause('join')) {
             throw new \RuntimeException(
@@ -248,7 +248,7 @@ trait SqlDialectTrait
      * @param \Cake\Database\Query $query The query to translate
      * @return \Cake\Database\Query The modified query
      */
-    protected function _insertQueryTranslator($query)
+    protected function _insertQueryTranslator(Query $query): Query
     {
         return $query;
     }

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -256,10 +256,10 @@ trait SqlDialectTrait
     /**
      * Returns a SQL snippet for creating a new transaction savepoint
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function savePointSQL(string $name): string
+    public function savePointSQL($name): string
     {
         return 'SAVEPOINT LEVEL' . $name;
     }
@@ -267,10 +267,10 @@ trait SqlDialectTrait
     /**
      * Returns a SQL snippet for releasing a previously created save point
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function releaseSavePointSQL(string $name): string
+    public function releaseSavePointSQL($name): string
     {
         return 'RELEASE SAVEPOINT LEVEL' . $name;
     }
@@ -278,10 +278,10 @@ trait SqlDialectTrait
     /**
      * Returns a SQL snippet for rollbacking a previously created save point
      *
-     * @param string $name save point name
+     * @param string|int $name save point name
      * @return string
      */
-    public function rollbackSavePointSQL(string $name): string
+    public function rollbackSavePointSQL($name): string
     {
         return 'ROLLBACK TO SAVEPOINT LEVEL' . $name;
     }

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -39,7 +39,16 @@ class SqlserverCompiler extends QueryCompiler
         'group' => ' GROUP BY %s ',
         'having' => ' HAVING %s ',
         'order' => ' %s',
+        'offset' => ' OFFSET %s ROWS',
         'epilog' => ' %s',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_selectParts = [
+        'select', 'from', 'join', 'where', 'group', 'having', 'order', 'offset',
+        'limit', 'union', 'epilog',
     ];
 
     /**
@@ -77,33 +86,10 @@ class SqlserverCompiler extends QueryCompiler
      */
     protected function _buildLimitPart(int $limit, Query $query): string
     {
-        $offset = $query->clause('offset');
-        if ($limit === null || $offset === null) {
-            return '';
-        }
-        if ($offset !== 0 && $offset !== '') {
-            $offset = sprintf(' OFFSET %s ROWS', $offset);
-        }
-
-        return sprintf('%s FETCH FIRST %d ROWS ONLY', $offset, $limit);
-    }
-
-    /**
-     * Generate the OFFSET part of the query.
-     *
-     * Because of SQLServer syntax requirements, the offset must precede the
-     * limit part. This requires coupling between these two methods.
-     *
-     * @param int $value The offset value.
-     * @param \Cake\Database\Query $query The query being changed.
-     * @return string
-     */
-    protected function _buildOffsetPart(int $value, $query)
-    {
-        if ($query->clause('limit')) {
+        if ($limit === null || $query->clause('offset') === null) {
             return '';
         }
 
-        return sprintf(' OFFSET %s ROWS', $value);
+        return sprintf(' FETCH FIRST %d ROWS ONLY', $limit);
     }
 }

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -54,7 +54,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
      * @return string
      */
-    protected function _buildInsertPart(array $parts, \Cake\Database\Query $query, \Cake\Database\ValueBinder $generator): string
+    protected function _buildInsertPart(array $parts, Query $query, ValueBinder $generator): string
     {
         $table = $parts[0];
         $columns = $this->_stringifyExpressions($parts[1], $generator);

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -237,7 +237,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * ```
      *
      * @param string|int $type num for fetching columns as positional keys or assoc for column names as keys
-     * @return array List of all results from database for this statement
+     * @return array|false List of all results from database for this statement. False on failure.
      */
     public function fetchAll($type = self::FETCH_TYPE_NUM)
     {

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -1,3 +1,4 @@
 <?php
+declare(strict_types=1);
 // @deprecated Backwards compatibility alias
 class_alias('Cake\Database\TypeFactory', 'Cake\Database\Type');

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -44,7 +44,7 @@ abstract class BaseType implements TypeInterface
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->_name;
     }
@@ -52,7 +52,7 @@ abstract class BaseType implements TypeInterface
     /**
      * {@inheritDoc}
      */
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return $this->_name;
     }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -154,7 +154,7 @@ class DateTimeType extends BaseType
     /**
      * Convert strings into DateTime instances.
      *
-     * @param string $value The value to convert.
+     * @param string|int|null $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return \Cake\I18n\Time|\DateTime|null
      */

--- a/src/Database/TypeConverterTrait.php
+++ b/src/Database/TypeConverterTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypeConverterTrait.php
+++ b/src/Database/TypeConverterTrait.php
@@ -28,7 +28,7 @@ trait TypeConverterTrait
      * @param \Cake\Database\Type|string $type The type name or type instance to use.
      * @return array list containing converted value and internal type
      */
-    public function cast($value, $type)
+    public function cast($value, $type): array
     {
         if (is_string($type)) {
             $type = TypeFactory::build($type);
@@ -51,7 +51,7 @@ trait TypeConverterTrait
      * @param array $types list or associative array of types
      * @return array
      */
-    public function matchTypes($columns, $types)
+    public function matchTypes(array $columns, array $types): array
     {
         if (!is_int(key($types))) {
             $positions = array_intersect_key(array_flip($columns), $types);

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -63,7 +63,7 @@ class TypeFactory
      * @throws \InvalidArgumentException If type identifier is unknown
      * @return \Cake\Database\TypeInterface
      */
-    public static function build($name)
+    public static function build(string $name): TypeInterface
     {
         if (isset(static::$_builtTypes[$name])) {
             return static::$_builtTypes[$name];
@@ -80,7 +80,7 @@ class TypeFactory
      *
      * @return array
      */
-    public static function buildAll()
+    public static function buildAll(): array
     {
         $result = [];
         foreach (static::$_types as $name => $type) {
@@ -97,7 +97,7 @@ class TypeFactory
      * @param \Cake\Database\TypeInterface $instance The type instance you want to set.
      * @return void
      */
-    public static function set($name, TypeInterface $instance)
+    public static function set(string $name, TypeInterface $instance): void
     {
         static::$_builtTypes[$name] = $instance;
     }
@@ -109,7 +109,7 @@ class TypeFactory
      * @param string $className The classname to register.
      * @return void
      */
-    public static function map(string $type, $className)
+    public static function map(string $type, string $className): void
     {
         static::$_types[$type] = $className;
         unset(static::$_builtTypes[$type]);
@@ -121,7 +121,7 @@ class TypeFactory
      * @param string[] $map List of types to be mapped.
      * @return void
      */
-    public static function setMap(array $map)
+    public static function setMap(array $map): void
     {
         static::$_types = $map;
         static::$_builtTypes = [];
@@ -147,7 +147,7 @@ class TypeFactory
      *
      * @return void
      */
-    public static function clear()
+    public static function clear(): void
     {
         static::$_types = [];
         static::$_builtTypes = [];

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -68,14 +68,14 @@ interface TypeInterface
      *
      * @return string The base type name that this class is inheriting.
      */
-    public function getBaseType();
+    public function getBaseType(): string;
 
     /**
      * Returns type identifier name for this object.
      *
      * @return string The type identifier name for this object.
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Generate a new primary key value for a given type.

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -80,7 +80,7 @@ class TypeMap
      *
      * @return array
      */
-    public function getDefaults()
+    public function getDefaults(): array
     {
         return $this->_defaults;
     }
@@ -93,7 +93,7 @@ class TypeMap
      * @param array $types The additional types to add.
      * @return void
      */
-    public function addDefaults(array $types)
+    public function addDefaults(array $types): void
     {
         $this->_defaults += $types;
     }
@@ -125,7 +125,7 @@ class TypeMap
      *
      * @return array
      */
-    public function getTypes()
+    public function getTypes(): array
     {
         return $this->_types;
     }
@@ -135,10 +135,10 @@ class TypeMap
      * the column type will be looked for inside the default mapping. If neither exist,
      * null will be returned.
      *
-     * @param string $column The type for a given column
+     * @param string|int $column The type for a given column
      * @return null|string
      */
-    public function type($column)
+    public function type($column): ?string
     {
         if (isset($this->_types[$column])) {
             return $this->_types[$column];
@@ -155,7 +155,7 @@ class TypeMap
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->_types + $this->_defaults;
     }

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -46,7 +46,7 @@ trait TypeMapTrait
      *
      * @return \Cake\Database\TypeMap
      */
-    public function getTypeMap()
+    public function getTypeMap(): TypeMap
     {
         if ($this->_typeMap === null) {
             $this->_typeMap = new TypeMap();
@@ -73,7 +73,7 @@ trait TypeMapTrait
      *
      * @return array
      */
-    public function getDefaultTypes()
+    public function getDefaultTypes(): array
     {
         return $this->getTypeMap()->getDefaults();
     }

--- a/src/Database/TypedResultInterface.php
+++ b/src/Database/TypedResultInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypedResultInterface.php
+++ b/src/Database/TypedResultInterface.php
@@ -17,10 +17,21 @@ namespace Cake\Database;
 
 /**
  * Represents an expression that is known to return a specific type
- *
- * @method string getReturnType()
- * @method $this setReturnType($type)
  */
 interface TypedResultInterface
 {
+    /**
+     * Return the abstract type this expression will return
+     *
+     * @return string
+     */
+    public function getReturnType(): string;
+
+    /**
+     * Set the return type of the expression
+     *
+     * @param string $type The type name to use.
+     * @return void
+     */
+    public function setReturnType(string $type);
 }

--- a/src/Database/TypedResultTrait.php
+++ b/src/Database/TypedResultTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/TypedResultTrait.php
+++ b/src/Database/TypedResultTrait.php
@@ -32,7 +32,7 @@ trait TypedResultTrait
      *
      * @return string
      */
-    public function getReturnType()
+    public function getReturnType(): string
     {
         return $this->_returnType;
     }
@@ -43,7 +43,7 @@ trait TypedResultTrait
      * @param string $type The name of the type that is to be returned
      * @return $this
      */
-    public function setReturnType($type)
+    public function setReturnType(string $type)
     {
         $this->_returnType = $type;
 

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -48,7 +48,7 @@ class ValueBinder
      * to database
      * @return void
      */
-    public function bind($param, $value, $type = 'string')
+    public function bind($param, $value, $type = 'string'): void
     {
         $this->_bindings[$param] = compact('value', 'type') + [
             'placeholder' => is_int($param) ? $param : substr($param, 1),
@@ -64,7 +64,7 @@ class ValueBinder
      * if it starts with a colon, then the same string is returned
      * @return string to be used as a placeholder in a query expression
      */
-    public function placeholder($token)
+    public function placeholder(string $token): string
     {
         $number = $this->_bindingsCount++;
         if ($token[0] !== ':' && $token !== '?') {
@@ -82,7 +82,7 @@ class ValueBinder
      * @param string $type The type with which all values will be bound
      * @return array with the placeholders to insert in the query
      */
-    public function generateManyNamed(iterable $values, $type = 'string')
+    public function generateManyNamed(iterable $values, string $type = 'string'): array
     {
         $placeholders = [];
         foreach ($values as $k => $value) {
@@ -104,7 +104,7 @@ class ValueBinder
      *
      * @return array
      */
-    public function bindings()
+    public function bindings(): array
     {
         return $this->_bindings;
     }
@@ -114,7 +114,7 @@ class ValueBinder
      *
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->_bindings = [];
         $this->_bindingsCount = 0;
@@ -125,7 +125,7 @@ class ValueBinder
      *
      * @return void
      */
-    public function resetCount()
+    public function resetCount(): void
     {
         $this->_bindingsCount = 0;
     }
@@ -136,7 +136,7 @@ class ValueBinder
      * @param \Cake\Database\StatementInterface $statement The statement to add parameters to.
      * @return void
      */
-    public function attachTo($statement)
+    public function attachTo(StatementInterface $statement): void
     {
         $bindings = $this->bindings();
         if (empty($bindings)) {

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -19,8 +19,6 @@ namespace Cake\Datasource;
  * This interface defines the methods you can depend on in
  * a connection.
  *
- * @method object getLogger() Get the current logger instance
- * @method $this setLogger($logger) Set the current logger.
  * @method bool supportsDynamicConstraints()
  * @method \Cake\Database\Schema\Collection getSchemaCollection()
  * @method \Cake\Database\Query newQuery()
@@ -30,6 +28,21 @@ namespace Cake\Datasource;
  */
 interface ConnectionInterface
 {
+    /**
+     * Set a logger, or clear the current logger.
+     *
+     * @param \Cake\Database\Log\QueryLogger|null $logger Logger object
+     * @return $this
+     */
+    public function setLogger($logger);
+
+    /**
+     * Gets the current logger object.
+     *
+     * @return \Cake\Database\Log\QueryLogger logger instance
+     */
+    public function getLogger();
+
     /**
      * Get the configuration name for this connection.
      *
@@ -78,12 +91,12 @@ interface ConnectionInterface
      * @param bool $value Enable/disable query logging
      * @return $this
      */
-    public function enableQueryLogging($value): self;
+    public function enableQueryLogging(bool $value);
 
     /**
      * Check if query logging is enabled.
      *
      * @return bool
      */
-    public function isQueryLoggingEnabled();
+    public function isQueryLoggingEnabled(): bool;
 }

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -159,7 +159,7 @@ interface QueryInterface
      * $query->limit($query->newExpr()->add(['1 + 1'])); // LIMIT (1 + 1)
      * ```
      *
-     * @param int $num number of records to be returned
+     * @param int|mixed $num number of records to be returned
      * @return $this
      */
     public function limit($num);
@@ -179,7 +179,7 @@ interface QueryInterface
      *  $query->offset($query->newExpr()->add(['1 + 1'])); // OFFSET (1 + 1)
      * ```
      *
-     * @param int $num number of records to be skipped
+     * @param int|mixed $num number of records to be skipped
      * @return $this
      */
     public function offset($num);
@@ -248,7 +248,7 @@ interface QueryInterface
      * @return $this
      * @throws \InvalidArgumentException If page number < 1.
      */
-    public function page($num, $limit = null);
+    public function page(int $num, ?int $limit = null);
 
     /**
      * Returns an array representation of the results after executing the query.

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1207,7 +1207,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param string|null $table Unused parameter.
      * @return $this
      */
-    public function delete($table = null)
+    public function delete(?string $table = null)
     {
         /** @var \Cake\ORM\Table $repository */
         $repository = $this->getRepository();

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -103,7 +103,7 @@ class SqlserverTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([]));
+            ->will($this->returnValue(true));
         $driver->connect();
     }
 
@@ -248,19 +248,17 @@ class SqlserverTest extends TestCase
     public function testSelectLimitVersion12()
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect', 'getConnection', '_version'])
+            ->setMethods(['_connect', 'getConnection', 'version'])
             ->setConstructorArgs([[]])
             ->getMock();
-        $driver->expects($this->any())
-            ->method('_version')
+        $driver->method('version')
             ->will($this->returnValue(12));
 
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
+        $connection->method('getDriver')
             ->will($this->returnValue($driver));
 
         $query = new Query($connection);
@@ -299,11 +297,11 @@ class SqlserverTest extends TestCase
     public function testSelectLimitOldServer()
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect', 'getConnection', '_version'])
+            ->setMethods(['_connect', 'getConnection', 'version'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->expects($this->any())
-            ->method('_version')
+            ->method('version')
             ->will($this->returnValue(8));
 
         $connection = $this->getMockBuilder('Cake\Database\Connection')

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -199,18 +200,6 @@ class DriverTest extends TestCase
         $this->assertTrue($this->driver->isAutoQuotingEnabled());
 
         $this->driver->enableAutoQuoting(false);
-        $this->assertFalse($this->driver->isAutoQuotingEnabled());
-
-        $this->driver->enableAutoQuoting('string');
-        $this->assertTrue($this->driver->isAutoQuotingEnabled());
-
-        $this->driver->enableAutoQuoting('0');
-        $this->assertFalse($this->driver->isAutoQuotingEnabled());
-
-        $this->driver->enableAutoQuoting(1);
-        $this->assertTrue($this->driver->isAutoQuotingEnabled());
-
-        $this->driver->enableAutoQuoting(0);
         $this->assertFalse($this->driver->isAutoQuotingEnabled());
     }
 

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -217,7 +217,7 @@ class DriverTest extends TestCase
         $compiler
             ->expects($this->once())
             ->method('compile')
-            ->willReturn(true);
+            ->willReturn('1');
 
         $driver = $this->getMockBuilder(Driver::class)
             ->setMethods(['newCompiler', 'queryTranslator'])
@@ -244,7 +244,7 @@ class DriverTest extends TestCase
 
         $this->assertInternalType('array', $result);
         $this->assertSame($query, $result[0]);
-        $this->assertTrue($result[1]);
+        $this->assertSame('1', $result[1]);
     }
 
     /**

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4007,7 +4007,7 @@ class QueryTest extends TestCase
         /* @var \Cake\ORM\Query|\PHPUnit_Framework_MockObject_MockObject $queryMock */
         $queryMock = $this->getMockBuilder(Query::class)
             ->setMethods(['execute'])
-            ->setConstructorArgs((array)$this->connection)
+            ->setConstructorArgs([$this->connection])
             ->getMock();
 
         $queryMock->expects($this->once())

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -26,7 +26,7 @@ use Cake\TestSuite\TestCase;
  */
 class FooType extends IntegerType
 {
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'integer';
     }

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -189,7 +189,7 @@ class BelongsToManyTest extends TestCase
     {
         $mock = $this->getMockBuilder('Cake\Database\Connection')
                 ->setMethods(['setDriver'])
-                ->setConstructorArgs(['name' => 'other_source'])
+                ->setConstructorArgs([['name' => 'other_source']])
                 ->getMock();
         ConnectionManager::setConfig('other_source', $mock);
         $this->article->setConnection(ConnectionManager::get('other_source'));

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Database\Schema\TableSchema;
+use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\Fixture\TestFixture;
@@ -321,11 +322,10 @@ class TestFixtureTest extends TestCase
             ->will($this->returnValue(['sql', 'sql']));
         $fixture->setTableSchema($table);
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['execute', 'closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->atLeastOnce())->method('closeCursor');
         $statement->expects($this->atLeastOnce())->method('execute');
+
         $db->expects($this->exactly(2))
             ->method('prepare')
             ->will($this->returnValue($statement));
@@ -403,10 +403,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[2])
             ->will($this->returnSelf());
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())->method('closeCursor');
+
         $query->expects($this->once())
             ->method('execute')
             ->will($this->returnValue($statement));
@@ -451,10 +450,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[0])
             ->will($this->returnSelf());
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())->method('closeCursor');
+
         $query->expects($this->once())
             ->method('execute')
             ->will($this->returnValue($statement));
@@ -509,10 +507,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[2])
             ->will($this->returnSelf());
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())->method('closeCursor');
+
         $query->expects($this->once())
             ->method('execute')
             ->will($this->returnValue($statement));
@@ -532,9 +529,7 @@ class TestFixtureTest extends TestCase
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()
             ->getMock();
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())->method('closeCursor');
         $db->expects($this->once())->method('execute')
             ->with('sql')
@@ -564,10 +559,9 @@ class TestFixtureTest extends TestCase
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()
             ->getMock();
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->setMethods(['closeCursor'])
-            ->getMock();
+        $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())->method('closeCursor');
+
         $db->expects($this->once())->method('execute')
             ->with('sql')
             ->will($this->returnValue($statement));

--- a/tests/test_app/TestApp/Database/Type/BarType.php
+++ b/tests/test_app/TestApp/Database/Type/BarType.php
@@ -18,7 +18,7 @@ use Cake\Database\Type\StringType;
 
 class BarType extends StringType
 {
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'text';
     }

--- a/tests/test_app/TestApp/Database/Type/FooType.php
+++ b/tests/test_app/TestApp/Database/Type/FooType.php
@@ -18,7 +18,7 @@ use Cake\Database\Type\StringType;
 
 class FooType extends StringType
 {
-    public function getBaseType()
+    public function getBaseType(): string
     {
         return 'text';
     }


### PR DESCRIPTION
I had to move the part lists into Query::traverse() to maintain interface consistentcy with ExpressionInterface. Moving part lists also required a more clunky implementation for SQLServer, but that driver already has a few clunky parts.

A few other types needed to become nullable as we use them in a nullable way in test cases. I was concerned that removing those tests would break real-world usage.

Refs #11935