### PR TITLE
Option to show the relative paths in the .pot comments

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -50,6 +50,13 @@ class ExtractTask extends Shell
     protected $_merge = false;
 
     /**
+     * Use relative paths in the pot files rather than full path
+     *
+     * @var bool
+     */
+    protected $_relativePaths = false;
+
+    /**
      * Current file being processed
      *
      * @var string|null
@@ -233,6 +240,10 @@ class ExtractTask extends Shell
             $this->_merge = strtolower($response) === 'y';
         }
 
+        if (isset($this->params['relative-paths'])) {
+            $this->_relativePaths = !(strtolower($this->params['relative-paths']) === 'no');
+        }
+
         if (empty($this->_files)) {
             $this->_searchFiles();
         }
@@ -320,6 +331,9 @@ class ExtractTask extends Shell
             'help' => 'Comma separated list of paths.'
         ])->addOption('merge', [
             'help' => 'Merge all domain strings into the default.po file.',
+            'choices' => ['yes', 'no']
+        ])->addOption('relative-paths', [
+            'help' => 'Use relative paths in the .pot file',
             'choices' => ['yes', 'no']
         ])->addOption('output', [
             'help' => 'Full path to output directory.'
@@ -447,6 +461,9 @@ class ExtractTask extends Shell
                         'file' => $this->_file,
                         'line' => $line,
                     ];
+                    if ($this->_relativePaths) {
+                        $details['file'] = '.' . str_replace(ROOT, '', $details['file']);
+                    }
                     if (isset($plural)) {
                         $details['msgid_plural'] = $plural;
                     }

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -184,6 +184,7 @@ class ExtractTaskTest extends TestCase
         $pattern = '/\#: .*default\.ctp:\d+\n/';
         $this->assertNotRegExp($pattern, $result);
     }
+
     /**
      * testExtractWithoutLocations method
      *
@@ -357,5 +358,30 @@ class ExtractTaskTest extends TestCase
 
         $pattern = '/#: Test\//';
         $this->assertNotRegExp($pattern, $result);
+    }
+
+    /**
+     * test relative-paths option
+     *
+     * @return void
+     */
+    public function testExtractWithRelativePaths()
+    {
+        $this->Task->interactive = false;
+
+        $this->Task->params['paths'] = TEST_APP . 'TestApp/Template';
+        $this->Task->params['output'] = $this->path . DS;
+        $this->Task->params['extract-core'] = 'no';
+        $this->Task->params['relative-paths'] = true;
+
+        $this->Task->method('in')
+            ->will($this->returnValue('y'));
+
+        $this->Task->main();
+        $this->assertFileExists($this->path . DS . 'default.pot');
+        $result = file_get_contents($this->path . DS . 'default.pot');
+
+        $expected = '#: ./tests/test_app/TestApp/Template/Pages/extract.ctp:';
+        $this->assertContains($expected, $result);
     }
 }


### PR DESCRIPTION
This change makes is possible to put in a relative path in the `.pot` file generated by the [ExtractTask](https://github.com/cakephp/cakephp/blob/master/src/Shell/Task/ExtractTask.php) used by the [I18nShell](https://github.com/cakephp/cakephp/blob/master/src/Shell/I18nShell.php).

Without using this new argument: 
```
#: /var/lib/jenkins/jobs/apacta-translations-update/workspace/plugins/Companies/src/Template/Projects/add.ctp:425
```

With this new argumentthis would be
```
#: ./plugins/Companies/src/Template/Projects/add.ctp:425
```

Not using this argument creates a lot of diffs when this file is sometimes updated through CI server, sometimes by developers or maybe by a 3rd party tool that doesn't quite understand these paths anyway - at least the full path doesn't make a lot of sense to either us or our tools :-)

I don't see a lot of tests covering the comments in the file, and my regex is not strong - so maybe someone would like to help a bit? 👍 