### PR TITLE
Fix route reset and preserve extensions

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -515,6 +515,30 @@ class Router
     }
 
     /**
+     * Reset routes and related state.
+     *
+     * Similar to reload() except that this doesn't reset all global state,
+     * as that leads to incorrect behavior in some plugin test case scenarios.
+     *
+     * This method will reset:
+     *
+     * - routes
+     * - URL Filters
+     * - the initialized property
+     *
+     * Extensions and default route classes will not be modified
+     *
+     * @internal
+     * @return void
+     */
+    public static function resetRoutes()
+    {
+        static::$_collection = new RouteCollection();
+        static::$_urlFilters = [];
+        static::$initialized = false;
+    }
+
+    /**
      * Add a URL filter to Router.
      *
      * URL filter functions are applied to every array $url provided to

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -194,13 +194,6 @@ trait IntegrationTestTrait
     protected $_cookieEncryptionKey;
 
     /**
-     * Allow router reloading to be disabled.
-     *
-     * @var bool
-     */
-    protected $_disableRouterReload = false;
-
-    /**
      * Auto-detect if the HTTP middleware stack should be used.
      *
      * @return void
@@ -547,7 +540,7 @@ trait IntegrationTestTrait
     protected function _makeDispatcher()
     {
         if ($this->_useHttpServer) {
-            return new MiddlewareDispatcher($this, $this->_appClass, $this->_appArgs, $this->_disableRouterReload);
+            return new MiddlewareDispatcher($this, $this->_appClass, $this->_appArgs);
         }
 
         return new LegacyRequestDispatcher($this);

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -55,13 +55,6 @@ class MiddlewareDispatcher
     protected $_constructorArgs;
 
     /**
-     * Allow router reloading to be disabled.
-     *
-     * @var bool
-     */
-    protected $_disableRouterReload = false;
-
-    /**
      * The application that is being dispatched.
      *
      * @var \Cake\Core\HttpApplicationInterface
@@ -85,7 +78,6 @@ class MiddlewareDispatcher
         $this->_test = $test;
         $this->_class = $class ?: Configure::read('App.namespace') . '\Application';
         $this->_constructorArgs = $constructorArgs ?: [CONFIG];
-        $this->_disableRouterReload = $disableRouterReload;
 
         try {
             $reflect = new ReflectionClass($this->_class);
@@ -137,9 +129,7 @@ class MiddlewareDispatcher
         }
 
         $out = Router::url($url);
-        if (!$this->_disableRouterReload) {
-            Router::reload();
-        }
+        Router::resetRoutes();
 
         return $out;
     }


### PR DESCRIPTION
I wasn't entirely happy with the solution in #12695 and wanted to try an alternate approach. This set of changes adds state to fewer places and doesn't require plugins to opt-in to backwards compatible behavior. Instead it introduces new internal methods to reset router state that can cause conflicts/duplicate work. Global extensions and default route classes are not reset.

I've targeted this for 3.7 as it adds new methods, but I'm open to shipping it in 3.6 if people would like that more.

Refs #12695
Refs #12577