### PR TITLE
2.x - Don't break UNC file paths

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -764,8 +764,6 @@ class Shell extends CakeObject {
  * @link https://book.cakephp.org/2.0/en/console-and-shells.html#Shell::createFile
  */
 	public function createFile($path, $contents) {
-		$path = str_replace(DS . DS, DS, $path);
-
 		$this->out();
 
 		if (is_file($path) && empty($this->params['force']) && $this->interactive === true) {


### PR DESCRIPTION
Blindly replacing // causes network paths and paths with protocols to break. Relying on correct input allows the user to get what they want without the framework interfering.

Refs #12657