### PR TITLE
Added a collection lazy() method

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -784,6 +784,16 @@ interface CollectionInterface extends Iterator, JsonSerializable
     public function compile($preserveKeys = true);
 
     /**
+     * Returns a new collection where any operations chained after it are guaranteed
+     * to be run lazily. That is, elements will be yieleded one at a time.
+     *
+     * A lazy collection can only be iterated once. A second attempt results in an error.
+     *
+     * @return \Cake\Collection\CollectionInterface
+     */
+    public function lazy();
+
+    /**
      * Returns a new collection where the operations performed by this collection.
      * No matter how many times the new collection is iterated, those operations will
      * only be performed once.

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -588,6 +588,20 @@ trait CollectionTrait
 
     /**
      * {@inheritDoc}
+     */
+    public function lazy()
+    {
+        $generator = function () {
+            foreach ($this->unwrap() as $k => $v) {
+                yield $k => $v;
+            }
+        };
+
+        return new Collection($generator());
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @return \Cake\Collection\Iterator\BufferedIterator
      */

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2634,7 +2634,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * Tests that elements in a lazy collection are only fetched once
+     * Tests that elements in a lazy collection are not fetched immediately.
      *
      * @return void
      */

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2632,4 +2632,21 @@ class CollectionTest extends TestCase
         $this->assertTrue($newIterator->checkValues());
         $this->assertCount(3, $newIterator->toArray());
     }
+
+    /**
+     * Tests that elements in a lazy collection are only fetched once
+     *
+     * @return void
+     */
+    public function testLazy()
+    {
+        $items = ['a' => 1, 'b' => 2, 'c' => 3];
+        $collection = (new Collection($items))->lazy();
+        $callable = $this->getMockBuilder(\StdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
+
+        $callable->expects($this->never())->method('__invoke');
+        $collection->filter($callable)->filter($callable);
+    }
 }


### PR DESCRIPTION
Since cake 3.6 collections are not entirely lazy anymore. This is
because in the greate majority of cases, running the computations
eagerly is faster than doing it on demand.

This assumption fails, though, when the computations are very intensive
or when you actually only need a handful of elements anyways. In order
to get this feature back, I'm introducing the `lazy()` method. It will
make sure that computations only happen on demand.

I feel that this give more power to the developer who's trying to find
the most performant way of traversing a set of results.