### PR TITLE
Improve documentation

### DIFF
--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -22,7 +22,7 @@ App::uses('LogEngineCollection', 'Log');
 
 /**
  * Logs messages to configured Log adapters.
- * 
+ *
  * One or more adapters
  * can be configured using CakeLogs's methods.
  *
@@ -84,7 +84,7 @@ class CakeLog {
 /**
  * Default log levels as detailed in RFC 5424
  * http://tools.ietf.org/html/rfc5424
- * 
+ *
  * Windows has fewer levels, thus notice, info and debug are the same.
  * https://bugs.php.net/bug.php?id=18090
  *
@@ -398,7 +398,7 @@ class CakeLog {
  *
  * @param int|string $type Type of message being written. When value is an integer
  *    or a string matching the recognized levels, then it will
- *    be treated log levels. Otherwise it's treated as scope.
+ *    be treated as a log level. Otherwise it's treated as a scope.
  * @param string $message Message content to log
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -183,7 +183,7 @@ class Debugger {
  * @param mixed $var Variable or content to log
  * @param int|string $level Type of log to use. Defaults to LOG_DEBUG. When value is an integer
  *    or a string matching the recognized levels, then it will
- *    be treated log levels. Otherwise it's treated as scope.
+ *    be treated as a log level. Otherwise it's treated as a scope.
  * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @link https://book.cakephp.org/2.0/en/development/debugging.html#Debugger::log

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -181,7 +181,9 @@ class Debugger {
  * as well as export the variable using exportVar. By default the log is written to the debug log.
  *
  * @param mixed $var Variable or content to log
- * @param int $level type of log to use. Defaults to LOG_DEBUG
+ * @param int|string $level Type of log to use. Defaults to LOG_DEBUG. When value is an integer
+ *    or a string matching the recognized levels, then it will
+ *    be treated log levels. Otherwise it's treated as scope.
  * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @link https://book.cakephp.org/2.0/en/development/debugging.html#Debugger::log


### PR DESCRIPTION
The parameter description is copied from `CakeLog::write` method.
