### PR TITLE
Replace hard coded test directory paths with constants, fixes #12636

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -360,23 +360,19 @@ class TestShell extends Shell {
 		}
 
 		$testFile = $testCase = null;
-
+		$testCaseFolder = str_replace(APP, '', APP_TEST_CASES);
 		if (preg_match('@Test[\\\/]@', $file)) {
-
 			if (substr($file, -8) === 'Test.php') {
-
 				$testCase = substr($file, 0, -8);
 				$testCase = str_replace(DS, '/', $testCase);
-
-				if ($testCase = preg_replace('@.*Test\/Case\/@', '', $testCase)) {
-
+				$testCaseFolderEscaped = str_replace('/', '\/', $testCaseFolder);
+				$testCase = preg_replace('@.*' . $testCaseFolderEscaped . '\/@', '', $testCase);
+				if (!empty($testCase)) {
 					if ($category === 'core') {
 						$testCase = str_replace('lib/Cake', '', $testCase);
 					}
-
 					return $testCase;
 				}
-
 				throw new Exception(__d('cake_dev', 'Test case %s cannot be run via this shell', $testFile));
 			}
 		}
@@ -397,11 +393,11 @@ class TestShell extends Shell {
 		}
 
 		if ($category === 'app') {
-			$testFile = str_replace(APP, APP . 'Test/Case/', $file) . 'Test.php';
+			$testFile = str_replace(APP, APP_TEST_CASES . '/', $file) . 'Test.php';
 		} else {
 			$testFile = preg_replace(
 				"@((?:plugins|Plugin)[\\/]{$category}[\\/])(.*)$@",
-				'\1Test/Case/\2Test.php',
+				'\1' . $testCaseFolder . '/\2Test.php',
 				$file
 			);
 		}
@@ -412,8 +408,7 @@ class TestShell extends Shell {
 
 		$testCase = substr($testFile, 0, -8);
 		$testCase = str_replace(DS, '/', $testCase);
-		$testCase = preg_replace('@.*Test/Case/@', '', $testCase);
-
+		$testCase = preg_replace('@.*' . $testCaseFolder . '/@', '', $testCase);
 		return $testCase;
 	}
 

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -114,6 +114,9 @@ class Configure {
 				class_exists('Debugger');
 				class_exists('CakeText');
 			}
+			if (!defined('TESTS')) {
+				define('TESTS', APP . 'Test' . DS);
+			}
 		}
 	}
 

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -16,8 +16,24 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
+/**
+ * Path to the tests directory of the app.
+ */
+if (!defined('TESTS')) {
+	define('TESTS', APP . 'Test' . DS);
+}
+
+/**
+ * Path to the test cases directory of CakePHP.
+ */
 define('CORE_TEST_CASES', CAKE . 'Test' . DS . 'Case');
-define('APP_TEST_CASES', TESTS . 'Case');
+
+/**
+ * Path to the test cases directory of the app.
+ */
+if (!defined('APP_TEST_CASES')) {
+	define('APP_TEST_CASES', TESTS . 'Case');
+}
 
 App::uses('CakeTestSuiteCommand', 'TestSuite');
 

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -87,13 +87,6 @@ if (!defined('IMAGES')) {
 }
 
 /**
- * Path to the tests directory.
- */
-if (!defined('TESTS')) {
-	define('TESTS', APP . 'Test' . DS);
-}
-
-/**
  * Path to the temporary files directory.
  */
 if (!defined('TMP')) {


### PR DESCRIPTION
The `TESTS` constant definition is moved from bootstrap.php in order
to make it possible to set the constant in test.php or in the project's
bootstrap file so that CakePHP would detect tests in a different folder.