### PR TITLE
Fix class name usage to const

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -150,7 +150,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @var string
      */
-    const RULES_CLASS = 'Cake\ORM\RulesChecker';
+    const RULES_CLASS = RulesChecker::class;
+
+    /**
+     * The IsUnique class name that is used.
+     *
+     * @var string
+     */
+    const IS_UNIQUE_CLASS = IsUnique::class;
 
     /**
      * Name of the table as it can be found in the database
@@ -2797,7 +2804,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return false;
             }
         }
-        $rule = new IsUnique($fields, $options);
+        $class = static::IS_UNIQUE_CLASS;
+        $rule = new $class($fields, $options);
 
         return $rule($entity, ['repository' => $this]);
     }


### PR DESCRIPTION
We have ~400 new in our code directly, most are acceptable. But there are a few cases where a factory of some sort would have been better.

I needed to extend IsUnique to allow for parent belongsToModule usage, but due to the hardcoded new command there is no possibility.
This makes it at least possible on a basic extension level in the Table class.