### PR TITLE
Test with SQLite first to get first results faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ dist: trusty
 
 env:
   matrix:
+    - DB=sqlite db_dsn='sqlite:///:memory:'
     - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
     - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
     - CODECOVERAGE=0


### PR DESCRIPTION
Travis takes about 7.5 minutes for builds with MySQL, and takes only a bit more than 2 minutes with SQLite.

Testing with SQLite first would save 5 minutes to see non-DB-specific failures, and it would allow to start fixing sooner.