### PR TITLE
Add PHP extension PDO SQLite as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",
+        "ext-pdo_sqlite": "*",
         "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
It is required to run the test suite.

I noticed this while I was playing around with a vanilla Ubuntu 18.10 for fun...