### PR TITLE
3.next - Allow Plugin::getCollection() to be used

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -411,7 +411,9 @@ class Plugin
     /**
      * Get the shared plugin collection.
      *
-     * @internal
+     * This method should generally not be used during application
+     * runtime as plugins should be set during Application startup.
+     *
      * @return \Cake\Core\PluginCollection
      */
     public static function getCollection()


### PR DESCRIPTION
Add this method to the public API of `Plugin` as it has some use cases for plugin test case setup.

Refs #12682
