### PR TITLE
Don't break UNC file paths

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -540,12 +540,6 @@ class ConsoleIo
      */
     public function createFile($path, $contents, $forceOverwrite = false)
     {
-        $path = str_replace(
-            DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR,
-            DIRECTORY_SEPARATOR,
-            $path
-        );
-
         $this->out();
         $forceOverwrite = $forceOverwrite || $this->forceOverwrite;
 


### PR DESCRIPTION
Blindly replacing `//` causes network paths and paths with protocols to break. Relying on correct input allows the user to get what they want without the framework interfering.

Refs #12657