### PR TITLE
Try to fix codecov builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
+    - CODECOVERAGE=0
 
 services:
   - memcached
@@ -40,6 +41,9 @@ matrix:
 
     - php: 7.1
       env: PHPSTAN=1 DEFAULT=0
+
+    - php: 7.2
+      env: CODECOVERAGE=1 DEFAULT=0
 
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
@@ -72,14 +76,14 @@ before_script:
   - composer install --prefer-dist --no-interaction
 
 script:
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then export CODECOVERAGE=1; phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
+  - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
+  - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan:^0.10" && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src; fi
 
 after_success:
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $CODECOVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: false


### PR DESCRIPTION
Don't include TRAVIS_PHP_VERSION in the commands that run coverage. Due to codecov/codecov-bash#133 we should try to not have a version number in the command so that codecov can detect environment variables better.

This will add more builds, but we might get coverage for all versions of PHP & all database drivers.