### PR TITLE
Fix MoParser if a message exist with and without context

### DIFF
--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -134,9 +134,9 @@ class MoFileParser
                 continue;
             }
 
-            $messages[$singularId] = $singular;
+            $messages[$singularId]['_context'][''] = $singular;
             if ($pluralId !== null) {
-                $messages[$pluralId] = $plurals;
+                $messages[$pluralId]['_context'][''] = $plurals;
             }
         }
 

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\I18n\Parser;
 
 use Cake\I18n\Parser\MoFileParser;

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\I18n\Parser;
 
 use Cake\I18n\Parser\MoFileParser;
@@ -35,12 +36,24 @@ class MoFileParserTest extends TestCase
         $messages = $parser->parse($file);
         $this->assertCount(3, $messages);
         $expected = [
-            '%d = 1 (from core)' => '%d = 1 (from core translated)',
-            '%d = 0 or > 1 (from core)' => [
-                '%d = 1 (from core translated)',
-                '%d = 0 or > 1 (from core translated)'
+            '%d = 1 (from core)' => [
+                '_context' => [
+                    '' => '%d = 1 (from core translated)'
+                ]
             ],
-            'Plural Rule 1 (from core)' => 'Plural Rule 1 (from core translated)'
+            '%d = 0 or > 1 (from core)' => [
+                '_context' => [
+                    '' => [
+                        '%d = 1 (from core translated)',
+                        '%d = 0 or > 1 (from core translated)'
+                    ]
+                ]
+            ],
+            'Plural Rule 1 (from core)' => [
+                '_context' => [
+                    '' => 'Plural Rule 1 (from core translated)'
+                ]
+            ]
         ];
         $this->assertEquals($expected, $messages);
     }
@@ -57,10 +70,22 @@ class MoFileParserTest extends TestCase
         $messages = $parser->parse($file);
         $this->assertCount(3, $messages);
         $expected = [
-            'Plural Rule 1 (from core)' => 'Plural Rule 0 (from core translated)',
-            '%d = 1 (from core)' => '%d ends with any # (from core translated)',
+            'Plural Rule 1 (from core)' => [
+                '_context' => [
+                    '' => 'Plural Rule 0 (from core translated)'
+                ]
+            ],
+            '%d = 1 (from core)' => [
+                '_context' => [
+                    '' => '%d ends with any # (from core translated)'
+                ]
+            ],
             '%d = 0 or > 1 (from core)' => [
-                '%d ends with any # (from core translated)',
+                '_context' => [
+                    '' => [
+                        '%d ends with any # (from core translated)',
+                    ]
+                ]
             ],
         ];
         $this->assertEquals($expected, $messages);
@@ -78,13 +103,25 @@ class MoFileParserTest extends TestCase
         $messages = $parser->parse($file);
         $this->assertCount(3, $messages);
         $expected = [
-            '%d = 1 (from core)' => '%d is 1 (from core translated)',
-            '%d = 0 or > 1 (from core)' => [
-                '%d is 1 (from core translated)',
-                '%d ends in 2-4, not 12-14 (from core translated)',
-                '%d everything else (from core translated)'
+            '%d = 1 (from core)' => [
+                '_context' => [
+                    '' => '%d is 1 (from core translated)'
+                ]
             ],
-            'Plural Rule 1 (from core)' => 'Plural Rule 9 (from core translated)'
+            '%d = 0 or > 1 (from core)' => [
+                '_context' => [
+                    '' => [
+                        '%d is 1 (from core translated)',
+                        '%d ends in 2-4, not 12-14 (from core translated)',
+                        '%d everything else (from core translated)'
+                    ]
+                ]
+            ],
+            'Plural Rule 1 (from core)' => [
+                '_context' => [
+                    '' => 'Plural Rule 9 (from core translated)'
+                ]
+            ]
         ];
         $this->assertEquals($expected, $messages);
     }
@@ -101,7 +138,11 @@ class MoFileParserTest extends TestCase
         $messages = $parser->parse($file);
         $this->assertCount(5, $messages);
         $expected = [
-            'Plural Rule 1' => 'Plural Rule 1 (translated)',
+            'Plural Rule 1' => [
+                '_context' => [
+                    '' => 'Plural Rule 1 (translated)'
+                ]
+            ],
             '%d = 1' => [
                 '_context' => [
                     'This is the context' => 'First Context trasnlation',
@@ -116,10 +157,18 @@ class MoFileParserTest extends TestCase
                     ]
                 ]
             ],
-            '%-5d = 1' => '%-5d = 1 (translated)',
+            '%-5d = 1' => [
+                '_context' => [
+                    '' => '%-5d = 1 (translated)'
+                ]
+            ],
             '%-5d = 0 or > 1' => [
-                '%-5d = 1 (translated)',
-                '%-5d = 0 or > 1 (translated)'
+                '_context' => [
+                    '' => [
+                        '%-5d = 1 (translated)',
+                        '%-5d = 0 or > 1 (translated)'
+                    ]
+                ]
             ]
         ];
         $this->assertEquals($expected, $messages);


### PR DESCRIPTION
Fix MoParser if an message exist with and without context. And it also makes MoFileParser more inline with the PoFileParser.

Here a example if you have a message where one has a context:
```po
#: Template/Cart/index.ctp:153
msgid "Shipping fee"
msgstr "Verzendkosten"

#: Template/Cart/index.ctp:96
msgctxt "indication"
msgid "Shipping fee"
msgstr "Indicatie verzendkosten"
```
