### PR TITLE
In BelongsToMany, linking entities will set the junction table registry alias

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -825,12 +825,12 @@ class BelongsToMany extends Association
         $targetPrimaryKey = (array)$target->getPrimaryKey();
         $bindingKey = (array)$this->getBindingKey();
         $jointProperty = $this->_junctionProperty;
-        $junctionAlias = $junction->getAlias();
+        $junctionRegistryAlias = $junction->getRegistryAlias();
 
         foreach ($targetEntities as $e) {
             $joint = $e->get($jointProperty);
             if (!$joint || !($joint instanceof EntityInterface)) {
-                $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionAlias]);
+                $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionRegistryAlias]);
             }
             $sourceKeys = array_combine($foreignKey, $sourceEntity->extract($bindingKey));
             $targetKeys = array_combine($assocForeignKey, $e->extract($targetPrimaryKey));


### PR DESCRIPTION
In BelongsToMany, linking entities `source` to set junction table's `alias`, now.
But the Entity.source seems to expect set the `registryAlias`. (eg. [Table::save](https://github.com/cakephp/cakephp/blob/master/src/ORM/Table.php#L1924)

If `alias` and `registryAlias` are different, for example if you are using a plugin, writing code to resolve the Table class based on the `source` of the entity will cause problems.