### PR TITLE
Dasherize path elements by default instead of underscoring.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -281,7 +281,7 @@ class RouteBuilder
      * });
      * ```
      *
-     * Plugins will create lower_case underscored resource routes. e.g
+     * Plugins will create lowercase dasherized resource routes. e.g
      * `/comments/comments`
      *
      * Connect resource routes for the Articles controller in the
@@ -293,7 +293,7 @@ class RouteBuilder
      * });
      * ```
      *
-     * Prefixes will create lower_case underscored resource routes. e.g
+     * Prefixes will create lowercase dasherized resource routes. e.g
      * `/admin/posts`
      *
      * You can create nested resources by passing a callback in:
@@ -320,7 +320,7 @@ class RouteBuilder
      * You can use the `inflect` option to change how path segments are generated:
      *
      * ```
-     * $routes->resources('PaymentTypes', ['inflect' => 'dasherize']);
+     * $routes->resources('PaymentTypes', ['inflect' => 'underscore']);
      * ```
      *
      * Will generate routes like `/payment-types` instead of `/payment_types`
@@ -329,7 +329,7 @@ class RouteBuilder
      *
      * - 'id' - The regular expression fragment to use when matching IDs. By default, matches
      *    integer values and UUIDs.
-     * - 'inflect' - Choose the inflection method used on the resource name. Defaults to 'underscore'.
+     * - 'inflect' - Choose the inflection method used on the resource name. Defaults to 'dasherize'.
      * - 'only' - Only connect the specific list of actions.
      * - 'actions' - Override the method names used for connecting actions.
      * - 'map' - Additional resource routes that should be connected. If you define 'only' and 'map',
@@ -354,7 +354,7 @@ class RouteBuilder
         }
         $options += [
             'connectOptions' => [],
-            'inflect' => 'underscore',
+            'inflect' => 'dasherize',
             'id' => static::ID . '|' . static::UUID,
             'only' => [],
             'actions' => [],
@@ -857,8 +857,8 @@ class RouteBuilder
             $callback = $params;
             $params = [];
         }
+        $path = '/' . Inflector::dasherize($name);
         $name = Inflector::underscore($name);
-        $path = '/' . $name;
         if (isset($params['path'])) {
             $path = $params['path'];
             unset($params['path']);
@@ -897,7 +897,7 @@ class RouteBuilder
         }
         $params = ['plugin' => $name] + $this->_params;
         if (empty($options['path'])) {
-            $options['path'] = '/' . Inflector::underscore($name);
+            $options['path'] = '/' . Inflector::dasherize($name);
         }
         $this->scope($options['path'], $params, $callback);
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -796,7 +796,7 @@ class Router
      * For example a path of `admin` would result in `'prefix' => 'admin'` being
      * applied to all connected routes.
      *
-     * The prefix name will be inflected to the underscore version to create
+     * The prefix name will be inflected to the dasherized version to create
      * the routing path. If you want a custom path name, use the `path` option.
      *
      * You can re-open a prefix as many times as necessary, as well as nest prefixes.
@@ -816,16 +816,15 @@ class Router
             $callback = $params;
             $params = [];
         }
-        $name = Inflector::underscore($name);
 
         if (empty($params['path'])) {
-            $path = '/' . $name;
+            $path = '/' . Inflector::dasherize($name);
         } else {
             $path = $params['path'];
             unset($params['path']);
         }
 
-        $params = array_merge($params, ['prefix' => $name]);
+        $params = array_merge($params, ['prefix' => Inflector::underscore($name)]);
         static::scope($path, $params, $callback);
     }
 
@@ -835,7 +834,7 @@ class Router
      * This method creates a scoped route collection that includes
      * relevant plugin information.
      *
-     * The plugin name will be inflected to the underscore version to create
+     * The plugin name will be inflected to the dasherized version to create
      * the routing path. If you want a custom path name, use the `path` option.
      *
      * Routes connected in the scoped collection will have the correct path segment
@@ -856,7 +855,7 @@ class Router
         }
         $params = ['plugin' => $name];
         if (empty($options['path'])) {
-            $options['path'] = '/' . Inflector::underscore($name);
+            $options['path'] = '/' . Inflector::dasherize($name);
         }
         if (isset($options['_namePrefix'])) {
             $params['_namePrefix'] = $options['_namePrefix'];

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -860,7 +860,7 @@ class RouterTest extends TestCase
             });
         });
         $result = Router::url(['prefix' => 'admin', 'plugin' => 'MyPlugin', 'controller' => 'Forms', 'action' => 'edit', 2]);
-        $expected = '/admin/my_plugin/forms/edit/2';
+        $expected = '/admin/my-plugin/forms/edit/2';
         $this->assertEquals($expected, $result);
     }
 
@@ -2877,8 +2877,8 @@ class RouterTest extends TestCase
             $this->assertEquals(['prefix' => 'admin', 'param' => 'value'], $routes->params());
         });
 
-        Router::prefix('CustomPath', ['path' => '/custom-path'], function (RouteBuilder $routes) {
-            $this->assertEquals('/custom-path', $routes->path());
+        Router::prefix('CustomPath', ['path' => '/custom_path'], function (RouteBuilder $routes) {
+            $this->assertEquals('/custom_path', $routes->path());
             $this->assertEquals(['prefix' => 'custom_path'], $routes->params());
         });
     }
@@ -2891,7 +2891,7 @@ class RouterTest extends TestCase
     public function testPlugin()
     {
         Router::plugin('DebugKit', function (RouteBuilder $routes) {
-            $this->assertEquals('/debug_kit', $routes->path());
+            $this->assertEquals('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
     }


### PR DESCRIPTION
This creates more consistent URLs by default.