### PR TITLE
Replace Magic Literals in SecurityHeadersMiddleware with Class Constants from separate Classes

### DIFF
--- a/src/Http/Middleware/SecurityHeaders/ContentTypeOption.php
+++ b/src/Http/Middleware/SecurityHeaders/ContentTypeOption.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * X-Content-Type-Option Header Values
+ */
+interface ContentTypeOption
+{
+    /** @var string X-Content-Type-Option nosniff */
+    const NOSNIFF = 'nosniff';
+}

--- a/src/Http/Middleware/SecurityHeaders/DownloadOption.php
+++ b/src/Http/Middleware/SecurityHeaders/DownloadOption.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * X-Download-Option Header Values
+ */
+interface DownloadOption
+{
+    /** @var string X-Download-Option noopen */
+    const NOOPEN = 'noopen';
+}

--- a/src/Http/Middleware/SecurityHeaders/FrameOption.php
+++ b/src/Http/Middleware/SecurityHeaders/FrameOption.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * X-Frame-Option Header Values
+ */
+interface FrameOption
+{
+    /** @var string X-Frame-Option deny */
+    const DENY = 'deny';
+
+    /** @var string X-Frame-Option sameorigin */
+    const SAMEORIGIN = 'sameorigin';
+
+    /** @var string X-Frame-Option allow-from */
+    const ALLOW_FROM = 'allow-from';
+}

--- a/src/Http/Middleware/SecurityHeaders/PermittedCrossDomainPolicy.php
+++ b/src/Http/Middleware/SecurityHeaders/PermittedCrossDomainPolicy.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * X-Permitted-Cross-Domain-Policy Header Values
+ */
+interface PermittedCrossDomainPolicy
+{
+    /** @var string X-Permitted-Cross-Domain-Policy all */
+    const ALL = 'all';
+
+    /** @var string X-Permitted-Cross-Domain-Policy none */
+    const NONE = 'none';
+
+    /** @var string X-Permitted-Cross-Domain-Policy master-only */
+    const MASTER_ONLY = 'master-only';
+
+    /** @var string X-Permitted-Cross-Domain-Policy by-content-type */
+    const BY_CONTENT_TYPE = 'by-content-type';
+
+    /** @var string X-Permitted-Cross-Domain-Policy by-ftp-filename */
+    const BY_FTP_FILENAME = 'by-ftp-filename';
+}

--- a/src/Http/Middleware/SecurityHeaders/ReferrerPolicy.php
+++ b/src/Http/Middleware/SecurityHeaders/ReferrerPolicy.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * Referrer-Policy Header Values
+ */
+interface ReferrerPolicy
+{
+    /** @var string Referrer-Policy no-referrer */
+    const NO_REFERRER = 'no-referrer';
+
+    /** @var string Referrer-Policy no-referrer-when-downgrade */
+    const NO_REFERRER_WHEN_DOWNGRADE = 'no-referrer-when-downgrade';
+
+    /** @var string Referrer-Policy origin */
+    const ORIGIN = 'origin';
+
+    /** @var string Referrer-Policy origin-when-cross-origin */
+    const ORIGIN_WHEN_CROSS_ORIGIN = 'origin-when-cross-origin';
+
+    /** @var string Referrer-Policy same-origin */
+    const SAME_ORIGIN = 'same-origin';
+
+    /** @var string Referrer-Policy strict-origin */
+    const STRICT_ORIGIN = 'strict-origin';
+
+    /** @var string Referrer-Policy strict-origin-when-cross-origin */
+    const STRICT_ORIGIN_WHEN_CROSS_ORIGIN = 'strict-origin-when-cross-origin';
+
+    /** @var string Referrer-Policy unsafe-url */
+    const UNSAFE_URL = 'unsafe-url';
+}

--- a/src/Http/Middleware/SecurityHeaders/XssProtection.php
+++ b/src/Http/Middleware/SecurityHeaders/XssProtection.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware\SecurityHeaders;
+
+/**
+ * X-XSS-Protection Header Values
+ */
+interface XssProtection
+{
+    /** @var string X-XSS-Protection block, sets enabled with block */
+    const BLOCK = 'block';
+
+    /** @var string X-XSS-Protection enabled with block */
+    const ENABLED_BLOCK = '1; mode=block';
+
+    /** @var string X-XSS-Protection enabled */
+    const ENABLED = '1';
+
+    /** @var string X-XSS-Protection disabled */
+    const DISABLED = '0';
+}

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -23,6 +23,71 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
+    /** @var string X-Content-Type-Option nosniff */
+    const NOSNIFF = 'nosniff';
+
+    /** @var string X-Download-Option noopen */
+    const NOOPEN = 'noopen';
+
+    /** @var string Referrer-Policy no-referrer */
+    const NO_REFERRER = 'no-referrer';
+
+    /** @var string Referrer-Policy no-referrer-when-downgrade */
+    const NO_REFERRER_WHEN_DOWNGRADE = 'no-referrer-when-downgrade';
+
+    /** @var string Referrer-Policy origin */
+    const ORIGIN = 'origin';
+
+    /** @var string Referrer-Policy origin-when-cross-origin */
+    const ORIGIN_WHEN_CROSS_ORIGIN = 'origin-when-cross-origin';
+
+    /** @var string Referrer-Policy same-origin */
+    const SAME_ORIGIN = 'same-origin';
+
+    /** @var string Referrer-Policy strict-origin */
+    const STRICT_ORIGIN = 'strict-origin';
+
+    /** @var string Referrer-Policy strict-origin-when-cross-origin */
+    const STRICT_ORIGIN_WHEN_CROSS_ORIGIN = 'strict-origin-when-cross-origin';
+
+    /** @var string Referrer-Policy unsafe-url */
+    const UNSAFE_URL = 'unsafe-url';
+
+    /** @var string X-Frame-Option deny */
+    const DENY = 'deny';
+
+    /** @var string X-Frame-Option sameorigin */
+    const SAMEORIGIN = 'sameorigin';
+
+    /** @var string X-Frame-Option allow-from */
+    const ALLOW_FROM = 'allow-from';
+
+    /** @var string X-XSS-Protection block, sets enabled with block */
+    const XSS_BLOCK = 'block';
+
+    /** @var string X-XSS-Protection enabled with block */
+    const XSS_ENABLED_BLOCK = '1; mode=block';
+
+    /** @var string X-XSS-Protection enabled */
+    const XSS_ENABLED = '1';
+
+    /** @var string X-XSS-Protection disabled */
+    const XSS_DISABLED = '0';
+
+    /** @var string X-Permitted-Cross-Domain-Policy all */
+    const ALL = 'all';
+
+    /** @var string X-Permitted-Cross-Domain-Policy none */
+    const NONE = 'none';
+
+    /** @var string X-Permitted-Cross-Domain-Policy master-only */
+    const MASTER_ONLY = 'master-only';
+
+    /** @var string X-Permitted-Cross-Domain-Policy by-content-type */
+    const BY_CONTENT_TYPE = 'by-content-type';
+
+    /** @var string X-Permitted-Cross-Domain-Policy by-ftp-filename */
+    const BY_FTP_FILENAME = 'by-ftp-filename';
 
     /**
      * Security related headers to set
@@ -41,7 +106,7 @@ class SecurityHeadersMiddleware
      */
     public function noSniff()
     {
-        $this->headers['x-content-type-options'] = 'nosniff';
+        $this->headers['x-content-type-options'] = self::NOSNIFF;
 
         return $this;
     }
@@ -56,7 +121,7 @@ class SecurityHeadersMiddleware
      */
     public function noOpen()
     {
-        $this->headers['x-download-options'] = 'noopen';
+        $this->headers['x-download-options'] = self::NOOPEN;
 
         return $this;
     }
@@ -69,13 +134,17 @@ class SecurityHeadersMiddleware
      *        'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
      * @return $this
      */
-    public function setReferrerPolicy($policy = 'same-origin')
+    public function setReferrerPolicy($policy = self::SAME_ORIGIN)
     {
         $available = [
-            'no-referrer', 'no-referrer-when-downgrade', 'origin',
-            'origin-when-cross-origin',
-            'same-origin', 'strict-origin', 'strict-origin-when-cross-origin',
-            'unsafe-url'
+            self::NO_REFERRER,
+            self::NO_REFERRER_WHEN_DOWNGRADE,
+            self::ORIGIN,
+            self::ORIGIN_WHEN_CROSS_ORIGIN,
+            self::SAME_ORIGIN,
+            self::STRICT_ORIGIN,
+            self::STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            self::UNSAFE_URL
         ];
 
         $this->checkValues($policy, $available);
@@ -92,11 +161,11 @@ class SecurityHeadersMiddleware
      * @param string $url URL if mode is `allow-from`
      * @return $this
      */
-    public function setXFrameOptions($option = 'sameorigin', $url = null)
+    public function setXFrameOptions($option = self::SAMEORIGIN, $url = null)
     {
-        $this->checkValues($option, ['deny', 'sameorigin', 'allow-from']);
+        $this->checkValues($option, [self::DENY, self::SAMEORIGIN, self::ALLOW_FROM]);
 
-        if ($option === 'allow-from') {
+        if ($option === self::ALLOW_FROM) {
             if (empty($url)) {
                 throw new InvalidArgumentException('The 2nd arg $url can not be empty when `allow-from` is used');
             }
@@ -115,15 +184,15 @@ class SecurityHeadersMiddleware
      * @param string $mode Mode value. Available Values: '1', '0', 'block'
      * @return $this
      */
-    public function setXssProtection($mode = 'block')
+    public function setXssProtection($mode = self::XSS_BLOCK)
     {
         $mode = (string)$mode;
 
-        if ($mode === 'block') {
-            $mode = '1; mode=block';
+        if ($mode === self::XSS_BLOCK) {
+            $mode = self::XSS_ENABLED_BLOCK;
         }
 
-        $this->checkValues($mode, ['1', '0', '1; mode=block']);
+        $this->checkValues($mode, [self::XSS_ENABLED, self::XSS_DISABLED, self::XSS_ENABLED_BLOCK]);
         $this->headers['x-xss-protection'] = $mode;
 
         return $this;
@@ -136,9 +205,11 @@ class SecurityHeadersMiddleware
      * @param string $policy Policy value. Available Values: 'all', 'none', 'master-only', 'by-content-type', 'by-ftp-filename'
      * @return $this
      */
-    public function setCrossDomainPolicy($policy = 'all')
+    public function setCrossDomainPolicy($policy = self::ALL)
     {
-        $this->checkValues($policy, ['all', 'none', 'master-only', 'by-content-type', 'by-ftp-filename']);
+        $this->checkValues($policy,
+            [self::ALL, self::NONE, self::MASTER_ONLY, self::BY_CONTENT_TYPE, self::BY_FTP_FILENAME]
+        );
         $this->headers['x-permitted-cross-domain-policies'] = $policy;
 
         return $this;

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -158,8 +158,7 @@ class SecurityHeadersMiddleware
                 PermittedCrossDomainPolicy::MASTER_ONLY,
                 PermittedCrossDomainPolicy::BY_CONTENT_TYPE,
                 PermittedCrossDomainPolicy::BY_FTP_FILENAME,
-            ]
-        );
+            ]);
         $this->headers['x-permitted-cross-domain-policies'] = $policy;
 
         return $this;

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Http\Middleware;
 
+use Cake\Http\Middleware\SecurityHeaders\ContentTypeOption;
 use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -24,9 +25,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
-    /** @var string X-Content-Type-Option nosniff */
-    const NOSNIFF = 'nosniff';
-
     /** @var string X-Download-Option noopen */
     const NOOPEN = 'noopen';
 
@@ -95,7 +93,7 @@ class SecurityHeadersMiddleware
      */
     public function noSniff()
     {
-        $this->headers['x-content-type-options'] = self::NOSNIFF;
+        $this->headers['x-content-type-options'] = ContentTypeOption::NOSNIFF;
 
         return $this;
     }

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -15,6 +15,7 @@
 namespace Cake\Http\Middleware;
 
 use Cake\Http\Middleware\SecurityHeaders\ContentTypeOption;
+use Cake\Http\Middleware\SecurityHeaders\DownloadOption;
 use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -25,9 +26,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
-    /** @var string X-Download-Option noopen */
-    const NOOPEN = 'noopen';
-
     /** @var string Referrer-Policy no-referrer */
     const NO_REFERRER = 'no-referrer';
 
@@ -108,7 +106,7 @@ class SecurityHeadersMiddleware
      */
     public function noOpen()
     {
-        $this->headers['x-download-options'] = self::NOOPEN;
+        $this->headers['x-download-options'] = DownloadOption::NOOPEN;
 
         return $this;
     }

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -16,6 +16,7 @@ namespace Cake\Http\Middleware;
 
 use Cake\Http\Middleware\SecurityHeaders\ContentTypeOption;
 use Cake\Http\Middleware\SecurityHeaders\DownloadOption;
+use Cake\Http\Middleware\SecurityHeaders\ReferrerPolicy;
 use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -26,30 +27,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
-    /** @var string Referrer-Policy no-referrer */
-    const NO_REFERRER = 'no-referrer';
-
-    /** @var string Referrer-Policy no-referrer-when-downgrade */
-    const NO_REFERRER_WHEN_DOWNGRADE = 'no-referrer-when-downgrade';
-
-    /** @var string Referrer-Policy origin */
-    const ORIGIN = 'origin';
-
-    /** @var string Referrer-Policy origin-when-cross-origin */
-    const ORIGIN_WHEN_CROSS_ORIGIN = 'origin-when-cross-origin';
-
-    /** @var string Referrer-Policy same-origin */
-    const SAME_ORIGIN = 'same-origin';
-
-    /** @var string Referrer-Policy strict-origin */
-    const STRICT_ORIGIN = 'strict-origin';
-
-    /** @var string Referrer-Policy strict-origin-when-cross-origin */
-    const STRICT_ORIGIN_WHEN_CROSS_ORIGIN = 'strict-origin-when-cross-origin';
-
-    /** @var string Referrer-Policy unsafe-url */
-    const UNSAFE_URL = 'unsafe-url';
-
     /** @var string X-Frame-Option deny */
     const DENY = 'deny';
 
@@ -119,17 +96,17 @@ class SecurityHeadersMiddleware
      *        'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
      * @return $this
      */
-    public function setReferrerPolicy($policy = self::SAME_ORIGIN)
+    public function setReferrerPolicy($policy = ReferrerPolicy::SAME_ORIGIN)
     {
         $available = [
-            self::NO_REFERRER,
-            self::NO_REFERRER_WHEN_DOWNGRADE,
-            self::ORIGIN,
-            self::ORIGIN_WHEN_CROSS_ORIGIN,
-            self::SAME_ORIGIN,
-            self::STRICT_ORIGIN,
-            self::STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            self::UNSAFE_URL
+            ReferrerPolicy::NO_REFERRER,
+            ReferrerPolicy::NO_REFERRER_WHEN_DOWNGRADE,
+            ReferrerPolicy::ORIGIN,
+            ReferrerPolicy::ORIGIN_WHEN_CROSS_ORIGIN,
+            ReferrerPolicy::SAME_ORIGIN,
+            ReferrerPolicy::STRICT_ORIGIN,
+            ReferrerPolicy::STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            ReferrerPolicy::UNSAFE_URL
         ];
 
         $this->checkValues($policy, $available);

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -16,6 +16,7 @@ namespace Cake\Http\Middleware;
 
 use Cake\Http\Middleware\SecurityHeaders\ContentTypeOption;
 use Cake\Http\Middleware\SecurityHeaders\DownloadOption;
+use Cake\Http\Middleware\SecurityHeaders\FrameOption;
 use Cake\Http\Middleware\SecurityHeaders\ReferrerPolicy;
 use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
@@ -27,15 +28,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
-    /** @var string X-Frame-Option deny */
-    const DENY = 'deny';
-
-    /** @var string X-Frame-Option sameorigin */
-    const SAMEORIGIN = 'sameorigin';
-
-    /** @var string X-Frame-Option allow-from */
-    const ALLOW_FROM = 'allow-from';
-
     /** @var string X-Permitted-Cross-Domain-Policy all */
     const ALL = 'all';
 
@@ -123,11 +115,11 @@ class SecurityHeadersMiddleware
      * @param string $url URL if mode is `allow-from`
      * @return $this
      */
-    public function setXFrameOptions($option = self::SAMEORIGIN, $url = null)
+    public function setXFrameOptions($option = FrameOption::SAMEORIGIN, $url = null)
     {
-        $this->checkValues($option, [self::DENY, self::SAMEORIGIN, self::ALLOW_FROM]);
+        $this->checkValues($option, [FrameOption::DENY, FrameOption::SAMEORIGIN, FrameOption::ALLOW_FROM]);
 
-        if ($option === self::ALLOW_FROM) {
+        if ($option === FrameOption::ALLOW_FROM) {
             if (empty($url)) {
                 throw new InvalidArgumentException('The 2nd arg $url can not be empty when `allow-from` is used');
             }

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Http\Middleware;
 
+use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -61,18 +62,6 @@ class SecurityHeadersMiddleware
 
     /** @var string X-Frame-Option allow-from */
     const ALLOW_FROM = 'allow-from';
-
-    /** @var string X-XSS-Protection block, sets enabled with block */
-    const XSS_BLOCK = 'block';
-
-    /** @var string X-XSS-Protection enabled with block */
-    const XSS_ENABLED_BLOCK = '1; mode=block';
-
-    /** @var string X-XSS-Protection enabled */
-    const XSS_ENABLED = '1';
-
-    /** @var string X-XSS-Protection disabled */
-    const XSS_DISABLED = '0';
 
     /** @var string X-Permitted-Cross-Domain-Policy all */
     const ALL = 'all';
@@ -184,15 +173,19 @@ class SecurityHeadersMiddleware
      * @param string $mode Mode value. Available Values: '1', '0', 'block'
      * @return $this
      */
-    public function setXssProtection($mode = self::XSS_BLOCK)
+    public function setXssProtection($mode = XssProtection::BLOCK)
     {
         $mode = (string)$mode;
 
-        if ($mode === self::XSS_BLOCK) {
-            $mode = self::XSS_ENABLED_BLOCK;
+        if ($mode === XssProtection::BLOCK) {
+            $mode = XssProtection::ENABLED_BLOCK;
         }
 
-        $this->checkValues($mode, [self::XSS_ENABLED, self::XSS_DISABLED, self::XSS_ENABLED_BLOCK]);
+        $this->checkValues($mode, [
+            XssProtection::ENABLED,
+            XssProtection::DISABLED,
+            XssProtection::ENABLED_BLOCK
+        ]);
         $this->headers['x-xss-protection'] = $mode;
 
         return $this;

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -70,8 +70,8 @@ class SecurityHeadersMiddleware
      * Referrer-Policy
      *
      * @link https://w3c.github.io/webappsec-referrer-policy
-     * @param string $policy Policy value. Available Value: 'no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin',
-     *        'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
+     * @param string $policy Policy value. Available Value: 'no-referrer', 'no-referrer-when-downgrade', 'origin',
+     *     'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
      * @return $this
      */
     public function setReferrerPolicy($policy = ReferrerPolicy::SAME_ORIGIN)
@@ -84,7 +84,7 @@ class SecurityHeadersMiddleware
             ReferrerPolicy::SAME_ORIGIN,
             ReferrerPolicy::STRICT_ORIGIN,
             ReferrerPolicy::STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            ReferrerPolicy::UNSAFE_URL
+            ReferrerPolicy::UNSAFE_URL,
         ];
 
         $this->checkValues($policy, $available);
@@ -135,7 +135,7 @@ class SecurityHeadersMiddleware
         $this->checkValues($mode, [
             XssProtection::ENABLED,
             XssProtection::DISABLED,
-            XssProtection::ENABLED_BLOCK
+            XssProtection::ENABLED_BLOCK,
         ]);
         $this->headers['x-xss-protection'] = $mode;
 
@@ -146,7 +146,8 @@ class SecurityHeadersMiddleware
      * X-Permitted-Cross-Domain-Policies
      *
      * @link https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
-     * @param string $policy Policy value. Available Values: 'all', 'none', 'master-only', 'by-content-type', 'by-ftp-filename'
+     * @param string $policy Policy value. Available Values: 'all', 'none', 'master-only', 'by-content-type',
+     *     'by-ftp-filename'
      * @return $this
      */
     public function setCrossDomainPolicy($policy = PermittedCrossDomainPolicy::ALL)
@@ -156,7 +157,7 @@ class SecurityHeadersMiddleware
                 PermittedCrossDomainPolicy::NONE,
                 PermittedCrossDomainPolicy::MASTER_ONLY,
                 PermittedCrossDomainPolicy::BY_CONTENT_TYPE,
-                PermittedCrossDomainPolicy::BY_FTP_FILENAME
+                PermittedCrossDomainPolicy::BY_FTP_FILENAME,
             ]
         );
         $this->headers['x-permitted-cross-domain-policies'] = $policy;

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -17,6 +17,7 @@ namespace Cake\Http\Middleware;
 use Cake\Http\Middleware\SecurityHeaders\ContentTypeOption;
 use Cake\Http\Middleware\SecurityHeaders\DownloadOption;
 use Cake\Http\Middleware\SecurityHeaders\FrameOption;
+use Cake\Http\Middleware\SecurityHeaders\PermittedCrossDomainPolicy;
 use Cake\Http\Middleware\SecurityHeaders\ReferrerPolicy;
 use Cake\Http\Middleware\SecurityHeaders\XssProtection;
 use InvalidArgumentException;
@@ -28,21 +29,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class SecurityHeadersMiddleware
 {
-    /** @var string X-Permitted-Cross-Domain-Policy all */
-    const ALL = 'all';
-
-    /** @var string X-Permitted-Cross-Domain-Policy none */
-    const NONE = 'none';
-
-    /** @var string X-Permitted-Cross-Domain-Policy master-only */
-    const MASTER_ONLY = 'master-only';
-
-    /** @var string X-Permitted-Cross-Domain-Policy by-content-type */
-    const BY_CONTENT_TYPE = 'by-content-type';
-
-    /** @var string X-Permitted-Cross-Domain-Policy by-ftp-filename */
-    const BY_FTP_FILENAME = 'by-ftp-filename';
-
     /**
      * Security related headers to set
      *
@@ -163,10 +149,15 @@ class SecurityHeadersMiddleware
      * @param string $policy Policy value. Available Values: 'all', 'none', 'master-only', 'by-content-type', 'by-ftp-filename'
      * @return $this
      */
-    public function setCrossDomainPolicy($policy = self::ALL)
+    public function setCrossDomainPolicy($policy = PermittedCrossDomainPolicy::ALL)
     {
-        $this->checkValues($policy,
-            [self::ALL, self::NONE, self::MASTER_ONLY, self::BY_CONTENT_TYPE, self::BY_FTP_FILENAME]
+        $this->checkValues($policy, [
+                PermittedCrossDomainPolicy::ALL,
+                PermittedCrossDomainPolicy::NONE,
+                PermittedCrossDomainPolicy::MASTER_ONLY,
+                PermittedCrossDomainPolicy::BY_CONTENT_TYPE,
+                PermittedCrossDomainPolicy::BY_FTP_FILENAME
+            ]
         );
         $this->headers['x-permitted-cross-domain-policies'] = $policy;
 


### PR DESCRIPTION
Replace magic literals in SecurityHeadersMiddleware with class constants from separate classes.
Except for the HTTP header keys. They could be constants, too, but should be placed in another class, e.g. a general HTTP related class. They could als be placed in those new classes, too.

Constant doc blocks as per PSR-19 (in draft)
https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#522-var

Closes #12666
Alternative to #12664

Personally, I prefer #12665 over this, as it is more readable and has a clear separation.