### PR TITLE
Deprecate ViewVarsTrait::viewOptions() and related property.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -205,6 +205,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var array
      * @see \Cake\View\View
+     * @deprecated 3.7.0 Use ViewBuilder::setOptions() or any one of it's setter methods instead.
      */
     protected $_validViewOptions = [
         'passedArgs'

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -84,6 +84,7 @@ abstract class Cell
      *
      * @var array
      * @see \Cake\View\View
+     * @deprecated 3.7.0 Use ViewBuilder::setOptions() or any one of it's setter methods instead.
      */
     protected $_validViewOptions = [
         'viewPath'

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -80,7 +80,7 @@ trait ViewVarsTrait
             $builder->setClassName($viewClass);
         }
 
-        $validViewOptions = $this->viewOptions();
+        $validViewOptions = isset($this->_validViewOptions) ? $this->_validViewOptions : [];
         $viewOptions = [];
         foreach ($validViewOptions as $option) {
             if (property_exists($this, $option)) {
@@ -161,6 +161,10 @@ trait ViewVarsTrait
      */
     public function viewOptions($options = null, $merge = true)
     {
+        deprecationWarning(
+            'ViewVarsTrait::viewOptions() is deprecated, used ViewBuilder::setOptions() instead.'
+        );
+
         if (!isset($this->_validViewOptions)) {
             $this->_validViewOptions = [];
         }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -157,6 +157,7 @@ trait ViewVarsTrait
      * @param bool $merge Whether to merge with or override existing valid View options.
      *   Defaults to `true`.
      * @return array The updated view options as an array.
+     * @deprecated 3.7.0 Use ViewBuilder::setOptions() or any one of it's setter methods instead.
      */
     public function viewOptions($options = null, $merge = true)
     {

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -101,10 +101,12 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testAddOneViewOption()
     {
-        $option = 'newOption';
-        $this->subject->viewOptions($option);
+        $this->deprecated(function () {
+            $option = 'newOption';
+            $this->subject->viewOptions($option);
 
-        $this->assertContains($option, $this->subject->viewOptions());
+            $this->assertContains($option, $this->subject->viewOptions());
+        });
     }
 
     /**
@@ -114,13 +116,15 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testAddTwoViewOption()
     {
-        $this->subject->viewOptions(['oldOption'], false);
-        $option = ['newOption', 'anotherOption'];
-        $result = $this->subject->viewOptions($option);
-        $expects = ['oldOption', 'newOption', 'anotherOption'];
+        $this->deprecated(function () {
+            $this->subject->viewOptions(['oldOption'], false);
+            $option = ['newOption', 'anotherOption'];
+            $result = $this->subject->viewOptions($option);
+            $expects = ['oldOption', 'newOption', 'anotherOption'];
 
-        $this->assertContainsOnly('string', $result);
-        $this->assertEquals($expects, $result);
+            $this->assertContainsOnly('string', $result);
+            $this->assertEquals($expects, $result);
+        });
     }
 
     /**
@@ -130,10 +134,12 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testReadingViewOptions()
     {
-        $expected = $this->subject->viewOptions(['one', 'two', 'three'], false);
-        $result = $this->subject->viewOptions();
+        $this->deprecated(function () {
+            $expected = $this->subject->viewOptions(['one', 'two', 'three'], false);
+            $result = $this->subject->viewOptions();
 
-        $this->assertEquals($expected, $result);
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -143,11 +149,13 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testMergeFalseViewOptions()
     {
-        $this->subject->viewOptions(['one', 'two', 'three'], false);
-        $expected = ['four', 'five', 'six'];
-        $result = $this->subject->viewOptions($expected, false);
+        $this->deprecated(function () {
+            $this->subject->viewOptions(['one', 'two', 'three'], false);
+            $expected = ['four', 'five', 'six'];
+            $result = $this->subject->viewOptions($expected, false);
 
-        $this->assertEquals($expected, $result);
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -157,10 +165,11 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testUndefinedValidViewOptions()
     {
-        $result = $this->subject->viewOptions([], false);
-
-        $this->assertInternalType('array', $result);
-        $this->assertEmpty($result);
+        $this->deprecated(function () {
+            $result = $this->subject->viewOptions([], false);
+            $this->assertInternalType('array', $result);
+            $this->assertEmpty($result);
+        });
     }
 
     /**


### PR DESCRIPTION
Since we have deprecated all view related public properties from classes using
this trait, this method is now redundant.