### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -298,7 +298,7 @@ class CommandRunner implements EventDispatcherInterface
     /**
      * Resolve the command name into a name that exists in the collection.
      *
-     * Apply backwards compatibile inflections and aliases.
+     * Apply backwards compatible inflections and aliases.
      *
      * @param \Cake\Console\CommandCollection $commands The command collection to check.
      * @param \Cake\Console\ConsoleIo $io ConsoleIo object for errors.

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -498,7 +498,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     }
 
     /**
-     * Disbale automatic action rendering.
+     * Disable automatic action rendering.
      *
      * @return $this
      * @since 3.6.0

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -195,7 +195,7 @@ class FunctionsBuilder
      * Add the time unit to the date expression
      *
      * @param string $expression Expression to obtain the date part from.
-     * @param string $value Value to be added. Use negative to substract.
+     * @param string $value Value to be added. Use negative to subtract.
      * @param string $unit Unit of the value e.g. hour or day.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -956,7 +956,7 @@ trait EntityTrait
 
             // String messages are appended to the list,
             // while more complex error structures need their
-            // keys perserved for nested validator.
+            // keys preserved for nested validator.
             if (is_string($error)) {
                 $this->_errors[$f][] = $error;
             } else {

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -45,7 +45,7 @@ class EncryptedCookieMiddleware
     protected $cookieNames;
 
     /**
-     * Encrpytion key to use.
+     * Encryption key to use.
      *
      * @var string
      */

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -79,7 +79,7 @@ abstract class ServerRequestFactory extends BaseFactory
      * Build a UriInterface object.
      *
      * Add in some CakePHP specific logic/properties that help
-     * perserve backwards compatibility.
+     * preserve backwards compatibility.
      *
      * @param array $server The server parameters.
      * @param array $headers The normalized headers

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1848,7 +1848,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   listeners will receive the entity and the options array as arguments. The type
      *   of operation performed (insert or update) can be determined by checking the
      *   entity's method `isNew`, true meaning an insert and false an update.
-     * - Model.afterSaveCommit: Will be triggered after the transaction is commited
+     * - Model.afterSaveCommit: Will be triggered after the transaction is committed
      *   for atomic save, listeners will receive the entity and the options array
      *   as arguments.
      *

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -33,7 +33,7 @@ class Mcrypt
      * @param string $key Key to use as the encryption key for encrypted data.
      * @param string $operation Operation to perform, encrypt or decrypt
      * @throws \LogicException When there are errors.
-     * @return string Encrytped binary string data, or decrypted data depending on operation.
+     * @return string Encrypted binary string data, or decrypted data depending on operation.
      * @deprecated 3.3.0 This method will be removed in 4.0.0.
      */
     public static function rijndael($text, $key, $operation)

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1350,7 +1350,7 @@ class Validation
      * Validates the image width.
      *
      * @param array $file The uploaded file data from PHP.
-     * @param string $operator Comparision operator.
+     * @param string $operator Comparison operator.
      * @param int $width Min or max width.
      * @return bool
      */
@@ -1368,7 +1368,7 @@ class Validation
      * Validates the image width.
      *
      * @param array $file The uploaded file data from PHP.
-     * @param string $operator Comparision operator.
+     * @param string $operator Comparison operator.
      * @param int $height Min or max width.
      * @return bool
      */

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -198,7 +198,7 @@ SQL;
                 50,
                 null,
                 null,
-                // Sqlserver returns double lenghts for unicode columns
+                // Sqlserver returns double lengths for unicode columns
                 ['type' => 'string', 'length' => 25]
             ],
             [

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -266,7 +266,7 @@ class I18nTest extends TestCase
     }
 
     /**
-     * Tests the __() functions with explict null params
+     * Tests the __() functions with explicit null params
      *
      * @return void
      */

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -173,7 +173,7 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that fields from a translated model use the I18n class locale
-     * and that it propogates to associated models
+     * and that it propagates to associated models
      *
      * @return void
      */

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6541,7 +6541,7 @@ class TableTest extends TestCase
 
     /**
      * Tests that passing a coned entity that was marked as new to save() will
-     * actaully save it as a new entity
+     * actually save it as a new entity
      *
      * @group save
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4985,7 +4985,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Integration test for replacing entities with HasMany and an empty target list. The transaction must be successfull
+     * Integration test for replacing entities with HasMany and an empty target list. The transaction must be successful
      *
      * @return void
      */
@@ -5027,7 +5027,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Integration test for replacing entities with HasMany and no already persisted entities. The transaction must be successfull.
+     * Integration test for replacing entities with HasMany and no already persisted entities. The transaction must be successful.
      * Replace operation should prevent considering 0 changed records an error when they are not found in the table
      *
      * @return void

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -582,7 +582,7 @@ class RouteTest extends TestCase
         $this->assertRegExp($result, '/source/view');
         $this->assertRegExp($result, '/source/view/other/params');
         $this->assertNotRegExp($result, '/chaw_test/wiki');
-        $this->assertNotRegExp($result, '/source/wierd_action');
+        $this->assertNotRegExp($result, '/source/weird_action');
     }
 
     /**

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1189,7 +1189,7 @@ class HashTest extends TestCase
     }
 
     /**
-     * Test the attribute presense selector.
+     * Test the attribute presence selector.
      *
      * @dataProvider articleDataSets
      * @return void

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -468,7 +468,7 @@ TEXT;
     }
 
     /**
-     * test wrapBlock() indentical to wrap()
+     * test wrapBlock() identical to wrap()
      *
      * @return void
      */

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1978,7 +1978,7 @@ class ValidationTest extends TestCase
      */
     public function testEmailDeep()
     {
-        $this->skipIf((bool)gethostbynamel('example.abcd'), 'Your DNS service responds for non-existant domains, skipping deep email checks.');
+        $this->skipIf((bool)gethostbynamel('example.abcd'), 'Your DNS service responds for non-existent domains, skipping deep email checks.');
 
         $this->assertTrue(Validation::email('abc.efg@cakephp.org', true));
         $this->assertFalse(Validation::email('abc.efg@caphpkeinvalid.com', true));

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -832,7 +832,7 @@ class PaginatorHelperTest extends TestCase
     /**
      * Returns data sets of:
      *  * the name of the field being sorted on
-     *  * url paramters to pass to paginator sort
+     *  * url parameters to pass to paginator sort
      *  * expected result as a string
      *
      * @return array

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1941,7 +1941,7 @@ TEXT;
     }
 
     /**
-     * Test extend() preceeded by an element()
+     * Test extend() preceded by an element()
      *
      * @return void
      */
@@ -1958,7 +1958,7 @@ TEXT;
     }
 
     /**
-     * Test extend() preceeded by an element()
+     * Test extend() preceded by an element()
      *
      * @return void
      */


### PR DESCRIPTION
I fixed typos using [github.com/client9/misspell](https://github.com/client9/misspell).

Depending on American English or British English, it may not be typo.
But I fixed all automatically.