### PR TITLE
Check disable_functions before set_time_limit

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2708,7 +2708,7 @@ class Response implements ResponseInterface
         }
 
         $bufferSize = 8192;
-        if (strpos(ini_get('disable_functions'),'set_time_limit') === false) {
+        if (strpos(ini_get('disable_functions'), 'set_time_limit') === false) {
             set_time_limit(0);
         }
         session_write_close();

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2708,7 +2708,7 @@ class Response implements ResponseInterface
         }
 
         $bufferSize = 8192;
-        if (array_search('set_time_limit', explode(',', ini_get('disable_functions'))) === false) {
+        if (strpos(ini_get('disable_functions'),'set_time_limit') === false) {
             set_time_limit(0);
         }
         session_write_close();

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2708,7 +2708,9 @@ class Response implements ResponseInterface
         }
 
         $bufferSize = 8192;
-        set_time_limit(0);
+        if (array_search('set_time_limit', explode(',', ini_get('disable_functions'))) === false) {
+            set_time_limit(0);
+        }
         session_write_close();
         while (!feof($file->handle)) {
             if (!$this->_isActive()) {


### PR DESCRIPTION
On many shared hosting providers you probably can't use of `set_time_limit()`. 

When you now try to Response with a File you probably don't see anything in case of display_errors=1 and Configure::write('debug') > 0.

File Response breaks with trying to display the warning message: `set_time_limit() has been disabled for security reasons`. The implementation is based on some other frameworks to avoid this behaviour and checks first, that you can safely use this function.