### PR TITLE
Fix merging of label options in MultiCheckboxWidget.

### DIFF
--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -194,17 +194,14 @@ class MultiCheckboxWidget implements WidgetInterface
         if ($checkbox['label'] === false && strpos($this->_templates->get('checkboxWrapper'), '{{input}}') === false) {
             $label = $input;
         } else {
-            $labelAttrs = [
+            $labelAttrs = is_array($checkbox['label']) ? $checkbox['label'] : [];
+            $labelAttrs += [
                 'for' => $checkbox['id'],
                 'escape' => $checkbox['escape'],
                 'text' => $checkbox['text'],
                 'templateVars' => $checkbox['templateVars'],
                 'input' => $input
             ];
-
-            if (is_array($checkbox['label'])) {
-                $labelAttrs += $checkbox['label'];
-            }
 
             if ($checkbox['checked']) {
                 $labelAttrs = $this->_templates->addClass($labelAttrs, 'selected');

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -18,6 +18,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\LabelWidget;
 use Cake\View\Widget\MultiCheckboxWidget;
+use Cake\View\Widget\NestingLabelWidget;
 
 /**
  * MultiCheckbox test case.
@@ -36,6 +37,7 @@ class MultiCheckboxWidgetTest extends TestCase
         $templates = [
             'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
             'label' => '<label{{attrs}}>{{text}}</label>',
+            'nestingLabel' => '<label{{attrs}}>{{input}}{{text}}</label>',
             'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
             'multicheckboxWrapper' => '<fieldset{{attrs}}>{{content}}</fieldset>',
             'multicheckboxTitle' => '<legend>{{text}}</legend>',
@@ -435,6 +437,42 @@ class MultiCheckboxWidgetTest extends TestCase
                 'value' => '2',
                 'id' => 'test-2',
             ]],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test rendering without input nesting inspite of using NestingLabelWidget
+     *
+     * @return void
+     */
+    public function testRenderNestingLabelWidgetWithoutInputNesting()
+    {
+        $label = new NestingLabelWidget($this->templates);
+        $input = new MultiCheckboxWidget($this->templates, $label);
+        $data = [
+            'name' => 'tags',
+            'label' => [
+                'input' => false,
+            ],
+            'options' => [
+                1 => 'CakePHP',
+            ],
+        ];
+        $result = $input->render($data, $this->context);
+
+        $expected = [
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'tags[]',
+                'value' => 1,
+                'id' => 'tags-1',
+            ]],
+            ['label' => ['for' => 'tags-1']],
+            'CakePHP',
+            '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);


### PR DESCRIPTION
This allows generating checkboxes without inputs nested inside labels.