### PR TITLE
Remove unneeded ignored errors from phpstan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,9 +26,7 @@ parameters:
         - '#Call to an undefined method Cake\\Auth\\Storage\\StorageInterface::getConfig\(\)#'
         - '#Call to an undefined method Cake\\Auth\\Storage\\StorageInterface::setConfig\(\)#'
         - '#Variable \$_SESSION in isset\(\) always exists and is not nullable#'
-        - '#Call to an undefined method Traversable::getInnerIterator\(\)#'
         - '#PHPDoc tag @throws with type PHPUnit\\Exception is not subtype of Throwable#'
-        - '#Binary operation "\+=" between \(array\&hasOffset\(.*\)\) and array results in an error#'
     earlyTerminatingMethodCalls:
         Cake\Shell\Shell:
             - abort


### PR DESCRIPTION
phpstan v0.10.3 doesn't require these ignores anymore.