### PR TITLE
Add deprecation warning for routing middleware

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -59,6 +59,12 @@ class RoutingMiddleware
      */
     public function __construct(HttpApplicationInterface $app = null, $cacheConfig = null)
     {
+        if ($app === null) {
+            deprecationWarning(
+                'RoutingMiddleware should be passed an application instance. ' .
+                'Failing to do so can cause plugin routes to not behave correctly.'
+            );
+        }
         $this->app = $app;
         $this->cacheConfig = $cacheConfig;
     }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -61,7 +61,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = new Response();
         $next = function ($req, $res) {
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $response = $middleware($request, $response, $next);
 
         $this->assertEquals(301, $response->getStatusCode());
@@ -82,7 +82,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = new Response('php://memory', 200, ['X-testing' => 'Yes']);
         $next = function ($req, $res) {
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $response = $middleware($request, $response, $next);
 
         $this->assertEquals(301, $response->getStatusCode());
@@ -109,7 +109,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $middleware($request, $response, $next);
     }
 
@@ -134,7 +134,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $middleware($request, $response, $next);
     }
 
@@ -207,7 +207,7 @@ class RoutingMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             $this->assertEquals(['controller' => 'Articles'], $req->getAttribute('params'));
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $middleware($request, $response, $next);
     }
 
@@ -222,7 +222,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = new Response();
         $next = function ($req, $res) {
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $middleware($request, $response, $next);
     }
 
@@ -259,7 +259,7 @@ class RoutingMiddlewareTest extends TestCase
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertEquals('PATCH', $req->getMethod());
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $middleware($request, $response, $next);
     }
 
@@ -299,7 +299,7 @@ class RoutingMiddlewareTest extends TestCase
 
             return $res;
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $result = $middleware($request, $response, $next);
         $this->assertSame($response, $result, 'Should return result');
         $this->assertSame(['second', 'first', 'last'], $this->log);
@@ -344,7 +344,7 @@ class RoutingMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             $this->fail('Should not be invoked as first should be ignored.');
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $result = $middleware($request, $response, $next);
 
         $this->assertSame($response, $result, 'Should return result');
@@ -387,7 +387,7 @@ class RoutingMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             $this->fail('Should not be invoked as second should be ignored.');
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $result = $middleware($request, $response, $next);
 
         $this->assertSame($response, $result, 'Should return result');
@@ -438,7 +438,7 @@ class RoutingMiddlewareTest extends TestCase
 
             return $res;
         };
-        $middleware = new RoutingMiddleware();
+        $middleware = new RoutingMiddleware($this->app());
         $result = $middleware($request, $response, $next);
         $this->assertSame($response, $result, 'Should return result');
         $this->assertSame($expected, $this->log);
@@ -542,5 +542,21 @@ class RoutingMiddlewareTest extends TestCase
         $middleware($request, $response, $next);
 
         Cache::drop('_cake_router_');
+    }
+
+    /**
+     * Create a stub application for testing.
+     *
+     * @return \Cake\Core\HttpApplicationInterface
+     */
+    protected function app()
+    {
+        $mock = $this->createMock(Application::class);
+        $mock->method('routes')
+            ->will($this->returnCallback(function ($routes) {
+                return $routes;
+            }));
+
+        return $mock;
     }
 }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -624,6 +624,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     public function testArrayUrls()
     {
         $this->post(['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
+        $this->assertResponseOk();
         $this->assertEquals('value', $this->viewVariable('test'));
     }
 
@@ -638,6 +639,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
         $this->assertFalse(Router::$initialized);
 
         $this->post(['controller' => 'Posts', 'action' => 'index']);
+        $this->assertResponseOk();
         $this->assertEquals('value', $this->viewVariable('test'));
     }
 

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -48,7 +48,7 @@ class Application extends BaseApplication
      */
     public function middleware($middleware)
     {
-        $middleware->add(new RoutingMiddleware());
+        $middleware->add(new RoutingMiddleware($this));
         $middleware->add(function ($req, $res, $next) {
             /** @var \Cake\Http\ServerRequest $res */
             $res = $next($req, $res);
@@ -69,6 +69,7 @@ class Application extends BaseApplication
     {
         $routes->scope('/app', function (RouteBuilder $routes) {
             $routes->connect('/articles', ['controller' => 'Articles']);
+            $routes->fallbacks();
         });
     }
 }


### PR DESCRIPTION
While routing 'works' without an application plugin routing will not work correctly.

Fixes #12740
