### PR TITLE
Switch from master/slave in datasource readme

### DIFF
--- a/src/Datasource/README.md
+++ b/src/Datasource/README.md
@@ -44,13 +44,13 @@ easy:
 ```php
 use Cake\Datasource\ConnectionManager;
 
-ConnectionManager::config('master', [
+ConnectionManager::config('connection-one', [
     'className' => 'MyApp\Connections\CustomConnection',
     'param1' => 'value',
     'param2' => 'another value'
 ]);
 
-ConnectionManager::config('slave', [
+ConnectionManager::config('connection-two', [
     'className' => 'MyApp\Connections\CustomConnection',
     'param1' => 'different value',
     'param2' => 'another value'


### PR DESCRIPTION
This also makes it slightly clearer that connections are arbitrarily named.