### PR TITLE
3.x Fix ConsoleIo:: and Shell:: constants => self:: constants

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -84,7 +84,7 @@ class ConsoleIo
      *
      * @var int
      */
-    protected $_level = ConsoleIo::NORMAL;
+    protected $_level = self::NORMAL;
 
     /**
      * The number of bytes last written to the output stream
@@ -163,17 +163,17 @@ class ConsoleIo
      *
      * ### Output levels
      *
-     * There are 3 built-in output level. Shell::QUIET, Shell::NORMAL, Shell::VERBOSE.
+     * There are 3 built-in output level. self::QUIET, self::NORMAL, self::VERBOSE.
      * The verbose and quiet output levels, map to the `verbose` and `quiet` output switches
-     * present in most shells. Using Shell::QUIET for a message means it will always display.
-     * While using Shell::VERBOSE means it will only display when verbose output is toggled.
+     * present in most shells. Using self::QUIET for a message means it will always display.
+     * While using self::VERBOSE means it will only display when verbose output is toggled.
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|bool The number of bytes returned from writing to stdout.
      */
-    public function out($message = '', $newlines = 1, $level = ConsoleIo::NORMAL)
+    public function out($message = '', $newlines = 1, $level = self::NORMAL)
     {
         if ($level <= $this->_level) {
             $this->_lastWritten = (int)$this->_out->write($message, $newlines);
@@ -191,9 +191,9 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|bool The number of bytes returned from writing to stdout.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::out
      */
-    public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function info($message = null, $newlines = 1, $level = self::NORMAL)
     {
         $messageType = 'info';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -207,7 +207,7 @@ class ConsoleIo
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stderr.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::err
      */
     public function warning($message = null, $newlines = 1)
     {
@@ -223,7 +223,7 @@ class ConsoleIo
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|bool The number of bytes returned from writing to stderr.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::err
      */
     public function error($message = null, $newlines = 1)
     {
@@ -240,9 +240,9 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|bool The number of bytes returned from writing to stdout.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::out
      */
-    public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
+    public function success($message = null, $newlines = 1, $level = self::NORMAL)
     {
         $messageType = 'success';
         $message = $this->wrapMessageWithType($messageType, $message);

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -165,8 +165,8 @@ class ConsoleIo
      *
      * There are 3 built-in output level. ConsoleIo::QUIET, ConsoleIo::NORMAL, ConsoleIo::VERBOSE.
      * The verbose and quiet output levels, map to the `verbose` and `quiet` output switches
-     * present in most shells. Using self::QUIET for a message means it will always display.
-     * While using self::VERBOSE means it will only display when verbose output is toggled.
+     * present in most shells. Using ConsoleIo::QUIET for a message means it will always display.
+     * While using ConsoleIo::VERBOSE means it will only display when verbose output is toggled.
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -163,7 +163,7 @@ class ConsoleIo
      *
      * ### Output levels
      *
-     * There are 3 built-in output level. self::QUIET, self::NORMAL, self::VERBOSE.
+     * There are 3 built-in output level. ConsoleIo::QUIET, ConsoleIo::NORMAL, ConsoleIo::VERBOSE.
      * The verbose and quiet output levels, map to the `verbose` and `quiet` output switches
      * present in most shells. Using self::QUIET for a message means it will always display.
      * While using self::VERBOSE means it will only display when verbose output is toggled.


### PR DESCRIPTION
Attempts to fix #12439 

Note: The book links do not work... nor did they before...