### PR TITLE
Var.CI should accept `composer show` output

### DIFF
--- a/.varci.yml
+++ b/.varci.yml
@@ -40,5 +40,6 @@ ruleset:
       - body matches "/\[x\] bug/"
       - 'not(body matches "/CakePHP Version: v?(\d+\.)?(\d+\.)?(\*|\d+)/")'
       - 'not(body matches "/CakePHP Version: [0-9a-f]{5,40}/")'
+      - 'not(body matches "/cakephp\/cakephp\s+\d+\.\d+\.\d+/")'
     comment: '{{ user.login }}, please include the CakePHP version number you are using in your description. It helps us debug your issue.'
 


### PR DESCRIPTION
Var.CI should accept CakePHP version number from `composer show` output as in https://github.com/cakephp/cakephp/issues/12509