### PR TITLE
Make reverse routes match `[_method => GET]` by default.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -769,7 +769,7 @@ class Route
             $url['_method'] = $url['[method]'];
         }
         if (empty($url['_method'])) {
-            return false;
+            $url['_method'] = 'GET';
         }
         $methods = array_map('strtoupper', (array)$url['_method']);
         foreach ($methods as $value) {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1070,6 +1070,24 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Test that match() matches explicit GET routes
+     *
+     * @return void
+     */
+    public function testMatchWithExplicitGet()
+    {
+        $route = new Route(
+            '/anything',
+            ['controller' => 'Articles', 'action' => 'foo', '_method' => 'GET']
+        );
+        $result = $route->match([
+            'controller' => 'Articles',
+            'action' => 'foo'
+        ]);
+        $this->assertEquals("/anything", $result);
+    }
+
+    /**
      * Test separartor.
      *
      * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -609,7 +609,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
      */
     public function testArrayUrls()
     {
-        $this->post(['controller' => 'Posts', 'action' => 'index']);
+        $this->post(['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
         $this->assertEquals('value', $this->viewVariable('test'));
     }
 
@@ -932,10 +932,10 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     public function testAssertRedirect()
     {
         $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Location', 'http://localhost/tasks/index');
+        $this->_response = $this->_response->withHeader('Location', 'http://localhost/get/tasks/index');
 
         $this->assertRedirect();
-        $this->assertRedirect('/tasks/index');
+        $this->assertRedirect('/get/tasks/index');
         $this->assertRedirect(['controller' => 'Tasks', 'action' => 'index']);
 
         $this->assertResponseEmpty();


### PR DESCRIPTION
As discussed in #11467 ([comment thread starts here](https://github.com/cakephp/cakephp/issues/11467#issuecomment-423275388)), this PR adjusts reverse routing to match by default routes that explicitly declare `[_method => GET]`. This is best illustrated with an example:

```php
// Create a route that explicitly only accepts GET.
$routes->get('/something', ['controller' => 'Foo', 'action' => 'bar']);

// Before this PR, not explicitly specifying `[_method => GET]` would fail with,
// `Error: A route matching "array ( 'controller' => 'Foo', 'action' => 'bar', 'plugin' => NULL, '_ext' => NULL, )" could not be found.`
Router::url(['controller' => 'Foo', 'action' => 'bar']);

// Providing an explicit `_method` succeeds both before and after the PR:
Router::url(['controller' => 'Foo', 'action' => 'bar', '_method' => 'GET']);
```
