### PR TITLE
Deprecate RequestHandler's wrapper methods.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -49,7 +49,7 @@ class RequestHandlerComponent extends Component
     /**
      * Contains the file extension parsed out by the Router
      *
-     * Deprecated 3.7.0: This property will be made protected in 4.0.0
+     * Deprecated as of 3.7.0. This property will be made protected in 4.0.0.
      *
      * @var string|null
      * @see \Cake\Routing\Router::extensions()

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -49,6 +49,8 @@ class RequestHandlerComponent extends Component
     /**
      * Contains the file extension parsed out by the Router
      *
+     * Deprecated 3.7.0: This property will be made protected in 4.0.0
+     *
      * @var string|null
      * @see \Cake\Routing\Router::extensions()
      */
@@ -354,9 +356,14 @@ class RequestHandlerComponent extends Component
      * Returns true if the current call accepts an XML response, false otherwise
      *
      * @return bool True if client accepts an XML response
+     * @deprecated 3.7.0 Use RequestHandler::prefers('xml') instead.
      */
     public function isXml()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::isXml() is deprecated. Use RequestHandlerComponent::prefers(\'xml\') instead.'
+        );
+
         return $this->prefers('xml');
     }
 
@@ -364,19 +371,29 @@ class RequestHandlerComponent extends Component
      * Returns true if the current call accepts an RSS response, false otherwise
      *
      * @return bool True if client accepts an RSS response
+     * @deprecated 3.7.0 Use RequestHandler::prefers('rss') instead.
      */
     public function isRss()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::isRss() is deprecated. Use RequestHandlerComponent::prefers(\'rss\') instead.'
+        );
+
         return $this->prefers('rss');
     }
 
     /**
      * Returns true if the current call accepts an Atom response, false otherwise
      *
-     * @return bool True if client accepts an RSS response
+     * @return bool True if client accepts an Atom response
+     * @deprecated 3.7.0 Use RequestHandler::prefers('atom') instead.
      */
     public function isAtom()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::isRss() is deprecated. Use RequestHandlerComponent::prefers(\'atom\') instead.'
+        );
+
         return $this->prefers('atom');
     }
 
@@ -385,9 +402,14 @@ class RequestHandlerComponent extends Component
      * client accepts WAP content.
      *
      * @return bool True if user agent is a mobile web browser
+     * @deprecated 3.7.0 Use ServerRequest::is('mobile') instead.
      */
     public function isMobile()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::isMobile() is deprecated. Use ServerRequest::is(\'mobile\') instead.'
+        );
+
         $request = $this->getController()->getRequest();
 
         return $request->is('mobile') || $this->accepts('wap');
@@ -397,9 +419,14 @@ class RequestHandlerComponent extends Component
      * Returns true if the client accepts WAP content
      *
      * @return bool
+     * @deprecated 3.7.0 Use RequestHandler::prefers('wap') instead.
      */
     public function isWap()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::isWap() is deprecated. Use RequestHandlerComponent::prefers(\'wap\') instead.'
+        );
+
         return $this->prefers('wap');
     }
 
@@ -679,9 +706,14 @@ class RequestHandlerComponent extends Component
      *
      * @return mixed A string content type alias, or raw content type if no alias map exists,
      *  otherwise null
+     * @deprecated 3.7.0 Use $response->mapType($response->getType()) instead.
      */
     public function responseType()
     {
+        deprecationWarning(
+            'RequestHandlerComponent::responseType() is deprecated. Use $response->mapType($response->getType()) instead.'
+        );
+
         $response = $this->getController()->response;
 
         return $response->mapType($response->getType());

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -391,7 +391,7 @@ class RequestHandlerComponent extends Component
     public function isAtom()
     {
         deprecationWarning(
-            'RequestHandlerComponent::isRss() is deprecated. Use RequestHandlerComponent::prefers(\'atom\') instead.'
+            'RequestHandlerComponent::isAtom() is deprecated. Use RequestHandlerComponent::prefers(\'atom\') instead.'
         );
 
         return $this->prefers('atom');

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -970,30 +970,40 @@ XML;
             'Accept',
             'text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*'
         );
-        $this->assertTrue($this->RequestHandler->isXml());
-        $this->assertFalse($this->RequestHandler->isAtom());
-        $this->assertFalse($this->RequestHandler->isRSS());
+        $this->deprecated(function () {
+            $this->assertTrue($this->RequestHandler->isXml());
+            $this->assertFalse($this->RequestHandler->isAtom());
+            $this->assertFalse($this->RequestHandler->isRSS());
+        });
 
         $this->Controller->request = $this->request->withHeader(
             'Accept',
             'application/atom+xml,text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*'
         );
-        $this->assertTrue($this->RequestHandler->isAtom());
-        $this->assertFalse($this->RequestHandler->isRSS());
+        $this->deprecated(function () {
+            $this->assertTrue($this->RequestHandler->isAtom());
+            $this->assertFalse($this->RequestHandler->isRSS());
+        });
 
         $this->Controller->request = $this->request->withHeader(
             'Accept',
             'application/rss+xml,text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*'
         );
-        $this->assertFalse($this->RequestHandler->isAtom());
-        $this->assertTrue($this->RequestHandler->isRSS());
+        $this->deprecated(function () {
+            $this->assertFalse($this->RequestHandler->isAtom());
+            $this->assertTrue($this->RequestHandler->isRSS());
+        });
 
-        $this->assertFalse($this->RequestHandler->isWap());
+        $this->deprecated(function () {
+            $this->assertFalse($this->RequestHandler->isWap());
+        });
         $this->Controller->request = $this->request->withHeader(
             'Accept',
             'text/vnd.wap.wml,text/html,text/plain,image/png,*/*'
         );
-        $this->assertTrue($this->RequestHandler->isWap());
+        $this->deprecated(function () {
+            $this->assertTrue($this->RequestHandler->isWap());
+        });
     }
 
     /**
@@ -1003,9 +1013,11 @@ XML;
      */
     public function testResponseContentType()
     {
-        $this->assertEquals('html', $this->RequestHandler->responseType());
-        $this->assertTrue($this->RequestHandler->respondAs('atom'));
-        $this->assertEquals('atom', $this->RequestHandler->responseType());
+        $this->deprecated(function () {
+            $this->assertEquals('html', $this->RequestHandler->responseType());
+            $this->assertTrue($this->RequestHandler->respondAs('atom'));
+            $this->assertEquals('atom', $this->RequestHandler->responseType());
+        });
     }
 
     /**
@@ -1023,7 +1035,9 @@ XML;
             ->will($this->returnValue(true));
 
         $this->Controller->request = $request;
-        $this->assertTrue($this->RequestHandler->isMobile());
+        $this->deprecated(function () {
+            $this->assertTrue($this->RequestHandler->isMobile());
+        });
     }
 
     /**


### PR DESCRIPTION
Also mark RequestHandler::$ext to be made protected in 4.0.
