### PR TITLE
Raise phpstan to level 3. WIP

### DIFF
--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Cache\Cache;
-use Cake\Datasource\ConnectionInterface;
 
 /**
  * Schema Cache.
@@ -38,9 +37,9 @@ class SchemaCache
     /**
      * Constructor
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection Connection name to get the schema for or a connection instance
+     * @param \Cake\Database\Connection $connection Connection name to get the schema for or a connection instance
      */
-    public function __construct(ConnectionInterface $connection)
+    public function __construct(Connection $connection)
     {
         $this->_schema = $this->getSchema($connection);
     }
@@ -90,11 +89,11 @@ class SchemaCache
     /**
      * Helper method to get the schema collection.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection Connection object
+     * @param \Cake\Database\Connection $connection Connection object
      * @return \Cake\Database\Schema\Collection|\Cake\Database\Schema\CachedCollection
      * @throws \RuntimeException If given connection object is not compatible with schema caching
      */
-    public function getSchema(ConnectionInterface $connection)
+    public function getSchema(Connection $connection)
     {
         $config = $connection->config();
         if (empty($config['cacheMetadata'])) {

--- a/src/Shell/SchemaCacheShell.php
+++ b/src/Shell/SchemaCacheShell.php
@@ -80,6 +80,7 @@ class SchemaCacheShell extends Shell
     protected function _getSchemaCache(): SchemaCache
     {
         try {
+            /** @var \Cake\Database\Connection $connection */
             $connection = ConnectionManager::get($this->params['connection']);
 
             return new SchemaCache($connection);


### PR DESCRIPTION
But that is less than ideal.
As this means the whole class needs it, also means we get IDE errors on ConnectionManager::get('test') return value and usage between the cache and non cache versions using either concrete or interface contracts.
I made a PR to this one, but I sure dont like it.
Better to somehow add cacheMetadata() and throw not implemented exception or alike IMO.