### PR TITLE
Previous trace

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -217,9 +217,7 @@ class ErrorHandlerMiddleware
         if ($referer) {
             $message .= "\nReferer URL: " . $referer;
         }
-        if ($this->getConfig('trace')) {
-            $message .= "\nStack Trace:\n" . $exception->getTraceAsString() . "\n\n";
-        }
+        $message .= "\n\n";
 
         return $message;
     }
@@ -235,7 +233,7 @@ class ErrorHandlerMiddleware
     {
         $message = sprintf(
             '%s[%s] %s',
-            $isPrevious ? "\nPrevious: " : '',
+            $isPrevious ? "\nCaused by: " : '',
             get_class($exception),
             $exception->getMessage()
         );
@@ -246,6 +244,10 @@ class ErrorHandlerMiddleware
             if ($attributes) {
                 $message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);
             }
+        }
+
+        if ($this->getConfig('trace')) {
+            $message .= "\n" . $exception->getTraceAsString();
         }
 
         $previous = $exception->getPrevious();

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -233,8 +233,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
             ->method('log')
             ->with('error', $this->logicalAnd(
                 $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->stringContains('Previous: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged'),
-                $this->stringContains('ErrorHandlerMiddlewareTest->testHandleException'),
+                $this->stringContains('Caused by: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged'),
+                $this->stringContains('ErrorHandlerMiddlewareTest->testHandleExceptionLogAndTraceWithPrevious'),
                 $this->stringContains('Request URL: /target/url'),
                 $this->stringContains('Referer URL: /other/path')
             ));


### PR DESCRIPTION
Previous PR #12673 added previous exceptions to logs, but did not include the trace of previous. I found out previous exception logging was really helpfull when adding the trace as well. This really gives a clear sight onn what is actually going on when an exception is thrown.