### PR TITLE
Fix invalid Shell class namespace

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,7 +28,7 @@ parameters:
         - '#Variable \$_SESSION in isset\(\) always exists and is not nullable#'
         - '#PHPDoc tag @throws with type PHPUnit\\Exception is not subtype of Throwable#'
     earlyTerminatingMethodCalls:
-        Cake\Shell\Shell:
+        Cake\Console\Shell:
             - abort
 
 services:


### PR DESCRIPTION
In `phpstan.neon`,  `Cake\Shell\Shell` is set in earlyTerminatingMethodCalls params.
It seems to be incorrect, `Cake\Consle\Shell` is right?