### PR TITLE
Allow multiple delimiters on Inflector::humanize

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -150,7 +150,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @var string
      */
-    const RULES_CLASS = 'Cake\ORM\RulesChecker';
+    const RULES_CLASS = RulesChecker::class;
+
+    /**
+     * The IsUnique class name that is used.
+     *
+     * @var string
+     */
+    const IS_UNIQUE_CLASS = IsUnique::class;
 
     /**
      * Name of the table as it can be found in the database
@@ -2797,7 +2804,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return false;
             }
         }
-        $rule = new IsUnique($fields, $options);
+        $class = static::IS_UNIQUE_CLASS;
+        $rule = new $class($fields, $options);
 
         return $rule($entity, ['repository' => $this]);
     }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -644,12 +644,12 @@ class Inflector
     public static function humanize($string, $delimiter = '_')
     {
         $delimiters = $delimiter;
-        if(is_array($delimiter)){
+        if(is_array($delimiter))
+        {
             $delimiters = implode("_", $delimiter);
         }
         
         $cacheKey = __FUNCTION__ . $delimiters;
-
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -625,7 +625,7 @@ class Inflector
      * Also replaces underscores with dashes
      *
      * @param string $string The string to dasherize.
-     * @return mixed Dashed version of the input string
+     * @return string|array Dashed version of the input string or multiple strings
      */
     public static function dasherize($string)
     {

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -645,7 +645,7 @@ class Inflector
     {
         $delimiters = $delimiter;
         if (is_array($delimiter)) {
-            $delimiters = implode("_", $delimiter);
+            $delimiters = implode('_', $delimiter);
         }
         
         $cacheKey = __FUNCTION__ . $delimiters;

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -647,7 +647,7 @@ class Inflector
         if (is_array($delimiter)) {
             $delimiters = implode('_', $delimiter);
         }
-        
+
         $cacheKey = __FUNCTION__ . $delimiters;
         $result = static::_cache($cacheKey, $string);
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -644,8 +644,7 @@ class Inflector
     public static function humanize($string, $delimiter = '_')
     {
         $delimiters = $delimiter;
-        if(is_array($delimiter))
-        {
+        if(is_array($delimiter)) {
             $delimiters = implode("_", $delimiter);
         }
         

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -625,7 +625,7 @@ class Inflector
      * Also replaces underscores with dashes
      *
      * @param string $string The string to dasherize.
-     * @return string Dashed version of the input string
+     * @return mixed Dashed version of the input string
      */
     public static function dasherize($string)
     {
@@ -643,6 +643,11 @@ class Inflector
      */
     public static function humanize($string, $delimiter = '_')
     {
+        $delimiters = $delimiter;
+        if(is_array($delimiter)){
+            $delimiters = implode("_", $delimiter);
+        }
+        
         $cacheKey = __FUNCTION__ . $delimiter;
 
         $result = static::_cache($cacheKey, $string);

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -625,7 +625,7 @@ class Inflector
      * Also replaces underscores with dashes
      *
      * @param string $string The string to dasherize.
-     * @return string|array Dashed version of the input string or multiple strings
+     * @return string Dashed version of the input string
      */
     public static function dasherize($string)
     {
@@ -637,7 +637,7 @@ class Inflector
      * (Underscores are replaced by spaces and capitalized following words.)
      *
      * @param string $string String to be humanized
-     * @param string $delimiter the character to replace with a space
+     * @param string|array $delimiter the character or multiple characters to replace with a space
      * @return string Human-readable string
      * @link https://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-human-readable-forms
      */

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -648,7 +648,7 @@ class Inflector
             $delimiters = implode("_", $delimiter);
         }
         
-        $cacheKey = __FUNCTION__ . $delimiter;
+        $cacheKey = __FUNCTION__ . $delimiters;
 
         $result = static::_cache($cacheKey, $string);
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -644,7 +644,7 @@ class Inflector
     public static function humanize($string, $delimiter = '_')
     {
         $delimiters = $delimiter;
-        if(is_array($delimiter)) {
+        if (is_array($delimiter)) {
             $delimiters = implode("_", $delimiter);
         }
         

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -607,6 +607,7 @@ class InflectorTest extends TestCase
         $this->assertSame('', Inflector::humanize(false));
         $this->assertSame('Hello Wörld', Inflector::humanize('hello_wörld'));
         $this->assertSame('福岡 City', Inflector::humanize('福岡_city'));
+        $this->assertSame('User Is Active', Inflector::humanize('user.is_active',['.','_']));
     }
 
     /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -607,7 +607,7 @@ class InflectorTest extends TestCase
         $this->assertSame('', Inflector::humanize(false));
         $this->assertSame('Hello Wörld', Inflector::humanize('hello_wörld'));
         $this->assertSame('福岡 City', Inflector::humanize('福岡_city'));
-        $this->assertSame('User Is Active', Inflector::humanize('user.is_active',['.','_']));
+        $this->assertSame('User Is Active', Inflector::humanize('user.is_active', ['.', '_']));
     }
 
     /**


### PR DESCRIPTION
Allow mutiple delimiters for Inflector::humanize method
eg.
```PHP
$field = "user.is_active";
echo Inflector::humanize($field,[".","_"]); 
```
Will return User Is Active instead of User.is_active or User Is_active