### PR TITLE
Schema fixes

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -138,8 +138,8 @@ class SqlserverSchema extends BaseSchema
             return ['type' => TableSchema::TYPE_TEXT, 'length' => null];
         }
 
-        if ($col === 'image' || strpos($col, 'binary')) {
-            return ['type' => TableSchema::TYPE_BINARY, 'length' => null];
+        if ($col === 'image' || strpos($col, 'binary') !== false) {
+            return ['type' => TableSchema::TYPE_BINARY, 'length' => $length];
         }
 
         if ($col === 'uniqueidentifier') {

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -244,6 +244,27 @@ SQL;
                 null,
                 ['type' => 'text', 'length' => null]
             ],
+            [
+                'IMAGE',
+                10,
+                null,
+                null,
+                ['type' => 'binary', 'length' => 10]
+            ],
+            [
+                'BINARY',
+                20,
+                null,
+                null,
+                ['type' => 'binary', 'length' => 20]
+            ],
+            [
+                'VARBINARY',
+                30,
+                null,
+                null,
+                ['type' => 'binary', 'length' => 30]
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixed "Binary" column being detected as `string` by SqlserverSchema.
SqlserverSchema now returns lengths of binary fields.

Refs #12552 
