### PR TITLE
Always call custom exception renderer method.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -191,10 +191,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
         $template = $this->_template($exception, $method, $code);
         $unwrapped = $this->_unwrap($exception);
 
-        $isDebug = Configure::read('debug');
-        if (($isDebug || $exception instanceof HttpException) &&
-            method_exists($this, $method)
-        ) {
+        if (method_exists($this, $method)) {
             return $this->_customMethod($method, $unwrapped);
         }
 
@@ -216,6 +213,8 @@ class ExceptionRenderer implements ExceptionRendererInterface
             'code' => $code,
             '_serialize' => ['message', 'url', 'code']
         ];
+
+        $isDebug = Configure::read('debug');
         if ($isDebug) {
             $viewVars['trace'] = Debugger::formatTrace($unwrapped->getTrace(), [
                 'format' => 'array',

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -727,6 +727,13 @@ class ExceptionRendererTest extends TestCase
 
         $result = (string)$exceptionRenderer->render()->getBody();
         $this->assertContains('widget thing is missing', $result);
+
+        // Custom method should be called even when debug is off.
+        Configure::write('debug', false);
+        $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
+
+        $result = (string)$exceptionRenderer->render()->getBody();
+        $this->assertContains('widget thing is missing', $result);
     }
 
     /**


### PR DESCRIPTION
Closes #9905.