### PR TITLE
Close directory handle to prevent locking issues

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -336,6 +336,8 @@ class FileEngine extends CacheEngine
                 //@codingStandardsIgnoreEnd
             }
         }
+
+        $dir->close();
     }
 
     /**


### PR DESCRIPTION
Directory handles opened by `dir()` must be closed. Otherwise directory is locked on Windows, and prevents from deleting it.

It will fix https://github.com/cakephp/cakephp/pull/12670 too. I'm not sure why failures appeared only on `4.x`, but I fix bug on `master`.

