### PR TITLE
limiting the regex to consume only words in default value in pgsql

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -251,7 +251,7 @@ class Postgres extends DboSource {
 					'default' => preg_replace(
 						"/^'(.*)'$/",
 						"$1",
-						preg_replace('/::.*/', '', $c->default)
+						preg_replace('/::[\w\s]+/', '', $c->default)
 					),
 					'length' => $length,
 				);

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -1218,4 +1218,24 @@ class PostgresTest extends CakeTestCase {
 
 		$this->assertEquals('"col1" uuid', $result);
 	}
+
+/**
+ * Test that postgres describes default columns with functions correctly.
+ *
+ * @return void
+ */
+	public function testDescribeFunctionDefault() {
+		$db = $this->Dbo;
+		$db->execute('CREATE TABLE test_function_default_describe (id integer PRIMARY KEY, year int default date_part(\'year\'::text, now()))');
+		$data = $db->describe('test_function_default_describe');
+
+		$expected = array(
+			'type' => 'integer',
+			'null' => true,
+			'default' => 'date_part(\'year\', now())',
+			'length' => null,
+		);
+		$this->assertSame($expected, $data['year']);
+		$db->execute('DROP TABLE test_function_default_describe');
+	}
 }


### PR DESCRIPTION
Patch to #12652 
