### PR TITLE
Allow instance of HttpApplicationInterface in RoutingMiddleware

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -15,8 +15,8 @@
 namespace Cake\Routing\Middleware;
 
 use Cake\Cache\Cache;
+use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
-use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
 use Cake\Routing\Exception\RedirectException;
@@ -39,7 +39,7 @@ class RoutingMiddleware
     /**
      * The application that will have its routing hook invoked.
      *
-     * @var \Cake\Http\BaseApplication
+     * @var \Cake\Core\HttpApplicationInterface
      */
     protected $app;
 
@@ -54,10 +54,10 @@ class RoutingMiddleware
     /**
      * Constructor
      *
-     * @param \Cake\Http\BaseApplication $app The application instance that routes are defined on.
+     * @param \Cake\Core\HttpApplicationInterface $app The application instance that routes are defined on.
      * @param string|null $cacheConfig The cache config name to use or null to disable routes cache
      */
-    public function __construct(BaseApplication $app = null, $cacheConfig = null)
+    public function __construct(HttpApplicationInterface $app = null, $cacheConfig = null)
     {
         $this->app = $app;
         $this->cacheConfig = $cacheConfig;

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -54,7 +54,7 @@ class RoutingMiddleware
     /**
      * Constructor
      *
-     * @param \Cake\Core\HttpApplicationInterface $app The application instance that routes are defined on.
+     * @param \Cake\Core\HttpApplicationInterface|null $app The application instance that routes are defined on.
      * @param string|null $cacheConfig The cache config name to use or null to disable routes cache
      */
     public function __construct(HttpApplicationInterface $app = null, $cacheConfig = null)


### PR DESCRIPTION
Allow instance of HttpApplicationInterface in RoutingMiddleware.

The RoutingMiddleware only needs `routes()` and checks before executing `pluginRoutes()` if `$this->app` is an instance of `PluginApplicationInterface`.