### PR TITLE
Fix paginator defaulting for multi-default-sort.

### DIFF
--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -221,7 +221,7 @@ class Paginator implements PaginatorInterface
             'nextPage' => $count > ($page * $limit),
             'pageCount' => $pageCount,
             'sort' => $options['sort'],
-            'direction' => current($order),
+            'direction' => isset($options['sort']) ? current($order) : null,
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -436,6 +436,7 @@ class PaginatorHelper extends Helper
 
             $title = __(Inflector::humanize(preg_replace('/_id$/', '', $title)));
         }
+
         $defaultDir = isset($options['direction']) ? strtolower($options['direction']) : 'asc';
         unset($options['direction']);
 

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -248,6 +248,43 @@ class PaginatorTest extends TestCase
     }
 
     /**
+     * Tests that flat default pagination parameters work for multi order.
+     *
+     * @return void
+     */
+    public function testDefaultPaginateParamsMultiOrder()
+    {
+        $settings = [
+            'order' => ['PaginatorPosts.id' => 'DESC', 'PaginatorPosts.title' => 'ASC'],
+        ];
+
+        $table = $this->_getMockPosts(['query']);
+        $query = $this->_getMockFindQuery();
+
+        $table->expects($this->once())
+            ->method('query')
+            ->will($this->returnValue($query));
+
+        $query->expects($this->once())
+            ->method('applyOptions')
+            ->with([
+                'limit' => 20,
+                'page' => 1,
+                'order' => $settings['order'],
+                'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'scope' => null,
+                'sort' => null,
+            ]);
+
+        $this->Paginator->paginate($table, [], $settings);
+
+        $pagingParams = $this->Paginator->getPagingParams();
+        $this->assertNull($pagingParams['PaginatorPosts']['direction']);
+        $this->assertFalse($pagingParams['PaginatorPosts']['sortDefault']);
+        $this->assertFalse($pagingParams['PaginatorPosts']['directionDefault']);
+    }
+
+    /**
      * test that default sort and default direction are injected into request
      *
      * @return void

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
 
 class PaginatorTest extends TestCase
 {
-
     /**
      * fixtures property
      *
@@ -41,6 +40,11 @@ class PaginatorTest extends TestCase
      * @var bool
      */
     public $autoFixtures = false;
+
+    /**
+     * @var \Cake\Datasource\Paginator
+     */
+    public $Paginator;
 
     /**
      * setup
@@ -915,6 +919,9 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $result['order']);
     }
 
+    /**
+     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function getMockRepository()
     {
         $model = $this->getMockBuilder('Cake\Datasource\RepositoryInterface')
@@ -927,6 +934,9 @@ class PaginatorTest extends TestCase
         return $model;
     }
 
+    /**
+     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function mockAliasHasFieldModel()
     {
         $model = $this->getMockRepository();
@@ -1372,7 +1382,7 @@ class PaginatorTest extends TestCase
      * Helper method for making mocks.
      *
      * @param array $methods
-     * @return \Cake\ORM\Table
+     * @return \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function _getMockPosts($methods = [])
     {
@@ -1396,10 +1406,12 @@ class PaginatorTest extends TestCase
     /**
      * Helper method for mocking queries.
      *
-     * @return \Cake\ORM\Query
+     * @param string|null $table
+     * @return \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function _getMockFindQuery($table = null)
     {
+        /** @var \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject $query */
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['total', 'all', 'count', 'applyOptions'])
             ->disableOriginalConstructor()


### PR DESCRIPTION
```php
        $this->paginate = [
            'order' => ['released' => 'DESC', 'modified' => 'DESC'],
        ];
```
results in /index in links like

    /controller/action?page=x&direction=DESC

Currently, if you have a multi default sort set, it would always add the direction query string into even the index root (without any query string filters) pagination links it builds.
This is due to a logical error.
The result should be

    /controller/action?page=x

sort is not set here, but direction always is based on completeSort. This fixes it.