### PR TITLE
Fix return type in of `countBy` @method annotation in Query

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -45,7 +45,7 @@ use RuntimeException;
  * @method mixed min($field, $type = SORT_NUMERIC) Returns the minimum value for a single column in all the results.
  * @method \Cake\Collection\CollectionInterface groupBy(string|callable $field) In-memory group all results by the value of a column.
  * @method \Cake\Collection\CollectionInterface indexBy(string|callable $field) Returns the results indexed by the value of a column.
- * @method int countBy(string|callable $field) Returns the number of unique values for a column
+ * @method \Cake\Collection\CollectionInterface countBy(string|callable $field) Returns the number of unique values for a column
  * @method float sumOf(string|callable $field) Returns the sum of all values for a single column
  * @method \Cake\Collection\CollectionInterface shuffle() In-memory randomize the order the results are returned
  * @method \Cake\Collection\CollectionInterface sample($size = 10) In-memory shuffle the results and return a subset of them.


### PR DESCRIPTION
A return fix I noticed when I looked at the `@method`s for #12732