### PR TITLE
Collection test additions

### DIFF
--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -676,10 +676,9 @@ class CollectionTest extends TestCase
     public function testMaxCallable($items)
     {
         $collection = new Collection($items);
-        $callback = function ($e) {
+        $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max(function ($e) {
             return $e['a']['b']['c'] * - 1;
-        };
-        $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max($callback));
+        }));
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -19,6 +19,8 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Collection\CollectionTrait;
+use Cake\ORM\Entity;
+use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use NoRewindIterator;
 
@@ -682,6 +684,26 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Test max with a collection of Entities
+     *
+     * @return void
+     */
+    public function testMaxWithEntities()
+    {
+        $collection = new Collection([
+            new Entity(['id' => 1, 'count' => 18]),
+            new Entity(['id' => 2, 'count' => 9]),
+            new Entity(['id' => 3, 'count' => 42]),
+            new Entity(['id' => 4, 'count' => 4]),
+            new Entity(['id' => 5, 'count' => 22])
+        ]);
+
+        $expected = new Entity(['id' => 3, 'count' => 42]);
+
+        $this->assertEquals($expected, $collection->max('count'));
+    }
+
+    /**
      * Tests min
      *
      * @dataProvider sortProvider
@@ -691,6 +713,26 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection($items);
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->min('a.b.c'));
+    }
+
+    /**
+     * Test min with a collection of Entities
+     *
+     * @return void
+     */
+    public function testMinWithEntities()
+    {
+        $collection = new Collection([
+            new Entity(['id' => 1, 'count' => 18]),
+            new Entity(['id' => 2, 'count' => 9]),
+            new Entity(['id' => 3, 'count' => 42]),
+            new Entity(['id' => 4, 'count' => 4]),
+            new Entity(['id' => 5, 'count' => 22])
+        ]);
+
+        $expected = new Entity(['id' => 4, 'count' => 4]);
+
+        $this->assertEquals($expected, $collection->min('count'));
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use TestApp\Model\Entity\Article;
 
 /**
  * ResultSet test case.
@@ -415,5 +416,35 @@ class ResultSetTest extends TestCase
         $res = $query->all();
         $res->isEmpty();
         $this->assertCount(6, $res->toArray());
+    }
+
+    /**
+     * Test that ResultSet implements the CollectionInterface min method
+     *
+     * @return void
+     */
+    public function testCollectionMin()
+    {
+        $query = $this->table->find('all');
+
+        $result = $query->min('id');
+        $expected = $this->table->get(1);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that ResultSet implements the CollectionInterface max method
+     *
+     * @return void
+     */
+    public function testCollectionMax()
+    {
+        $query = $this->table->find('all');
+
+        $result = $query->max('id');
+        $expected = $this->table->get(3);
+
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -419,32 +419,21 @@ class ResultSetTest extends TestCase
     }
 
     /**
-     * Test that ResultSet implements the CollectionInterface min method
+     * Test that ResultSet
      *
      * @return void
      */
-    public function testCollectionMin()
+    public function testCollectionMinAndMax()
     {
         $query = $this->table->find('all');
 
-        $result = $query->min('id');
-        $expected = $this->table->get(1);
+        $min = $query->min('id');
+        $minExpected = $this->table->get(1);
 
-        $this->assertEquals($expected, $result);
-    }
+        $max = $query->max('id');
+        $maxExpected = $this->table->get(3);
 
-    /**
-     * Test that ResultSet implements the CollectionInterface max method
-     *
-     * @return void
-     */
-    public function testCollectionMax()
-    {
-        $query = $this->table->find('all');
-
-        $result = $query->max('id');
-        $expected = $this->table->get(3);
-
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($minExpected, $min);
+        $this->assertEquals($maxExpected, $max);
     }
 }

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -436,4 +436,21 @@ class ResultSetTest extends TestCase
         $this->assertEquals($minExpected, $min);
         $this->assertEquals($maxExpected, $max);
     }
+
+    /**
+     * Test that ResultSet
+     *
+     * @return void
+     */
+    public function testCollectionMinAndMaxWithAggregateField()
+    {
+        $query = $this->table->find();
+        $query->select(['count' => 'length(title)']);
+
+        $min = $query->min('count');
+        $max = $query->max('count');
+
+        $this->assertEquals(13, $min->count);
+        $this->assertEquals(14, $max->count);
+    }
 }


### PR DESCRIPTION
I have been having some trouble today trying to get a `min` and `max` from the same query. For some reason I get the same value back for both.

I thought that I would check the core tests for examples, and there aren't really any.

This pull request adds some tests which cover my use-case, and are hopefully of some use to the project, hence me contributing them.

I don't know what the feeling is of putting Collection tests into the ResultSet test is, but as the ResultSet class implements the CollectionInterface, this feel okay to me.

Oh and I also updated a duplicate test, which seems to be a copy and paste which was never updated.