### PR TITLE
Fix regression in integration testing

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -126,7 +126,6 @@ class MiddlewareDispatcher
         }
 
         $out = Router::url($url);
-        Router::reload();
 
         return $out;
     }


### PR DESCRIPTION
This resolves the regression introduced in 3.6.5 via
https://github.com/cakephp/cakephp/compare/3.6.4...3.6.5#diff-3d58de79d11037069356ea3dd5556605R126

Resolves ticket https://github.com/cakephp/cakephp/issues/12577

Any side effects, any other (better) solutions to fix the issue?

Proof:
- status quo, failing: https://github.com/dereuromark/cakephp-sandbox/pull/12
- with this branch, passing: https://github.com/dereuromark/cakephp-sandbox/pull/13

