### PR TITLE
Run cache tests when collecting coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   global:
     - DEFAULT=1
     - CODECOVERAGE=0
+    - PHPCS=0
 
 services:
   - memcached
@@ -57,19 +58,29 @@ before_install:
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
-  - if [[ $DEFAULT = 1 || $PHPSTAN = 1 ]] ; then pecl channel-update pecl.php.net; fi;
+  - if [[ $PHPCS = 0 ]] ; then pecl channel-update pecl.php.net; fi;
   - |
       if [[ ${TRAVIS_PHP_VERSION} != "7.3" && ${TRAVIS_PHP_VERSION} != "5.6" && ($DEFAULT = 1 || $PHPSTAN = 1) ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
       fi
-  - if [[ $DEFAULT = 1 || $PHPSTAN = 1 ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $DEFAULT = 1 || $PHPSTAN = 1 ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $DEFAULT = 1 || $PHPSTAN = 1 ]] ; then echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $PHPCS = 0 ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $PHPCS = 0 ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $PHPCS = 0 ]] ; then echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]] ; then echo "yes" | pecl install channel://pecl.php.net/apcu-5.1.5 || true; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]] ; then echo "yes" | pecl install apcu-4.0.11 || true; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" && $DB = 'mysql' ]] ; then wget http://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz; tar xf xcache-3.2.0.tar.gz; pushd xcache-3.2.0; phpize; ./configure; make; NO_INTERACTION=1 make test; make install; popd;printf "extension=xcache.so\nxcache.size=64M\nxcache.var_size=16M\nxcache.test=On" > ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-
+  - |
+      if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" && $DB = 'mysql' ]]; then
+        wget http://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz
+        tar xf xcache-3.2.0.tar.gz
+        pushd xcache-3.2.0
+        phpize; ./configure
+        make
+        NO_INTERACTION=1 make test
+        make install
+        popd
+        printf "extension=xcache.so\nxcache.size=64M\nxcache.var_size=16M\nxcache.test=On" > ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+      fi
   - sudo locale-gen da_DK
 
 before_script:


### PR DESCRIPTION
We weren't installing the cache driver extensions when running coverage so they always counted as 0s.