### PR TITLE
Consolidate path display

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -54,9 +54,9 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     {
         if (!$args->getOption('xml')) {
             $io->out('<info>Current Paths:</info>', 2);
-            $io->out('* app:  ' . APP_DIR);
-            $io->out('* root: ' . rtrim(ROOT, DIRECTORY_SEPARATOR));
-            $io->out('* core: ' . rtrim(CORE_PATH, DIRECTORY_SEPARATOR));
+            $io->out('* app:  ' . APP_DIR . DIRECTORY_SEPARATOR);
+            $io->out('* root: ' . ROOT . DIRECTORY_SEPARATOR);
+            $io->out('* core: ' . CORE_PATH);
             $io->out('');
 
             $io->out('<info>Available Commands:</info>', 2);

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -74,9 +74,9 @@ class CommandListShell extends Shell
     {
         if (!$this->param('xml') && !$this->param('version')) {
             $this->out('<info>Current Paths:</info>', 2);
-            $this->out('* app:  ' . APP_DIR);
-            $this->out('* root: ' . rtrim(ROOT, DIRECTORY_SEPARATOR));
-            $this->out('* core: ' . rtrim(CORE_PATH, DIRECTORY_SEPARATOR));
+            $this->out('* app:  ' . APP_DIR . DIRECTORY_SEPARATOR);
+            $this->out('* root: ' . ROOT . DIRECTORY_SEPARATOR);
+            $this->out('* core: ' . CORE_PATH);
             $this->out('');
 
             $this->out('<info>Available Shells:</info>', 2);


### PR DESCRIPTION
I would like to propose the following consolidation:
We should always configure and display paths with trailing slash to avoid them being mistaken/seen as files.
Especially in an env where many files can be extension-less, this clarifies things.
Or imagine the app being called `cake.img` or alike...

Before one could think those are files:
```
Current Paths:

* app:  src
* root: /home/vagrant/Apps/sandbox.local
* core: /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp
```

The output now is:
```
Current Paths:

* app:  src/
* root: /home/vagrant/Apps/sandbox.local/
* core: /home/vagrant/Apps/sandbox.local/vendor/cakephp/cakephp/
```