### PR TITLE
3.7 - ViewBuilder view vars

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -114,6 +114,66 @@ class ViewBuilder implements JsonSerializable, Serializable
     protected $_helpers = [];
 
     /**
+     * View vars
+     *
+     * @var array
+     */
+    protected $_vars = [];
+
+    /**
+     * Saves a variable for use inside a template.
+     *
+     * @param string $name A string or an array of data.
+     * @param mixed $value Value.
+     * @return $this
+     */
+    public function setVar($name, $value = null)
+    {
+        $this->_vars[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Saves view vars for use inside templates.
+     *
+     * @param array $data Array of data.
+     * @param bool $merge Whether to merge with existing vars, default true.
+     * @return $this
+     */
+    public function setVars($data, $merge = true)
+    {
+        if ($merge) {
+            $this->_vars = $data + $this->_vars;
+        } else {
+            $this->_vars = $data;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get view var
+     *
+     * @param string $name Var name
+     * @return mixed The var value or null if unset.
+     */
+    public function getVar($name)
+    {
+        return isset($this->_vars[$name]) ? $this->_vars[$name] : null;
+    }
+
+    /**
+     * Get all view vars.
+     *
+     * @return array
+     */
+    public function getVars()
+    {
+        return $this->_vars;
+    }
+
+    /**
      * Sets path for template files.
      *
      * @param string $path Path for view files.

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -153,6 +153,17 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
+     * Check if view var is set.
+     *
+     * @param string $name Var name
+     * @return bool
+     */
+    public function hasVar($name)
+    {
+        return array_key_exists($name, $this->_vars);
+    }
+
+    /**
      * Get view var
      *
      * @param string $name Var name

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -693,7 +693,7 @@ class ViewBuilder implements JsonSerializable, Serializable
             'autoLayout' => $this->_autoLayout,
             'layoutPath' => $this->_layoutPath,
             'helpers' => $this->_helpers,
-            'viewVars' => $vars,
+            'viewVars' => $vars + $this->_vars,
         ];
         $data += $this->_options;
 

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -38,7 +38,7 @@ trait ViewVarsTrait
      * Variables for the view
      *
      * @var array
-     * @deprecated 3.7.0 Use `$this->viewBuilder()->setVar()/getVar()` instead.
+     * @deprecated 3.7.0 Use `$this->set()` instead.
      */
     public $viewVars = [];
 

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -38,6 +38,7 @@ trait ViewVarsTrait
      * Variables for the view
      *
      * @var array
+     * @deprecated 3.7.0 Use `$this->viewBuilder()->setVar()/getVar()` instead.
      */
     public $viewVars = [];
 

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -55,6 +55,19 @@ class ViewBuilderTest extends TestCase
         );
     }
 
+    public function testHasVar()
+    {
+        $builder = new ViewBuilder();
+
+        $this->assertFalse($builder->hasVar('foo'));
+
+        $builder->setVar('foo', 'value');
+        $this->assertTrue($builder->hasVar('foo'));
+
+        $builder->setVar('bar', null);
+        $this->assertTrue($builder->hasVar('bar'));
+    }
+
     /**
      * data provider for string properties.
      *

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -264,9 +264,10 @@ class ViewBuilderTest extends TestCase
             ->setHelpers(['Form', 'Html'])
             ->setLayoutPath('Admin/')
             ->setTheme('TestTheme')
-            ->setPlugin('TestPlugin');
+            ->setPlugin('TestPlugin')
+            ->setVars(['foo' => 'bar', 'x' => 'old']);
         $view = $builder->build(
-            ['one' => 'value'],
+            ['one' => 'value', 'x' => 'new'],
             $request,
             $response,
             $events
@@ -281,7 +282,10 @@ class ViewBuilderTest extends TestCase
         $this->assertSame($request, $view->getRequest());
         $this->assertInstanceOf(Response::class, $view->getResponse());
         $this->assertSame($events, $view->getEventManager());
-        $this->assertSame(['one' => 'value'], $view->viewVars);
+        $this->assertEquals(
+            ['one' => 'value', 'foo' => 'bar', 'x' => 'new'],
+            $view->viewVars
+        );
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $view->Html);
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $view->Form);
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -24,6 +24,37 @@ use Cake\View\ViewBuilder;
  */
 class ViewBuilderTest extends TestCase
 {
+    public function testSetVar()
+    {
+        $builder = new ViewBuilder();
+
+        $builder->setVar('testing', 'value');
+        $this->assertSame('value', $builder->getVar('testing'));
+    }
+
+    public function testSetVars()
+    {
+        $builder = new ViewBuilder();
+
+        $data = ['test' => 'val', 'foo' => 'bar'];
+        $builder->setVars($data);
+        $this->assertEquals($data, $builder->getVars());
+
+        $update = ['test' => 'updated'];
+        $builder->setVars($update);
+        $this->assertEquals(
+            ['test' => 'val', 'foo' => 'bar', 'test' => 'updated'],
+            $builder->getVars()
+        );
+
+        $update = ['overwrite' => 'yes'];
+        $builder->setVars($update, false);
+        $this->assertEquals(
+            ['overwrite' => 'yes'],
+            $builder->getVars()
+        );
+    }
+
     /**
      * data provider for string properties.
      *


### PR DESCRIPTION
With this change `ViewVarsTrait::$viewVars` can be deprecated.

A bit unsure how to deal with `ViewVarsTrait::set()`. Most people will prefer continuing to use `$this->set()` instead of `$this->viewBuilder()->setVar()` so can't deprecate that.

Changing the guts of `ViewVarsTrait::set()` to proxy the calls to `ViewBuilder::setVar()/setVars()` would create a BC problem since then one won't be able to us `ViewVarsTrait::$viewVars` to read the vars.