### PR TITLE
3.next - Start using pool() internally in Cache

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Core">
- <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml"/>
+ <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml">
+    <!-- Exclude unwanted sniffs -->
+    <exclude name="Generic.Commenting.Todo.TaskFound"/> <!-- Excluded during 3.next development -->
+ </rule>
 
  <!-- Necessary for class aliases used for backwards compat -->
  <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -284,19 +284,19 @@ class Cache
      */
     public static function write($key, $value, $config = 'default')
     {
-        $engine = static::engine($config);
         if (is_resource($value)) {
             return false;
         }
 
-        $success = $engine->write($key, $value);
+        $backend = static::pool($config);
+        $success = $backend->set($key, $value);
         if ($success === false && $value !== '') {
             trigger_error(
                 sprintf(
                     "%s cache was unable to write '%s' to %s cache",
                     $config,
                     $key,
-                    get_class($engine)
+                    get_class($backend)
                 ),
                 E_USER_WARNING
             );
@@ -329,8 +329,8 @@ class Cache
      */
     public static function writeMany($data, $config = 'default')
     {
-        $engine = static::engine($config);
-        $return = $engine->writeMany($data);
+        $backend = static::pool($config);
+        $return = $backend->setMultiple($data);
         foreach ($return as $key => $success) {
             if ($success === false && $data[$key] !== '') {
                 throw new RuntimeException(sprintf(
@@ -368,6 +368,7 @@ class Cache
      */
     public static function read($key, $config = 'default')
     {
+        // In 4.x this needs to change to use pool()
         $engine = static::engine($config);
 
         return $engine->read($key);
@@ -397,6 +398,7 @@ class Cache
      */
     public static function readMany($keys, $config = 'default')
     {
+        // In 4.x this needs to change to use pool()
         $engine = static::engine($config);
 
         return $engine->readMany($keys);
@@ -463,9 +465,9 @@ class Cache
      */
     public static function delete($key, $config = 'default')
     {
-        $engine = static::engine($config);
+        $backend = static::pool($config);
 
-        return $engine->delete($key);
+        return $backend->delete($key);
     }
 
     /**
@@ -492,9 +494,9 @@ class Cache
      */
     public static function deleteMany($keys, $config = 'default')
     {
-        $engine = static::engine($config);
+        $backend = static::pool($config);
 
-        return $engine->deleteMany($keys);
+        return $backend->deleteMultiple($keys);
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -368,7 +368,7 @@ class Cache
      */
     public static function read($key, $config = 'default')
     {
-        // In 4.x this needs to change to use pool()
+        // TODO In 4.x this needs to change to use pool()
         $engine = static::engine($config);
 
         return $engine->read($key);

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -337,7 +337,7 @@ class Cache
                     '%s cache was unable to write \'%s\' to %s cache',
                     $config,
                     $key,
-                    get_class($engine)
+                    get_class($backend)
                 ));
             }
         }

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -17,7 +17,7 @@ namespace Cake\Cache\Engine;
 use Cake\Cache\CacheEngine;
 
 /**
- * Null cache engine, all operations return false.
+ * Null cache engine, all operations appear to work, but do nothing.
  *
  * This is used internally for when Cache::disable() has been called.
  */
@@ -44,6 +44,7 @@ class NullEngine extends CacheEngine
      */
     public function write($key, $value)
     {
+        return true;
     }
 
     /**
@@ -51,6 +52,7 @@ class NullEngine extends CacheEngine
      */
     public function writeMany($data)
     {
+        return true;
     }
 
     /**
@@ -74,6 +76,7 @@ class NullEngine extends CacheEngine
      */
     public function increment($key, $offset = 1)
     {
+        return true;
     }
 
     /**
@@ -81,6 +84,7 @@ class NullEngine extends CacheEngine
      */
     public function decrement($key, $offset = 1)
     {
+        return true;
     }
 
     /**
@@ -88,6 +92,7 @@ class NullEngine extends CacheEngine
      */
     public function delete($key)
     {
+        return true;
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -18,6 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\NullEngine;
+use Cake\Cache\InvalidArgumentException as CacheInvalidArgumentException;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -236,9 +237,9 @@ class CacheTest extends TestCase
         Cache::disable();
         $this->_configCache();
 
-        $this->assertNull(Cache::write('no_save', 'Noooo!', 'tests'));
+        $this->assertTrue(Cache::write('no_save', 'Noooo!', 'tests'));
         $this->assertFalse(Cache::read('no_save', 'tests'));
-        $this->assertNull(Cache::delete('no_save', 'tests'));
+        $this->assertTrue(Cache::delete('no_save', 'tests'));
     }
 
     /**
@@ -324,7 +325,7 @@ class CacheTest extends TestCase
      */
     public function testWriteNonExistingConfig()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->assertFalse(Cache::write('key', 'value', 'totally fake'));
     }
 
@@ -335,7 +336,7 @@ class CacheTest extends TestCase
      */
     public function testIncrementNonExistingConfig()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->assertFalse(Cache::increment('key', 1, 'totally fake'));
     }
 
@@ -642,8 +643,8 @@ class CacheTest extends TestCase
      */
     public function testWriteEmptyKey()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('An empty value is not valid as a cache key');
+        $this->expectException(CacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('A cache key must be a non-empty string');
         $this->_configCache();
         Cache::write(null, 'not null', 'tests');
     }
@@ -740,7 +741,7 @@ class CacheTest extends TestCase
 
         Cache::disable();
 
-        $this->assertNull(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
+        $this->assertTrue(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
         $this->assertFalse(Cache::read('key_2', 'test_cache_disable_1'));
 
         Cache::enable();
@@ -755,7 +756,7 @@ class CacheTest extends TestCase
             'path' => TMP . 'tests'
         ]);
 
-        $this->assertNull(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
+        $this->assertTrue(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
         $this->assertFalse(Cache::read('key_4', 'test_cache_disable_2'));
 
         Cache::enable();
@@ -764,7 +765,7 @@ class CacheTest extends TestCase
         $this->assertSame(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
 
         Cache::disable();
-        $this->assertNull(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
+        $this->assertTrue(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
         $this->assertFalse(Cache::read('key_6', 'test_cache_disable_2'));
 
         Cache::enable();

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -12,7 +12,7 @@
  * @since         3.6.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\ORM;
+namespace Cake\Test\TestCase\Database;
 
 use Cake\Cache\Cache;
 use Cake\Cache\CacheEngine;
@@ -114,6 +114,8 @@ class SchemaCacheTest extends TestCase
     public function testBuildNoArgs()
     {
         $ds = ConnectionManager::get('test');
+        $this->cache->method('write')
+            ->will($this->returnValue(true));
         $this->cache->expects($this->at(3))
             ->method('write')
             ->with('test_articles');
@@ -133,7 +135,9 @@ class SchemaCacheTest extends TestCase
 
         $this->cache->expects($this->once())
             ->method('write')
-            ->with('test_articles');
+            ->with('test_articles')
+            ->will($this->returnValue(true));
+
         $this->cache->expects($this->never())
             ->method('delete');
 
@@ -152,7 +156,8 @@ class SchemaCacheTest extends TestCase
 
         $this->cache->expects($this->once())
             ->method('write')
-            ->with('test_articles');
+            ->with('test_articles')
+            ->will($this->returnValue(true));
         $this->cache->expects($this->never())
             ->method('read');
         $this->cache->expects($this->never())

--- a/tests/TestCase/Shell/SchemaCacheShellTest.php
+++ b/tests/TestCase/Shell/SchemaCacheShellTest.php
@@ -105,6 +105,9 @@ class SchemaCacheShellTest extends TestCase
      */
     public function testBuildNoArgs()
     {
+        $this->cache->expects($this->any())
+            ->method('write')
+            ->will($this->returnValue(true));
         $this->cache->expects($this->at(3))
             ->method('write')
             ->with('test_articles');
@@ -122,7 +125,8 @@ class SchemaCacheShellTest extends TestCase
     {
         $this->cache->expects($this->once())
             ->method('write')
-            ->with('test_articles');
+            ->with('test_articles')
+            ->will($this->returnValue(true));
         $this->cache->expects($this->never())
             ->method('delete');
 
@@ -139,7 +143,8 @@ class SchemaCacheShellTest extends TestCase
     {
         $this->cache->expects($this->once())
             ->method('write')
-            ->with('test_articles');
+            ->with('test_articles')
+            ->will($this->returnValue(true));
         $this->cache->expects($this->never())
             ->method('read');
         $this->cache->expects($this->never())
@@ -182,7 +187,8 @@ class SchemaCacheShellTest extends TestCase
     {
         $this->cache->expects($this->at(3))
             ->method('delete')
-            ->with('test_articles');
+            ->with('test_articles')
+            ->will($this->returnValue(true));
 
         $this->shell->params['connection'] = 'test';
         $this->shell->clear();

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -426,7 +426,8 @@ class CellTest extends TestCase
             ->will($this->returnValue(false));
         $mock->expects($this->once())
             ->method('write')
-            ->with('cell_test_app_view_cell_articles_cell_display_default', "dummy\n");
+            ->with('cell_test_app_view_cell_articles_cell_display_default', "dummy\n")
+            ->will($this->returnValue(true));
         Cache::setConfig('default', $mock);
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
@@ -471,7 +472,8 @@ class CellTest extends TestCase
             ->will($this->returnValue(false));
         $mock->expects($this->once())
             ->method('write')
-            ->with('my_key', "dummy\n");
+            ->with('my_key', "dummy\n")
+            ->will($this->returnValue(true));
         Cache::setConfig('cell', $mock);
 
         $cell = $this->View->cell('Articles', [], [
@@ -496,7 +498,8 @@ class CellTest extends TestCase
             ->will($this->returnValue(false));
         $mock->expects($this->once())
             ->method('write')
-            ->with('cell_test_app_view_cell_articles_cell_customTemplate_default', "<h1>This is the alternate template</h1>\n");
+            ->with('cell_test_app_view_cell_articles_cell_customTemplate_default', "<h1>This is the alternate template</h1>\n")
+            ->will($this->returnValue(true));
         Cache::setConfig('default', $mock);
 
         $this->deprecated(function () {


### PR DESCRIPTION
Start adopting the new pool() method and PSR16 interface internally. There are a number of current day `Cache` methods that don't fit inside the PSR16 interface. I am considering adding our own interface that encompasses these methods as static tools will complain about
`pool()->increment()` in the future.

The methods that would be needed in this expanded interface are:

- increment
- decrement
- add
- clearGroup