### PR TITLE
4.x avoid constants

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -22,6 +22,7 @@ use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\ConsoleOutput;
+use Cake\Core\Configure;
 use SimpleXMLElement;
 
 /**
@@ -55,7 +56,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     {
         if (!$args->getOption('xml')) {
             $io->out('<info>Current Paths:</info>', 2);
-            $io->out('* app:  ' . APP_DIR);
+            $io->out('* app:  ' . Configure::read('App.dir'));
             $io->out('* root: ' . rtrim(ROOT, DIRECTORY_SEPARATOR));
             $io->out('* core: ' . rtrim(CORE_PATH, DIRECTORY_SEPARATOR));
             $io->out('');

--- a/src/Shell/ServerShell.php
+++ b/src/Shell/ServerShell.php
@@ -118,7 +118,7 @@ class ServerShell extends Shell
         $this->out();
         $this->out(sprintf('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
         $this->hr();
-        $this->out(sprintf('App : %s', APP_DIR));
+        $this->out(sprintf('App : %s', Configure::read('App.dir')));
         $this->out(sprintf('Path: %s', APP));
         $this->out(sprintf('DocumentRoot: %s', $this->_documentRoot));
         $this->out(sprintf('Ini Path: %s', $this->_iniPath));

--- a/src/Shell/Task/AssetsTask.php
+++ b/src/Shell/Task/AssetsTask.php
@@ -17,6 +17,7 @@ namespace Cake\Shell\Task;
 
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
 use Cake\Utility\Inflector;
@@ -111,13 +112,14 @@ class AssetsTask extends Shell
             }
 
             $link = Inflector::underscore($plugin);
-            $dir = WWW_ROOT;
+            $wwwRoot = Configure::read('App.wwwRoot');
+            $dir = $wwwRoot;
             $namespaced = false;
             if (strpos($link, '/') !== false) {
                 $namespaced = true;
                 $parts = explode('/', $link);
                 $link = array_pop($parts);
-                $dir = WWW_ROOT . implode(DIRECTORY_SEPARATOR, $parts) . DIRECTORY_SEPARATOR;
+                $dir = $wwwRoot . implode(DIRECTORY_SEPARATOR, $parts) . DIRECTORY_SEPARATOR;
             }
 
             $plugins[$plugin] = [

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -223,7 +223,7 @@ class UrlHelper extends Helper
      * Configure. If Asset.timestamp is true and debug is true, or Asset.timestamp === 'force'
      * a timestamp will be added.
      *
-     * @param string $path The file path to timestamp, the path must be inside WWW_ROOT
+     * @param string $path The file path to timestamp, the path must be inside `App.wwwRoot` in Configure.
      * @param bool|string $timestamp If set will overrule the value of `Asset.timestamp` in Configure.
      * @return string Path with a timestamp added, or not.
      */
@@ -239,7 +239,7 @@ class UrlHelper extends Helper
                 '',
                 urldecode($path)
             );
-            $webrootPath = WWW_ROOT . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
+            $webrootPath = Configure::read('App.wwwRoot') . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
             if (file_exists($webrootPath)) {
                 return $path . '?' . filemtime($webrootPath);
             }


### PR DESCRIPTION
This will mainly help in tests where you can set alternate locations and prevent test cases from modifying files in `tests/test_app` folder. It becomes a pain to restore it's state if a tests fails and changes done by it are not properly cleaned up.

The `APP` constant is also used quite a lot in shells/commands but we don't have a configure value for it.