### PR TITLE
Fix deprecationWarning message

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -780,7 +780,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     {
         deprecationWarning(
             'TableSchema::temporary() is deprecated. ' .
-            'Use TableSchema::setTemporary()/getTemporary() instead.'
+            'Use TableSchema::setTemporary()/isTemporary() instead.'
         );
         if ($temporary !== null) {
             return $this->setTemporary($temporary);


### PR DESCRIPTION
`TableSchema::temporary()` is described as separated into `(set|get)Temporary`, but `getTemporary` method is not exists.
It means `isTemporary`?