### PR TITLE
Include prefer lowest and simplify checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 7.0
   - 5.6
-  - 7.1
   - 7.2
   - 7.3
 
@@ -17,7 +16,7 @@ env:
   global:
     - DEFAULT=1
     - CODECOVERAGE=0
-    - PHPCS=0
+    - CHECKS=0
 
 services:
   - memcached
@@ -37,13 +36,13 @@ matrix:
   fast_finish: true
 
   include:
+    - php: 5.6
+      env: PREFER_LOWEST=1
+
     - php: 7.0
-      env: PHPCS=1 DEFAULT=0
+      env: CHECKS=1 DEFAULT=0
 
     - php: 7.1
-      env: PHPSTAN=1 DEFAULT=0
-
-    - php: 7.2
       env: CODECOVERAGE=1 DEFAULT=0
 
 before_install:
@@ -58,14 +57,14 @@ before_install:
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
-  - if [[ $PHPCS = 0 ]] ; then pecl channel-update pecl.php.net; fi;
+  - pecl channel-update pecl.php.net
   - |
-      if [[ ${TRAVIS_PHP_VERSION} != "7.3" && ${TRAVIS_PHP_VERSION} != "5.6" && ($DEFAULT = 1 || $PHPSTAN = 1) ]]; then
+      if [[ ${TRAVIS_PHP_VERSION} != "7.3" && ${TRAVIS_PHP_VERSION} != "5.6" ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
       fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]] ; then echo "yes" | pecl install channel://pecl.php.net/apcu-5.1.5 || true; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]] ; then echo "yes" | pecl install apcu-4.0.11 || true; fi
@@ -90,8 +89,8 @@ script:
   - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
   - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
-  - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
-  - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan:^0.10" && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src; fi
+  - if [[ $CHECKS = 1 ]]; then composer require --dev "phpstan/phpstan:^0.10" && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src/; fi
+  - if [[ $CHECKS = 1 ]]; then composer cs-check; fi
 
 after_success:
   - if [[ $CODECOVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - php: 5.6
       env: PREFER_LOWEST=1
 
-    - php: 7.3
+    - php: 7.2
       env: CHECKS=1 DEFAULT=0
 
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,12 @@ before_install:
   - sudo locale-gen da_DK
 
 before_script:
-  - composer install --prefer-dist --no-interaction
+  - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction; fi
 
 script:
   - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
+
   - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $CHECKS = 1 ]]; then composer require --dev "phpstan/phpstan:^0.10" && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src/; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - php: 5.6
       env: PREFER_LOWEST=1
 
-    - php: 7.0
+    - php: 7.3
       env: CHECKS=1 DEFAULT=0
 
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,9 @@
         "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.14|^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "cakephp/cakephp-codesniffer": "^3.0",
+        "cakephp/chronos": "^1.2.1",
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ parameters:
     autoload_files:
         - tests/bootstrap.php
     ignoreErrors:
+        - '#Constant MCRYPT_[A-Z0-9_]+ not found#'
+        - '#Function mcrypt_[a-zA-Z0-9_]+ not found#'
         - '#Function wincache_ucache_[a-zA-Z0-9_]+ not found#'
         - '#Function xcache_[a-zA-Z0-9_]+ not found#'
         - '#Cake\\Database\\Type\\[a-zA-Z0-9_]+Type::__construct\(\) does not call parent constructor from Cake\\Database\\Type#'


### PR DESCRIPTION
We have way too many jobs IMO, I think we can cut down a bit on the matrix of all PHP versions vs all DB types. Usually testing min and max should be enough between php versions.
But I dont want to touch too much

For now:
- Simplify checks together
- Add prefer lowest as we have more and more dependencies in core, and as such min requirements should also be tested.

This way the current job count doesnt increase.
CS on top of phpstan is fair IMO as the stickler auto-fixes them now anyway.
So having a combined "checks" run seems like a pragmatic way moving forward.
