### PR TITLE
4.x internal filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,10 @@
         "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
         "cakephp/cakephp-codesniffer": "^3.0",
-        "slevomat/coding-standard": "^4.6.2",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsStream": "^1.6",
+        "phpunit/phpunit": "^7.0",
+        "slevomat/coding-standard": "^4.6.2"
     },
     "autoload": {
         "psr-4": {
@@ -99,5 +99,8 @@
         "cs-fix": "phpcbf --colors ./src ./tests",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -143,6 +143,6 @@ class CommandScanner
 
         ksort($shells);
 
-        return $shells;
+        return array_values($shells);
     }
 }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -18,8 +18,9 @@ namespace Cake\Console;
 use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\App;
+use Cake\Core\Exception\Exception;
 use Cake\Datasource\ModelAwareTrait;
-use Cake\Filesystem\File;
+use Cake\Filesystem\Filesystem;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Locator\LocatorInterface;
@@ -857,22 +858,18 @@ class Shell
             $this->out(sprintf('Creating file %s', $path));
         }
 
-        $File = new File($path, true);
-
         try {
-            if ($File->exists() && $File->writable()) {
-                $File->write($contents);
-                $this->_io->out(sprintf('<success>Wrote</success> `%s`', $path));
+            $fs = new Filesystem();
+            $fs->dumpFile($path, $contents);
 
-                return true;
-            }
-
+            $this->_io->out(sprintf('<success>Wrote</success> `%s`', $path));
+        } catch (Exception $e) {
             $this->_io->err(sprintf('<error>Could not write to `%s`</error>.', $path), 2);
 
             return false;
-        } finally {
-            $File->close();
         }
+
+        return true;
     }
 
     /**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -20,6 +20,8 @@ use SplFileInfo;
 
 /**
  * Convenience class for reading, writing and appending to files.
+ *
+ * @deprecated 4.0.0 Will be removed in 5.0.
  */
 class File
 {

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -116,7 +116,7 @@ class Filesystem
      * @param string $filename File path.
      * @param string $content Content to dump.
      * @return void
-     * @throws \Cake\Core\Exception When dumping fails.
+     * @throws \Cake\Core\Exception\Exception When dumping fails.
      */
     public function dumpFile(string $filename, string $content): void
     {
@@ -150,7 +150,7 @@ class Filesystem
      * @param string $dir Directory path.
      * @param int $mode Octal mode passed to mkdir(). Defaults to 0755.
      * @return void
-     * @throws \Cake\Core\Exception When directory creation fails.
+     * @throws \Cake\Core\Exception\Exception When directory creation fails.
      */
     public function mkdir(string $dir, int $mode = 0755): void
     {
@@ -173,7 +173,7 @@ class Filesystem
      *
      * @param string $path Directory path.
      * @return bool
-     * @throws \Cake\Core\Exception If path is not a directory.
+     * @throws \Cake\Core\Exception\Exception If path is not a directory.
      */
     public function deleteDir(string $path): bool
     {

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Filesystem;
+
+use CallbackFilterIterator;
+use FilesystemIterator;
+use RegexIterator;
+use Traversable;
+
+/**
+ * @since 4.0.0
+ * @internal
+ */
+class Filesystem
+{
+    public function find(string $path, $filter = null, ?int $flags = null): Traversable
+    {
+        if ($flags) {
+            $directory = new FilesystemIterator($path, $flags);
+        } else {
+            $directory = new FilesystemIterator($path);
+        }
+
+        if ($filter === null) {
+            return $directory;
+        }
+
+        if (is_string($filter)) {
+            return new RegexIterator($directory, $filter);
+        }
+
+        return new CallbackFilterIterator($directory, $filter);
+    }
+}

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -40,7 +40,7 @@ class Filesystem
     public const TYPE_DIR = 'dir';
 
     /**
-     * Find files (non-recursively) in given directory path.
+     * Find files / directories (non-recursively) in given directory path.
      *
      * @param string $path Directory path.
      * @param mixed $filter If string will be used as regex for filtering using
@@ -59,15 +59,11 @@ class Filesystem
             return $directory;
         }
 
-        if (is_string($filter)) {
-            return new RegexIterator($directory, $filter);
-        }
-
-        return new CallbackFilterIterator($directory, $filter);
+        return $this->filterIterator($directory, $filter);
     }
 
     /**
-     * Find files recursively in given directory path.
+     * Find files/ directories recursively in given directory path.
      *
      * @param string $path Directory path.
      * @param mixed $filter If string will be used as regex for filtering using
@@ -103,11 +99,23 @@ class Filesystem
             return $flatten;
         }
 
+        return $this->filterIterator($flatten, $filter);
+    }
+
+    /**
+     * Wrap iterator in additional filtering iterator.
+     *
+     * @param \Traversable $iterator Iterator
+     * @param mixed $filter Regex string or callback.
+     * @return \Traversable
+     */
+    protected function filterIterator(Traversable $iterator, $filter): Traversable
+    {
         if (is_string($filter)) {
-            return new RegexIterator($flatten, $filter);
+            return new RegexIterator($iterator, $filter);
         }
 
-        return new CallbackFilterIterator($flatten, $filter);
+        return new CallbackFilterIterator($iterator, $filter);
     }
 
     /**

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -32,8 +32,22 @@ use Traversable;
  */
 class Filesystem
 {
+    /**
+     * Direcotory type constant
+     *
+     * @var string
+     */
     public const TYPE_DIR = 'dir';
 
+    /**
+     * Find files (non-recursively) in given directory path.
+     *
+     * @param string $path Directory path.
+     * @param mixed $filter If string will be used as regex for filtering using
+     *   `RegexIterator`, if callable will be as callback for `CallbackFilterIterator`.
+     * @param int|null $flags Flags for FilesystemIterator::__construct();
+     * @return \Traversable
+     */
     public function find(string $path, $filter = null, ?int $flags = null): Traversable
     {
         $flags = $flags ?? FilesystemIterator::KEY_AS_PATHNAME
@@ -52,6 +66,16 @@ class Filesystem
         return new CallbackFilterIterator($directory, $filter);
     }
 
+    /**
+     * Find files recursively in given directory path.
+     *
+     * @param string $path Directory path.
+     * @param mixed $filter If string will be used as regex for filtering using
+     *   `RegexIterator`, if callable will be as callback for `CallbackFilterIterator`.
+     *   Hidden directories (starting with dot e.g. .git) are always skipped.
+     * @param int|null $flags Flags for FilesystemIterator::__construct();
+     * @return \Traversable
+     */
     public function findRecursive(string $path, $filter = null, ?int $flags = null): Traversable
     {
         $flags = $flags ?? FilesystemIterator::KEY_AS_PATHNAME
@@ -86,6 +110,14 @@ class Filesystem
         return new CallbackFilterIterator($flatten, $filter);
     }
 
+    /**
+     * Dump contents to file.
+     *
+     * @param string $filename File path.
+     * @param string $content Content to dump.
+     * @return void
+     * @throws \Cake\Core\Exception When dumping fails.
+     */
     public function dumpFile(string $filename, string $content): void
     {
         $dir = dirname($filename);
@@ -96,8 +128,10 @@ class Filesystem
         $exits = file_exists($filename);
 
         if ($this->isStream($filename)) {
+            // @codingStandardsIgnoreLine
             $success = @file_put_contents($filename, $content);
         } else {
+            // @codingStandardsIgnoreLine
             $success = @file_put_contents($filename, $content, LOCK_EX);
         }
 
@@ -110,6 +144,14 @@ class Filesystem
         }
     }
 
+    /**
+     * Create directory.
+     *
+     * @param string $dir Directory path.
+     * @param int $mode Octal mode passed to mkdir(). Defaults to 0755.
+     * @return void
+     * @throws \Cake\Core\Exception When directory creation fails.
+     */
     public function mkdir(string $dir, int $mode = 0755): void
     {
         if (is_dir($dir)) {
@@ -126,6 +168,13 @@ class Filesystem
         umask($old);
     }
 
+    /**
+     * Delete directory along with all it's contents.
+     *
+     * @param string $path Directory path.
+     * @return bool
+     * @throws \Cake\Core\Exception If path is not a directory.
+     */
     public function deleteDir(string $path): bool
     {
         if (!file_exists($path)) {
@@ -159,6 +208,13 @@ class Filesystem
         return $result;
     }
 
+    /**
+     * Copies directory with all it's contents.
+     *
+     * @param string $source Source path.
+     * @param string $destination Destination path.
+     * @return bool
+     */
     public function copyDir(string $source, string $destination): bool
     {
         $destination = (new SplFileInfo($destination))->getPathname();
@@ -188,6 +244,12 @@ class Filesystem
         return $result;
     }
 
+    /**
+     * Check whether given path is a stream path.
+     *
+     * @param string $path Path.
+     * @return bool
+     */
     public function isStream(string $path): bool
     {
         return strpos($path, '://') !== false;

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Filesystem;
 
 use Cake\Core\Exception\Exception;
@@ -33,7 +32,7 @@ use Traversable;
 class Filesystem
 {
     /**
-     * Direcotory type constant
+     * Directory type constant
      *
      * @var string
      */
@@ -133,7 +132,7 @@ class Filesystem
             $this->mkdir($dir);
         }
 
-        $exits = file_exists($filename);
+        $exists = file_exists($filename);
 
         if ($this->isStream($filename)) {
             // @codingStandardsIgnoreLine
@@ -147,7 +146,7 @@ class Filesystem
             throw new Exception(sprintf('Failed dumping content to file "%s"', $dir));
         }
 
-        if (!$exits) {
+        if (!$exists) {
             chmod($filename, 0666 & ~umask());
         }
     }
@@ -253,7 +252,7 @@ class Filesystem
     }
 
     /**
-     * Check whether given path is a stream path.
+     * Check whether the given path is a stream path.
      *
      * @param string $path Path.
      * @return bool

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -32,6 +32,8 @@ use Traversable;
  */
 class Filesystem
 {
+    public const TYPE_DIR = 'dir';
+
     public function find(string $path, $filter = null, ?int $flags = null): Traversable
     {
         $flags = $flags ?? FilesystemIterator::KEY_AS_PATHNAME
@@ -137,19 +139,14 @@ class Filesystem
 
         $result = true;
         foreach ($iterator as $fileInfo) {
-            switch ($fileInfo->getType()) {
-                case 'dir':
-                    // @codingStandardsIgnoreLine
-                    $result = $result && @rmdir($fileInfo->getPathname());
-                    break;
-                case 'link':
-                    // @codingStandardsIgnoreLine
-                    $result = $result && @unlink($fileInfo->getPathname());
-                    break;
-                default:
-                    // @codingStandardsIgnoreLine
-                    $result = $result && @unlink($fileInfo->getPathname());
+            if ($fileInfo->getType() === self::TYPE_DIR) {
+                // @codingStandardsIgnoreLine
+                $result = $result && @rmdir($fileInfo->getPathname());
+                continue;
             }
+
+            // @codingStandardsIgnoreLine
+            $result = $result && @unlink($fileInfo->getPathname());
         }
 
         // @codingStandardsIgnoreLine

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -96,9 +96,13 @@ class Filesystem
         $exits = file_exists($filename);
 
         if ($this->isStream($filename)) {
-            file_put_contents($filename, $content);
+            $success = @file_put_contents($filename, $content);
         } else {
-            file_put_contents($filename, $content, LOCK_EX);
+            $success = @file_put_contents($filename, $content, LOCK_EX);
+        }
+
+        if (!$success) {
+            throw new Exception(sprintf('Failed dumping content to file "%s"', $dir));
         }
 
         if (!$exits) {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -25,6 +25,7 @@ use RecursiveIteratorIterator;
  * Folder structure browser, lists folders and files.
  * Provides an Object interface for Common directory related tasks.
  *
+ * @deprecated 4.0.0 Will be removed in 5.0.
  * @link https://book.cakephp.org/3.0/en/core-libraries/file-folder.html#folder-api
  */
 class Folder

--- a/src/Filesystem/README.md
+++ b/src/Filesystem/README.md
@@ -1,7 +1,9 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/cakephp/filesystem.svg?style=flat-square)](https://packagist.org/packages/cakephp/filesystem)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.txt)
 
-# CakePHP Filesystem Library
+# This package is deprecated.
+
+## CakePHP Filesystem Library
 
 The Folder and File utilities are convenience classes to help you read from and write/append to files; list files within a folder and other common directory related tasks.
 

--- a/src/Shell/Task/AssetsTask.php
+++ b/src/Shell/Task/AssetsTask.php
@@ -19,7 +19,7 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\Utility\Inflector;
 
 /**
@@ -233,8 +233,8 @@ class AssetsTask extends Shell
             }
         }
 
-        $folder = new Folder($dest);
-        if ($folder->delete()) {
+        $fs = new Filesystem();
+        if ($fs->deleteDir($dest)) {
             $this->out('Deleted ' . $dest);
 
             return true;
@@ -301,8 +301,8 @@ class AssetsTask extends Shell
      */
     protected function _copyDirectory(string $source, string $destination): bool
     {
-        $folder = new Folder($source);
-        if ($folder->copy($destination)) {
+        $fs = new Filesystem();
+        if ($fs->copyDir($source, $destination)) {
             $this->out('Copied assets to directory ' . $destination);
 
             return true;

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -18,7 +18,7 @@ namespace Cake\Shell\Task;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Plugin;
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use ReflectionClass;
@@ -113,18 +113,19 @@ class CommandTask extends Shell
      */
     protected function _scanDir(string $dir): array
     {
-        $dir = new Folder($dir);
-        $contents = $dir->read(true, true);
-        if (empty($contents[1])) {
+        if (!is_dir($dir)) {
             return [];
         }
+
+        $fs = new Filesystem();
+        $files = $fs->find($dir, '/\.php$/');
+
         $shells = [];
-        foreach ($contents[1] as $file) {
-            if (substr($file, -4) !== '.php') {
-                continue;
-            }
-            $shells[] = substr($file, 0, -4);
+        foreach ($files as $file) {
+            $shells[] = $file->getBasename('.php');
         }
+
+        sort($shells);
 
         return $shells;
     }

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -21,7 +21,7 @@ use Cake\Core\App;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
 use Cake\Filesystem\File;
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\Utility\Inflector;
 
 /**
@@ -765,8 +765,10 @@ class ExtractTask extends Shell
         }
         foreach ($this->_paths as $path) {
             $path = realpath($path) . DIRECTORY_SEPARATOR;
-            $Folder = new Folder($path);
-            $files = $Folder->findRecursive('.*\.(php|ctp|thtml|inc|tpl)', true);
+            $fs = new Filesystem();
+            $files = $fs->findRecursive($path, '/\.php$/');
+            $files = array_keys(iterator_to_array($files));
+            sort($files);
             if (!empty($pattern)) {
                 $files = preg_grep($pattern, $files, PREG_GREP_INVERT);
                 $files = array_values($files);

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -20,7 +20,6 @@ use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
-use Cake\Filesystem\File;
 use Cake\Filesystem\Filesystem;
 use Cake\Utility\Inflector;
 
@@ -599,9 +598,11 @@ class ExtractTask extends Shell
             }
 
             $filename = str_replace('/', '_', $domain) . '.pot';
-            $File = new File($this->_output . $filename);
             $response = '';
-            while ($overwriteAll === false && $File->exists() && strtoupper($response) !== 'Y') {
+            while ($overwriteAll === false
+                && file_exists($this->_output . $filename)
+                && strtoupper($response) !== 'Y'
+            ) {
                 $this->out();
                 $response = $this->in(
                     sprintf('Error: %s already exists in this location. Overwrite? [Y]es, [N]o, [A]ll', $filename),
@@ -612,15 +613,14 @@ class ExtractTask extends Shell
                     $response = '';
                     while (!$response) {
                         $response = $this->in('What would you like to name this file?', null, 'new_' . $filename);
-                        $File = new File($this->_output . $response);
                         $filename = $response;
                     }
                 } elseif (strtoupper($response) === 'A') {
                     $overwriteAll = true;
                 }
             }
-            $File->write($output);
-            $File->close();
+            $fs = new Filesystem();
+            $fs->dumpFile($this->_output . $filename, $output);
         }
     }
 

--- a/src/TestSuite/TestSuite.php
+++ b/src/TestSuite/TestSuite.php
@@ -18,10 +18,8 @@ declare(strict_types=1);
 namespace Cake\TestSuite;
 
 use Cake\Filesystem\Filesystem;
-use SplFileInfo;
-
-
 use PHPUnit\Framework\TestSuite as BaseTestSuite;
+use SplFileInfo;
 
 /**
  * A class to contain test cases and run them with shared fixtures

--- a/src/TestSuite/TestSuite.php
+++ b/src/TestSuite/TestSuite.php
@@ -17,7 +17,10 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite;
 
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
+use SplFileInfo;
+
+
 use PHPUnit\Framework\TestSuite as BaseTestSuite;
 
 /**
@@ -33,13 +36,10 @@ class TestSuite extends BaseTestSuite
      */
     public function addTestDirectory(string $directory = '.'): void
     {
-        $Folder = new Folder($directory);
-        list(, $files) = $Folder->read(true, true, true);
-
-        foreach ($files as $file) {
-            if (substr($file, -4) === '.php') {
-                $this->addTestFile($file);
-            }
+        $fs = new Filesystem();
+        $files = $fs->find($directory, '/\.php$/');
+        foreach ($files as $file => $fileInfo) {
+            $this->addTestFile($file);
         }
     }
 
@@ -51,13 +51,17 @@ class TestSuite extends BaseTestSuite
      */
     public function addTestDirectoryRecursive(string $directory = '.'): void
     {
-        $Folder = new Folder($directory);
-        $files = $Folder->tree(null, true, 'files');
-
-        foreach ($files as $file) {
-            if (substr($file, -4) === '.php') {
-                $this->addTestFile($file);
+        $fs = new Filesystem();
+        $files = $fs->findRecursive($directory, function (SplFileInfo $current) {
+            $file = $current->getFilename();
+            if ($file[0] === '.' || !preg_match('/\.php$/', $file)) {
+                return false;
             }
+
+            return true;
+        });
+        foreach ($files as $file => $fileInfo) {
+            $this->addTestFile($file);
         }
     }
 }

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -21,6 +21,8 @@ use org\bovigo\vfs\vfsStream;
 
 /**
  * Filesystem class
+ *
+ * @coversDefaultClass \Cake\Filesystem\Filesystem
  */
 class FilesystemTest extends TestCase
 {

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Filesystem;
+
+use Cake\Filesystem\Filesystem;
+use Cake\TestSuite\TestCase;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Filesystem class
+ */
+class FilesystemTest extends TestCase
+{
+    protected $vfs;
+
+    protected $fs;
+
+    protected $vfsPath;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->vfs = vfsStream::setup('root');
+        $this->vfsPath = vfsStream::url('root');
+
+        $this->fs = new Filesystem();
+
+        clearstatcache();
+    }
+
+    /**
+     * @return void
+     * @covers ::mkdir
+     */
+    public function testMkdir()
+    {
+        $path = $this->vfsPath . DS . 'tests' . DS . 'first' . DS . 'second' . DS . 'third';
+        $this->fs->mkdir($path);
+        $this->assertTrue(is_dir($path));
+    }
+
+    /**
+     * @return void
+     * @covers ::dumpFile
+     */
+    public function testDumpFile()
+    {
+        $path = $this->vfsPath . DS . 'foo.txt';
+
+        $this->fs->dumpFile($path, 'bar');
+        $this->assertEquals(file_get_contents($path), 'bar');
+    }
+
+    /**
+     * @return void
+     * @covers ::copyDir
+     */
+    public function testCopyDir()
+    {
+        $return = $this->fs->copyDir(WWW_ROOT, $this->vfsPath . DS . 'dest');
+
+        $this->assertTrue($return);
+    }
+
+    /**
+     * @return void
+     * @covers ::deleteDir
+     */
+    public function testDeleteDir()
+    {
+        $structure = [
+            'Core' => [
+                'AbstractFactory' => [
+                    'test.php' => 'some text content',
+                    'other.php' => 'Some more text content',
+                    'Invalid.csv' => 'Something else',
+                ],
+                'AnEmptyFolder' => [],
+                'badlocation.php' => 'some bad content',
+            ]
+        ];
+        vfsStream::create($structure);
+
+        $return = $this->fs->deleteDir($this->vfsPath . DS . 'Core');
+
+        $this->assertTrue($return);
+    }
+}

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -94,7 +94,7 @@ class FilesystemTest extends TestCase
                 ],
                 'AnEmptyFolder' => [],
                 'badlocation.php' => 'some bad content',
-            ]
+            ],
         ];
         vfsStream::create($structure);
 


### PR DESCRIPTION
Refs #12569.

My previous PR #12650 combined with this takes care of removing all usage of `File` and `Folder` from core. I'll remove it from tests too once this approach is approved.

I have added a new internal class `Cake\Filesystem\Filesystem` with utility methods for file system operations to avoid code repetition.