### PR TITLE
4.x - Cache cleanup

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -113,41 +113,6 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     }
 
     /**
-     * Write data for many keys into cache
-     *
-     * @param array $data An array of data to be stored in the cache
-     * @return array of bools for each key provided, true if the data was successfully cached, false on failure
-     * @deprecated To be removed soon
-     */
-    public function writeMany(array $data): array
-    {
-        $return = [];
-        foreach ($data as $key => $value) {
-            $return[$key] = $this->set($key, $value);
-        }
-
-        return $return;
-    }
-
-    /**
-     * Read multiple keys from the cache
-     *
-     * @param array $keys An array of identifiers for the data
-     * @return array For each cache key (given as the array key) the cache data associated or false if the data doesn't
-     * exist, has expired, or if there was an error fetching it
-     * @deprecated To be removed soon
-     */
-    public function readMany(array $keys): array
-    {
-        $return = [];
-        foreach ($keys as $key) {
-            $return[$key] = $this->get($key);
-        }
-
-        return $return;
-    }
-
-    /**
      * Obtains multiple cache items by their unique keys.
      *
      * @param iterable $keys A list of keys that can obtained in a single operation.
@@ -301,24 +266,6 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return bool True if the cache was successfully cleared, false otherwise
      */
     abstract public function clear();
-
-    /**
-     * Deletes keys from the cache
-     *
-     * @param array $keys An array of identifiers for the data
-     * @return array For each provided cache key (given back as the array key) true if the value was successfully deleted,
-     * false if it didn't exist or couldn't be removed
-     * @deprecated To be removed soon
-     */
-    public function deleteMany(array $keys): array
-    {
-        $return = [];
-        foreach ($keys as $key) {
-            $return[$key] = $this->delete($key);
-        }
-
-        return $return;
-    }
 
     /**
      * Add a key to the cache if it does not already exist.

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -366,46 +366,26 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     }
 
     /**
-     * Generates a safe key for use with cache engine storage engines.
+     * Generates a key for cache backend usage.
+     *
+     * If the requested key is valid, the group prefix value and engine prefix are applied.
+     * Whitespace in keys will be replaced.
      *
      * @param string $key the key passed over
-     * @return bool|string string key or false
+     * @return string Prefixed key with potentially unsafe characters replaced.
+     * @throws \Cake\Cache\InvalidArgumentException If key's value is invalid.
      */
-    public function key(string $key)
+    protected function _key(string $key)
     {
-        if (!$key) {
-            return false;
-        }
+        $this->ensureValidKey($key);
 
         $prefix = '';
         if ($this->_groupPrefix) {
             $prefix = md5(implode('_', $this->groups()));
         }
+        $key = preg_replace('/[\s]+/', '_', (string)$key);
 
-        $key = preg_replace(
-            '/[\s]+/',
-            '_',
-            strtolower(trim(str_replace([DIRECTORY_SEPARATOR, '/', '.'], '_', (string)$key)))
-        );
-
-        return $prefix . $key;
-    }
-
-    /**
-     * Generates a safe key, taking account of the configured key prefix
-     *
-     * @param string $key the key passed over
-     * @return mixed string $key or false
-     * @throws \Cake\Cache\InvalidArgumentException If key's value is empty
-     */
-    protected function _key(string $key)
-    {
-        $key = $this->key($key);
-        if ($key === false) {
-            throw new InvalidArgumentException('An empty value is not valid as a cache key');
-        }
-
-        return $this->_config['prefix'] . $key;
+        return $this->_config['prefix'] . $prefix . $key;
     }
 
     /**

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
-use Cake\Utility\Inflector;
+use Cake\Cache\InvalidArgumentException;
 use CallbackFilterIterator;
 use Exception;
 use LogicException;
@@ -422,11 +422,14 @@ class FileEngine extends CacheEngine
     {
         $key = parent::_key($key);
 
-        return Inflector::underscore(str_replace(
-            [DIRECTORY_SEPARATOR, '/', '.', '<', '>', '?', ':', '|', '*', '"'],
-            '_',
-            (string)$key
-        ));
+        if (preg_match('/[\/\\<>?:|*"]/', (string)$key)) {
+            throw new InvalidArgumentException(
+                "Cache key `{$key}` contains invalid characters. " .
+                'You cannot use /, \\, <, >, ?, :, |, *, or " in cache keys.'
+            );
+        }
+
+        return $key;
     }
 
     /**

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -418,19 +418,15 @@ class FileEngine extends CacheEngine
      * @param string $key the key passed over
      * @return mixed string $key or false
      */
-    public function key(string $key)
+    protected function _key(string $key)
     {
-        if (empty($key)) {
-            return false;
-        }
+        $key = parent::_key($key);
 
-        $key = Inflector::underscore(str_replace(
+        return Inflector::underscore(str_replace(
             [DIRECTORY_SEPARATOR, '/', '.', '<', '>', '?', ':', '|', '*', '"'],
             '_',
             (string)$key
         ));
-
-        return $key;
     }
 
     /**

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -43,9 +43,9 @@ class NullEngine extends CacheEngine
     /**
      * {@inheritDoc}
      */
-    public function writeMany(array $data): array
+    public function setMultiple($data, $ttl = null): bool
     {
-        return [];
+        return false;
     }
 
     /**
@@ -59,7 +59,7 @@ class NullEngine extends CacheEngine
     /**
      * {@inheritDoc}
      */
-    public function readMany(array $keys): array
+    public function getMultiple($keys, $default = null): array
     {
         return [];
     }
@@ -91,9 +91,9 @@ class NullEngine extends CacheEngine
     /**
      * {@inheritDoc}
      */
-    public function deleteMany(array $keys): array
+    public function deleteMultiple($keys): bool
     {
-        return [];
+        return false;
     }
 
     /**

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -145,7 +145,9 @@ class TranslatorRegistry extends TranslatorLocator
             return $this->registry[$name][$locale] = $this->_getTranslator($name, $locale);
         }
 
-        $key = "translations.$name.$locale";
+        // Cache keys cannot contain / if they go to file engine.
+        $keyName = str_replace('/', '.', $name);
+        $key = "translations.{$keyName}.{$locale}";
         $translator = $this->_cacher->get($key);
         if (!$translator || !$translator->getPackage()) {
             $translator = $this->_getTranslator($name, $locale);

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -643,7 +643,7 @@ class CacheTest extends TestCase
     public function testWriteEmptyKey()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('An empty value is not valid as a cache key');
+        $this->expectExceptionMessage('A cache key must be a non-empty string');
         $this->_configCache();
         Cache::write('', 'not null', 'tests');
     }

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Cache\Engine;
 
 use Cake\Cache\Cache;
+use Cake\Cache\InvalidArgumentException;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
@@ -292,21 +293,37 @@ class FileEngineTest extends TestCase
     {
         $result = Cache::write('views.countries.something', 'here', 'file_test');
         $this->assertTrue($result);
-        $this->assertFileExists(TMP . 'tests/cake_views_countries_something');
+        $this->assertFileExists(TMP . 'tests/cake_views.countries.something');
 
         $result = Cache::read('views.countries.something', 'file_test');
         $this->assertEquals('here', $result);
 
         $result = Cache::clear('file_test');
         $this->assertTrue($result);
+    }
 
-        $result = Cache::write('domain.test.com:8080', 'here', 'file_test');
-        $this->assertTrue($result);
-        $this->assertFileExists(TMP . 'tests/cake_domain_test_com_8080');
+    /**
+     * Test invalid key() containing :
+     *
+     * @return void
+     */
+    public function testInvalidKeyColon()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('contains invalid characters');
+        Cache::write('domain.test.com:8080', 'here', 'file_test');
+    }
 
-        $result = Cache::write('command>dir|more', 'here', 'file_test');
-        $this->assertTrue($result);
-        $this->assertFileExists(TMP . 'tests/cake_command_dir_more');
+    /**
+     * Test invalid key() containing >
+     *
+     * @return void
+     */
+    public function testInvalidKeyAngleBracket()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('contains invalid characters');
+        Cache::write('command>dir|more', 'here', 'file_test');
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Cache\Engine;
 
 use Cake\Cache\Cache;
-use Cake\Cache\InvalidArgumentException;
 use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\InvalidArgumentException;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -498,7 +498,7 @@ class MemcachedEngineTest extends TestCase
         $this->assertNull($read['App.nullTest']);
         $this->assertSame($read['App.zeroTest'], 0);
         $this->assertSame($read['App.zeroTest2'], '0');
-        $this->assertFalse($read['App.doesNotExist']);
+        $this->assertNull($read['App.doesNotExist']);
     }
 
     /**


### PR DESCRIPTION
Fix up some internals of `CacheEngine` to reduce the number of transformations done to cache keys. The transformations done in the base class were overkill for most engines and were only really necessary for `FileEngine` which is where the they live now.

I've also updated the frontend `*Many` methods to call the `*Multiple` methods on the engines. This allowed the `*Many` methods to be removed.