### PR TITLE
RFC - Implement a PSR16 bridge for existing Cache adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "cakephp/chronos": "^1.0.1",
         "aura/intl": "^3.0.0",
         "psr/log": "^1.0.0",
+        "psr/simple-cache": "^1.0.0",
         "zendframework/zend-diactoros": "^1.4.0"
     },
     "suggest": {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -235,6 +235,17 @@ class Cache
     }
 
     /**
+     * Get a SimpleCacheEngine object for the named cache pool.
+     *
+     * @param string $pool The name of the configured cache backend.
+     * @return \Cake\Cache\SimpleCacheEngine
+     */
+    public static function pool($config)
+    {
+        return new SimpleCacheEngine(static::engine($config));
+    }
+
+    /**
      * Garbage collection
      *
      * Permanently remove all expired and deleted data

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -237,7 +237,7 @@ class Cache
     /**
      * Get a SimpleCacheEngine object for the named cache pool.
      *
-     * @param string $pool The name of the configured cache backend.
+     * @param string $config The name of the configured cache backend.
      * @return \Cake\Cache\SimpleCacheEngine
      */
     public static function pool($config)

--- a/src/Cache/InvalidArgumentException.php
+++ b/src/Cache/InvalidArgumentException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache;
+
+use Cake\Core\Exception\Exception;
+use Psr\SimpleCache\InvalidArgumentException as InvalidInterface;
+
+/**
+ * Exception raised when cache keys are invalid.
+ */
+class InvalidArgumentException extends Exception implements InvalidInterface
+{
+}

--- a/src/Cache/InvalidArgumentException.php
+++ b/src/Cache/InvalidArgumentException.php
@@ -15,11 +15,11 @@
 namespace Cake\Cache;
 
 use Cake\Core\Exception\Exception;
-use Psr\SimpleCache\InvalidArgumentException as InvalidInterface;
+use Psr\SimpleCache\InvalidArgumentException as InvalidArgumentInterface;
 
 /**
  * Exception raised when cache keys are invalid.
  */
-class InvalidArgumentException extends Exception implements InvalidInterface
+class InvalidArgumentException extends Exception implements InvalidArgumentInterface
 {
 }

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -206,8 +206,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key The cache item key.
      * @return bool
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if the $key string is not a legal value.
+     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function has($key)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -1,0 +1,175 @@
+<?php
+namespace Cake\Cache;
+
+use Cake\Cache\CacheEngine;
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+
+/**
+ * Wrapper for Cake engines that allow them to support
+ * the PSR16 Simple Cache Interface
+ */
+class SimpleCacheEngine implements CacheInterface
+{
+    protected $inner;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Cache\CacheEngine $inner The decorated engine.
+     */
+    public function __construct($inner)
+    {
+        $this->inner = $inner;
+    }
+
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get($key, $default = null)
+    {
+        $result = $this->inner->read($key);
+        if ($result === false) {
+            return $default;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *   the driver supports TTL then the library may set a default value
+     *   for it or let the driver take care of that.
+     * @return bool True on success and false on failure.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        if ($ttl !== null) {
+            $restore = $this->inner->getConfig('duration');
+            $this->inner->setConfig('duration', $ttl);
+        }
+        try {
+            $result = $this->inner->write($key, $value);
+
+            return (bool)$result;
+        } finally {
+            if (isset($restore)) {
+                $this->inner->setConfig('duration', $restore);
+            }
+        }
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     * @return bool True if the item was successfully removed. False if there was an error.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        return $this->inner->delete($key);
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        return $this->inner->clear(false);
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $results = $this->inner->readMany($keys);
+        foreach ($results as $key => $value) {
+            if ($value === false) {
+                $results[$key] = $default;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *   the driver supports TTL then the library may set a default value
+     *   for it or let the driver take care of that.
+     * @return bool True on success and false on failure.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        if ($ttl !== null) {
+            $restore = $this->inner->getConfig('duration');
+            $this->inner->setConfig('duration', $ttl);
+        }
+        try {
+            return $this->inner->writeMany($values);
+        } finally {
+            if (isset($restore)) {
+                $this->inner->setConfig('duration', $restore);
+            }
+        }
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     * @return bool True if the items were successfully removed. False if there was an error.
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     * @return bool
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+    }
+}

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -62,8 +62,7 @@ class SimpleCacheEngine implements CacheInterface
      * @param string $key The unique key of this item in the cache.
      * @param mixed $default Default value to return if the key does not exist.
      * @return mixed The value of the item from the cache, or $default in case of cache miss.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if the $key string is not a legal value.
+     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function get($key, $default = null)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -158,8 +158,7 @@ class SimpleCacheEngine implements CacheInterface
      *   the driver supports TTL then the library may set a default value
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $values is neither an array nor a Traversable,
+     * @throws \Psr\SimpleCache\InvalidArgumentException If $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
     public function setMultiple($values, $ttl = null)

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -110,8 +110,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key The unique cache key of the item to delete.
      * @return bool True if the item was successfully removed. False if there was an error.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if the $key string is not a legal value.
+     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function delete($key)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -52,7 +52,7 @@ class SimpleCacheEngine implements CacheInterface
     protected function ensureValidKey($key)
     {
         if (!is_string($key) || strlen($key) === 0) {
-            throw new InvalidArgumentException('Cache keys must be non-empty strings.');
+            throw new InvalidArgumentException('A cache key must be a non-empty string.');
         }
     }
 

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -57,7 +57,7 @@ class SimpleCacheEngine implements CacheInterface
     }
 
     /**
-     * Fetches a value from the cache.
+     * Fetches the value for a given key from the cache.
      *
      * @param string $key The unique key of this item in the cache.
      * @param mixed $default Default value to return if the key does not exist.

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -30,16 +30,16 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param \Cake\Cache\CacheEngine
      */
-    protected $inner;
+    protected $innerEngine;
 
     /**
      * Constructor
      *
-     * @param \Cake\Cache\CacheEngine $inner The decorated engine.
+     * @param \Cake\Cache\CacheEngine $innerEngine The decorated engine.
      */
-    public function __construct($inner)
+    public function __construct($innerEngine)
     {
-        $this->inner = $inner;
+        $this->innerEngine = $innerEngine;
     }
 
     /**
@@ -68,7 +68,7 @@ class SimpleCacheEngine implements CacheInterface
     public function get($key, $default = null)
     {
         $this->checkKey($key);
-        $result = $this->inner->read($key);
+        $result = $this->innerEngine->read($key);
         if ($result === false) {
             return $default;
         }
@@ -92,16 +92,16 @@ class SimpleCacheEngine implements CacheInterface
     {
         $this->checkKey($key);
         if ($ttl !== null) {
-            $restore = $this->inner->getConfig('duration');
-            $this->inner->setConfig('duration', $ttl);
+            $restore = $this->innerEngine->getConfig('duration');
+            $this->innerEngine->setConfig('duration', $ttl);
         }
         try {
-            $result = $this->inner->write($key, $value);
+            $result = $this->innerEngine->write($key, $value);
 
             return (bool)$result;
         } finally {
             if (isset($restore)) {
-                $this->inner->setConfig('duration', $restore);
+                $this->innerEngine->setConfig('duration', $restore);
             }
         }
     }
@@ -118,7 +118,7 @@ class SimpleCacheEngine implements CacheInterface
     {
         $this->checkKey($key);
 
-        return $this->inner->delete($key);
+        return $this->innerEngine->delete($key);
     }
 
     /**
@@ -128,7 +128,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function clear()
     {
-        return $this->inner->clear(false);
+        return $this->innerEngine->clear(false);
     }
 
     /**
@@ -143,7 +143,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
-        $results = $this->inner->readMany($keys);
+        $results = $this->innerEngine->readMany($keys);
         foreach ($results as $key => $value) {
             if ($value === false) {
                 $results[$key] = $default;
@@ -168,14 +168,14 @@ class SimpleCacheEngine implements CacheInterface
     public function setMultiple($values, $ttl = null)
     {
         if ($ttl !== null) {
-            $restore = $this->inner->getConfig('duration');
-            $this->inner->setConfig('duration', $ttl);
+            $restore = $this->innerEngine->getConfig('duration');
+            $this->innerEngine->setConfig('duration', $ttl);
         }
         try {
-            return $this->inner->writeMany($values);
+            return $this->innerEngine->writeMany($values);
         } finally {
             if (isset($restore)) {
-                $this->inner->setConfig('duration', $restore);
+                $this->innerEngine->setConfig('duration', $restore);
             }
         }
     }
@@ -191,7 +191,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function deleteMultiple($keys)
     {
-        $result = $this->inner->deleteMany($keys);
+        $result = $this->innerEngine->deleteMany($keys);
         foreach ($result as $key => $success) {
             if ($success === false) {
                 return false;

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -47,7 +47,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key Key to check.
      * @return void
-     * @throws \Psr\SimpleCache\InvalidArgumentException when key is not valid.
+     * @throws \Psr\SimpleCache\InvalidArgumentException When key is not valid.
      */
     protected function checkKey($key)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -76,7 +76,7 @@ class SimpleCacheEngine implements CacheInterface
     }
 
     /**
-     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     * Persists data in the cache, uniquely referenced by the given key with an optional expiration TTL time.
      *
      * @param string $key The key of the item to store.
      * @param mixed $value The value of the item to store, must be serializable.

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -29,7 +29,7 @@ class SimpleCacheEngine implements CacheInterface
     /**
      * The wrapped cache engine object.
      *
-     * @param \Cake\Cache\CacheEngine
+     * @var \Cake\Cache\CacheEngine
      */
     protected $innerEngine;
 
@@ -48,7 +48,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key Key to check.
      * @return void
-     * @throws \Psr\SimpleCache\InvalidArgumentException When the key is not valid.
+     * @throws \Cake\Cache\InvalidArgumentException When the key is not valid.
      */
     protected function ensureValidKey($key)
     {
@@ -62,11 +62,11 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param mixed $keys The keys to check.
      * @return void
-     * @throws \Psr\SimpleCache\InvalidArgumentException When the keys are not valid.
+     * @throws \Cake\Cache\InvalidArgumentException When the keys are not valid.
      */
     protected function ensureValidKeys($keys)
     {
-        if (!is_array($keys) && !($keys instanceOf \Traversable)) {
+        if (!is_array($keys) && !($keys instanceof \Traversable)) {
             throw new InvalidArgumentException('A cache key set must be either an array or a Traversable.');
         }
 
@@ -81,7 +81,7 @@ class SimpleCacheEngine implements CacheInterface
      * @param string $key The unique key of this item in the cache.
      * @param mixed $default Default value to return if the key does not exist.
      * @return mixed The value of the item from the cache, or $default in case of cache miss.
-     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
+     * @throws \Cake\Cache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function get($key, $default = null)
     {
@@ -103,7 +103,7 @@ class SimpleCacheEngine implements CacheInterface
      *   the driver supports TTL then the library may set a default value
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \Cake\Cache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
     public function set($key, $value, $ttl = null)
@@ -129,7 +129,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key The unique cache key of the item to delete.
      * @return bool True if the item was successfully removed. False if there was an error.
-     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
+     * @throws \Cake\Cache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function delete($key)
     {
@@ -154,7 +154,7 @@ class SimpleCacheEngine implements CacheInterface
      * @param iterable $keys A list of keys that can obtained in a single operation.
      * @param mixed $default Default value to return for keys that do not exist.
      * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
-     * @throws \Psr\SimpleCache\InvalidArgumentException If $keys is neither an array nor a Traversable,
+     * @throws \Cake\Cache\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
     public function getMultiple($keys, $default = null)
@@ -179,7 +179,7 @@ class SimpleCacheEngine implements CacheInterface
      *   the driver supports TTL then the library may set a default value
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
-     * @throws \Psr\SimpleCache\InvalidArgumentException If $values is neither an array nor a Traversable,
+     * @throws \Cake\Cache\InvalidArgumentException If $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
     public function setMultiple($values, $ttl = null)
@@ -204,7 +204,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param iterable $keys A list of string-based keys to be deleted.
      * @return bool True if the items were successfully removed. False if there was an error.
-     * @throws \Psr\SimpleCache\InvalidArgumentException If $keys is neither an array nor a Traversable,
+     * @throws \Cake\Cache\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
     public function deleteMultiple($keys)
@@ -231,7 +231,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param string $key The cache item key.
      * @return bool
-     * @throws \Psr\SimpleCache\InvalidArgumentException If the $key string is not a legal value.
+     * @throws \Cake\Cache\InvalidArgumentException If the $key string is not a legal value.
      */
     public function has($key)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -43,13 +43,13 @@ class SimpleCacheEngine implements CacheInterface
     }
 
     /**
-     * Check key for validity.
+     * Ensure the validity of the cache key.
      *
      * @param string $key Key to check.
      * @return void
-     * @throws \Psr\SimpleCache\InvalidArgumentException When key is not valid.
+     * @throws \Psr\SimpleCache\InvalidArgumentException When the key is not valid.
      */
-    protected function checkKey($key)
+    protected function ensureValidKey($key)
     {
         if (!is_string($key) || strlen($key) === 0) {
             throw new InvalidArgumentException('Cache keys must be non-empty strings.');
@@ -67,7 +67,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function get($key, $default = null)
     {
-        $this->checkKey($key);
+        $this->ensureValidKey($key);
         $result = $this->innerEngine->read($key);
         if ($result === false) {
             return $default;
@@ -90,7 +90,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function set($key, $value, $ttl = null)
     {
-        $this->checkKey($key);
+        $this->ensureValidKey($key);
         if ($ttl !== null) {
             $restore = $this->innerEngine->getConfig('duration');
             $this->innerEngine->setConfig('duration', $ttl);
@@ -116,7 +116,7 @@ class SimpleCacheEngine implements CacheInterface
      */
     public function delete($key)
     {
-        $this->checkKey($key);
+        $this->ensureValidKey($key);
 
         return $this->innerEngine->delete($key);
     }

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -135,8 +135,7 @@ class SimpleCacheEngine implements CacheInterface
      * @param iterable $keys A list of keys that can obtained in a single operation.
      * @param mixed $default Default value to return for keys that do not exist.
      * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     * @throws \Psr\SimpleCache\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
     public function getMultiple($keys, $default = null)

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -21,6 +21,7 @@ use Psr\SimpleCache\CacheInterface;
  * the PSR16 Simple Cache Interface
  *
  * @since 3.7.0
+ * @link https://www.php-fig.org/psr/psr-16/
  */
 class SimpleCacheEngine implements CacheInterface
 {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -12,6 +12,7 @@
  * @since         3.7.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Cache;
 
 use Psr\SimpleCache\CacheInterface;

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -181,8 +181,7 @@ class SimpleCacheEngine implements CacheInterface
      *
      * @param iterable $keys A list of string-based keys to be deleted.
      * @return bool True if the items were successfully removed. False if there was an error.
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     * @throws \Psr\SimpleCache\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
     public function deleteMultiple($keys)

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -1,16 +1,34 @@
 <?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Cache;
 
-use Cake\Cache\CacheEngine;
-use Cake\Cache\InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
 
 /**
  * Wrapper for Cake engines that allow them to support
  * the PSR16 Simple Cache Interface
+ *
+ * @since 3.7.0
  */
 class SimpleCacheEngine implements CacheInterface
 {
+    /**
+     * The wrapped cache engine object.
+     *
+     * @param \Cake\Cache\CacheEngine
+     */
     protected $inner;
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -22,6 +22,7 @@ use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Error\Error;
+use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 
 /**
  * CacheTest class
@@ -906,5 +907,30 @@ class CacheTest extends TestCase
         Cache::setRegistry($registry);
 
         $this->assertSame($registry, Cache::getRegistry());
+    }
+
+    /**
+     * Test getting instances with pool
+     *
+     * @return void
+     */
+    public function testPool()
+    {
+        $this->_configCache();
+
+        $pool = Cache::pool('tests');
+        $this->assertInstanceOf(SimpleCacheInterface::class, $pool);
+    }
+
+    /**
+     * Test getting instances with pool
+     *
+     * @return void
+     */
+    public function testPoolCacheDisabled()
+    {
+        Cache::disable();
+        $pool = Cache::pool('tests');
+        $this->assertInstanceOf(SimpleCacheInterface::class, $pool);
     }
 }

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -316,7 +316,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * Test setMultiple with ttl parameter
+     * Test setMultiple with TTL parameter
      *
      * @return void
      * @covers ::setMultiple

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Cache;
 
+use Cake\Cache\CacheEngine;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\SimpleCacheEngine;
 use Cake\TestSuite\TestCase;
@@ -26,6 +27,20 @@ use Psr\SimpleCache\InvalidArgumentException;
  */
 class SimpleCacheEngineTest extends TestCase
 {
+    /**
+     * The inner cache engine
+     *
+     * @var CacheEngine
+     */
+    protected $inner;
+
+    /**
+     * The simple cache engine under test
+     *
+     * @var SimpleCacheEngine
+     */
+    protected $cache;
+
     /**
      * Setup
      *

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -12,6 +12,7 @@
  * @since         3.7.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\Cache;
 
 use Cake\Cache\CacheEngine;

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -32,7 +32,7 @@ class SimpleCacheEngineTest extends TestCase
      *
      * @var CacheEngine
      */
-    protected $inner;
+    protected $innerEngine;
 
     /**
      * The simple cache engine under test
@@ -50,13 +50,13 @@ class SimpleCacheEngineTest extends TestCase
     {
         parent::setUp();
 
-        $this->inner = new FileEngine();
-        $this->inner->init([
+        $this->innerEngine = new FileEngine();
+        $this->innerEngine->init([
             'prefix' => '',
             'path' => TMP . 'tests',
             'duration' => 5,
         ]);
-        $this->cache = new SimpleCacheEngine($this->inner);
+        $this->cache = new SimpleCacheEngine($this->innerEngine);
     }
 
     /**
@@ -68,7 +68,7 @@ class SimpleCacheEngineTest extends TestCase
     {
         parent::tearDown();
 
-        $this->inner->clear(false);
+        $this->innerEngine->clear(false);
     }
 
     /**
@@ -81,7 +81,7 @@ class SimpleCacheEngineTest extends TestCase
      */
     public function testGetSuccess()
     {
-        $this->inner->write('key_one', 'Some Value');
+        $this->innerEngine->write('key_one', 'Some Value');
         $this->assertSame('Some Value', $this->cache->get('key_one'));
         $this->assertSame('Some Value', $this->cache->get('key_one', 'default'));
     }
@@ -140,7 +140,7 @@ class SimpleCacheEngineTest extends TestCase
         sleep(1);
         $this->assertSame('a value', $this->cache->get('key'));
         $this->assertNull($this->cache->get('expired'));
-        $this->assertSame(5, $this->inner->getConfig('duration'));
+        $this->assertSame(5, $this->innerEngine->getConfig('duration'));
     }
 
     /**
@@ -326,7 +326,7 @@ class SimpleCacheEngineTest extends TestCase
         $results = $this->cache->getMultiple(array_keys($data));
         $this->assertNull($results['key']);
         $this->assertNull($results['key2']);
-        $this->assertSame(5, $this->inner->getConfig('duration'));
+        $this->assertSame(5, $this->innerEngine->getConfig('duration'));
     }
 
     /**

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -275,6 +275,9 @@ class SimpleCacheEngineTest extends TestCase
     /**
      * Test setMultiple
      *
+     * We should not assert for array equality, as the PSR-16 specs
+     * do not make any guarantees on key order.
+     *
      * @return void
      * @covers ::setMultiple
      */
@@ -284,10 +287,14 @@ class SimpleCacheEngineTest extends TestCase
             'key' => 'a value',
             'key2' => 'other value',
         ];
+        $expected = [
+            'key2' => 'other value',
+            'key' => 'a value',
+        ];
         $this->cache->setMultiple($data);
 
         $results = $this->cache->getMultiple(array_keys($data));
-        $this->assertSame($data, $results);
+        $this->assertEquals($expected, $results);
     }
 
     /**

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -321,7 +321,8 @@ class SimpleCacheEngineTest extends TestCase
             'key' => 'a value',
             'key2' => 'other value',
         ];
-        $this->cache->setMultiple($data, 0);
+        $ttl = 0;
+        $this->cache->setMultiple($data, $ttl);
 
         sleep(1);
         $results = $this->cache->getMultiple(array_keys($data));

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -21,6 +21,8 @@ use Psr\SimpleCache\InvalidArgumentException;
 
 /**
  * SimpleCacheEngine class
+ *
+ * @coversDefaultClass \Cake\Cache\SimpleCacheEngine
  */
 class SimpleCacheEngineTest extends TestCase
 {
@@ -58,6 +60,9 @@ class SimpleCacheEngineTest extends TestCase
      * test getting keys
      *
      * @return void
+     * @covers ::get
+     * @covers ::__construct
+     * @covers ::ensureValidKey
      */
     public function testGetSuccess()
     {
@@ -70,6 +75,7 @@ class SimpleCacheEngineTest extends TestCase
      * test get on missing keys
      *
      * @return void
+     * @covers ::get
      */
     public function testGetNoKey()
     {
@@ -82,6 +88,8 @@ class SimpleCacheEngineTest extends TestCase
      * must be raised.
      *
      * @return void
+     * @covers ::get
+     * @covers ::ensureValidKey
      */
     public function testGetInvalidKey()
     {
@@ -93,6 +101,8 @@ class SimpleCacheEngineTest extends TestCase
      * test set() inheriting the default TTL
      *
      * @return void
+     * @covers ::set
+     * @covers ::__construct
      */
     public function testSetNoTtl()
     {
@@ -104,6 +114,7 @@ class SimpleCacheEngineTest extends TestCase
      * test the TTL parameter of set()
      *
      * @return void
+     * @covers ::set
      */
     public function testSetWithTtl()
     {
@@ -120,6 +131,8 @@ class SimpleCacheEngineTest extends TestCase
      * test set() with an invalid key.
      *
      * @return void
+     * @covers ::set
+     * @covers ::ensureValidKey
      */
     public function testSetInvalidKey()
     {
@@ -131,6 +144,7 @@ class SimpleCacheEngineTest extends TestCase
      * test delete on known and unknown keys
      *
      * @return void
+     * @covers ::delete
      */
     public function testDelete()
     {
@@ -143,6 +157,8 @@ class SimpleCacheEngineTest extends TestCase
      * test delete on an invalid key
      *
      * @return void
+     * @covers ::delete
+     * @covers ::ensureValidKey
      */
     public function testDeleteInvalidKey()
     {
@@ -154,6 +170,7 @@ class SimpleCacheEngineTest extends TestCase
      * test clearing cache data
      *
      * @return void
+     * @covers ::clear
      */
     public function testClear()
     {
@@ -169,6 +186,7 @@ class SimpleCacheEngineTest extends TestCase
      * test getMultiple
      *
      * @return void
+     * @covers ::getMultiple
      */
     public function testGetMultiple()
     {
@@ -188,6 +206,9 @@ class SimpleCacheEngineTest extends TestCase
      * test getting multiple keys with an invalid key
      *
      * @return void
+     * @covers ::getMultiple
+     * @covers ::ensureValidKeys
+     * @covers ::ensureValidKey
      */
     public function testGetMultipleInvalidKey()
     {
@@ -201,6 +222,8 @@ class SimpleCacheEngineTest extends TestCase
      * test getting multiple keys with an invalid keys parameter
      *
      * @return void
+     * @covers ::getMultiple
+     * @covers ::ensureValidKeys
      */
     public function testGetMultipleInvalidKeys()
     {
@@ -214,6 +237,7 @@ class SimpleCacheEngineTest extends TestCase
      * test getMultiple adding defaults in.
      *
      * @return void
+     * @covers ::getMultiple
      */
     public function testGetMultipleDefault()
     {
@@ -233,6 +257,7 @@ class SimpleCacheEngineTest extends TestCase
      * test setMultiple
      *
      * @return void
+     * @covers ::setMultiple
      */
     public function testSetMultiple()
     {
@@ -250,6 +275,9 @@ class SimpleCacheEngineTest extends TestCase
      * test setMultiple with an invalid key
      *
      * @return void
+     * @covers ::setMultiple
+     * @covers ::ensureValidKeys
+     * @covers ::ensureValidKey
      */
     public function testSetMultipleInvalidKey()
     {
@@ -265,6 +293,8 @@ class SimpleCacheEngineTest extends TestCase
      * test setMultiple with ttl parameter
      *
      * @return void
+     * @covers ::setMultiple
+     * @covers ::ensureValidKeys
      */
     public function testSetMultipleWithTtl()
     {
@@ -285,6 +315,7 @@ class SimpleCacheEngineTest extends TestCase
      * test deleting multiple keys
      *
      * @return void
+     * @covers ::deleteMultiple
      */
     public function testDeleteMultiple()
     {
@@ -304,6 +335,9 @@ class SimpleCacheEngineTest extends TestCase
      * test deleting multiple keys with an invalid key
      *
      * @return void
+     * @covers ::deleteMultiple
+     * @covers ::ensureValidKeys
+     * @covers ::ensureValidKey
      */
     public function testDeleteMultipleInvalidKey()
     {
@@ -317,6 +351,8 @@ class SimpleCacheEngineTest extends TestCase
      * test deleting multiple keys with an invalid keys parameter
      *
      * @return void
+     * @covers ::deleteMultiple
+     * @covers ::ensureValidKeys
      */
     public function testDeleteMultipleInvalidKeys()
     {
@@ -330,6 +366,7 @@ class SimpleCacheEngineTest extends TestCase
      * test partial success with deleteMultiple
      *
      * @return void
+     * @covers ::deleteMultiple
      */
     public function testDeleteMultipleSomeMisses()
     {
@@ -344,6 +381,7 @@ class SimpleCacheEngineTest extends TestCase
      * test has
      *
      * @return void
+     * @covers ::has
      */
     public function testHas()
     {
@@ -357,6 +395,8 @@ class SimpleCacheEngineTest extends TestCase
      * test has with invalid key
      *
      * @return void
+     * @covers ::has
+     * @covers ::ensureValidKey
      */
     public function testHasInvalidKey()
     {

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -135,7 +135,8 @@ class SimpleCacheEngineTest extends TestCase
     public function testSetWithTtl()
     {
         $this->assertTrue($this->cache->set('key', 'a value'));
-        $this->assertTrue($this->cache->set('expired', 'a value', 0));
+        $ttl = 0;
+        $this->assertTrue($this->cache->set('expired', 'a value', $ttl));
 
         sleep(1);
         $this->assertSame('a value', $this->cache->get('key'));

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Cache;
 
-use Cake\Cache\Cache;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\SimpleCacheEngine;
 use Cake\TestSuite\TestCase;
@@ -25,6 +24,11 @@ use Psr\SimpleCache\InvalidArgumentException;
  */
 class SimpleCacheEngineTest extends TestCase
 {
+    /**
+     * setup
+     *
+     * @return void
+     */
     public function setUp()
     {
         parent::setUp();
@@ -38,6 +42,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->cache = new SimpleCacheEngine($this->inner);
     }
 
+    /**
+     * tear down
+     *
+     * @return void
+     */
     public function tearDown()
     {
         parent::tearDown();
@@ -45,6 +54,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->inner->clear(false);
     }
 
+    /**
+     * test getting keys
+     *
+     * @return void
+     */
     public function testGetSuccess()
     {
         $this->inner->write('key_one', 'Some Value');
@@ -52,24 +66,45 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame('Some Value', $this->cache->get('key_one', 'default'));
     }
 
+    /**
+     * test get on missing keys
+     *
+     * @return void
+     */
     public function testGetNoKey()
     {
         $this->assertSame('default', $this->cache->get('no', 'default'));
         $this->assertNull($this->cache->get('no'));
     }
 
+    /**
+     * test get on invalid keys. The PSR spec outlines that an exception
+     * must be raised.
+     *
+     * @return void
+     */
     public function testGetInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->cache->get('');
     }
 
+    /**
+     * test set() inheriting the default TTL
+     *
+     * @return void
+     */
     public function testSetNoTtl()
     {
         $this->assertTrue($this->cache->set('key', 'a value'));
         $this->assertSame('a value', $this->cache->get('key'));
     }
 
+    /**
+     * test the TTL parameter of set()
+     *
+     * @return void
+     */
     public function testSetWithTtl()
     {
         $this->assertTrue($this->cache->set('key', 'a value'));
@@ -81,12 +116,22 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame(5, $this->inner->getConfig('duration'));
     }
 
+    /**
+     * test set() with an invalid key.
+     *
+     * @return void
+     */
     public function testSetInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->cache->set('', 'some data');
     }
 
+    /**
+     * test delete on known and unknown keys
+     *
+     * @return void
+     */
     public function testDelete()
     {
         $this->cache->set('key', 'a value');
@@ -94,12 +139,22 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertFalse($this->cache->delete('undefined'));
     }
 
+    /**
+     * test delete on an invalid key
+     *
+     * @return void
+     */
     public function testDeleteInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->cache->delete('');
     }
 
+    /**
+     * test clearing cache data
+     *
+     * @return void
+     */
     public function testClear()
     {
         $this->cache->set('key', 'a value');
@@ -110,6 +165,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertNull($this->cache->get('key2'));
     }
 
+    /**
+     * test getMultiple
+     *
+     * @return void
+     */
     public function testGetMultiple()
     {
         $this->cache->set('key', 'a value');
@@ -124,6 +184,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame($expected, $results);
     }
 
+    /**
+     * test getMultiple adding defaults in.
+     *
+     * @return void
+     */
     public function testGetMultipleDefault()
     {
         $this->cache->set('key', 'a value');
@@ -138,11 +203,16 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame($expected, $results);
     }
 
+    /**
+     * test setMultiple
+     *
+     * @return void
+     */
     public function testSetMultiple()
     {
         $data = [
             'key' => 'a value',
-            'key2' => 'other value'
+            'key2' => 'other value',
         ];
         $this->cache->setMultiple($data);
 
@@ -150,11 +220,16 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame($data, $results);
     }
 
+    /**
+     * test setMultiple with ttl parameter
+     *
+     * @return void
+     */
     public function testSetMultipleWithTtl()
     {
         $data = [
             'key' => 'a value',
-            'key2' => 'other value'
+            'key2' => 'other value',
         ];
         $this->cache->setMultiple($data, 0);
 
@@ -165,6 +240,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame(5, $this->inner->getConfig('duration'));
     }
 
+    /**
+     * test deleting multiple keys
+     *
+     * @return void
+     */
     public function testDeleteMultiple()
     {
         $data = [
@@ -179,6 +259,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertSame('other value', $this->cache->get('key2'));
     }
 
+    /**
+     * test partial success with deleteMultiple
+     *
+     * @return void
+     */
     public function testDeleteMultipleSomeMisses()
     {
         $data = [
@@ -188,6 +273,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertFalse($this->cache->deleteMultiple(['key', 'key3']));
     }
 
+    /**
+     * test has
+     *
+     * @return void
+     */
     public function testHas()
     {
         $this->assertFalse($this->cache->has('key'));
@@ -196,6 +286,11 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertTrue($this->cache->has('key'));
     }
 
+    /**
+     * test has with invalid key
+     *
+     * @return void
+     */
     public function testHasInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -27,7 +27,7 @@ use Psr\SimpleCache\InvalidArgumentException;
 class SimpleCacheEngineTest extends TestCase
 {
     /**
-     * setup
+     * Setup
      *
      * @return void
      */
@@ -45,7 +45,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * tear down
+     * Tear down
      *
      * @return void
      */
@@ -57,7 +57,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test getting keys
+     * Test getting keys
      *
      * @return void
      * @covers ::get
@@ -72,7 +72,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test get on missing keys
+     * Test get on missing keys
      *
      * @return void
      * @covers ::get
@@ -84,7 +84,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test get on invalid keys. The PSR spec outlines that an exception
+     * Test get on invalid keys. The PSR spec outlines that an exception
      * must be raised.
      *
      * @return void
@@ -98,7 +98,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test set() inheriting the default TTL
+     * Test set() inheriting the default TTL
      *
      * @return void
      * @covers ::set
@@ -111,7 +111,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test the TTL parameter of set()
+     * Test the TTL parameter of set()
      *
      * @return void
      * @covers ::set
@@ -128,7 +128,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test set() with an invalid key.
+     * Test set() with an invalid key.
      *
      * @return void
      * @covers ::set
@@ -141,7 +141,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test delete on known and unknown keys
+     * Test delete on known and unknown keys
      *
      * @return void
      * @covers ::delete
@@ -154,7 +154,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test delete on an invalid key
+     * Test delete on an invalid key
      *
      * @return void
      * @covers ::delete
@@ -167,7 +167,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test clearing cache data
+     * Test clearing cache data
      *
      * @return void
      * @covers ::clear
@@ -183,7 +183,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test getMultiple
+     * Test getMultiple
      *
      * @return void
      * @covers ::getMultiple
@@ -203,7 +203,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test getting multiple keys with an invalid key
+     * Test getting multiple keys with an invalid key
      *
      * @return void
      * @covers ::getMultiple
@@ -219,7 +219,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test getting multiple keys with an invalid keys parameter
+     * Test getting multiple keys with an invalid keys parameter
      *
      * @return void
      * @covers ::getMultiple
@@ -234,7 +234,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test getMultiple adding defaults in.
+     * Test getMultiple adding defaults in.
      *
      * @return void
      * @covers ::getMultiple
@@ -254,7 +254,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test setMultiple
+     * Test setMultiple
      *
      * @return void
      * @covers ::setMultiple
@@ -272,7 +272,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test setMultiple with an invalid key
+     * Test setMultiple with an invalid key
      *
      * @return void
      * @covers ::setMultiple
@@ -290,7 +290,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test setMultiple with ttl parameter
+     * Test setMultiple with ttl parameter
      *
      * @return void
      * @covers ::setMultiple
@@ -312,7 +312,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test deleting multiple keys
+     * Test deleting multiple keys
      *
      * @return void
      * @covers ::deleteMultiple
@@ -332,7 +332,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test deleting multiple keys with an invalid key
+     * Test deleting multiple keys with an invalid key
      *
      * @return void
      * @covers ::deleteMultiple
@@ -348,7 +348,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test deleting multiple keys with an invalid keys parameter
+     * Test deleting multiple keys with an invalid keys parameter
      *
      * @return void
      * @covers ::deleteMultiple
@@ -363,7 +363,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test partial success with deleteMultiple
+     * Test partial success with deleteMultiple
      *
      * @return void
      * @covers ::deleteMultiple
@@ -378,7 +378,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test has
+     * Test has
      *
      * @return void
      * @covers ::has
@@ -392,7 +392,7 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
-     * test has with invalid key
+     * Test has with invalid key
      *
      * @return void
      * @covers ::has

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -185,6 +185,32 @@ class SimpleCacheEngineTest extends TestCase
     }
 
     /**
+     * test getting multiple keys with an invalid key
+     *
+     * @return void
+     */
+    public function testGetMultipleInvalidKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
+        $withInvalidKey = [''];
+        $this->cache->getMultiple($withInvalidKey);
+    }
+
+    /**
+     * test getting multiple keys with an invalid keys parameter
+     *
+     * @return void
+     */
+    public function testGetMultipleInvalidKeys()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key set must be either an array or a Traversable.');
+        $notAnArray = 'neither an array nor a Traversable';
+        $this->cache->getMultiple($notAnArray);
+    }
+
+    /**
      * test getMultiple adding defaults in.
      *
      * @return void
@@ -218,6 +244,21 @@ class SimpleCacheEngineTest extends TestCase
 
         $results = $this->cache->getMultiple(array_keys($data));
         $this->assertSame($data, $results);
+    }
+
+    /**
+     * test setMultiple with an invalid key
+     *
+     * @return void
+     */
+    public function testSetMultipleInvalidKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
+        $data = [
+            '' => 'a value wuth an invalid key',
+        ];
+        $this->cache->setMultiple($data);
     }
 
     /**
@@ -257,6 +298,32 @@ class SimpleCacheEngineTest extends TestCase
         $this->assertNull($this->cache->get('key'));
         $this->assertNull($this->cache->get('key3'));
         $this->assertSame('other value', $this->cache->get('key2'));
+    }
+
+    /**
+     * test deleting multiple keys with an invalid key
+     *
+     * @return void
+     */
+    public function testDeleteMultipleInvalidKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
+        $withInvalidKey = [''];
+        $this->cache->deleteMultiple($withInvalidKey);
+    }
+
+    /**
+     * test deleting multiple keys with an invalid keys parameter
+     *
+     * @return void
+     */
+    public function testDeleteMultipleInvalidKeys()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key set must be either an array or a Traversable.');
+        $notAnArray = 'neither an array nor a Traversable';
+        $this->cache->deleteMultiple($notAnArray);
     }
 
     /**

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -94,6 +94,7 @@ class SimpleCacheEngineTest extends TestCase
     public function testGetInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
         $this->cache->get('');
     }
 
@@ -137,6 +138,7 @@ class SimpleCacheEngineTest extends TestCase
     public function testSetInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
         $this->cache->set('', 'some data');
     }
 
@@ -163,6 +165,7 @@ class SimpleCacheEngineTest extends TestCase
     public function testDeleteInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
         $this->cache->delete('');
     }
 
@@ -401,6 +404,7 @@ class SimpleCacheEngineTest extends TestCase
     public function testHasInvalidKey()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string.');
         $this->cache->has('');
     }
 }

--- a/tests/TestCase/Cache/SimpleCacheEngineTest.php
+++ b/tests/TestCase/Cache/SimpleCacheEngineTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Cache;
+
+use Cake\Cache\Cache;
+use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\SimpleCacheEngine;
+use Cake\TestSuite\TestCase;
+
+/**
+ * SimpleCacheEngine class
+ */
+class SimpleCacheEngineTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->inner = new FileEngine();
+        $this->inner->init([
+            'prefix' => '',
+            'path' => TMP . 'tests',
+            'duration' => 5,
+        ]);
+        $this->cache = new SimpleCacheEngine($this->inner);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->inner->clear(false);
+    }
+
+    public function testGetSuccess()
+    {
+        $this->inner->write('key_one', 'Some Value');
+        $this->assertSame('Some Value', $this->cache->get('key_one'));
+        $this->assertSame('Some Value', $this->cache->get('key_one', 'default'));
+    }
+
+    public function testGetNoKey()
+    {
+        $this->assertSame('default', $this->cache->get('no', 'default'));
+        $this->assertNull($this->cache->get('no'));
+    }
+
+    public function testGetInvalidKey()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testSetNoTtl()
+    {
+        $this->assertTrue($this->cache->set('key', 'a value'));
+        $this->assertSame('a value', $this->cache->get('key'));
+    }
+
+    public function testSetWithTtl()
+    {
+        $this->assertTrue($this->cache->set('key', 'a value'));
+        $this->assertTrue($this->cache->set('expired', 'a value', 0));
+
+        sleep(1);
+        $this->assertSame('a value', $this->cache->get('key'));
+        $this->assertNull($this->cache->get('expired'));
+        $this->assertNotEquals(0, $this->inner->getConfig('duration'));
+    }
+
+    public function testSetInvalidKey()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testDelete()
+    {
+        $this->cache->set('key', 'a value');
+        $this->assertTrue($this->cache->delete('key'));
+        $this->assertFalse($this->cache->delete('undefined'));
+    }
+
+    public function testDeleteInvalidKey()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testClear()
+    {
+        $this->cache->set('key', 'a value');
+        $this->cache->set('key2', 'other value');
+
+        $this->assertTrue($this->cache->clear());
+        $this->assertNull($this->cache->get('key'));
+        $this->assertNull($this->cache->get('key2'));
+    }
+
+    public function testGetMultiple()
+    {
+        $this->cache->set('key', 'a value');
+        $this->cache->set('key2', 'other value');
+
+        $results = $this->cache->getMultiple(['key', 'key2', 'no']);
+        $expected = [
+            'key' => 'a value',
+            'key2' => 'other value',
+            'no' => null,
+        ];
+        $this->assertSame($expected, $results);
+    }
+
+    public function testGetMultipleDefault()
+    {
+        $this->cache->set('key', 'a value');
+        $this->cache->set('key2', 'other value');
+
+        $results = $this->cache->getMultiple(['key', 'key2', 'no'], 'default value');
+        $expected = [
+            'key' => 'a value',
+            'key2' => 'other value',
+            'no' => 'default value',
+        ];
+        $this->assertSame($expected, $results);
+    }
+
+    public function testSetMultiple()
+    {
+        $data = [
+            'key' => 'a value',
+            'key2' => 'other value'
+        ];
+        $this->cache->setMultiple($data);
+
+        $results = $this->cache->getMultiple(array_keys($data));
+        $this->assertSame($data, $results);
+    }
+
+    public function testSetMultipleWithTtl()
+    {
+        $data = [
+            'key' => 'a value',
+            'key2' => 'other value'
+        ];
+        $this->cache->setMultiple($data, 0);
+
+        sleep(1);
+        $results = $this->cache->getMultiple(array_keys($data));
+        $this->assertNull($results['key']);
+        $this->assertNull($results['key2']);
+        $this->assertGreaterThan(1, $this->inner->getConfig('duration'));
+    }
+}


### PR DESCRIPTION
I'd like to get some feedback on the approach taken here before completing all the work. This set of changes takes a different approach to get PSR16 compliant than #11848.

As detailed in #12483 this delivers the new bridge adapter and the `Cache::pool()` method. I've not yet completed the internal refactoring of `Cache` but will do that if folks are on board with the general direction.