### PR TITLE
Resolves the first part of object variable naming cleanup.

### DIFF
--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -93,9 +93,10 @@ class BasicAuthenticate extends BaseAuthenticate
      */
     public function unauthenticated(ServerRequest $request, Response $response)
     {
-        $Exception = new UnauthorizedException();
-        $Exception->responseHeader($this->loginHeaders($request));
-        throw $Exception;
+        $unauthorizedException = new UnauthorizedException();
+        $unauthorizedException->responseHeader($this->loginHeaders($request));
+
+        throw $unauthorizedException;
     }
 
     /**

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -207,29 +207,29 @@ class ShellDispatcher
      */
     protected function _dispatch(array $extra = [])
     {
-        $shell = $this->shiftArgs();
+        $shellName = $this->shiftArgs();
 
-        if (!$shell) {
+        if (!$shellName) {
             $this->help();
 
             return false;
         }
-        if (in_array($shell, ['help', '--help', '-h'])) {
+        if (in_array($shellName, ['help', '--help', '-h'])) {
             $this->help();
 
             return true;
         }
-        if (in_array($shell, ['version', '--version'])) {
+        if (in_array($shellName, ['version', '--version'])) {
             $this->version();
 
             return true;
         }
 
-        $Shell = $this->findShell($shell);
+        $shell = $this->findShell($shellName);
 
-        $Shell->initialize();
+        $shell->initialize();
 
-        return $Shell->runCommand($this->args, true, $extra);
+        return $shell->runCommand($this->args, true, $extra);
     }
 
     /**

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -35,11 +35,11 @@ class TaskRegistry extends ObjectRegistry
     /**
      * Constructor
      *
-     * @param \Cake\Console\Shell $Shell Shell instance
+     * @param \Cake\Console\Shell $shell Shell instance
      */
-    public function __construct(Shell $Shell)
+    public function __construct(Shell $shell)
     {
-        $this->_Shell = $Shell;
+        $this->_Shell = $shell;
     }
 
     /**

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -64,7 +64,7 @@ class Event implements EventInterface
      *
      * ```
      *  $event = new Event('Order.afterBuy', $this, ['buyer' => $userData]);
-     *  $event = new Event('User.afterRegister', $UserModel);
+     *  $event = new Event('User.afterRegister', $userModel);
      * ```
      *
      * @param string $name Name of the event

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1953,25 +1953,25 @@ class Email implements JsonSerializable, Serializable
             return $rendered;
         }
 
-        $View = $this->createView();
+        $view = $this->createView();
 
-        list($templatePlugin) = pluginSplit($View->getTemplate());
-        list($layoutPlugin) = pluginSplit((string)$View->getLayout());
+        list($templatePlugin) = pluginSplit($view->getTemplate());
+        list($layoutPlugin) = pluginSplit((string)$view->getLayout());
         if ($templatePlugin) {
-            $View->setPlugin($templatePlugin);
+            $view->setPlugin($templatePlugin);
         } elseif ($layoutPlugin) {
-            $View->setPlugin($layoutPlugin);
+            $view->setPlugin($layoutPlugin);
         }
 
-        if ($View->get('content') === null) {
-            $View->set('content', $content);
+        if ($view->get('content') === null) {
+            $view->set('content', $content);
         }
 
         foreach ($types as $type) {
-            $View->setTemplatePath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
-            $View->setLayoutPath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
+            $view->setTemplatePath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
+            $view->setLayoutPath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
 
-            $render = $View->render();
+            $render = $view->render();
             $render = str_replace(["\r\n", "\r"], "\n", $render);
             $rendered[$type] = $this->_encodeString($render, $this->charset);
         }

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -307,8 +307,8 @@ class Behavior implements EventListenerInterface
      *  ]
      * ```
      *
-     * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
-     * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
+     * With the above example, a call to `$table->find('this')` will call `$behavior->findThis()`
+     * and a call to `$table->find('alias')` will call `$behavior->findMethodName()`
      *
      * It is recommended, though not required, to define implementedFinders in the config property
      * of child classes such that it is not necessary to use reflections to derive the available
@@ -335,12 +335,12 @@ class Behavior implements EventListenerInterface
      * ```
      *  [
      *    'method' => 'method',
-     *    'aliasedmethod' => 'somethingElse'
+     *    'aliasedMethod' => 'somethingElse'
      *  ]
      * ```
      *
-     * With the above example, a call to `$Table->method()` will call `$Behavior->method()`
-     * and a call to `$Table->aliasedmethod()` will call `$Behavior->somethingElse()`
+     * With the above example, a call to `$table->method()` will call `$behavior->method()`
+     * and a call to `$table->aliasedMethod()` will call `$behavior->somethingElse()`
      *
      * It is recommended, though not required, to define implementedFinders in the config property
      * of child classes such that it is not necessary to use reflections to derive the available

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -169,13 +169,13 @@ class CommandTask extends Shell
      */
     public function subCommands(string $commandName): array
     {
-        $Shell = $this->getShell($commandName);
+        $shell = $this->getShell($commandName);
 
-        if (!$Shell) {
+        if (!$shell) {
             return [];
         }
 
-        $taskMap = $this->Tasks->normalizeArray((array)$Shell->tasks);
+        $taskMap = $this->Tasks->normalizeArray((array)$shell->tasks);
         $return = array_keys($taskMap);
         $return = array_map('Cake\Utility\Inflector::underscore', $return);
 
@@ -183,7 +183,7 @@ class CommandTask extends Shell
 
         $baseClasses = ['Object', 'Shell', 'AppShell'];
 
-        $Reflection = new ReflectionClass($Shell);
+        $Reflection = new ReflectionClass($shell);
         $methods = $Reflection->getMethods(ReflectionMethod::IS_PUBLIC);
         $methodNames = [];
         foreach ($methods as $method) {
@@ -239,12 +239,12 @@ class CommandTask extends Shell
             return false;
         }
 
-        /* @var \Cake\Console\Shell $Shell */
-        $Shell = new $class();
-        $Shell->plugin = trim($pluginDot, '.');
-        $Shell->initialize();
+        /* @var \Cake\Console\Shell $shell */
+        $shell = new $class();
+        $shell->plugin = trim($pluginDot, '.');
+        $shell->initialize();
 
-        return $Shell;
+        return $shell;
     }
 
     /**
@@ -257,18 +257,18 @@ class CommandTask extends Shell
      */
     public function options(string $commandName, string $subCommandName = ''): array
     {
-        $Shell = $this->getShell($commandName);
+        $shell = $this->getShell($commandName);
 
-        if (!$Shell) {
+        if (!$shell) {
             return [];
         }
 
-        $parser = $Shell->getOptionParser();
+        $parser = $shell->getOptionParser();
 
         if (!empty($subCommandName)) {
             $subCommandName = Inflector::camelize($subCommandName);
-            if ($Shell->hasTask($subCommandName)) {
-                $parser = $Shell->{$subCommandName}->getOptionParser();
+            if ($shell->hasTask($subCommandName)) {
+                $parser = $shell->{$subCommandName}->getOptionParser();
             } else {
                 return [];
             }

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -106,7 +106,7 @@ class Hash
      *  - `>`, `<`, `>=`, `<=` Value comparison.
      *  - `=/.../` Regular expression pattern match.
      *
-     * Given a set of User array data, from a `$User->find('all')` call:
+     * Given a set of User array data, from a `$usersTable->find('all')` call:
      *
      * - `1.User.name` Get the name of the user at index 1.
      * - `{n}.User.name` Get the name of every user in the set of users.

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -74,16 +74,16 @@ class Helper implements EventListenerInterface
     /**
      * Default Constructor
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
-        $this->_View = $View;
+        $this->_View = $view;
         $this->setConfig($config);
 
         if (!empty($this->helpers)) {
-            $this->_helperMap = $View->helpers()->normalizeArray($this->helpers);
+            $this->_helperMap = $view->helpers()->normalizeArray($this->helpers);
         }
 
         $this->initialize($config);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -265,10 +265,10 @@ class FormHelper extends Helper
     /**
      * Construct the widgets and binds the default context providers
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
         $locator = null;
         $widgets = $this->_defaultWidgets;
@@ -289,7 +289,7 @@ class FormHelper extends Helper
             unset($config['groupedInputTypes']);
         }
 
-        parent::__construct($View, $config);
+        parent::__construct($view, $config);
 
         if (!$locator) {
             $locator = new WidgetLocator($this->templater(), $this->_View, $widgets);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -129,12 +129,12 @@ class HtmlHelper extends Helper
      *
      * Using the `templates` option you can redefine the tag HtmlHelper will use.
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
-        parent::__construct($View, $config);
+        parent::__construct($view, $config);
         $this->response = $this->_View->getResponse() ?: new Response();
     }
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -54,13 +54,13 @@ class NumberHelper extends Helper
      * - `engine` Class name to use to replace Cake\I18n\Number functionality
      *            The class needs to be placed in the `Utility` directory.
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper
      * @throws \Cake\Core\Exception\Exception When the engine class could not be found.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
-        parent::__construct($View, $config);
+        parent::__construct($view, $config);
 
         $config = $this->_config;
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -95,12 +95,12 @@ class PaginatorHelper extends Helper
     /**
      * Constructor. Overridden to merge passed args with URL options.
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
-        parent::__construct($View, $config);
+        parent::__construct($view, $config);
 
         $query = $this->_View->getRequest()->getQueryParams();
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -71,13 +71,13 @@ class TextHelper extends Helper
      * - `engine` Class name to use to replace String functionality.
      *            The class needs to be placed in the `Utility` directory.
      *
-     * @param \Cake\View\View $View the view object the helper is attached to.
+     * @param \Cake\View\View $view the view object the helper is attached to.
      * @param array $config Settings array Settings array
      * @throws \Cake\Core\Exception\Exception when the engine class could not be found.
      */
-    public function __construct(View $View, array $config = [])
+    public function __construct(View $view, array $config = [])
     {
-        parent::__construct($View, $config);
+        parent::__construct($view, $config);
 
         $config = $this->_config;
         $engineClass = App::className($config['engine'], 'Utility');


### PR DESCRIPTION
This implements the first part of the RFC https://github.com/cakephp/cakephp/issues/12725 for a cleaner core code base.

I used IDE phpstorm refactoring, so no chance for BC breaks or missing parts here.
All inside of a method scope is safe.

Rest of the linked issue still remains open for further processing.