### PR TITLE
Quote column identifier for column names containing utf-8 chars (ä)

### DIFF
--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -38,19 +38,19 @@ trait SqlDialectTrait
         }
 
         // string
-        if (preg_match('/^[\w-]+$/', $identifier)) {
+        if (preg_match('/^[\w-]+$/u', $identifier)) {
             return $this->_startQuote . $identifier . $this->_endQuote;
         }
 
         // string.string
-        if (preg_match('/^[\w-]+\.[^ \*]*$/', $identifier)) {
+        if (preg_match('/^[\w-]+\.[^ \*]*$/u', $identifier)) {
             $items = explode('.', $identifier);
 
             return $this->_startQuote . implode($this->_endQuote . '.' . $this->_startQuote, $items) . $this->_endQuote;
         }
 
         // string.*
-        if (preg_match('/^[\w-]+\.\*$/', $identifier)) {
+        if (preg_match('/^[\w-]+\.\*$/u', $identifier)) {
             return $this->_startQuote . str_replace('.*', $this->_endQuote . '.*', $identifier);
         }
 
@@ -60,19 +60,19 @@ trait SqlDialectTrait
         }
 
         // Alias.field AS thing
-        if (preg_match('/^([\w-]+(\.[\w-\s]+|\(.*\))*)\s+AS\s*([\w-]+)$/i', $identifier, $matches)) {
+        if (preg_match('/^([\w-]+(\.[\w-\s]+|\(.*\))*)\s+AS\s*([\w-]+)$/ui', $identifier, $matches)) {
             return $this->quoteIdentifier($matches[1]) . ' AS ' . $this->quoteIdentifier($matches[3]);
         }
 
         // string.string with spaces
-        if (preg_match('/^([\w-]+\.[\w][\w\s\-]*[\w])(.*)/', $identifier, $matches)) {
+        if (preg_match('/^([\w-]+\.[\w][\w\s\-]*[\w])(.*)/u', $identifier, $matches)) {
             $items = explode('.', $matches[1]);
             $field = implode($this->_endQuote . '.' . $this->_startQuote, $items);
 
             return $this->_startQuote . $field . $this->_endQuote . $matches[2];
         }
 
-        if (preg_match('/^[\w-_\s]*[\w-_]+/', $identifier)) {
+        if (preg_match('/^[\w-_\s]*[\w-_]+/u', $identifier)) {
             return $this->_startQuote . $identifier . $this->_endQuote;
         }
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -853,6 +853,7 @@ class ConnectionTest extends TestCase
 
         $result = $connection->quoteIdentifier('Team.G/G');
         $expected = '"Team"."G/G"';
+        $this->assertEquals($expected, $result);
 
         $result = $connection->quoteIdentifier('Model.name as y');
         $expected = '"Model"."name" AS "y"';

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -858,7 +858,7 @@ class ConnectionTest extends TestCase
         $result = $connection->quoteIdentifier('Model.name as y');
         $expected = '"Model"."name" AS "y"';
         $this->assertEquals($expected, $result);
-        
+
         $result = $connection->quoteIdentifier('nämé');
         $expected = '"nämé"';
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -858,6 +858,14 @@ class ConnectionTest extends TestCase
         $result = $connection->quoteIdentifier('Model.name as y');
         $expected = '"Model"."name" AS "y"';
         $this->assertEquals($expected, $result);
+        
+        $result = $connection->quoteIdentifier('Modeß.nämé as y');
+        $expected = '"Modeß"."nämé" AS "y"';
+        $this->assertEquals($expected, $result);
+
+        $result = $connection->quoteIdentifier('Model.näme Datum as Model__näme Datum');
+        $expected = '"Model"."näme Datum" AS "Model__näme Datum"';
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -859,12 +859,24 @@ class ConnectionTest extends TestCase
         $expected = '"Model"."name" AS "y"';
         $this->assertEquals($expected, $result);
         
+        $result = $connection->quoteIdentifier('nämé');
+        $expected = '"nämé"';
+        $this->assertEquals($expected, $result);
+
+        $result = $connection->quoteIdentifier('aßa.nämé');
+        $expected = '"aßa"."nämé"';
+        $this->assertEquals($expected, $result);
+
+        $result = $connection->quoteIdentifier('aßa.*');
+        $expected = '"aßa".*';
+        $this->assertEquals($expected, $result);
+
         $result = $connection->quoteIdentifier('Modeß.nämé as y');
         $expected = '"Modeß"."nämé" AS "y"';
         $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Model.näme Datum as Model__näme Datum');
-        $expected = '"Model"."näme Datum" AS "Model__näme Datum"';
+        $result = $connection->quoteIdentifier('Model.näme Datum as y');
+        $expected = '"Model"."näme Datum" AS "y"';
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
Ref #12452

This simple query works now with my schema:

```php
TableRegistry::getTableLocator()->get('Tablename')->find()->first();
```
I will test some more with conditions etc.