### PR TITLE
4.x errorhandlermiddleware config

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -83,10 +83,7 @@ abstract class BaseErrorHandler
             if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && $this->_handled) {
                 return;
             }
-            $megabytes = Configure::read('Error.extraFatalErrorMemory');
-            if ($megabytes === null) {
-                $megabytes = 4;
-            }
+            $megabytes = $this->_options['extraFatalErrorMemory'] ?? 4;
             if ($megabytes > 0) {
                 $this->increaseMemoryLimit($megabytes * 1024);
             }

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -70,18 +70,22 @@ class ErrorHandlerMiddleware
      * Constructor
      *
      * @param string|callable|null $exceptionRenderer The renderer or class name
-     *   to use or a callable factory. If null, Configure::read('Error.exceptionRenderer')
-     *   will be used.
+     *   to use or a callable factory. If null, value of 'exceptionRenderer' key
+     *   from $config will be used with fallback to Cake\Error\ExceptionRenderer::class.
      * @param array $config Configuration options to use.
      *   will be used.
      */
     public function __construct($exceptionRenderer = null, array $config = [])
     {
+        $this->setConfig($config);
+
         if ($exceptionRenderer) {
             $this->exceptionRenderer = $exceptionRenderer;
+
+            return;
         }
 
-        $this->setConfig($config);
+        $this->exceptionRenderer = $this->getConfig('exceptionRenderer', ExceptionRenderer::class);
     }
 
     /**
@@ -150,10 +154,6 @@ class ErrorHandlerMiddleware
      */
     protected function getRenderer(Throwable $exception, ServerRequestInterface $request): ExceptionRendererInterface
     {
-        if (!$this->exceptionRenderer) {
-            $this->exceptionRenderer = $this->getConfig('exceptionRenderer') ?: ExceptionRenderer::class;
-        }
-
         if (is_string($this->exceptionRenderer)) {
             $class = App::className($this->exceptionRenderer, 'Error');
             if (!$class) {
@@ -165,6 +165,7 @@ class ErrorHandlerMiddleware
 
             return new $class($exception, $request);
         }
+
         $factory = $this->exceptionRenderer;
 
         return $factory($exception, $request);

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -72,7 +72,7 @@ class ErrorHandlerMiddleware
      * @param string|callable|null $exceptionRenderer The renderer or class name
      *   to use or a callable factory. If null, Configure::read('Error.exceptionRenderer')
      *   will be used.
-     * @param array $config Configuration options to use. If empty, `Configure::read('Error')`
+     * @param array $config Configuration options to use.
      *   will be used.
      */
     public function __construct($exceptionRenderer = null, array $config = [])
@@ -81,7 +81,6 @@ class ErrorHandlerMiddleware
             $this->exceptionRenderer = $exceptionRenderer;
         }
 
-        $config = $config ?: Configure::read('Error');
         $this->setConfig($config);
     }
 


### PR DESCRIPTION
Config should now be passed using `$config` argument instead of reading `Configure::read('Error')`.