### PR TITLE
4x - Support default values in cache engine

### DIFF
--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -78,9 +78,12 @@ class ApcuEngine extends CacheEngine
      */
     public function get($key, $default = null)
     {
-        $key = $this->_key($key);
+        $value = apcu_fetch($this->_key($key), $success);
+        if ($success === false) {
+            return $default;
+        }
 
-        return apcu_fetch($key);
+        return $value;
     }
 
     /**

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -72,7 +72,7 @@ class ApcuEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param mixed $default Default value in case the cache misses.
-     * @return mixed The cached data, or false if the data doesn't exist,
+     * @return mixed The cached data, or default if the data doesn't exist,
      *   has expired, or if there was an error fetching it
      * @link https://secure.php.net/manual/en/function.apcu-fetch.php
      */

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -174,7 +174,7 @@ class FileEngine extends CacheEngine
         $key = $this->_key($key);
 
         if (!$this->_init || $this->_setKey($key) === false) {
-            return null;
+            return $default;
         }
 
         if ($this->_config['lock']) {
@@ -190,7 +190,7 @@ class FileEngine extends CacheEngine
                 $this->_File->flock(LOCK_UN);
             }
 
-            return null;
+            return $default;
         }
 
         $data = '';

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -166,7 +166,7 @@ class FileEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param mixed $default Default value to return if the key does not exist.
-     * @return mixed The cached data, or null if the data doesn't exist, has
+     * @return mixed The cached data, or default value if the data doesn't exist, has
      *   expired, or if there was an error fetching it
      */
     public function get($key, $default = null)

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -328,8 +328,12 @@ class MemcachedEngine extends CacheEngine
     public function get($key, $default = null)
     {
         $key = $this->_key($key);
+        $value = $this->_Memcached->get($key);
+        if ($this->_Memcached->getResultCode() == Memcached::RES_NOTFOUND) {
+            return $default;
+        }
 
-        return $this->_Memcached->get($key);
+        return $value;
     }
 
     /**

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -322,7 +322,7 @@ class MemcachedEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param mixed $default Default value to return if the key does not exist.
-     * @return mixed The cached data, or false if the data doesn't exist, has
+     * @return mixed The cached data, or default value if the data doesn't exist, has
      * expired, or if there was an error fetching it.
      */
     public function get($key, $default = null)

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -153,18 +153,20 @@ class RedisEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param mixed $default Default value to return if the key does not exist.
-     * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
+     * @return mixed The cached data, or the default if the data doesn't exist, has
+     *   expired, or if there was an error fetching it
      */
     public function get($key, $default = null)
     {
-        $key = $this->_key($key);
-
-        $value = $this->_Redis->get($key);
+        $value = $this->_Redis->get($this->_key($key));
+        if ($value === false) {
+            return $default;
+        }
         $isString = is_string($value);
         if ($isString && preg_match('/^[-]?\d+$/', $value)) {
             return (int)$value;
         }
-        if ($value !== false && $isString) {
+        if ($isString) {
             return unserialize($value);
         }
 

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -79,6 +79,7 @@ class WincacheEngine extends CacheEngine
      */
     public function get($key, $default = null)
     {
+        $success = null;
         $value = wincache_ucache_get($this->_key($key), $success);
         if ($success === false) {
             return $default;

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -74,14 +74,17 @@ class WincacheEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param mixed $default Default value to return if the key does not exist.
-     * @return mixed The cached data, or false if the data doesn't exist,
+     * @return mixed The cached data, or default value if the data doesn't exist,
      *   has expired, or if there was an error fetching it
      */
     public function get($key, $default = null)
     {
-        $key = $this->_key($key);
+        $value = wincache_ucache_get($this->_key($key), $success);
+        if ($success === false) {
+            return $default;
+        }
 
-        return wincache_ucache_get($key);
+        return $value;
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -142,6 +142,23 @@ class ApcuEngineTest extends TestCase
     }
 
     /**
+     * Test get with default value
+     *
+     * @return void
+     */
+    public function testGetDefaultValue()
+    {
+        $apcu = Cache::pool('apcu');
+        $this->assertFalse($apcu->get('nope', false));
+        $this->assertNull($apcu->get('nope', null));
+        $this->assertTrue($apcu->get('nope', true));
+        $this->assertSame(0, $apcu->get('nope', 0));
+
+        $apcu->set('yep', 0);
+        $this->assertSame(0, $apcu->get('yep', false));
+    }
+
+    /**
      * testExpiry method
      *
      * @return void
@@ -151,7 +168,7 @@ class ApcuEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'apcu');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'apcu');
@@ -159,7 +176,8 @@ class ApcuEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'apcu');
-        $this->assertFalse($result);
+        $this->assertNull($result);
+        $this->assertSame(0, Cache::pool('apcu')->get('other_test', 0), 'expired values get default.');
     }
 
     /**
@@ -235,7 +253,7 @@ class ApcuEngineTest extends TestCase
 
         $result = Cache::clear('apcu');
         $this->assertTrue($result);
-        $this->assertFalse(Cache::read('some_value', 'apcu'));
+        $this->assertNull(Cache::read('some_value', 'apcu'));
         $this->assertEquals('survive', apcu_fetch('not_cake'));
         apcu_delete('not_cake');
     }
@@ -260,12 +278,12 @@ class ApcuEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'apcu_groups'));
 
         apcu_inc('test_group_a');
-        $this->assertFalse(Cache::read('test_groups', 'apcu_groups'));
+        $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'apcu_groups'));
         $this->assertEquals('value2', Cache::read('test_groups', 'apcu_groups'));
 
         apcu_inc('test_group_b');
-        $this->assertFalse(Cache::read('test_groups', 'apcu_groups'));
+        $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'apcu_groups'));
         $this->assertEquals('value3', Cache::read('test_groups', 'apcu_groups'));
     }
@@ -288,7 +306,7 @@ class ApcuEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'apcu_groups'));
 
-        $this->assertFalse(Cache::read('test_groups', 'apcu_groups'));
+        $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
     }
 
     /**
@@ -308,11 +326,11 @@ class ApcuEngineTest extends TestCase
 
         $this->assertTrue(Cache::write('test_groups', 'value', 'apcu_groups'));
         $this->assertTrue(Cache::clearGroup('group_a', 'apcu_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'apcu_groups'));
+        $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
 
         $this->assertTrue(Cache::write('test_groups', 'value2', 'apcu_groups'));
         $this->assertTrue(Cache::clearGroup('group_b', 'apcu_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'apcu_groups'));
+        $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -70,6 +70,23 @@ class FileEngineTest extends TestCase
     }
 
     /**
+     * Test get with default value
+     *
+     * @return void
+     */
+    public function testGetDefaultValue()
+    {
+        $file = Cache::pool('file_test');
+        $this->assertFalse($file->get('nope', false));
+        $this->assertNull($file->get('nope', null));
+        $this->assertTrue($file->get('nope', true));
+        $this->assertSame(0, $file->get('nope', 0));
+
+        $file->set('yep', 0);
+        $this->assertSame(0, $file->get('yep', false));
+    }
+
+    /**
      * testReadAndWriteCache method
      *
      * @return void
@@ -88,7 +105,7 @@ class FileEngineTest extends TestCase
      *
      * @return void
      */
-    public function testReadAndwrite()
+    public function testReadAndWrite()
     {
         $result = Cache::read('test', 'file_test');
         $expecting = '';
@@ -141,7 +158,8 @@ class FileEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'file_test');
-        $this->assertNull($result);
+        $this->assertNull($result, 'Expired key no result.');
+        $this->assertSame(0, Cache::pool('file_test')->get('other_test', 0), 'expired values get default.');
 
         $this->_configCache(['duration' => '+1 second']);
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -473,6 +473,23 @@ class MemcachedEngineTest extends TestCase
     }
 
     /**
+     * Test get with default value
+     *
+     * @return void
+     */
+    public function testGetDefaultValue()
+    {
+        $memcache = Cache::pool('memcached');
+        $this->assertFalse($memcache->get('nope', false));
+        $this->assertNull($memcache->get('nope', null));
+        $this->assertTrue($memcache->get('nope', true));
+        $this->assertSame(0, $memcache->get('nope', 0));
+
+        $memcache->set('yep', 0);
+        $this->assertSame(0, $memcache->get('yep', false));
+    }
+
+    /**
      * testReadMany method
      *
      * @return void
@@ -535,7 +552,7 @@ class MemcachedEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'memcached');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'memcached');
@@ -543,7 +560,7 @@ class MemcachedEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'memcached');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $this->_configCache(['duration' => '+1 second']);
 
@@ -553,10 +570,10 @@ class MemcachedEngineTest extends TestCase
 
         sleep(3);
         $result = Cache::read('other_test', 'memcached');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $result = Cache::read('other_test', 'memcached');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $this->_configCache(['duration' => '+29 days']);
         $data = 'this is a test of the emergency broadcasting system';
@@ -607,12 +624,12 @@ class MemcachedEngineTest extends TestCase
 
         Cache::deleteMany(array_merge(array_keys($data), ['App.doesNotExist']), 'memcached');
 
-        $this->assertFalse(Cache::read('App.falseTest', 'memcached'));
-        $this->assertFalse(Cache::read('App.trueTest', 'memcached'));
-        $this->assertFalse(Cache::read('App.nullTest', 'memcached'));
-        $this->assertFalse(Cache::read('App.zeroTest', 'memcached'));
-        $this->assertFalse(Cache::read('App.zeroTest2', 'memcached'));
-        $this->assertSame(Cache::read('App.keepTest', 'memcached'), 'keepMe');
+        $this->assertNull(Cache::read('App.falseTest', 'memcached'));
+        $this->assertNull(Cache::read('App.trueTest', 'memcached'));
+        $this->assertNull(Cache::read('App.nullTest', 'memcached'));
+        $this->assertNull(Cache::read('App.zeroTest', 'memcached'));
+        $this->assertNull(Cache::read('App.zeroTest2', 'memcached'));
+        $this->assertSame('keepMe', Cache::read('App.keepTest', 'memcached'));
     }
 
     /**
@@ -713,8 +730,8 @@ class MemcachedEngineTest extends TestCase
 
         sleep(1);
 
-        $this->assertFalse(Cache::read('test_increment', 'memcached'));
-        $this->assertFalse(Cache::read('test_decrement', 'memcached'));
+        $this->assertNull(Cache::read('test_increment', 'memcached'));
+        $this->assertNull(Cache::read('test_decrement', 'memcached'));
     }
 
     /**
@@ -777,8 +794,8 @@ class MemcachedEngineTest extends TestCase
         $this->assertEquals('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
 
         usleep(3000000);
-        $this->assertFalse(Cache::read('short_duration_test', 'short_memcached'), 'Cache was not invalidated %s');
-        $this->assertFalse(Cache::read('duration_test', 'long_memcached'), 'Value did not expire %s');
+        $this->assertNull(Cache::read('short_duration_test', 'short_memcached'), 'Cache was not invalidated %s');
+        $this->assertNull(Cache::read('duration_test', 'long_memcached'), 'Value did not expire %s');
 
         Cache::delete('duration_test', 'long_memcached');
         Cache::delete('short_duration_test', 'short_memcached');
@@ -802,7 +819,7 @@ class MemcachedEngineTest extends TestCase
         sleep(1);
         $this->assertTrue(Cache::clear('memcached'));
 
-        $this->assertFalse(Cache::read('some_value', 'memcached'));
+        $this->assertNull(Cache::read('some_value', 'memcached'));
         $this->assertEquals('cache2', Cache::read('some_value', 'memcached2'));
 
         Cache::clear('memcached2');
@@ -847,12 +864,12 @@ class MemcachedEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'memcached_groups'));
 
         Cache::increment('group_a', 1, 'memcached_helper');
-        $this->assertFalse(Cache::read('test_groups', 'memcached_groups'));
+        $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'memcached_groups'));
         $this->assertEquals('value2', Cache::read('test_groups', 'memcached_groups'));
 
         Cache::increment('group_b', 1, 'memcached_helper');
-        $this->assertFalse(Cache::read('test_groups', 'memcached_groups'));
+        $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'memcached_groups'));
         $this->assertEquals('value3', Cache::read('test_groups', 'memcached_groups'));
     }
@@ -873,7 +890,7 @@ class MemcachedEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'memcached_groups'));
 
-        $this->assertFalse(Cache::read('test_groups', 'memcached_groups'));
+        $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
     }
 
     /**
@@ -891,11 +908,11 @@ class MemcachedEngineTest extends TestCase
 
         $this->assertTrue(Cache::write('test_groups', 'value', 'memcached_groups'));
         $this->assertTrue(Cache::clearGroup('group_a', 'memcached_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'memcached_groups'));
+        $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
 
         $this->assertTrue(Cache::write('test_groups', 'value2', 'memcached_groups'));
         $this->assertTrue(Cache::clearGroup('group_b', 'memcached_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'memcached_groups'));
+        $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -170,17 +170,17 @@ class RedisEngineTest extends TestCase
         $result = Cache::write('save_in_1', true, 'redisdb1');
         $this->assertTrue($result);
         $exist = Cache::read('save_in_0', 'redisdb1');
-        $this->assertFalse($exist);
+        $this->assertNull($exist);
         $exist = Cache::read('save_in_1', 'redisdb1');
         $this->assertTrue($exist);
 
         Cache::delete('save_in_0', 'redisdb0');
         $exist = Cache::read('save_in_0', 'redisdb0');
-        $this->assertFalse($exist);
+        $this->assertNull($exist);
 
         Cache::delete('save_in_1', 'redisdb1');
         $exist = Cache::read('save_in_1', 'redisdb1');
-        $this->assertFalse($exist);
+        $this->assertNull($exist);
 
         Cache::drop('redisdb0');
         Cache::drop('redisdb1');
@@ -232,6 +232,23 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * Test get with default value
+     *
+     * @return void
+     */
+    public function testGetDefaultValue()
+    {
+        $redis = Cache::pool('redis');
+        $this->assertFalse($redis->get('nope', false));
+        $this->assertNull($redis->get('nope', null));
+        $this->assertTrue($redis->get('nope', true));
+        $this->assertSame(0, $redis->get('nope', 0));
+
+        $redis->set('yep', 0);
+        $this->assertSame(0, $redis->get('yep', false));
+    }
+
+    /**
      * testExpiry method
      *
      * @return void
@@ -241,7 +258,7 @@ class RedisEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'redis');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'redis');
@@ -249,7 +266,7 @@ class RedisEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'redis');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $this->_configCache(['duration' => '+1 second']);
 
@@ -259,12 +276,12 @@ class RedisEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'redis');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         sleep(2);
 
         $result = Cache::read('other_test', 'redis');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $this->_configCache(['duration' => '+29 days']);
         $data = 'this is a test of the emergency broadcasting system';
@@ -374,8 +391,8 @@ class RedisEngineTest extends TestCase
 
         sleep(2);
 
-        $this->assertFalse(Cache::read('test_increment', 'redis'));
-        $this->assertFalse(Cache::read('test_decrement', 'redis'));
+        $this->assertNull(Cache::read('test_increment', 'redis'));
+        $this->assertNull(Cache::read('test_decrement', 'redis'));
     }
 
     /**
@@ -394,12 +411,12 @@ class RedisEngineTest extends TestCase
         Cache::write('some_value', 'cache1', 'redis');
         $result = Cache::clear('redis');
         $this->assertTrue($result);
-        $this->assertFalse(Cache::read('some_value', 'redis'));
+        $this->assertNull(Cache::read('some_value', 'redis'));
 
         Cache::write('some_value', 'cache2', 'redis2');
         $result = Cache::clear('redis');
         $this->assertTrue($result);
-        $this->assertFalse(Cache::read('some_value', 'redis'));
+        $this->assertNull(Cache::read('some_value', 'redis'));
         $this->assertEquals('cache2', Cache::read('some_value', 'redis2'));
 
         Cache::clear('redis2');
@@ -444,12 +461,12 @@ class RedisEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'redis_groups'));
 
         Cache::increment('group_a', 1, 'redis_helper');
-        $this->assertFalse(Cache::read('test_groups', 'redis_groups'));
+        $this->assertNull(Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'redis_groups'));
         $this->assertEquals('value2', Cache::read('test_groups', 'redis_groups'));
 
         Cache::increment('group_b', 1, 'redis_helper');
-        $this->assertFalse(Cache::read('test_groups', 'redis_groups'));
+        $this->assertNull(Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'redis_groups'));
         $this->assertEquals('value3', Cache::read('test_groups', 'redis_groups'));
     }
@@ -470,7 +487,7 @@ class RedisEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'redis_groups'));
 
-        $this->assertFalse(Cache::read('test_groups', 'redis_groups'));
+        $this->assertNull(Cache::read('test_groups', 'redis_groups'));
     }
 
     /**
@@ -488,11 +505,11 @@ class RedisEngineTest extends TestCase
 
         $this->assertTrue(Cache::write('test_groups', 'value', 'redis_groups'));
         $this->assertTrue(Cache::clearGroup('group_a', 'redis_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'redis_groups'));
+        $this->assertNull(Cache::read('test_groups', 'redis_groups'));
 
         $this->assertTrue(Cache::write('test_groups', 'value2', 'redis_groups'));
         $this->assertTrue(Cache::clearGroup('group_b', 'redis_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'redis_groups'));
+        $this->assertNull(Cache::read('test_groups', 'redis_groups'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -90,6 +90,23 @@ class WincacheEngineTest extends TestCase
     }
 
     /**
+     * Test get with default value
+     *
+     * @return void
+     */
+    public function testGetDefaultValue()
+    {
+        $wincache = Cache::pool('wincache');
+        $this->assertFalse($wincache->get('nope', false));
+        $this->assertNull($wincache->get('nope', null));
+        $this->assertTrue($wincache->get('nope', true));
+        $this->assertSame(0, $wincache->get('nope', 0));
+
+        $wincache->set('yep', 0);
+        $this->assertSame(0, $wincache->get('yep', false));
+    }
+
+    /**
      * testExpiry method
      *
      * @return void
@@ -99,7 +116,7 @@ class WincacheEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'wincache');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'wincache');
@@ -107,7 +124,7 @@ class WincacheEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'wincache');
-        $this->assertFalse($result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'wincache');
@@ -115,7 +132,7 @@ class WincacheEngineTest extends TestCase
 
         sleep(2);
         $result = Cache::read('other_test', 'wincache');
-        $this->assertFalse($result);
+        $this->assertNull($result);
     }
 
     /**
@@ -201,7 +218,7 @@ class WincacheEngineTest extends TestCase
 
         $result = Cache::clear('wincache');
         $this->assertTrue($result);
-        $this->assertFalse(Cache::read('some_value', 'wincache'));
+        $this->assertNull(Cache::read('some_value', 'wincache'));
         $this->assertEquals('safe', wincache_ucache_get('not_cake'));
     }
 
@@ -224,12 +241,12 @@ class WincacheEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'wincache_groups'));
 
         wincache_ucache_inc('test_group_a');
-        $this->assertFalse(Cache::read('test_groups', 'wincache_groups'));
+        $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'wincache_groups'));
         $this->assertEquals('value2', Cache::read('test_groups', 'wincache_groups'));
 
         wincache_ucache_inc('test_group_b');
-        $this->assertFalse(Cache::read('test_groups', 'wincache_groups'));
+        $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'wincache_groups'));
         $this->assertEquals('value3', Cache::read('test_groups', 'wincache_groups'));
     }
@@ -251,7 +268,7 @@ class WincacheEngineTest extends TestCase
         $this->assertEquals('value', Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'wincache_groups'));
 
-        $this->assertFalse(Cache::read('test_groups', 'wincache_groups'));
+        $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
     }
 
     /**
@@ -270,10 +287,10 @@ class WincacheEngineTest extends TestCase
 
         $this->assertTrue(Cache::write('test_groups', 'value', 'wincache_groups'));
         $this->assertTrue(Cache::clearGroup('group_a', 'wincache_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'wincache_groups'));
+        $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
 
         $this->assertTrue(Cache::write('test_groups', 'value2', 'wincache_groups'));
         $this->assertTrue(Cache::clearGroup('group_b', 'wincache_groups'));
-        $this->assertFalse(Cache::read('test_groups', 'wincache_groups'));
+        $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
     }
 }


### PR DESCRIPTION
Add support for default values in `CacheEngine::get()`. This is a necessary piece of PSR16 support. This also normalized cache 'misses' to be `null`. Previously you would get null or false depending on which cache engine you were using :cry:

I have not tested wincache locally and will use Appveyor to muddle my way through getting that fixed :blush: