### PR TITLE
3.next - Add TestCase method to drop plugins.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -12,7 +12,6 @@
  * @since         0.2.9
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 use Cake\Routing\Router;
 
 define('TIME_START', microtime(true));

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -15,6 +15,7 @@ namespace Cake\TestSuite;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
@@ -218,6 +219,33 @@ abstract class TestCase extends BaseTestCase
         $app->pluginRoutes($builder);
 
         return $app;
+    }
+
+    /**
+     * Remove plugins from the global plugin collection.
+     *
+     * Useful in test case teardown methods.
+     *
+     * @return void
+     */
+    public function removePlugins(array $plugins = [])
+    {
+        $collection = Plugin::getCollection();
+        foreach ($plugins as $plugin) {
+            $collection->remove($plugin);
+        }
+    }
+
+    /**
+     * Clear all plugins from the global plugin collection.
+     *
+     * Useful in test case teardown methods.
+     *
+     * @return void
+     */
+    public function clearPlugins()
+    {
+        Plugin::getCollection()->clear();
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -226,6 +226,7 @@ abstract class TestCase extends BaseTestCase
      *
      * Useful in test case teardown methods.
      *
+     * @param array $plugins A list of plugins you want to remove.
      * @return void
      */
     public function removePlugins(array $plugins = [])

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -298,7 +298,7 @@ class FormAuthenticateTest extends TestCase
             'updated' => new Time('2007-03-17 01:18:31')
         ];
         $this->assertEquals($expected, $result);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -44,7 +44,7 @@ class PasswordHasherFactoryTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         $hasher = PasswordHasherFactory::build('TestPlugin.Legacy');
         $this->assertInstanceof('TestPlugin\Auth\LegacyPasswordHasher', $hasher);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -315,7 +315,7 @@ class CacheTest extends TestCase
         Cache::drop('libEngine');
         Cache::drop('pluginLibEngine');
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -34,7 +34,6 @@ class HelpCommandTest extends ConsoleIntegrationTestCase
         parent::setUp();
         $this->setAppNamespace();
         $this->useCommandRunner(true);
-        Plugin::getCollection()->clear();
         $app = $this->getMockForAbstractClass(
             BaseApplication::class,
             ['']
@@ -50,7 +49,7 @@ class HelpCommandTest extends ConsoleIntegrationTestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**
@@ -63,7 +62,7 @@ class HelpCommandTest extends ConsoleIntegrationTestCase
         $this->exec('help');
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertCommandList();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -296,6 +296,6 @@ class CommandCollectionTest extends TestCase
             'Long names are stored as well'
         );
         $this->assertSame($result['company'], $result['company/test_plugin_three.company']);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 }

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -127,6 +127,6 @@ class HelperRegistryTest extends TestCase
 
         $result = $this->helpers->loaded();
         $this->assertEquals(['SimpleAliased', 'SomeHelper'], $result, 'loaded() results are wrong.');
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 }

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -49,7 +49,7 @@ class ShellDispatcherTest extends TestCase
     {
         parent::tearDown();
         ShellDispatcher::resetAliases();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -141,7 +141,7 @@ class ShellTest extends TestCase
             'TestPlugin\Model\Table\TestPluginCommentsTable',
             $this->Shell->TestPluginComments
         );
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**
@@ -170,7 +170,7 @@ class ShellTest extends TestCase
             'TestPlugin\Model\Table\TestPluginCommentsTable',
             $this->Shell->TestPluginComments
         );
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -94,7 +94,7 @@ class TaskRegistryTest extends TestCase
         $result = $this->Tasks->load('TestPlugin.OtherTask');
         $this->assertInstanceOf('TestPlugin\Shell\Task\OtherTaskTask', $result, 'Task class is wrong.');
         $this->assertInstanceOf('TestPlugin\Shell\Task\OtherTaskTask', $this->Tasks->OtherTask, 'Class is wrong');
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**
@@ -119,6 +119,6 @@ class TaskRegistryTest extends TestCase
 
         $result = $this->Tasks->loaded();
         $this->assertEquals(['CommandAliased', 'SomeTask'], $result, 'loaded() results are wrong.');
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 }

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -54,7 +54,7 @@ class ComponentRegistryTest extends TestCase
     {
         parent::tearDown();
         unset($this->Components);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -257,7 +257,7 @@ class ControllerTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -32,7 +32,7 @@ class AppTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -39,7 +39,7 @@ class BasePluginTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -221,7 +221,7 @@ class IniConfigTest extends TestCase
 
         $result = $engine->read('TestPlugin.nested');
         $this->assertEquals('foo', $result['database']['db']['password']);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -142,7 +142,7 @@ class JsonConfigTest extends TestCase
         $result = $engine->read('TestPlugin.load');
         $this->assertArrayHasKey('plugin_load', $result);
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -128,7 +128,7 @@ class PhpConfigTest extends TestCase
         $result = $engine->read('TestPlugin.load');
         $this->assertArrayHasKey('plugin_load', $result);
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -406,7 +406,7 @@ class ConfigureTest extends TestCase
         $expected = '/test_app/Plugin/TestPlugin/Config/more.load.php';
         $config = Configure::read('plugin_more_load');
         $this->assertEquals($expected, $config);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -32,7 +32,7 @@ class PluginTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**
@@ -43,7 +43,7 @@ class PluginTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -68,6 +68,7 @@ class ConnectionManagerTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
+        $this->clearPlugins();
         Plugin::getCollection()->clear();
         ConnectionManager::drop('test_variant');
         ConnectionManager::dropAlias('other_name');

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -11,7 +11,6 @@
  */
 namespace Cake\Test\TestCase\Datasource;
 
-use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
@@ -69,7 +68,6 @@ class ConnectionManagerTest extends TestCase
     {
         parent::tearDown();
         $this->clearPlugins();
-        Plugin::getCollection()->clear();
         ConnectionManager::drop('test_variant');
         ConnectionManager::dropAlias('other_name');
     }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -112,7 +112,7 @@ class ErrorHandlerTest extends TestCase
     {
         parent::tearDown();
         Log::reset();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         if ($this->_restoreError) {
             restore_error_handler();
             restore_exception_handler();

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -183,7 +183,7 @@ class ExceptionRendererTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         if ($this->_restoreError) {
             restore_error_handler();
         }

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -49,7 +49,7 @@ class BaseApplicationTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -88,7 +88,7 @@ class SessionTest extends TestCase
     {
         unset($_SESSION);
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -56,7 +56,7 @@ class I18nTest extends TestCase
         I18n::clear();
         I18n::setDefaultFormatter('default');
         I18n::setLocale($this->locale);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         Cache::clear(false, '_cake_core_');
     }
 

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -64,7 +64,7 @@ class LogTest extends TestCase
 
         Log::write(LOG_INFO, 'TestPluginLog is not a BaseLog descendant');
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1792,7 +1792,7 @@ class EmailTest extends TestCase
         $this->assertContains('Message-ID: ', $result['headers']);
         $this->assertContains('To: ', $result['headers']);
         $this->assertContains('/test_theme/img/test.jpg', $result['message']);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**
@@ -1975,7 +1975,7 @@ class EmailTest extends TestCase
         $result = $this->Email->send();
         $this->assertContains('Here is your value: 12345', $result['message']);
         $this->assertContains('This email was sent using the TestPlugin.', $result['message']);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -540,7 +540,7 @@ class AssociationTest extends TestCase
         $this->assertSame('TestPlugin.ThisAssociationName', $table->getRegistryAlias());
         $this->assertSame('comments', $table->getTable());
         $this->assertSame('ThisAssociationName', $table->getAlias());
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -46,7 +46,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function tearDown()
     {
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->Table, $this->EventManager, $this->Behaviors);
         parent::tearDown();
     }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -68,7 +68,7 @@ class TableLocatorTest extends TestCase
      */
     public function tearDown()
     {
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         parent::tearDown();
     }
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -545,7 +545,7 @@ class QueryRegressionTest extends TestCase
             $result->author->id,
             'No SQL error and author exists.'
         );
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -398,7 +398,7 @@ class ResultSetTest extends TestCase
         })->first();
         $this->assertEquals('TestPlugin.Comments', $result->getSource());
         $this->assertEquals('TestPlugin.Authors', $result->_matchingData['Authors']->getSource());
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -128,7 +128,7 @@ class TableTest extends TestCase
     {
         parent::tearDown();
         $this->getTableLocator()->clear();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -61,7 +61,7 @@ class DispatcherTest extends TestCase
     {
         error_reporting($this->errorLevel);
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -44,7 +44,7 @@ class AssetFilterTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -43,7 +43,7 @@ class AssetMiddlewareTest extends TestCase
      */
     public function tearDown()
     {
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         parent::tearDown();
     }
 

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -65,7 +65,7 @@ class RequestActionTraitTest extends TestCase
         parent::tearDown();
         DispatcherFactory::clear();
         Router::reload();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
 
         error_reporting($this->errorLevel);
     }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -49,7 +49,7 @@ class RouteBuilderTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -51,7 +51,7 @@ class RouterTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         Router::reload();
         Router::defaultRouteClass('Cake\Routing\Route\Route');
     }
@@ -2692,7 +2692,7 @@ class RouterTest extends TestCase
             ['routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+']
         );
         $this->assertTrue(true); // Just to make sure the connect do not throw exception
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -44,7 +44,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -74,7 +74,7 @@ class CompletionShellTest extends TestCase
         parent::tearDown();
         unset($this->Shell);
         static::setAppNamespace('App');
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Shell/Task/AssetsTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssetsTaskTest.php
@@ -57,7 +57,7 @@ class AssetsTaskTest extends TestCase
     {
         parent::tearDown();
         unset($this->Task);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -66,7 +66,7 @@ class ExtractTaskTest extends TestCase
 
         $Folder = new Folder($this->path);
         $Folder->delete();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -67,7 +67,7 @@ class UnloadTaskTest extends ConsoleIntegrationTestCase
     {
         parent::tearDown();
         unset($this->shell);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
 
         file_put_contents($this->bootstrap, $this->originalBootstrapContent);
         file_put_contents($this->app, $this->originalAppContent);

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -45,7 +45,7 @@ class FixtureManagerTest extends TestCase
     {
         parent::tearDown();
         Log::reset();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -290,7 +290,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     {
         // first clean routes to have Router::$initailized === false
         Router::reload();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
 
         $this->configApplication(Configure::read('App.namespace') . '\ApplicationWithPluginRoutes', null);
 

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -465,7 +465,7 @@ class TestCaseTest extends TestCase
         $TestPluginAuthors = $this->getMockForModel('TestPlugin.Authors', ['doSomething']);
         $this->assertInstanceOf('TestPlugin\Model\Table\AuthorsTable', $TestPluginAuthors);
         $this->assertEquals('TestPlugin\Model\Entity\Author', $TestPluginAuthors->getEntityClass());
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -59,7 +59,7 @@ class CellTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->View);
     }
 

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -106,7 +106,7 @@ class FlashHelperTest extends TestCase
     {
         parent::tearDown();
         unset($this->View, $this->Flash);
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -87,7 +87,7 @@ class HtmlHelperTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->Html, $this->View);
     }
 
@@ -599,7 +599,7 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->css('TestPlugin.style', ['plugin' => false]);
         $expected['link']['href'] = 'preg:/.*css\/TestPlugin\.style\.css/';
         $this->assertHtml($expected, $result);
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
 
         $result = $this->Html->css('my.css.library');
         $expected['link']['href'] = 'preg:/.*css\/my\.css\.library\.css/';
@@ -737,7 +737,7 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result[1]);
         $this->assertCount(2, $result);
 
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugin(['TestPlugin']);
     }
 
     /**
@@ -823,7 +823,7 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'preg:/\/testing\/longer\/test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
         $this->assertHtml($expected, $result);
 
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**
@@ -897,7 +897,7 @@ class HtmlHelperTest extends TestCase
         unlink($pluginJsPath . DS . '__cake_js_test.js');
         Configure::write('Asset.timestamp', false);
 
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**
@@ -1066,7 +1066,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -737,7 +737,7 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result[1]);
         $this->assertCount(2, $result);
 
-        $this->removePlugin(['TestPlugin']);
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -74,7 +74,7 @@ class NumberHelperTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         static::setAppNamespace($this->_appNamespace);
         unset($this->View);
     }
@@ -131,6 +131,6 @@ class NumberHelperTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);
         $this->assertInstanceOf('TestPlugin\Utility\TestPluginEngine', $Number->engine());
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 }

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -142,7 +142,7 @@ class TextHelperTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         $Text = new TextHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);
         $this->assertInstanceOf('TestPlugin\Utility\TestPluginEngine', $Text->engine());
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -60,7 +60,7 @@ class UrlHelperTest extends TestCase
         parent::tearDown();
         Configure::delete('Asset');
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->Helper, $this->View);
     }
 
@@ -287,7 +287,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->assetUrl('TestPlugin.style', ['ext' => '.css', 'plugin' => false]);
         $this->assertEquals('TestPlugin.style.css', $result);
 
-        Plugin::getCollection()->remove('TestPlugin');
+        $this->removePlugins(['TestPlugin']);
     }
 
     /**

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -67,7 +67,7 @@ class HelperRegistryTest extends TestCase
      */
     public function tearDown()
     {
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->Helpers, $this->View);
         parent::tearDown();
     }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -78,7 +78,7 @@ class HelperTest extends TestCase
         parent::tearDown();
         Configure::delete('Asset');
 
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->View);
     }
 

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -195,7 +195,7 @@ class StringTemplateTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         $this->assertNull($this->template->load('TestPlugin.test_templates'));
         $this->assertEquals('<em>{{text}}</em>', $this->template->get('italic'));
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -324,7 +324,7 @@ class ViewTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
         unset($this->View);
         unset($this->PostsController);
         unset($this->Controller);

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -99,7 +99,7 @@ class WidgetLocatorTestCase extends TestCase
         ];
         $inputs = new WidgetLocator($this->templates, $this->view, $widgets);
         $this->assertInstanceOf('Cake\View\Widget\LabelWidget', $inputs->get('text'));
-        Plugin::getCollection()->clear();
+        $this->clearPlugins();
     }
 
     /**


### PR DESCRIPTION
Add veneer methods so that folks don't have to interact with PluginCollection directly if they have to dynamically load plugins. This lets us match the interface style used for loadPlugins()

Refs #12691
Refs #12687