### PR TITLE
Fix scopes with actions not working.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -724,14 +724,9 @@ class RouteBuilder
     public function connect($route, $defaults = [], array $options = [])
     {
         $defaults = $this->parseDefaults($defaults);
-        if (!isset($options['action']) && !isset($defaults['action'])) {
-            $defaults['action'] = 'index';
-        }
-
         if (empty($options['_ext'])) {
             $options['_ext'] = $this->_extensions;
         }
-
         if (empty($options['routeClass'])) {
             $options['routeClass'] = $this->_routeClass;
         }
@@ -823,6 +818,9 @@ class RouteBuilder
                 }
             }
             $defaults += $this->_params + ['plugin' => null];
+            if (!isset($defaults['action']) && !isset($options['action'])) {
+                $defaults['action'] = 'index';
+            }
 
             $route = new $routeClass($route, $defaults, $options);
         }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -941,6 +941,27 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test adding a scope with action in the scope
+     *
+     * @return void
+     */
+    public function testScopeWithAction()
+    {
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function ($routes) {
+            $routes->connect('/shared', ['shared' => true]);
+            $routes->get('/exclusive', ['exclusive' => true]);
+        });
+        $all = $this->collection->routes();
+        $this->assertCount(2, $all);
+        $this->assertSame('view', $all[0]->defaults['action']);
+        $this->assertArrayHasKey('shared', $all[0]->defaults);
+
+        $this->assertSame('view', $all[1]->defaults['action']);
+        $this->assertArrayHasKey('exclusive', $all[1]->defaults);
+    }
+
+    /**
      * Test that nested scopes inherit middleware.
      *
      * @return void


### PR DESCRIPTION
Scopes that define an action other than `index` should be able to connect routes.

Fixes #12535
