### PR TITLE
Avoid undefined index: null (update action)

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2177,7 +2177,7 @@ class DboSource extends DataSource {
 			$update = $quoted . ' = ';
 
 			if ($quoteValues) {
-				$update .= $this->value($value, $Model->getColumnType($field), isset($schema[$field]) ? $schema[$field]['null'] : true);
+				$update .= $this->value($value, $Model->getColumnType($field), isset($schema[$field]['null']) ? $schema[$field]['null'] : true);
 			} elseif ($Model->getColumnType($field) === 'boolean' && (is_int($value) || is_bool($value))) {
 				$update .= $this->boolean($value, true);
 			} elseif (!$alias) {


### PR DESCRIPTION
Avoid Notice (8): Undefined index: null [APP/Vendor/cakephp/cakephp/lib/Cake/Model/Datasource/DboSource.php, line 2180]
also discussed here: 22b0275#diff-b8a4043bec5d20830b77d240ae8fdef5R2087
fix for previous instance of the same bug already merged here: cakephp#12411
(sorry for overlooking this second use-case :( )