### PR TITLE
Small tidy up on MySQL binary column type generation

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -359,13 +359,9 @@ class MysqlSchema extends BaseSchema
                     break;
                 case TableSchema::TYPE_BINARY:
                     $isKnownLength = in_array($data['length'], TableSchema::$columnLengths);
-
-                    if (!empty($data['length']) && !$isKnownLength) {
-                        if ($data['length'] > 2) {
-                            $out .= ' VARBINARY(' . $data['length'] . ')';
-                        } else {
-                            $out .= ' BINARY(' . $data['length'] . ')';
-                        }
+                    if ($isKnownLength) {
+                        $length = array_search($data['length'], TableSchema::$columnLengths);
+                        $out .= ' ' . strtoupper($length) . 'BLOB';
                         break;
                     }
 
@@ -374,11 +370,11 @@ class MysqlSchema extends BaseSchema
                         break;
                     }
 
-                    if ($isKnownLength) {
-                        $length = array_search($data['length'], TableSchema::$columnLengths);
-                        $out .= ' ' . strtoupper($length) . 'BLOB';
+                    if ($data['length'] > 2) {
+                        $out .= ' VARBINARY(' . $data['length'] . ')';
+                    } else {
+                        $out .= ' BINARY(' . $data['length'] . ')';
                     }
-
                     break;
             }
         }


### PR DESCRIPTION
I've refactored the changes from #12552 to reduce nesting and complexity. I felt the original schema generation change was safe for 3.6 as it should generally only effect test suite schema generation.
