### PR TITLE
[RFC] Make RouteBuilder::redirect() return route instances

### DIFF
--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -108,4 +108,17 @@ class RedirectRoute extends Route
     {
         return false;
     }
+
+    /**
+     * Sets the HTTP status
+     *
+     * @param int $status The status code for this route
+     * @return $this
+     */
+    public function setStatus($status)
+    {
+        $this->options['status'] = $status;
+
+        return $this;
+    }
 }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -866,7 +866,7 @@ class RouteBuilder
      * @param array $options An array matching the named elements in the route to regular expressions which that
      *   element should match. Also contains additional parameters such as which routed parameters should be
      *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
-     * @return void
+     * @return \Cake\Routing\Route\Route|\Cake\Routing\Route\RedirectRoute
      */
     public function redirect($route, $url, array $options = [])
     {
@@ -876,7 +876,8 @@ class RouteBuilder
         if (is_string($url)) {
             $url = ['redirect' => $url];
         }
-        $this->connect($route, $url, $options);
+
+        return $this->connect($route, $url, $options);
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -236,4 +236,17 @@ class RedirectRouteTest extends TestCase
         $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }
+
+    /**
+     * Test setting HTTP status
+     *
+     * @return void
+     */
+    public function testSetStatus()
+    {
+        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $result = $route->setStatus(302);
+        $this->assertSame($result, $route, 'Should return this');
+        $this->assertEquals(302, $route->options['status']);
+    }
 }

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -246,7 +246,7 @@ class RedirectRouteTest extends TestCase
     {
         $route = new RedirectRoute('/home', ['controller' => 'posts']);
         $result = $route->setStatus(302);
-        $this->assertSame($result, $route, 'Should return this');
+        $this->assertSame($result, $route);
         $this->assertEquals(302, $route->options['status']);
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -428,6 +428,10 @@ class RouteBuilderTest extends TestCase
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
         $this->assertEquals('/forums', $route->redirect[0]);
+
+        $route = $routes->redirect('/old', '/forums');
+        $this->assertInstanceOf(RedirectRoute::class, $route);
+        $this->assertSame($route, $this->collection->routes()[2]);
     }
 
     /**


### PR DESCRIPTION
Following #10738, I think it's handy to make the redirect also fluent so we can do something like this:
`$routes->redirect('/old', '/forums')->setStatus(302)`

The only thing is that `setPersist` in `Route` only accepts an array, but in `redirect` a boolean is also accepted. Don't know what the best way to solve this? One way is to change the function in `Route` to also accepts `boolean`.