### PR TITLE
bug 12730 - testcase for IsMobile with specific user agent

### DIFF
--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1276,6 +1276,9 @@ class ServerRequestTest extends TestCase
         $request = $request->withEnv('TEST_VAR', 'wrong value');
         $this->assertFalse($request->isBanana());
 
+        $request = $request->withEnv('HTTP_USER_AGENT', 'Mozilla/5.0 (Linux; Android 8.1.0; Nexus 5X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36');
+        $this->assertTrue($request->isMobile());
+
         ServerRequest::addDetector('mobile', ['env' => 'HTTP_USER_AGENT', 'options' => ['Imagination']]);
         $request = $request->withEnv('HTTP_USER_AGENT', 'Imagination land');
         $this->assertTrue($request->isMobile());


### PR DESCRIPTION
This is the testcase for the ticket #12730 
I don't know what the issue is here, is the string for my user agent weird? Or is there a bug. If it is a bug, I would be happy to provide a fix, but could somebody point me in the right direction please. Where is the detection code located?