### PR TITLE
3.next type marshalling

### DIFF
--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -161,6 +161,9 @@ class BoolType extends Type implements TypeInterface, BatchCastingInterface
         if ($value === 'false') {
             return false;
         }
+        if (!is_scalar($value)) {
+            return null;
+        }
 
         return !empty($value);
     }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -157,8 +157,8 @@ class DecimalType extends Type implements TypeInterface, BatchCastingInterface
         if (is_numeric($value)) {
             return (float)$value;
         }
-        if (is_array($value)) {
-            return 1;
+        if (!is_scalar($value)) {
+            return null;
         }
 
         return $value;

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -157,11 +157,8 @@ class DecimalType extends Type implements TypeInterface, BatchCastingInterface
         if (is_numeric($value)) {
             return (float)$value;
         }
-        if (!is_scalar($value)) {
-            return null;
-        }
 
-        return $value;
+        return null;
     }
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -140,17 +140,14 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_numeric($value)) {
-            return (float)$value;
-        }
         if (is_string($value) && $this->_useLocaleParser) {
             return $this->_parseValue($value);
         }
-        if (!is_scalar($value)) {
-            return null;
+        if (is_numeric($value)) {
+            return (float)$value;
         }
 
-        return $value;
+        return null;
     }
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -146,8 +146,8 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
         if (is_string($value) && $this->_useLocaleParser) {
             return $this->_parseValue($value);
         }
-        if (is_array($value)) {
-            return 1.0;
+        if (!is_scalar($value)) {
+            return null;
         }
 
         return $value;

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -130,11 +130,8 @@ class IntegerType extends Type implements TypeInterface, BatchCastingInterface
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_numeric($value) || ctype_digit($value)) {
+        if (is_numeric($value)) {
             return (int)$value;
-        }
-        if (is_array($value)) {
-            return 1;
         }
 
         return null;

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -157,7 +157,7 @@ class BoolTypeTest extends TestCase
         $this->assertFalse($this->type->marshal(0));
         $this->assertFalse($this->type->marshal(''));
         $this->assertTrue($this->type->marshal('not empty'));
-        $this->assertTrue($this->type->marshal(['2', '3']));
+        $this->assertNull($this->type->marshal(['2', '3']));
     }
 
     /**

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -171,7 +171,7 @@ class DecimalTypeTest extends TestCase
         $this->assertSame('3.5 bears', $result);
 
         $result = $this->type->marshal(['3', '4']);
-        $this->assertSame(1, $result);
+        $this->assertNull($result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -159,7 +159,7 @@ class DecimalTypeTest extends TestCase
     public function testMarshal()
     {
         $result = $this->type->marshal('some data');
-        $this->assertSame('some data', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal('');
         $this->assertNull($result);
@@ -168,7 +168,7 @@ class DecimalTypeTest extends TestCase
         $this->assertSame(2.51, $result);
 
         $result = $this->type->marshal('3.5 bears');
-        $this->assertSame('3.5 bears', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal(['3', '4']);
         $this->assertNull($result);

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -148,7 +148,7 @@ class FloatTypeTest extends TestCase
     public function testMarshal()
     {
         $result = $this->type->marshal('some data');
-        $this->assertSame('some data', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal('');
         $this->assertNull($result);
@@ -157,7 +157,7 @@ class FloatTypeTest extends TestCase
         $this->assertSame(2.51, $result);
 
         $result = $this->type->marshal('3.5 bears');
-        $this->assertSame('3.5 bears', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal(['3', '4']);
         $this->assertNull($result);

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -160,7 +160,7 @@ class FloatTypeTest extends TestCase
         $this->assertSame('3.5 bears', $result);
 
         $result = $this->type->marshal(['3', '4']);
-        $this->assertSame(1.0, $result);
+        $this->assertNull($result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -159,7 +159,10 @@ class IntegerTypeTest extends TestCase
         $this->assertNull($result);
 
         $result = $this->type->marshal(['3', '4']);
-        $this->assertSame(1, $result);
+        $this->assertNull($result);
+
+        $result = $this->type->marshal('+0123.45e2');
+        $this->assertSame(12345, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -162,7 +162,11 @@ class IntegerTypeTest extends TestCase
         $this->assertNull($result);
 
         $result = $this->type->marshal('+0123.45e2');
-        $this->assertSame(12345, $result);
+        if (version_compare(PHP_VERSION, '7.1', '<')) {
+            $this->assertSame(123, $result);
+        } else {
+            $this->assertSame(12345, $result);
+        }
     }
 
     /**


### PR DESCRIPTION
Marshalling arrays to `null` is lot more sensible than `1` or `1.0`.