### PR TITLE
Fixed binary column length not being returned by SqliteSchema & MysqlSchema

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -139,7 +139,7 @@ class MysqlSchema extends BaseSchema
         }
         if (strpos($col, 'blob') !== false || $col === 'binary') {
             $lengthName = substr($col, 0, -4);
-            $length = isset(TableSchema::$columnLengths[$lengthName]) ? TableSchema::$columnLengths[$lengthName] : null;
+            $length = isset(TableSchema::$columnLengths[$lengthName]) ? TableSchema::$columnLengths[$lengthName] : $length;
 
             return ['type' => TableSchema::TYPE_BINARY, 'length' => $length];
         }

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -102,8 +102,8 @@ class SqliteSchema extends BaseSchema
         if ($col === 'binary' && $length === 16) {
             return ['type' => TableSchema::TYPE_BINARY_UUID, 'length' => null];
         }
-        if (in_array($col, ['blob', 'clob'])) {
-            return ['type' => TableSchema::TYPE_BINARY, 'length' => null];
+        if (in_array($col, ['blob', 'clob', 'binary'])) {
+            return ['type' => TableSchema::TYPE_BINARY, 'length' => $length];
         }
         if (in_array($col, ['date', 'time', 'timestamp', 'datetime'])) {
             return ['type' => $col, 'length' => null];

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -124,6 +124,10 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'binaryuuid', 'length' => null]
             ],
             [
+                'BINARY(1)',
+                ['type' => 'binary', 'length' => 1]
+            ],
+            [
                 'TEXT',
                 ['type' => 'text', 'length' => null]
             ],

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -88,6 +88,10 @@ class SqliteSchemaTest extends TestCase
                 ['type' => 'binaryuuid', 'length' => null]
             ],
             [
+                'BINARY(1)',
+                ['type' => 'binary', 'length' => 1]
+            ],
+            [
                 'BLOB',
                 ['type' => 'binary', 'length' => null]
             ],


### PR DESCRIPTION
Fixed binary column length not being returned by SqliteSchema & MysqlSchema.