### PR TITLE
Fix incorrect class_exists('PHPUnit_Framework_Test')

### DIFF
--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -4,7 +4,7 @@ if (class_exists('PHPUnit_Runner_Version')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
 
-    if (!interface_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
+    if (!class_exists('PHPUnit\Runner\Version')) {
         class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
         class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
         class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -4,7 +4,7 @@ if (class_exists('PHPUnit_Runner_Version')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
 
-    if (!class_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
+    if (!interface_exists('PHPUnit_Framework_Test') && class_exists('PHPUnit_Framework_TestCase')) {
         class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
         class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
         class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');


### PR DESCRIPTION
Fixes #12603

`PHPUnit_Framework_Test` is interface, so `class_exists('PHPUnit_Framework_Test')` is always `false`.