### PR TITLE
Only store the unique set of middleware.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -1062,7 +1062,7 @@ class RouteBuilder
                 throw new RuntimeException($message);
             }
         }
-        $this->middleware = array_merge($this->middleware, $names);
+        $this->middleware = array_unique(array_merge($this->middleware, $names));
 
         return $this;
     }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -1082,6 +1082,25 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test that applyMiddleware() uses unique middleware set
+     *
+     * @return void
+     */
+    public function testApplyMiddlewareUnique()
+    {
+        $func = function () {
+        };
+        $routes = new RouteBuilder($this->collection, '/api');
+        $routes->registerMiddleware('test', $func)
+            ->registerMiddleware('test2', $func);
+
+        $routes->applyMiddleware('test', 'test2');
+        $routes->applyMiddleware('test2', 'test');
+
+        $this->assertAttributeEquals(['test', 'test2'], 'middleware', $routes);
+    }
+
+    /**
      * Test applying middleware results in middleware attached to the route.
      *
      * @return void


### PR DESCRIPTION
When using scoped middleware and refactoring routes one can end up doubly applying middleware. We should only apply each middleware once, as middleware like CSRF protection have side-effects.
