### PR TITLE
Update CookieCryptTrait.php

### DIFF
--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -84,7 +84,7 @@ trait CookieCryptTrait
     {
         if (!in_array($encrypt, $this->_validCiphers)) {
             $msg = sprintf(
-                'Invalid encryption cipher. Must be one of %s.',
+                'Invalid encryption cipher. Must be one of %s or false.',
                 implode(', ', $this->_validCiphers)
             );
             throw new RuntimeException($msg);

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -166,7 +166,7 @@ class CookieComponentTest extends TestCase
     public function testReadInvalidCipher()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Invalid encryption cipher. Must be one of aes, rijndael.');
+        $this->expectExceptionMessage('Invalid encryption cipher. Must be one of aes, rijndael or false.');
         $this->Controller->request = $this->request->withCookieParams([
             'Test' => $this->_encrypt('value'),
         ]);
@@ -249,7 +249,7 @@ class CookieComponentTest extends TestCase
     public function testWriteInvalidCipher()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Invalid encryption cipher. Must be one of aes, rijndael.');
+        $this->expectExceptionMessage('Invalid encryption cipher. Must be one of aes, rijndael or false.');
         $this->Cookie->setConfig('encryption', 'derp');
         $this->Cookie->write('Test', 'nope');
     }


### PR DESCRIPTION
When trying to disable cookie encryption, I accidentally set it to null.
The error message was unclear that it could be turned off.

Specify in the error message, that false is an option.