### PR TITLE
Do not change session handler if session is active

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -290,7 +290,7 @@ class Session
      */
     protected function setEngine(SessionHandlerInterface $handler)
     {
-        if (!headers_sent()) {
+        if (!headers_sent() && session_status() !== \PHP_SESSION_ACTIVE) {
             session_set_save_handler($handler, false);
         }
 
@@ -535,7 +535,7 @@ class Session
             $this->start();
         }
 
-        if (!$this->_isCLI && session_status() === PHP_SESSION_ACTIVE) {
+        if (!$this->_isCLI && session_status() === \PHP_SESSION_ACTIVE) {
             session_destroy();
         }
 


### PR DESCRIPTION
If app has set session handler to `'cache'`, `'database'` or custom handler, and session is started twice (ex. uses `$this->request->getSession()->write()` and then `ServerRequestFactory::fromGlobals()` [somewhere](https://github.com/FriendsOfCake/CakePdf/blob/710a838d2550faa5fcbd7801a78fb8fb12adb598/src/Pdf/CakePdf.php#L957)), then PHP 7.2 emits notice "session_set_save_handler(): Cannot change save handler when session is active".

Do not call `session_set_save_handler()` if headers already sent or session is active
 
