### PR TITLE
Fixes required field div classes

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1389,7 +1389,7 @@ class FormHelper extends AppHelper {
 		} elseif (is_array($div)) {
 			$divOptions = array_merge($divOptions, $div);
 		}
-		if ($this->_extractOption('required', $options) !== false &&
+		if ($this->_extractOption('required', $options) !== false ||
 			$this->_introspectModel($this->model(), 'validates', $this->field())
 		) {
 			$divOptions = $this->addClass($divOptions, 'required');


### PR DESCRIPTION
If you have a field that is manually required (`'required' => true`), but not included in the model validation, the `div` doesn't have the `required` class. This patches that.