### PR TITLE
Use Locale::lookup to handle generic options as a fallback

### DIFF
--- a/src/I18n/Middleware/LocaleSelectorMiddleware.php
+++ b/src/I18n/Middleware/LocaleSelectorMiddleware.php
@@ -55,7 +55,10 @@ class LocaleSelectorMiddleware
         if (!$locale) {
             return $next($request, $response);
         }
-        if (in_array($locale, $this->locales) || $this->locales === ['*']) {
+        if ($this->locales !== ['*']) {
+            $locale = Locale::lookup($this->locales, $locale, true);
+        }
+        if ($locale || $this->locales === ['*']) {
             I18n::setLocale($locale);
         }
 

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -102,6 +102,20 @@ class LocaleSelectorMiddlewareTest extends TestCase
     }
 
     /**
+     * The default locale should change when the request locale has an accepted fallback option
+     *
+     * @return void
+     */
+    public function testInvokeLocaleAcceptedFallback()
+    {
+        $request = ServerRequestFactory::fromGlobals(['HTTP_ACCEPT_LANGUAGE' => 'es-ES;q=0.8,da;q=0.4']);
+        $response = new Response();
+        $middleware = new LocaleSelectorMiddleware(['en_CA', 'es']);
+        $middleware($request, $response, $this->next);
+        $this->assertSame('es', I18n::getLocale(), 'es is accepted');
+    }
+
+    /**
      * The default locale should change when the '*' is accepted
      *
      * @return void


### PR DESCRIPTION
Resolve issue #12648.