### PR TITLE
Fix paginator for falling back to default sort.

### DIFF
--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -224,7 +224,7 @@ class Paginator implements PaginatorInterface
             'direction' => isset($options['sort']) ? current($order) : null,
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
-            'directionDefault' => $directionDefault ? strtolower($directionDefault) : $directionDefault,
+            'directionDefault' => $directionDefault,
             'scope' => $options['scope'],
             'completeSort' => $order,
         ];
@@ -424,12 +424,12 @@ class Paginator implements PaginatorInterface
 
             list ($alias, $currentField) = explode('.', $field);
 
-            if ($alias !== $model) {
-                $result[$field] = $sort;
+            if ($alias === $model) {
+                $result[$currentField] = $sort;
                 continue;
             }
 
-            $result[$currentField] = $sort;
+            $result[$field] = $sort;
         }
 
         return $result;

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -224,7 +224,7 @@ class Paginator implements PaginatorInterface
             'direction' => isset($options['sort']) ? current($order) : null,
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
-            'directionDefault' => $directionDefault,
+            'directionDefault' => $directionDefault ? strtolower($directionDefault) : $directionDefault,
             'scope' => $options['scope'],
             'completeSort' => $order,
         ];
@@ -363,7 +363,12 @@ class Paginator implements PaginatorInterface
             if (!in_array($direction, ['asc', 'desc'])) {
                 $direction = 'asc';
             }
+
             $order = (isset($options['order']) && is_array($options['order'])) ? $options['order'] : [];
+            if ($order && $options['sort'] && strpos($options['sort'], '.') === false) {
+                $order = $this->_removeAliases($order, $object->getAlias());
+            }
+
             $options['order'] = [$options['sort'] => $direction] + $order;
         } else {
             $options['sort'] = null;
@@ -399,6 +404,35 @@ class Paginator implements PaginatorInterface
         $options['order'] = $this->_prefix($object, $options['order'], $inWhitelist);
 
         return $options;
+    }
+
+    /**
+     * Remove alias if needed.
+     *
+     * @param array $fields Current fields
+     * @param string $model Current model alias
+     * @return array $fields Unaliased fields where applicable
+     */
+    protected function _removeAliases($fields, $model)
+    {
+        $result = [];
+        foreach ($fields as $field => $sort) {
+            if (strpos($field, '.') === false) {
+                $result[$field] = $sort;
+                continue;
+            }
+
+            list ($alias, $currentField) = explode('.', $field);
+
+            if ($alias !== $model) {
+                $result[$field] = $sort;
+                continue;
+            }
+
+            $result[$currentField] = $sort;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -528,7 +528,7 @@ class PaginatorHelper extends Helper
             $paging['sort'] = $this->_removeAlias($paging['sort'], $model = null);
         }
         if (!empty($paging['sortDefault']) && !empty($options['sort']) && strpos($options['sort'], '.') === false) {
-            $paging['sortDefault'] = $this->_removeAlias($paging['sortDefault'], $model = null);
+            $paging['sortDefault'] = $this->_removeAlias($paging['sortDefault'], $model);
         }
 
         $url = [
@@ -554,7 +554,7 @@ class PaginatorHelper extends Helper
 
         if (isset($paging['sortDefault'], $paging['directionDefault'], $url['sort'], $url['direction']) &&
             $url['sort'] === $paging['sortDefault'] &&
-            $url['direction'] === $paging['directionDefault']
+            strtolower($url['direction']) === strtolower($paging['directionDefault'])
         ) {
             $url['sort'] = $url['direction'] = null;
         }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -524,6 +524,13 @@ class PaginatorHelper extends Helper
         $paging = $this->params($model);
         $paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 
+        if (!empty($paging['sort']) && !empty($options['sort']) && strpos($options['sort'], '.') === false) {
+            $paging['sort'] = $this->_removeAlias($paging['sort'], $model = null);
+        }
+        if (!empty($paging['sortDefault']) && !empty($options['sort']) && strpos($options['sort'], '.') === false) {
+            $paging['sortDefault'] = $this->_removeAlias($paging['sortDefault'], $model = null);
+        }
+
         $url = [
             'page' => $paging['page'],
             'limit' => $paging['limit'],
@@ -544,6 +551,7 @@ class PaginatorHelper extends Helper
         if (!empty($url['page']) && $url['page'] == 1) {
             $url['page'] = false;
         }
+
         if (isset($paging['sortDefault'], $paging['directionDefault'], $url['sort'], $url['direction']) &&
             $url['sort'] === $paging['sortDefault'] &&
             $url['direction'] === $paging['directionDefault']
@@ -572,6 +580,30 @@ class PaginatorHelper extends Helper
         }
 
         return $url;
+    }
+
+    /**
+     * Remove alias if needed.
+     *
+     * @param string $field Current field
+     * @param string|null $model Current model alias
+     * @return string Unaliased field if applicable
+     */
+    protected function _removeAlias($field, $model = null)
+    {
+        $currentModel = $model ?: $this->defaultModel();
+
+        if (strpos($field, '.') === false) {
+            return $field;
+        }
+
+        list ($alias, $currentField) = explode('.', $field);
+
+        if ($alias === $currentModel) {
+            return $currentField;
+        }
+
+        return $field;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -363,7 +363,7 @@ class PaginatorComponentTest extends TestCase
 
         $this->Paginator->paginate($table, $settings);
         $this->assertEquals('PaginatorPosts.id', $this->controller->request->getParam('paging.PaginatorPosts.sortDefault'));
-        $this->assertEquals('desc', $this->controller->request->getParam('paging.PaginatorPosts.directionDefault'));
+        $this->assertEquals('DESC', $this->controller->request->getParam('paging.PaginatorPosts.directionDefault'));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -363,7 +363,7 @@ class PaginatorComponentTest extends TestCase
 
         $this->Paginator->paginate($table, $settings);
         $this->assertEquals('PaginatorPosts.id', $this->controller->request->getParam('paging.PaginatorPosts.sortDefault'));
-        $this->assertEquals('DESC', $this->controller->request->getParam('paging.PaginatorPosts.directionDefault'));
+        $this->assertEquals('desc', $this->controller->request->getParam('paging.PaginatorPosts.directionDefault'));
     }
 
     /**

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -321,7 +321,7 @@ class PaginatorTest extends TestCase
         $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $this->Paginator->getPagingParams();
         $this->assertEquals('PaginatorPosts.id', $pagingParams['PaginatorPosts']['sortDefault']);
-        $this->assertEquals('desc', $pagingParams['PaginatorPosts']['directionDefault']);
+        $this->assertEquals('DESC', $pagingParams['PaginatorPosts']['directionDefault']);
     }
 
     /**

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -321,7 +321,7 @@ class PaginatorTest extends TestCase
         $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $this->Paginator->getPagingParams();
         $this->assertEquals('PaginatorPosts.id', $pagingParams['PaginatorPosts']['sortDefault']);
-        $this->assertEquals('DESC', $pagingParams['PaginatorPosts']['directionDefault']);
+        $this->assertEquals('desc', $pagingParams['PaginatorPosts']['directionDefault']);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1216,6 +1216,38 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Tests that generated default order URL doesn't include sort and direction parameters.
+     *
+     * @return void
+     */
+    public function testDefaultSortRemovedFromUrlWithAliases()
+    {
+        $request = new ServerRequest([
+            'params' => ['controller' => 'articles', 'action' => 'index', 'plugin' => null],
+            'url' => '/articles?sort=title&direction=asc'
+        ]);
+        Router::setRequestInfo($request);
+
+        $this->Paginator->options(['model' => 'Articles']);
+        $this->Paginator->request = $this->Paginator->request->withParam('paging', [
+            'Articles' => [
+                'page' => 1, 'current' => 3, 'count' => 13,
+                'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
+                'sort' => 'Articles.title', 'direction' => 'asc',
+                'sortDefault' => 'Articles.title', 'directionDefault' => 'desc',
+            ],
+        ]);
+
+        $result = $this->Paginator->sort('title');
+        $expected = [
+            'a' => ['class' => 'asc', 'href' => '/articles/index'],
+            'Title',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test the prev() method.
      *
      * @return void


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/12743

They main issue is around

	/**
	 * @var array
	 */
	public $paginate = ['order' => ['Countries.sort' => 'DESC']];

and

    <?php echo $this->Paginator->sort('sort') ?>

where the aliasing silently makes this bug appear right now.

Check out live bug @ https://sandbox.dereuromark.de/data/countries
Click on the "sort" filter, see the URL generated, but never applied.
This has been in Paginator since 3.5 or 3.6 very early it seems (probably around Paginator extract).

Paginator fixes the actual bug around the query adjustment.
The PaginationHelper fix then re-adjusts the URLs for the primary model and non-aliases default columns used.
So that with default order "sort DESC" the URLs generated and clicked are:
- `/countries`
- `/countries?sort=sort&direction=asc`
- `/countries` again

Any possible side effects here?
How can we test this, as the tests do not include the options, only params?

Additional adjustment:
directionDefault is now also consolidated to lowercase version when passed on.