### PR TITLE
Add alias for PHPUnit\Framework\Error\Notice

### DIFF
--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -300,11 +300,7 @@ class ControllerTest extends TestCase
         $controller->Bar = true;
         $this->assertTrue($controller->Bar);
 
-        if (class_exists(Notice::class)) {
-            $this->expectException(Notice::class);
-        } else {
-            $this->expectException(\PHPUnit_Framework_Error_Notice::class);
-        }
+        $this->expectException(Notice::class);
         $this->expectExceptionMessage(sprintf(
             'Undefined property: Controller::$Foo in %s on line %s',
             __FILE__,

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -11,6 +11,7 @@ if (class_exists('PHPUnit_Runner_Version')) {
         class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
         class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
         class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
+        class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
         class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
         class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
     }


### PR DESCRIPTION
Add missing alias for `Notice` same way as `Error`/`Deprecated`/`Warning`.

#12593 used `class_exists()` for PHPUnit 5.7/6.x compat. This adds unnecessary complexity.

It already merged to `4.x` where non-namespaced PHPUnit 5.7 classes completely not used, but it will be OK when `master` with this PR will merge again.