### PR TITLE
Consistent result value for malformed encrypted cookies

### DIFF
--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -128,9 +128,15 @@ trait CookieCryptTrait
         }
         $this->_checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
-        $value = base64_decode(substr($value, strlen($prefix)));
+        $prefixLength = strlen($prefix);
 
-        if ($value === '') {
+        if (strncmp($value, $prefix, $prefixLength) !== 0) {
+            return '';
+        }
+
+        $value = base64_decode(substr($value, $prefixLength), true);
+
+        if ($value === false ||$value === '') {
             return '';
         }
 
@@ -142,6 +148,10 @@ trait CookieCryptTrait
         }
         if ($encrypt === 'aes') {
             $value = Security::decrypt($value, $key);
+        }
+
+        if ($value === false) {
+            return '';
         }
 
         return $this->_explode($value);

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -129,6 +129,11 @@ trait CookieCryptTrait
         $this->_checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $value = base64_decode(substr($value, strlen($prefix)));
+
+        if ($value === '') {
+            return '';
+        }
+
         if ($key === null) {
             $key = $this->_getCookieEncryptionKey();
         }

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -136,7 +136,7 @@ trait CookieCryptTrait
 
         $value = base64_decode(substr($value, $prefixLength), true);
 
-        if ($value === false ||$value === '') {
+        if ($value === false || $value === '') {
             return '';
         }
 

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -650,6 +650,33 @@ class CookieComponentTest extends TestCase
     }
 
     /**
+     * testReadingMalformedEncryptedCookies
+     *
+     * @return void
+     */
+    public function testReadingMalformedEncryptedCookies()
+    {
+        $this->Cookie->configKey('Encrypted_empty', 'encryption', 'aes');
+        $this->Cookie->configKey('Encrypted_too_short', 'encryption', 'aes');
+        $this->Cookie->configKey('Encrypted_altered', 'encryption', 'aes');
+
+        $this->Controller->request = $this->request->withCookieParams([
+            'Encrypted_empty' => '',
+            'Encrypted_too_short' => 'Q2FrZQ',
+            'Encrypted_altered' => 'Q2FrZQ==.ModifiedBase64Data==',
+        ]);
+
+        $data = $this->Cookie->read('Encrypted_empty');
+        $this->assertEquals('', $data);
+
+        $data = $this->Cookie->read('Encrypted_too_short');
+        $this->assertEquals('', $data);
+
+        $data = $this->Cookie->read('Encrypted_altered');
+        $this->assertEquals('', $data);
+    }
+
+    /**
      * Test Reading legacy cookie values.
      *
      * @return void

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -657,22 +657,29 @@ class CookieComponentTest extends TestCase
     public function testReadingMalformedEncryptedCookies()
     {
         $this->Cookie->configKey('Encrypted_empty', 'encryption', 'aes');
-        $this->Cookie->configKey('Encrypted_too_short', 'encryption', 'aes');
+        $this->Cookie->configKey('Encrypted_wrong_prefix', 'encryption', 'aes');
         $this->Cookie->configKey('Encrypted_altered', 'encryption', 'aes');
+        $this->Cookie->configKey('Encrypted_invalid_chars', 'encryption', 'aes');
+
+        $encrypted = $this->_encrypt('secret data', 'aes');
 
         $this->Controller->request = $this->request->withCookieParams([
             'Encrypted_empty' => '',
-            'Encrypted_too_short' => 'Q2FrZQ',
-            'Encrypted_altered' => 'Q2FrZQ==.ModifiedBase64Data==',
+            'Encrypted_wrong_prefix' => substr_replace($encrypted, 'foo', 0, 3),
+            'Encrypted_altered' => str_replace('M', 'A', $encrypted),
+            'Encrypted_invalid_chars' => str_replace('M', 'M#', $encrypted),
         ]);
 
         $data = $this->Cookie->read('Encrypted_empty');
         $this->assertEquals('', $data);
 
-        $data = $this->Cookie->read('Encrypted_too_short');
+        $data = $this->Cookie->read('Encrypted_wrong_prefix');
         $this->assertEquals('', $data);
 
         $data = $this->Cookie->read('Encrypted_altered');
+        $this->assertEquals('', $data);
+
+        $data = $this->Cookie->read('Encrypted_invalid_chars');
         $this->assertEquals('', $data);
     }
 

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -76,32 +76,44 @@ class EncryptedCookieMiddlewareTest extends TestCase
     /**
      * Test decoding malformed cookies
      *
+     * @dataProvider malformedCookies
+     * @param string $cookie
      * @return void
      */
-    public function testDecodeMalformedCookies()
+    public function testDecodeMalformedCookies($cookie)
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
-        $request = $request->withCookieParams([
-            'secret_empty' => '',
-            'secret_too_short' => 'Q2FrZQ',
-            'secret_altered' => 'Q2FrZQ==.ModifiedBase64Data==',
-        ]);
-        $this->assertNotEquals('decoded', $request->getCookie('decoded'));
+        $request = $request->withCookieParams(['secret' => $cookie]);
 
         $response = new Response();
         $next = function ($req, $res) {
-            $this->assertSame('', $req->getCookie('secret_empty'));
-            $this->assertSame('', $req->getCookie('secret_too_short'));
-            $this->assertSame('', $req->getCookie('secret_altered'));
+            $this->assertSame('', $req->getCookie('secret'));
 
             return $res;
         };
         $middleware = new EncryptedCookieMiddleware(
-            ['secret_empty', 'secret_too_short', 'secret_altered'],
+            ['secret'],
             $this->_getCookieEncryptionKey(),
             'aes'
         );
         $response = $middleware($request, $response, $next);
+    }
+
+    /**
+     * Data provider for malformed cookies.
+     *
+     * @return array
+     */
+    public function malformedCookies()
+    {
+        $encrypted = $this->_encrypt('secret data', 'aes');
+
+        return [
+            'empty' => [''],
+            'wrong prefix' => [substr_replace($encrypted, 'foo', 0, 3)],
+            'altered' => [str_replace('M', 'A', $encrypted)],
+            'invalid chars' => [str_replace('M', 'M#', $encrypted)],
+        ];
     }
 
     /**


### PR DESCRIPTION
If encrypted cookie is empty or 9 (`Q2FrZQ==.`) characters or shorter, reading cookie throws  `InvalidArgumentException('The data to decrypt cannot be empty.')`, because after removing first 9 chars, string is empty and `Security::decrypt()` receives empty string.

However reading cookie with altered encrypted data, cookie returned as empty string.

I think it should behave same in both cases and return empty string.

With exception, end user receives 500 error on each request with no explanation and must remove cookie to be able use website.