### PR TITLE
`getMockForModel()` method can take `null` for `$methods` parameter

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -69,6 +69,7 @@ if (!function_exists('h')) {
                 'Use the 3rd argument instead.'
             );
             $charset = $double;
+            $double = true;
         }
 
         return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, $charset ?: $defaultCharset, $double);

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -221,7 +221,7 @@ class Paginator implements PaginatorInterface
             'nextPage' => $count > ($page * $limit),
             'pageCount' => $pageCount,
             'sort' => $options['sort'],
-            'direction' => current($order),
+            'direction' => isset($options['sort']) ? current($order) : null,
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -673,12 +673,12 @@ abstract class TestCase extends BaseTestCase
      * Mock a model, maintain fixtures and table association
      *
      * @param string $alias The model to get a mock for.
-     * @param array $methods The list of methods to mock
+     * @param array|null $methods The list of methods to mock
      * @param array $options The config data for the mock's constructor.
      * @throws \Cake\ORM\Exception\MissingTableClassException
      * @return \Cake\ORM\Table|\PHPUnit_Framework_MockObject_MockObject
      */
-    public function getMockForModel($alias, array $methods = [], array $options = [])
+    public function getMockForModel($alias, $methods = [], array $options = [])
     {
         /** @var \Cake\ORM\Table $className */
         $className = $this->_getTableClassName($alias, $options);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -436,6 +436,7 @@ class PaginatorHelper extends Helper
 
             $title = __(Inflector::humanize(preg_replace('/_id$/', '', $title)));
         }
+
         $defaultDir = isset($options['direction']) ? strtolower($options['direction']) : 'asc';
         unset($options['direction']);
 

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -248,6 +248,43 @@ class PaginatorTest extends TestCase
     }
 
     /**
+     * Tests that flat default pagination parameters work for multi order.
+     *
+     * @return void
+     */
+    public function testDefaultPaginateParamsMultiOrder()
+    {
+        $settings = [
+            'order' => ['PaginatorPosts.id' => 'DESC', 'PaginatorPosts.title' => 'ASC'],
+        ];
+
+        $table = $this->_getMockPosts(['query']);
+        $query = $this->_getMockFindQuery();
+
+        $table->expects($this->once())
+            ->method('query')
+            ->will($this->returnValue($query));
+
+        $query->expects($this->once())
+            ->method('applyOptions')
+            ->with([
+                'limit' => 20,
+                'page' => 1,
+                'order' => $settings['order'],
+                'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'scope' => null,
+                'sort' => null,
+            ]);
+
+        $this->Paginator->paginate($table, [], $settings);
+
+        $pagingParams = $this->Paginator->getPagingParams();
+        $this->assertNull($pagingParams['PaginatorPosts']['direction']);
+        $this->assertFalse($pagingParams['PaginatorPosts']['sortDefault']);
+        $this->assertFalse($pagingParams['PaginatorPosts']['directionDefault']);
+    }
+
+    /**
      * test that default sort and default direction are injected into request
      *
      * @return void

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
 
 class PaginatorTest extends TestCase
 {
-
     /**
      * fixtures property
      *
@@ -41,6 +40,11 @@ class PaginatorTest extends TestCase
      * @var bool
      */
     public $autoFixtures = false;
+
+    /**
+     * @var \Cake\Datasource\Paginator
+     */
+    public $Paginator;
 
     /**
      * setup
@@ -915,6 +919,9 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $result['order']);
     }
 
+    /**
+     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function getMockRepository()
     {
         $model = $this->getMockBuilder('Cake\Datasource\RepositoryInterface')
@@ -927,6 +934,9 @@ class PaginatorTest extends TestCase
         return $model;
     }
 
+    /**
+     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function mockAliasHasFieldModel()
     {
         $model = $this->getMockRepository();
@@ -1372,7 +1382,7 @@ class PaginatorTest extends TestCase
      * Helper method for making mocks.
      *
      * @param array $methods
-     * @return \Cake\ORM\Table
+     * @return \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function _getMockPosts($methods = [])
     {
@@ -1396,10 +1406,12 @@ class PaginatorTest extends TestCase
     /**
      * Helper method for mocking queries.
      *
-     * @return \Cake\ORM\Query
+     * @param string|null $table
+     * @return \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function _getMockFindQuery($table = null)
     {
+        /** @var \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject $query */
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->setMethods(['total', 'all', 'count', 'applyOptions'])
             ->disableOriginalConstructor()

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -494,6 +494,16 @@ class TestCaseTest extends TestCase
         $entity = new Entity([]);
         $this->assertTrue($Mock->save($entity));
         $this->assertFalse($Mock->save($entity));
+        
+        $Mock = $this->getMockForModel(
+            'Table',
+            null,
+            ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
+        );
+
+        $result = $this->getTableLocator()->get('Comments');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('Comments', $Mock->getAlias());
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -494,16 +494,26 @@ class TestCaseTest extends TestCase
         $entity = new Entity([]);
         $this->assertTrue($Mock->save($entity));
         $this->assertFalse($Mock->save($entity));
-        
-        $Mock = $this->getMockForModel(
+
+        $allMethodsStubs = $this->getMockForModel(
+            'Table',
+            [],
+            ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
+        );
+        $result = $this->getTableLocator()->get('Comments');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEmpty([], $allMethodsStubs->getAlias());
+
+        $allMethodsMocks = $this->getMockForModel(
             'Table',
             null,
             ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
         );
-
         $result = $this->getTableLocator()->get('Comments');
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('Comments', $Mock->getAlias());
+        $this->assertEquals('Comments', $allMethodsMocks->getAlias());
+
+        $this->assertNotEquals($allMethodsStubs, $allMethodsMocks);
     }
 
     /**


### PR DESCRIPTION
I can not really understand why the `getMockForModel()` method should not be able to accept a `null` value as `$methods` parameter.

Yes, I realize that for many it will seem useless. But the `setMethods()` method can accept that value, I do not see why it should not be so here too.
