### PR TITLE
Fix NullEngine::write() return value to match abstract method's signature - issue #12758

### DIFF
--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -44,6 +44,7 @@ class NullEngine extends CacheEngine
      */
     public function write($key, $value)
     {
+        return true;
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -235,7 +235,7 @@ class CacheTest extends TestCase
         Cache::disable();
         $this->_configCache();
 
-        $this->assertNull(Cache::write('no_save', 'Noooo!', 'tests'));
+        $this->assertTrue(Cache::write('no_save', 'Noooo!', 'tests'));
         $this->assertFalse(Cache::read('no_save', 'tests'));
         $this->assertNull(Cache::delete('no_save', 'tests'));
     }
@@ -739,7 +739,7 @@ class CacheTest extends TestCase
 
         Cache::disable();
 
-        $this->assertNull(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
+        $this->assertTrue(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
         $this->assertFalse(Cache::read('key_2', 'test_cache_disable_1'));
 
         Cache::enable();
@@ -754,7 +754,7 @@ class CacheTest extends TestCase
             'path' => CACHE . 'tests'
         ]);
 
-        $this->assertNull(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
+        $this->assertTrue(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
         $this->assertFalse(Cache::read('key_4', 'test_cache_disable_2'));
 
         Cache::enable();
@@ -763,7 +763,7 @@ class CacheTest extends TestCase
         $this->assertSame(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
 
         Cache::disable();
-        $this->assertNull(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
+        $this->assertTrue(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
         $this->assertFalse(Cache::read('key_6', 'test_cache_disable_2'));
 
         Cache::enable();


### PR DESCRIPTION
Issue link: https://github.com/cakephp/cakephp/issues/12758

Cache's NullEngine::write() method will now return `true`. This in effect will comply with parent's abstract method return type declaration.

Returning `false` is not currently an option, because Cache class will trigger an error:
https://github.com/cakephp/cakephp/blob/3.6.13/src/Cache/Cache.php#L282-L292