### PR TITLE
Add missing method definitions

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -765,10 +765,10 @@ class Postgres extends DboSource {
 /**
  * resultSet method
  *
- * @param array &$results The results
+ * @param PDOStatement $results The results
  * @return void
  */
-	public function resultSet(&$results) {
+	public function resultSet($results) {
 		$this->map = array();
 		$numFields = $results->columnCount();
 		$index = 0;

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -299,7 +299,7 @@ class Sqlite extends DboSource {
 /**
  * Generate ResultSet
  *
- * @param mixed $results The results to modify.
+ * @param PDOStatement $results The results to modify.
  * @return void
  */
 	public function resultSet($results) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -632,7 +632,7 @@ class DboSource extends DataSource {
 /**
  * Builds a map of the columns contained in a result
  *
- * @param array|PDOStatement $results The results to format.
+ * @param PDOStatement $results The results to format.
  * @return void
  */
 	public function resultSet($results) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -273,6 +273,16 @@ class DboSource extends DataSource {
 	}
 
 /**
+ * Connects to the database.
+ *
+ * @return bool
+ */
+	public function connect() {
+		// This method is implemented in subclasses
+		return $this->connected;
+	}
+
+/**
  * Reconnects to database server with optional new settings
  *
  * @param array $config An array defining the new configuration settings
@@ -617,6 +627,16 @@ class DboSource extends DataSource {
 			}
 			return $this->fetchAll($args[0], $args[1], array('cache' => $cache));
 		}
+	}
+
+/**
+ * Builds a map of the columns contained in a result
+ *
+ * @param array|PDOStatement $results The results to format.
+ * @return void
+ */
+	public function resultSet($results) {
+		// This method is implemented in subclasses
 	}
 
 /**

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -231,7 +231,6 @@ class CakeTestFixtureTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		$methods = array_diff(get_class_methods('DboSource'), array('enabled'));
-		$methods[] = 'connect';
 
 		$this->criticDb = $this->getMock('DboSource', $methods);
 		$this->criticDb->fullDebug = true;


### PR DESCRIPTION
`connect` and `resultSet` methods are used in `DboSource` class but are defined only in sub-classes. Another alternative would be to make these methods abstract in DboSource but that would require to make DboSource itself abstract.