### PR TITLE
Fix Association::$finder type

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -860,7 +860,7 @@ abstract class Association
     /**
      * Gets the default finder to use for fetching rows from the target table.
      *
-     * @return string
+     * @return string|array
      */
     public function getFinder()
     {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -179,8 +179,9 @@ abstract class Association
 
     /**
      * The default finder name to use for fetching rows from the target table
+     * With array value, finder name and default options are allowed.
      *
-     * @var string
+     * @var string|array
      */
     protected $_finder = 'all';
 
@@ -869,7 +870,7 @@ abstract class Association
     /**
      * Sets the default finder to use for fetching rows from the target table.
      *
-     * @param string $finder the finder name to use
+     * @param string|array $finder the finder name to use or array of finder name and option.
      * @return $this
      */
     public function setFinder($finder)
@@ -886,7 +887,7 @@ abstract class Association
      *
      * @deprecated 3.4.0 Use setFinder()/getFinder() instead.
      * @param string|null $finder the finder name to use
-     * @return string
+     * @return string|array
      */
     public function finder($finder = null)
     {


### PR DESCRIPTION
phpdoc describes `type string`, but it can retrieve an array as `[$finder:string, $options:array]` .
We can use this as bellow.

```php
$Table->belongsTo('Users')
    ->setFinder(['custom' => ['opt1' => 'some value']]);
```

This works like:

```php
// ORM\Association
$this->getTarget()->find($type, $options + $opts);
```
Because `_extractFinder()` method returns array including options.
https://github.com/cakephp/cakephp/blob/3.7.0-RC3/src/ORM/Association.php#L1391-L1399