### PR TITLE
- Add the functionality to accept enum MySQL datatype storing the Integer values as String

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -367,18 +367,18 @@ class DboSource extends DataSource {
 			$column = $this->introspectType($data);
 		}
 
+		$isStringEnum = false;
 		if (strpos($column, "enum") === 0) {
-			preg_match("/(enum\()(.*)(\))/", $column, $acceptingValues);
+			$firstValue = null;
 			if(preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues)){
-			    $values = explode(",", $acceptingValues[2]);
-			    $firstValue = $value[0];
+				$values = explode(",", $acceptingValues[2]);
+				$firstValue = $value[0];
 			}
 			if (is_string($firstValue)) {
 				$isStringEnum = true;
 			}
 		}
 
-		
 		switch ($column) {
 			case 'binary':
 				return $this->_connection->quote($data, PDO::PARAM_LOB);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -368,7 +368,7 @@ class DboSource extends DataSource {
 		}
 
 		if (strpos($column, "enum")===0){
-			preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues);
+			preg_match("/(enum\()(.*)(\))/", $column, $acceptingValues);
 			$firstValue = explode(",", $acceptingValues[2])[0];
 			if (is_string($firstValue)){
 				$isStringEnum = true;

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -367,6 +367,15 @@ class DboSource extends DataSource {
 			$column = $this->introspectType($data);
 		}
 
+		if (strpos($column, "enum")===0){
+			preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues);
+			$firstValue = explode(",", $acceptingValues[2])[0];
+			if (is_string($firstValue)){
+				$isStringEnum = true;
+			}
+		}
+
+		
 		switch ($column) {
 			case 'binary':
 				return $this->_connection->quote($data, PDO::PARAM_LOB);
@@ -382,11 +391,12 @@ class DboSource extends DataSource {
 				if (is_float($data)) {
 					return str_replace(',', '.', strval($data));
 				}
-				if ((is_int($data) || $data === '0') || (
+				if (((is_int($data) || $data === '0') || (
 					is_numeric($data) &&
 					strpos($data, ',') === false &&
 					$data[0] != '0' &&
 					strpos($data, 'e') === false)
+					) && empty($isStringEnum)
 				) {
 					return $data;
 				}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -370,7 +370,7 @@ class DboSource extends DataSource {
 		$isStringEnum = false;
 		if (strpos($column, "enum") === 0) {
 			$firstValue = null;
-			if(preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues)){
+			if (preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues)) {
 				$values = explode(",", $acceptingValues[2]);
 				$firstValue = $value[0];
 			}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -367,7 +367,7 @@ class DboSource extends DataSource {
 			$column = $this->introspectType($data);
 		}
 
-		if (strpos($column, "enum")===0){
+		if (strpos($column, "enum") === 0) {
 			preg_match("/(enum\()(.*)(\))/", $column, $acceptingValues);
 			$firstValue = explode(",", $acceptingValues[2])[0];
 			if (is_string($firstValue)){

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -370,9 +370,9 @@ class DboSource extends DataSource {
 		$isStringEnum = false;
 		if (strpos($column, "enum") === 0) {
 			$firstValue = null;
-			if (preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues)) {
+			if (preg_match("/(enum\()(.*)(\))/i",$column, $acceptingValues)) {
 				$values = explode(",", $acceptingValues[2]);
-				$firstValue = $value[0];
+				$firstValue = $values[0];
 			}
 			if (is_string($firstValue)) {
 				$isStringEnum = true;

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -370,7 +370,7 @@ class DboSource extends DataSource {
 		if (strpos($column, "enum") === 0) {
 			preg_match("/(enum\()(.*)(\))/", $column, $acceptingValues);
 			$firstValue = explode(",", $acceptingValues[2])[0];
-			if (is_string($firstValue)){
+			if (is_string($firstValue)) {
 				$isStringEnum = true;
 			}
 		}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -396,7 +396,7 @@ class DboSource extends DataSource {
 					strpos($data, ',') === false &&
 					$data[0] != '0' &&
 					strpos($data, 'e') === false)
-					) && empty($isStringEnum)
+					) && !$isStringEnum
 				) {
 					return $data;
 				}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -370,7 +370,7 @@ class DboSource extends DataSource {
 		$isStringEnum = false;
 		if (strpos($column, "enum") === 0) {
 			$firstValue = null;
-			if (preg_match("/(enum\()(.*)(\))/i",$column, $acceptingValues)) {
+			if (preg_match("/(enum\()(.*)(\))/i", $column, $acceptingValues)) {
 				$values = explode(",", $acceptingValues[2]);
 				$firstValue = $values[0];
 			}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -369,7 +369,10 @@ class DboSource extends DataSource {
 
 		if (strpos($column, "enum") === 0) {
 			preg_match("/(enum\()(.*)(\))/", $column, $acceptingValues);
-			$firstValue = explode(",", $acceptingValues[2])[0];
+			if(preg_match("/(enum\()(.*)(\))/",$column, $acceptingValues)){
+			    $values = explode(",", $acceptingValues[2]);
+			    $firstValue = $value[0];
+			}
 			if (is_string($firstValue)) {
 				$isStringEnum = true;
 			}

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1056,7 +1056,7 @@ class DboSourceTest extends CakeTestCase {
 		if (!$this->db instanceof Mysql) {
 			$this->markTestSkipped('This test can only run on MySQL');
 		}
-		$name = $this->db->fullTableName('enum_tests');
+		$name = $this->db->fullTableName('enum_tests_faya');
 		$query = "CREATE TABLE {$name} (faya ENUM('10','20','30','40') NOT NULL);";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);
@@ -1075,7 +1075,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		), $enumResult);
 	}
-        
+
 /**
  * test order to generate query order clause for virtual fields
  *

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1056,20 +1056,20 @@ class DboSourceTest extends CakeTestCase {
 		if (!$this->db instanceof Mysql) {
 			$this->markTestSkipped('This test can only run on MySQL');
 		}
-		$name = $this->db->fullTableName('enum_tests_faya');
-		$query = "CREATE TABLE {$name} (faya ENUM('10','20','30','40') NOT NULL);";
+		$name = $this->db->fullTableName('enum_faya_tests');
+		$query = "CREATE TABLE {$name} (faya enum('10','20','30','40') NOT NULL);";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);
 
-		$EnumTest = ClassRegistry::init('EnumTest');
-		$enumResult = $EnumTest->save(array('faya' => '20'));
+		$EnumFayaTest = ClassRegistry::init('EnumFayaTest');
+		$enumResult = $EnumFayaTest->save(array('faya' => '20'));
 
 		$query = "DROP TABLE {$name};";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);
 
 		$this->assertEquals(array(
-			'EnumTest' => array(
+			'EnumFayaTest' => array(
 				'faya' => '20',
 				'id' => '1'
 			)

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1028,6 +1028,11 @@ class DboSourceTest extends CakeTestCase {
 			$this->markTestSkipped('This test can only run on MySQL');
 		}
 		$name = $this->db->fullTableName('enum_tests');
+
+		$query = "DROP TABLE {$name};";
+		$result = $this->db->query($query);
+		$this->assertTrue($result);
+
 		$query = "CREATE TABLE {$name} (mood ENUM('','happy','sad','ok') NOT NULL);";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);
@@ -1057,6 +1062,11 @@ class DboSourceTest extends CakeTestCase {
 			$this->markTestSkipped('This test can only run on MySQL');
 		}
 		$name = $this->db->fullTableName('enum_faya_tests');
+
+		$query = "DROP TABLE IF EXISTS {$name};";
+		$result = $this->db->query($query);
+		$this->assertTrue($result);
+
 		$query = "CREATE TABLE {$name} (faya enum('10','20','30','40') NOT NULL);";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1048,6 +1048,35 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * Test for MySQL enum datatype for a list of Integer stored as String
+ *
+ * @return void
+ */
+	public function testIntValueAsStringOnEnum() {
+		if (!$this->db instanceof Mysql) {
+			$this->markTestSkipped('This test can only run on MySQL');
+		}
+		$name = $this->db->fullTableName('enum_tests');
+		$query = "CREATE TABLE {$name} (faya ENUM('10','20','30','40') NOT NULL);";
+		$result = $this->db->query($query);
+		$this->assertTrue($result);
+
+		$EnumTest = ClassRegistry::init('EnumTest');
+		$enumResult = $EnumTest->save(array('faya' => '20'));
+
+		$query = "DROP TABLE {$name};";
+		$result = $this->db->query($query);
+		$this->assertTrue($result);
+
+		$this->assertEquals(array(
+			'EnumTest' => array(
+				'faya' => '20',
+				'id' => '1'
+			)
+		), $enumResult);
+	}
+        
+/**
  * test order to generate query order clause for virtual fields
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1029,7 +1029,7 @@ class DboSourceTest extends CakeTestCase {
 		}
 		$name = $this->db->fullTableName('enum_tests');
 
-		$query = "DROP TABLE {$name};";
+		$query = "DROP TABLE IF EXISTS {$name};";
 		$result = $this->db->query($query);
 		$this->assertTrue($result);
 

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1062,7 +1062,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$EnumFayaTest = ClassRegistry::init('EnumFayaTest');
-		$enumResult = $EnumFayaTest->save(array('faya' => '20'));
+		$enumResult = $EnumFayaTest->save(array('faya' => '10'));
 
 		$query = "DROP TABLE {$name};";
 		$result = $this->db->query($query);
@@ -1070,8 +1070,8 @@ class DboSourceTest extends CakeTestCase {
 
 		$this->assertEquals(array(
 			'EnumFayaTest' => array(
-				'faya' => '20',
-				'id' => '1'
+				'faya' => '10',
+				'id' => '0'
 			)
 		), $enumResult);
 	}


### PR DESCRIPTION
This is a:
* [x] bug
* [ ] enhancement
* [ ] feature-discussion (RFC)

* CakePHP Version: 2.9.8
* Platform and Target: MySQL as Database

### What you did
I have a table with like this:
```
CREATE TABLE `configs` (
	...
  `define_time_format` enum('12','24') NOT NULL DEFAULT '24',
  ...
  )

```

### What happened
In a **HTML select** I send the **"24"** as the value but in **"...\lib\Cake\Model\Datasource\DboSource.php"** the **"value"** function it consider as numeric value  **24** and cause error in save.


