### PR TITLE
Throw warning when using underscored fixture names.

### DIFF
--- a/src/Core/ConventionsTrait.php
+++ b/src/Core/ConventionsTrait.php
@@ -30,7 +30,7 @@ trait ConventionsTrait
      */
     protected function _fixtureName($name)
     {
-        return Inflector::underscore($name);
+        return Inflector::camelize($name);
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -190,19 +190,43 @@ class FixtureManager
                     list($plugin, $name) = explode('.', $pathName);
                     // Flip vendored plugin separators
                     $path = str_replace('/', '\\', $plugin);
+                    $uninflected = $path;
                     $baseNamespace = Inflector::camelize(str_replace('\\', '\ ', $path));
+                    if ($baseNamespace !== $uninflected) {
+                        deprecationWarning(sprintf(
+                            'Declaring fixtures in underscored format in TestCase::$fixtures is deprecated.' . "\n" .
+                            'Expected "%s" instead in "%s".',
+                            str_replace('\\', '/', $baseNamespace),
+                            get_class($test)
+                        ));
+                    }
                     $additionalPath = null;
                 } else {
                     $baseNamespace = '';
                     $name = $fixture;
                 }
 
+                $uninflected = $name;
                 // Tweak subdirectory names, so camelize() can make the correct name
                 if (strpos($name, '/') > 0) {
-                    $name = str_replace('/', '\\ ', $name);
+                    $name = str_replace('/', '\\', $name);
+                    $uninflected = $name;
+                    $name = str_replace('\\', '\ ', $name);
                 }
 
                 $name = Inflector::camelize($name);
+                if ($name !== $uninflected) {
+                    deprecationWarning(sprintf(
+                        'Declaring fixtures in underscored format in TestCase::$fixtures is deprecated.' . "\n" .
+                        'Found "%s.%s" in "%s". Expected "%s.%s" instead.',
+                        $type,
+                        $uninflected,
+                        get_class($test),
+                        $type,
+                        str_replace('\\', '/', $name)
+                    ));
+                }
+
                 $nameSegments = [
                     $baseNamespace,
                     'Test\Fixture',

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -14,7 +14,7 @@ class FixturizedTestCase extends TestCase
      * Fixtures to use in this test
      * @var array
      */
-    public $fixtures = ['core.categories', 'core.articles'];
+    public $fixtures = ['core.Categories', 'core.Articles'];
 
     /**
      * test that the shared fixture is correctly set

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -33,7 +33,7 @@ class BasicAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.auth_users', 'core.users'];
+    public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
      * setup

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -45,7 +45,7 @@ class DigestAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.auth_users', 'core.users'];
+    public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
      * setup

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -35,7 +35,7 @@ class FormAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.auth_users', 'core.users'];
+    public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
      * setup

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -53,13 +53,13 @@ class ShellTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles',
-        'core.articles_tags',
-        'core.attachments',
-        'core.comments',
-        'core.posts',
-        'core.tags',
-        'core.users'
+        'core.Articles',
+        'core.ArticlesTags',
+        'core.Attachments',
+        'core.Comments',
+        'core.Posts',
+        'core.Tags',
+        'core.Users'
     ];
 
     /** @var \Cake\Console\Shell */

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -47,7 +47,7 @@ class AuthComponentTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.auth_users', 'core.users'];
+    public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
      * setUp method

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -57,8 +57,8 @@ class PaginatorComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.posts', 'core.articles', 'core.articles_tags',
-        'core.authors', 'core.authors_tags', 'core.tags'
+        'core.Posts', 'core.Articles', 'core.ArticlesTags',
+        'core.Authors', 'core.AuthorsTags', 'core.Tags'
     ];
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -231,8 +231,8 @@ class ControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.comments',
-        'core.posts'
+        'core.Comments',
+        'core.Posts'
     ];
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -36,7 +36,7 @@ use ReflectionProperty;
 class ConnectionTest extends TestCase
 {
 
-    public $fixtures = ['core.things'];
+    public $fixtures = ['core.Things'];
 
     /**
      * Where the NestedTransactionRollbackException was created.

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -73,7 +73,7 @@ class OrderedUuidType extends Type implements ExpressionTypeInterface
 class ExpressionTypeCastingIntegrationTest extends TestCase
 {
 
-    public $fixtures = ['core.ordered_uuid_items'];
+    public $fixtures = ['core.OrderedUuidItems'];
 
     public function setUp()
     {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -31,11 +31,11 @@ class QueryTest extends TestCase
 {
 
     public $fixtures = [
-        'core.articles',
-        'core.authors',
-        'core.comments',
-        'core.profiles',
-        'core.menu_link_trees'
+        'core.Articles',
+        'core.Authors',
+        'core.Comments',
+        'core.Profiles',
+        'core.MenuLinkTrees'
     ];
 
     public $autoFixtures = false;

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -33,7 +33,7 @@ class CollectionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.users'
+        'core.Users'
     ];
 
     /**

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -38,11 +38,11 @@ class TableTest extends TestCase
 {
 
     public $fixtures = [
-        'core.articles',
-        'core.tags',
-        'core.articles_tags',
-        'core.orders',
-        'core.products'
+        'core.Articles',
+        'core.Tags',
+        'core.ArticlesTags',
+        'core.Orders',
+        'core.Products'
     ];
 
     protected $_map;

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -32,7 +32,7 @@ class SchemaCacheTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.tags'];
+    public $fixtures = ['core.Articles', 'core.Tags'];
 
     /**
      * Cache Engine Mock

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -31,8 +31,8 @@ class PaginatorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.posts', 'core.articles', 'core.articles_tags',
-        'core.authors', 'core.authors_tags', 'core.tags'
+        'core.Posts', 'core.Articles', 'core.ArticlesTags',
+        'core.Authors', 'core.AuthorsTags', 'core.Tags'
     ];
 
     /**

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -32,7 +32,7 @@ class DatabaseSessionTest extends TestCase
      *
      * @var string
      */
-    public $fixtures = ['core.sessions'];
+    public $fixtures = ['core.Sessions'];
 
     /**
      * setUp

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -77,7 +77,7 @@ class SessionTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.cake_sessions', 'core.sessions'];
+    public $fixtures = ['core.CakeSessions', 'core.Sessions'];
 
     /**
      * tearDown method

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -106,7 +106,7 @@ class TestEmail extends Email
 class EmailTest extends TestCase
 {
 
-    public $fixtures = ['core.users'];
+    public $fixtures = ['core.Users'];
 
     /**
      * @var \Cake\Mailer\Email

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -34,7 +34,7 @@ class BelongsToManyTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.special_tags', 'core.articles_tags', 'core.tags'];
+    public $fixtures = ['core.Articles', 'core.SpecialTags', 'core.ArticlesTags', 'core.Tags'];
 
     /**
      * Set up

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -32,7 +32,7 @@ class BelongsToTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.authors', 'core.comments'];
+    public $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**
      * Set up

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -35,7 +35,7 @@ class HasManyTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.comments', 'core.articles', 'core.authors'];
+    public $fixtures = ['core.Comments', 'core.Articles', 'core.Authors'];
 
     /**
      * Set up

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -31,7 +31,7 @@ class HasOneTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.profiles'];
+    public $fixtures = ['core.Users', 'core.Profiles'];
 
     /**
      * @var bool

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -29,7 +29,7 @@ class AssociationProxyTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles', 'core.authors', 'core.comments'
+        'core.Articles', 'core.Authors', 'core.Comments'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -38,8 +38,8 @@ class BehaviorRegressionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.number_trees',
-        'core.translates'
+        'core.NumberTrees',
+        'core.Translates'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -46,11 +46,11 @@ class CounterCacheBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.counter_cache_categories',
-        'core.counter_cache_posts',
-        'core.counter_cache_comments',
-        'core.counter_cache_users',
-        'core.counter_cache_user_category_posts'
+        'core.CounterCacheCategories',
+        'core.CounterCachePosts',
+        'core.CounterCacheComments',
+        'core.CounterCacheUsers',
+        'core.CounterCacheUserCategoryPosts'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -44,7 +44,7 @@ class TimestampBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.users'
+        'core.Users'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -43,13 +43,13 @@ class TranslateBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles',
-        'core.authors',
-        'core.groups',
-        'core.special_tags',
-        'core.tags',
-        'core.comments',
-        'core.translates'
+        'core.Articles',
+        'core.Authors',
+        'core.Groups',
+        'core.SpecialTags',
+        'core.Tags',
+        'core.Comments',
+        'core.Translates'
     ];
 
     public function tearDown()

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -29,8 +29,8 @@ class TreeBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.menu_link_trees',
-        'core.number_trees'
+        'core.MenuLinkTrees',
+        'core.NumberTrees'
     ];
 
     public function setUp()

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -28,9 +28,9 @@ class BindingKeyTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.auth_users',
-        'core.site_authors',
-        'core.users'
+        'core.AuthUsers',
+        'core.SiteAuthors',
+        'core.Users'
     ];
 
     /**

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -47,11 +47,11 @@ class CompositeKeyTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.composite_increments',
-        'core.site_articles',
-        'core.site_articles_tags',
-        'core.site_authors',
-        'core.site_tags'
+        'core.CompositeIncrements',
+        'core.SiteArticles',
+        'core.SiteArticlesTags',
+        'core.SiteAuthors',
+        'core.SiteTags'
     ];
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -99,12 +99,12 @@ class MarshallerTest extends TestCase
 {
 
     public $fixtures = [
-        'core.articles',
-        'core.articles_tags',
-        'core.comments',
-        'core.special_tags',
-        'core.tags',
-        'core.users'
+        'core.Articles',
+        'core.ArticlesTags',
+        'core.Comments',
+        'core.SpecialTags',
+        'core.Tags',
+        'core.Users'
     ];
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -34,17 +34,17 @@ class QueryRegressionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles',
-        'core.tags',
-        'core.articles_tags',
-        'core.authors',
-        'core.authors_tags',
-        'core.comments',
-        'core.featured_tags',
-        'core.special_tags',
-        'core.tags_translations',
-        'core.translates',
-        'core.users'
+        'core.Articles',
+        'core.Tags',
+        'core.ArticlesTags',
+        'core.Authors',
+        'core.AuthorsTags',
+        'core.Comments',
+        'core.FeaturedTags',
+        'core.SpecialTags',
+        'core.TagsTranslations',
+        'core.Translates',
+        'core.Users'
     ];
 
     public $autoFixtures = false;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -38,13 +38,13 @@ class QueryTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles',
-        'core.articles_tags',
-        'core.authors',
-        'core.comments',
-        'core.datatypes',
-        'core.posts',
-        'core.tags'
+        'core.Articles',
+        'core.ArticlesTags',
+        'core.Authors',
+        'core.Comments',
+        'core.Datatypes',
+        'core.Posts',
+        'core.Tags'
     ];
 
     /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -28,7 +28,7 @@ use Cake\TestSuite\TestCase;
 class ResultSetTest extends TestCase
 {
 
-    public $fixtures = ['core.articles', 'core.authors', 'core.comments'];
+    public $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**
      * setup

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -31,9 +31,9 @@ class RulesCheckerIntegrationTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles', 'core.articles_tags', 'core.authors', 'core.tags',
-        'core.special_tags', 'core.categories', 'core.site_articles', 'core.site_authors',
-        'core.comments',
+        'core.Articles', 'core.ArticlesTags', 'core.Authors', 'core.Tags',
+        'core.SpecialTags', 'core.Categories', 'core.SiteArticles', 'core.SiteAuthors',
+        'core.Comments',
     ];
 
     /**

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -26,10 +26,10 @@ class SaveOptionsBuilderTest extends TestCase
 {
 
     public $fixtures = [
-        'core.articles',
-        'core.authors',
-        'core.comments',
-        'core.users',
+        'core.Articles',
+        'core.Authors',
+        'core.Comments',
+        'core.Users',
     ];
 
     /**

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -29,7 +29,7 @@ class TableRegressionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.authors',
+        'core.Authors',
     ];
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -55,18 +55,18 @@ class TableTest extends TestCase
 {
 
     public $fixtures = [
-        'core.articles',
-        'core.tags',
-        'core.articles_tags',
-        'core.authors',
-        'core.categories',
-        'core.comments',
-        'core.groups',
-        'core.groups_members',
-        'core.members',
-        'core.polymorphic_tagged',
-        'core.site_articles',
-        'core.users'
+        'core.Articles',
+        'core.Tags',
+        'core.ArticlesTags',
+        'core.Authors',
+        'core.Categories',
+        'core.Comments',
+        'core.Groups',
+        'core.GroupsMembers',
+        'core.Members',
+        'core.PolymorphicTagged',
+        'core.SiteArticles',
+        'core.Users'
     ];
 
     /**

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -31,8 +31,8 @@ class TableUuidTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.binary_uuiditems',
-        'core.uuiditems',
+        'core.BinaryUuiditems',
+        'core.Uuiditems',
     ];
 
     /**

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -32,7 +32,7 @@ class RequestActionTraitTest extends TestCase
      *
      * @var string
      */
-    public $fixtures = ['core.comments', 'core.posts', 'core.test_plugin_comments'];
+    public $fixtures = ['core.Comments', 'core.Posts', 'core.test_plugin_comments'];
 
     /**
      * Setup

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -32,7 +32,7 @@ class RequestActionTraitTest extends TestCase
      *
      * @var string
      */
-    public $fixtures = ['core.Comments', 'core.Posts', 'core.test_plugin_comments'];
+    public $fixtures = ['core.Comments', 'core.Posts', 'core.TestPluginComments'];
 
     /**
      * Setup

--- a/tests/TestCase/Shell/SchemaCacheShellTest.php
+++ b/tests/TestCase/Shell/SchemaCacheShellTest.php
@@ -31,7 +31,7 @@ class SchemaCacheShellTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.tags'];
+    public $fixtures = ['core.Articles', 'core.Tags'];
 
     /**
      * setup method

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -215,7 +215,7 @@ class FixtureManagerTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['plugin.TestPlugin.blog/comments'];
+        $test->fixtures = ['plugin.TestPlugin.Blog/Comments'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
         $this->assertCount(1, $fixtures);

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -56,12 +56,12 @@ class FixtureManagerTest extends TestCase
     public function testFixturizeCore()
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.articles'];
+        $test->fixtures = ['core.Articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
         $this->assertCount(1, $fixtures);
-        $this->assertArrayHasKey('core.articles', $fixtures);
-        $this->assertInstanceOf('Cake\Test\Fixture\ArticlesFixture', $fixtures['core.articles']);
+        $this->assertArrayHasKey('core.Articles', $fixtures);
+        $this->assertInstanceOf('Cake\Test\Fixture\ArticlesFixture', $fixtures['core.Articles']);
     }
 
     /**
@@ -83,7 +83,7 @@ class FixtureManagerTest extends TestCase
         ]);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.articles'];
+        $test->fixtures = ['core.Articles'];
         $this->manager->fixturize($test);
         // Need to load/shutdown twice to ensure fixture is created.
         $this->manager->load($test);
@@ -125,7 +125,7 @@ class FixtureManagerTest extends TestCase
         }
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.articles'];
+        $test->fixtures = ['core.Articles'];
         $this->manager->fixturize($test);
         $this->manager->load($test);
 
@@ -141,7 +141,7 @@ class FixtureManagerTest extends TestCase
     public function testFixturizeCoreConstraint()
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.articles', 'core.articles_tags', 'core.tags'];
+        $test->fixtures = ['core.Articles', 'core.ArticlesTags', 'core.Tags'];
         $this->manager->fixturize($test);
         $this->manager->load($test);
 
@@ -194,14 +194,14 @@ class FixtureManagerTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['plugin.test_plugin.articles'];
+        $test->fixtures = ['plugin.TestPlugin.Articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
         $this->assertCount(1, $fixtures);
-        $this->assertArrayHasKey('plugin.test_plugin.articles', $fixtures);
+        $this->assertArrayHasKey('plugin.TestPlugin.Articles', $fixtures);
         $this->assertInstanceOf(
             'TestPlugin\Test\Fixture\ArticlesFixture',
-            $fixtures['plugin.test_plugin.articles']
+            $fixtures['plugin.TestPlugin.Articles']
         );
     }
 
@@ -215,14 +215,14 @@ class FixtureManagerTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['plugin.test_plugin.blog/comments'];
+        $test->fixtures = ['plugin.TestPlugin.blog/comments'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
         $this->assertCount(1, $fixtures);
-        $this->assertArrayHasKey('plugin.test_plugin.blog/comments', $fixtures);
+        $this->assertArrayHasKey('plugin.TestPlugin.Blog/Comments', $fixtures);
         $this->assertInstanceOf(
             'TestPlugin\Test\Fixture\Blog\CommentsFixture',
-            $fixtures['plugin.test_plugin.blog/comments']
+            $fixtures['plugin.TestPlugin.Blog/Comments']
         );
     }
 
@@ -234,14 +234,14 @@ class FixtureManagerTest extends TestCase
     public function testFixturizeVendorPlugin()
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['plugin.Company/TestPluginThree.articles'];
+        $test->fixtures = ['plugin.Company/TestPluginThree.Articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
         $this->assertCount(1, $fixtures);
-        $this->assertArrayHasKey('plugin.Company/TestPluginThree.articles', $fixtures);
+        $this->assertArrayHasKey('plugin.Company/TestPluginThree.Articles', $fixtures);
         $this->assertInstanceOf(
             'Company\TestPluginThree\Test\Fixture\ArticlesFixture',
-            $fixtures['plugin.Company/TestPluginThree.articles']
+            $fixtures['plugin.Company/TestPluginThree.Articles']
         );
     }
 
@@ -271,9 +271,9 @@ class FixtureManagerTest extends TestCase
     public function testFixturizeInvalidType()
     {
         $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Referenced fixture class "Test\Fixture\Derp.derpFixture" not found. Fixture "derp.derp" was referenced');
+        $this->expectExceptionMessage('Referenced fixture class "Test\Fixture\Derp.DerpFixture" not found. Fixture "Derp.Derp" was referenced');
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['derp.derp'];
+        $test->fixtures = ['Derp.Derp'];
         $this->manager->fixturize($test);
     }
 
@@ -321,7 +321,7 @@ class FixtureManagerTest extends TestCase
         ConnectionManager::alias('test_other', 'other');
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.other_articles'];
+        $test->fixtures = ['core.OtherArticles'];
         $this->manager->fixturize($test);
         $this->manager->load($test);
 
@@ -338,7 +338,7 @@ class FixtureManagerTest extends TestCase
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->autoFixtures = false;
-        $test->fixtures = ['core.articles', 'core.articles_tags', 'core.tags'];
+        $test->fixtures = ['core.Articles', 'core.ArticlesTags', 'core.Tags'];
         $this->manager->fixturize($test);
         $this->manager->loadSingle('Articles');
         $this->manager->loadSingle('Tags');
@@ -398,7 +398,7 @@ class FixtureManagerTest extends TestCase
     public function testExceptionOnLoad()
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
-        $test->fixtures = ['core.products'];
+        $test->fixtures = ['core.Products'];
 
         $manager = $this->getMockBuilder(FixtureManager::class)
             ->setMethods(['_runOperation'])
@@ -440,7 +440,7 @@ class FixtureManagerTest extends TestCase
             }));
 
         $fixtures = [
-            'core.products' => $fixture,
+            'core.Products' => $fixture,
         ];
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -150,7 +150,7 @@ class TestFixtureTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.posts'];
+    public $fixtures = ['core.Posts'];
 
     /**
      * Set up

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -39,7 +39,7 @@ class XmlTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.articles', 'core.users'
+        'core.Articles', 'core.Users'
     ];
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -53,7 +53,7 @@ class EntityContextTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.comments', 'core.articles_tags', 'core.tags'];
+    public $fixtures = ['core.Articles', 'core.Comments', 'core.ArticlesTags', 'core.Tags'];
 
     /**
      * setup method.

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -119,7 +119,7 @@ class FormHelperTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.comments'];
+    public $fixtures = ['core.Articles', 'core.Comments'];
 
     /**
      * Do not load the fixtures by default

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -277,7 +277,7 @@ class ViewTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.posts', 'core.users'];
+    public $fixtures = ['core.Posts', 'core.Users'];
 
     /**
      * @var \Cake\View\View


### PR DESCRIPTION
This will allow us to drop the implicit inflection to CameCased names in fixture manager.