### PR TITLE
Fix router reload regression in integration testing.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -173,6 +173,13 @@ abstract class IntegrationTestCase extends TestCase
     protected $_cookieEncryptionKey;
 
     /**
+     * Allow router reloading to be disabled.
+     * 
+     * @var bool
+     */
+    protected $_disableRouterReload = false;
+
+    /**
      * Auto-detect if the HTTP middleware stack should be used.
      *
      * @return void
@@ -207,6 +214,7 @@ abstract class IntegrationTestCase extends TestCase
         $this->_csrfToken = false;
         $this->_retainFlashMessages = false;
         $this->_useHttpServer = false;
+        $this->_disableRouterReload = true;
     }
 
     /**
@@ -518,7 +526,7 @@ abstract class IntegrationTestCase extends TestCase
     protected function _makeDispatcher()
     {
         if ($this->_useHttpServer) {
-            return new MiddlewareDispatcher($this, $this->_appClass, $this->_appArgs);
+            return new MiddlewareDispatcher($this, $this->_appClass, $this->_appArgs, $this->_disableRouterReload);
         }
 
         return new LegacyRequestDispatcher($this);

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -174,7 +174,7 @@ abstract class IntegrationTestCase extends TestCase
 
     /**
      * Allow router reloading to be disabled.
-     * 
+     *
      * @var bool
      */
     protected $_disableRouterReload = false;

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -55,6 +55,13 @@ class MiddlewareDispatcher
     protected $_constructorArgs;
 
     /**
+     * Allow router reloading to be disabled.
+     *
+     * @var bool
+     */
+    protected $_disableRouterReload = false;
+
+    /**
      * The application that is being dispatched.
      *
      * @var \Cake\Core\HttpApplicationInterface
@@ -68,13 +75,15 @@ class MiddlewareDispatcher
      * @param string|null $class The application class name. Defaults to App\Application.
      * @param array|null $constructorArgs The constructor arguments for your application class.
      *   Defaults to `['./config']`
+     * @param bool $disableRouterReload Disable Router::reload() call.
      * @throws \LogicException If it cannot load class for use in integration testing.
      */
-    public function __construct($test, $class = null, $constructorArgs = null)
+    public function __construct($test, $class = null, $constructorArgs = null, $disableRouterReload = false)
     {
         $this->_test = $test;
         $this->_class = $class ?: Configure::read('App.namespace') . '\Application';
         $this->_constructorArgs = $constructorArgs ?: [CONFIG];
+        $this->_disableRouterReload = $disableRouterReload;
 
         try {
             $reflect = new ReflectionClass($this->_class);
@@ -126,7 +135,9 @@ class MiddlewareDispatcher
         }
 
         $out = Router::url($url);
-        Router::reload();
+        if (!$this->_disableRouterReload) {
+            Router::reload();
+        }
 
         return $out;
     }

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -18,6 +18,7 @@ use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Filter\RoutingFilter;
+use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
@@ -82,7 +83,7 @@ class RoutingFilterTest extends TestCase
      */
     public function testBeforeDispatchRedirectRoute()
     {
-        Router::scope('/', function ($routes) {
+        Router::scope('/', function (RouteBuilder $routes) {
             $routes->redirect('/home', ['controller' => 'articles']);
             $routes->connect('/:controller/:action/*');
         });

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -582,7 +582,7 @@ class RouteBuilderTest extends TestCase
     public function testResourcesPathOption()
     {
         $routes = new RouteBuilder($this->collection, '/api');
-        $routes->resources('Articles', ['path' => 'posts'], function ($routes) {
+        $routes->resources('Articles', ['path' => 'posts'], function (RouteBuilder $routes) {
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -19,6 +19,7 @@ use Cake\Core\Plugin;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Routing\DispatcherFactory;
+use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\TestSuite\IntegrationTestCase;
@@ -43,7 +44,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         static::setAppNamespace();
 
         Router::reload();
-        Router::scope('/', function ($routes) {
+        Router::extensions(['json']);
+        Router::scope('/', function (RouteBuilder $routes) {
             $routes->setRouteClass(InflectedRoute::class);
             $routes->get('/get/:controller/:action', []);
             $routes->head('/head/:controller/:action', []);
@@ -568,6 +570,18 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertTemplate('index');
         $this->assertLayout('default');
         $this->assertEquals('value', $this->viewVariable('test'));
+    }
+
+    /**
+     * Tests URLs containing extensions.
+     *
+     * @return void
+     */
+    public function testRequestWithExt()
+    {
+        $this->get(['controller' => 'Posts', 'action' => 'ajax', '_ext' => 'json']);
+
+        $this->assertResponseCode(200);
     }
 
     /**

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -16,16 +16,24 @@ namespace TestApp;
 
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\RoutingMiddleware;
+use Cake\Routing\RouteBuilder;
 use TestApp\Command\AbortCommand;
 
 class Application extends BaseApplication
 {
-
+    /**
+     * @return void
+     */
     public function bootstrap()
     {
         parent::bootstrap();
     }
 
+    /**
+     * @param \Cake\Console\CommandCollection $commands
+     *
+     * @return \Cake\Console\CommandCollection
+     */
     public function console($commands)
     {
         return $commands
@@ -33,10 +41,16 @@ class Application extends BaseApplication
             ->addMany($commands->autoDiscover());
     }
 
+    /**
+     * @param \Cake\Http\MiddlewareQueue $middleware
+     *
+     * @return \Cake\Http\MiddlewareQueue
+     */
     public function middleware($middleware)
     {
         $middleware->add(new RoutingMiddleware());
         $middleware->add(function ($req, $res, $next) {
+            /** @var \Cake\Http\ServerRequest $res */
             $res = $next($req, $res);
 
             return $res->withHeader('X-Middleware', 'true');
@@ -53,7 +67,7 @@ class Application extends BaseApplication
      */
     public function routes($routes)
     {
-        $routes->scope('/app', function ($routes) {
+        $routes->scope('/app', function (RouteBuilder $routes) {
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
     }

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -39,6 +39,11 @@ class ApplicationWithDefaultRoutes extends BaseApplication
         // Do nothing.
     }
 
+    /**
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue
+     *
+     * @return \Cake\Http\MiddlewareQueue
+     */
     public function middleware($middlewareQueue)
     {
         $middlewareQueue->add(new RoutingMiddleware($this));

--- a/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
@@ -16,15 +16,24 @@ namespace TestApp;
 
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\RoutingMiddleware;
+use Cake\Routing\RouteBuilder;
 
 class ApplicationWithPluginRoutes extends BaseApplication
 {
+    /**
+     * @return void
+     */
     public function bootstrap()
     {
         parent::bootstrap();
         $this->addPlugin('TestPlugin');
     }
 
+    /**
+     * @param \Cake\Http\MiddlewareQueue $middleware
+     *
+     * @return \Cake\Http\MiddlewareQueue
+     */
     public function middleware($middleware)
     {
         $middleware->add(new RoutingMiddleware($this));
@@ -40,7 +49,7 @@ class ApplicationWithPluginRoutes extends BaseApplication
      */
     public function routes($routes)
     {
-        $routes->scope('/app', function ($routes) {
+        $routes->scope('/app', function (RouteBuilder $routes) {
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
         $routes->loadPlugin('TestPlugin');

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -83,6 +83,19 @@ class PostsController extends AppController
     }
 
     /**
+     * Stub AJAX method
+     *
+     * @return void
+     */
+    public function ajax()
+    {
+        $data = [];
+
+        $this->set(compact('data'));
+        $this->set('_serialize', ['data']);
+    }
+
+    /**
      * Post endpoint for integration testing with security component.
      *
      * @return void

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -12,10 +12,12 @@
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
+use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
 Router::extensions('json');
-Router::scope('/', function ($routes) {
+Router::scope('/', function (RouteBuilder $routes) {
     $routes->connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
     $routes->connect(
         '/some_alias',


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/12628
It provides a now "BC way" to shim it back for the use cases where we need it.
Not sure that is the best solution, but it would provide a way for integration tests to fix the regression manually where needed via
```php
class FeedExamplesControllerTest extends IntegrationTestCase {

	/**
	 * Allow router reloading to be disabled.
	 *
	 * @var bool
	 */
	protected $_disableRouterReload = true;
...
```
per class.