### PR TITLE
Fix potential timing side channel in digest auth.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -122,7 +122,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
             // null passwords as authentication systems
             // like digest auth don't use passwords
             // and hashing *could* create a timing side-channel.
-            if (strlen($password) > 0) {
+            if ($password !== null) {
                 $hasher = $this->passwordHasher();
                 $hasher->hash($password);
             }

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -117,8 +117,15 @@ abstract class BaseAuthenticate implements EventListenerInterface
         $result = $this->_query($username)->first();
 
         if (empty($result)) {
-            $hasher = $this->passwordHasher();
-            $hasher->hash((string)$password);
+            // Waste time hashing the password, to prevent
+            // timing side-channels. However, don't hash
+            // null passwords as authentication systems
+            // like digest auth don't use passwords
+            // and hashing *could* create a timing side-channel.
+            if (strlen($password) > 0) {
+                $hasher = $this->passwordHasher();
+                $hasher->hash($password);
+            }
 
             return false;
         }


### PR DESCRIPTION
This change reduces the potential ability to use digest authentication as a side channel for user enumeration. Previously passwords would be hashed for digest users that did not exist, but not hashed for users that *did*. These changes ensure that if password===null no hashing is done. This also means we can remove the string cast.

Thanks to Edgaras Janušauskas for raising this issue through our responsible disclosure mailing list.