### PR TITLE
Update Breadcrumb trails from ajax load page

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -329,10 +329,11 @@ class BreadcrumbsHelper extends Helper
      * If you use the default for this option (empty), it will not render a separator.
      * @return null This will run a javascript code.
      */
-
-    public function ajaxRender(array $attributes = [], array $separator = []){
+    public function ajaxRender(array $attributes = [], array $separator = [])
+    {
         $breadcrumbClass = !empty($attributes['class'])?$attributes['class']:'breadcrumb';
         echo "<script type='text/javascript'>var el = document.getElementsByClassName('{$breadcrumbClass}');el[0].outerHTML = '{$this->render($attributes,$separator)}'</script>";
+
         return null;
     }
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -316,6 +316,27 @@ class BreadcrumbsHelper extends Helper
     }
 
     /**
+     * Renders the breadcrumbs trail with javascript.
+     *
+     * @param array $attributes Array of attributes applied to the `wrapper` template. Accepts the `templateVars` key to
+     * allow the insertion of custom template variable in the template.
+     * @param array $separator Array of attributes for the `separator` template.
+     * Possible properties are :
+     * - *separator* The string to be displayed as a separator
+     * - *templateVars* Allows the insertion of custom template variable in the template
+     * - *innerAttrs* To provide attributes in case your separator is divided in two elements.
+     * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template.
+     * If you use the default for this option (empty), it will not render a separator.
+     * @return null This will run a javascript code.
+     */
+
+    public function ajaxRender(array $attributes = [], array $separator = []){
+        $breadcrumbClass = !empty($attributes['class'])?$attributes['class']:'breadcrumb';
+        echo "<script type='text/javascript'>var el = document.getElementsByClassName('{$breadcrumbClass}');el[0].outerHTML = '{$this->render($attributes,$separator)}'</script>";
+        return null;
+    }
+
+    /**
      * Search a crumb in the current stack which title matches the one provided as argument.
      * If found, the index of the matching crumb will be returned.
      *


### PR DESCRIPTION
Breadcrumb update from ajax load pages. This will help to update breadcrumb automatically from any ajax loaded page.

Prerequisite:  Need to declare
`$this->Breadcrumbs->render([ 'class' => 'breadcrumb']); `
inside layout with 'class' attribute

Usage: Just calling following method will update default Breadcrumb rendering template
`$this->Breadcrumbs->ajaxRender(['class' => 'breadcrumb']);`

Note: Must have to use the same 'class' name. If we want to add any breadcrumb trail we have to use like following
`$this->Breadcrumbs->add(
    __('List'), null, ['class' => 'breadcrumb-item active']
);
$this->Breadcrumbs->ajaxRender([ 'class' => 'breadcrumb']);`

Example:
Previous page was **List** page, 
<img width="294" alt="screen shot 2018-08-15 at 4 52 20 pm" src="https://user-images.githubusercontent.com/4234756/44145033-cb2507cc-a0ab-11e8-939e-0bfeda4e5f2c.png">
After clicking on **Add** page, breadcrumb will be automatically updated
<img width="364" alt="screen shot 2018-08-15 at 4 52 26 pm" src="https://user-images.githubusercontent.com/4234756/44145049-de15f116-a0ab-11e8-84f1-41facc0c8fbd.png">

Thanks

