### PR TITLE
Form Helper maxlength attribute uses validation #12773

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\View\Form;
 
 use Cake\Http\ServerRequest;
@@ -212,19 +213,20 @@ class ArrayContext implements ContextInterface
      * In this context class, this is simply defined by the 'maxlength' array.
      *
      * @param string $field A dot separated path to check required-ness for.
-     * @return int|false
+     * @return int|null
      */
     public function getMaxLength($field)
     {
         if (!is_array($this->_context['schema'])) {
-            return false;
+            return null;
         }
         $fieldShema = Hash::get($this->_context['schema'], $field);
-        if(is_array($fieldShema)) {
+
+        if (is_array($fieldShema)) {
             $maxLength = Hash::get($fieldShema, 'length');
         }
 
-        return $maxLength ?? false;
+        return $maxLength ?? null;
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -226,10 +226,8 @@ class ArrayContext implements ContextInterface
         if(!$fieldSchema){
             return null;
         }
-
-        if (is_array($fieldSchema)) {
-            $maxLength = Hash::get($fieldSchema, 'length');
-        }
+        
+        $maxLength = Hash::get($fieldSchema, 'length');
 
         return $maxLength ?? null;
     }

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -220,9 +220,11 @@ class ArrayContext implements ContextInterface
             return false;
         }
         $fieldShema = Hash::get($this->_context['schema'], $field);
-        $maxLength =  Hash::get($fieldShema, 'length');
+        if(is_array($fieldShema)) {
+            $maxLength = Hash::get($fieldShema, 'length');
+        }
 
-        return $maxLength??false;
+        return $maxLength ?? false;
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -220,10 +220,15 @@ class ArrayContext implements ContextInterface
         if (!is_array($this->_context['schema'])) {
             return null;
         }
-        $fieldShema = Hash::get($this->_context['schema'], $field);
 
-        if (is_array($fieldShema)) {
-            $maxLength = Hash::get($fieldShema, 'length');
+        $fieldSchema = Hash::get($this->_context['schema'], $field);
+
+        if(!$fieldSchema){
+            return null;
+        }
+
+        if (is_array($fieldSchema)) {
+            $maxLength = Hash::get($fieldSchema, 'length');
         }
 
         return $maxLength ?? null;

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -207,6 +207,25 @@ class ArrayContext implements ContextInterface
     }
 
     /**
+     * Get field length from validation
+     *
+     * In this context class, this is simply defined by the 'maxlength' array.
+     *
+     * @param string $field A dot separated path to check required-ness for.
+     * @return int|false
+     */
+    public function getMaxLength($field)
+    {
+        if (!is_array($this->_context['schema'])) {
+            return false;
+        }
+        $fieldShema = Hash::get($this->_context['schema'], $field);
+        $maxLength =  Hash::get($fieldShema, 'length');
+
+        return $maxLength??false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function fieldNames()

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\View\Form;
 
 use Cake\Http\ServerRequest;
@@ -226,10 +225,12 @@ class ArrayContext implements ContextInterface
         if(!$fieldSchema){
             return null;
         }
-        
-        $maxLength = Hash::get($fieldSchema, 'length');
 
-        return $maxLength ?? null;
+        if (is_array($fieldSchema)) {
+            return Hash::get($fieldSchema, 'length');
+        }
+
+        return null;
     }
 
     /**

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -74,7 +74,7 @@ interface ContextInterface
      * Get maximum length of a filed from model validation
      *
      * @param string $field A dot separated path to check required-ness for.
-     * @return bool|false
+     * @return bool|null
      */
     public function getMaxLength($field);
 

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -74,7 +74,7 @@ interface ContextInterface
      * Get maximum length of a field from model validation
      *
      * @param string $field A dot separated path to check required-ness for.
-     * @return bool|null
+     * @return int|null
      */
     public function getMaxLength($field);
 

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -71,6 +71,14 @@ interface ContextInterface
     public function isRequired($field);
 
     /**
+     * Get maximum length of a filed from model validation
+     *
+     * @param string $field A dot separated path to check required-ness for.
+     * @return bool|false
+     */
+    public function getMaxLength($field);
+
+    /**
      * Get the fieldnames of the top level object in this context.
      *
      * @return array A list of the field names in the context.

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -71,7 +71,7 @@ interface ContextInterface
     public function isRequired($field);
 
     /**
-     * Get maximum length of a filed from model validation
+     * Get maximum length of a field from model validation
      *
      * @param string $field A dot separated path to check required-ness for.
      * @return bool|null

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -442,11 +442,7 @@ class EntityContext implements ContextInterface
         }
         foreach ($validator->field($fieldName)->rules() as $rule) {
             if ($rule->get('rule') === 'maxLength') {
-<<<<<<< 892251dd39a1c5c9a91c83d1a6b50a402ed59a37
-                return $rule->get('pass')[0] ?? null;
-=======
                 return isset($rule->get('pass')[0]) ? $rule->get('pass')[0] : null;
->>>>>>> Form Helper maxlength attribute uses validation
             }
         }
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -430,7 +430,7 @@ class EntityContext implements ContextInterface
      * Get field length from validation
      *
      * @param string $field The dot separated path to the field you want to check.
-     * @return int|false
+     * @return int|null
      */
     public function getMaxLength($field)
     {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -427,6 +427,26 @@ class EntityContext implements ContextInterface
     }
 
     /**
+     * Get field length from validation
+     *
+     * @param string $field The dot separated path to the field you want to check.
+     * @return int|false
+     */
+    public function getMaxLength($field){
+        $parts = explode('.', $field);
+        $validator = $this->_getValidator($parts);
+        $fieldName = array_pop($parts);
+        if (!$validator->hasField($fieldName)) {
+            return false;
+        }
+        foreach($validator->field($fieldName)->rules() as $rule){
+            if($rule->get('rule') == 'maxLength'){
+                return $rule->get('pass')[0] ?? false;
+            }
+        }
+    }
+
+    /**
      * Get the field names from the top level entity.
      *
      * If the context is for an array of entities, the 0th index will be used.

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -432,16 +432,17 @@ class EntityContext implements ContextInterface
      * @param string $field The dot separated path to the field you want to check.
      * @return int|false
      */
-    public function getMaxLength($field){
+    public function getMaxLength($field)
+    {
         $parts = explode('.', $field);
         $validator = $this->_getValidator($parts);
         $fieldName = array_pop($parts);
         if (!$validator->hasField($fieldName)) {
-            return false;
+            return null;
         }
-        foreach($validator->field($fieldName)->rules() as $rule){
-            if($rule->get('rule') == 'maxLength'){
-                return $rule->get('pass')[0] ?? false;
+        foreach ($validator->field($fieldName)->rules() as $rule) {
+            if ($rule->get('rule') == 'maxLength') {
+                return $rule->get('pass')[0] ?? null;
             }
         }
     }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -442,7 +442,11 @@ class EntityContext implements ContextInterface
         }
         foreach ($validator->field($fieldName)->rules() as $rule) {
             if ($rule->get('rule') === 'maxLength') {
+<<<<<<< 892251dd39a1c5c9a91c83d1a6b50a402ed59a37
                 return $rule->get('pass')[0] ?? null;
+=======
+                return isset($rule->get('pass')[0]) ? $rule->get('pass')[0] : null;
+>>>>>>> Form Helper maxlength attribute uses validation
             }
         }
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -441,10 +441,12 @@ class EntityContext implements ContextInterface
             return null;
         }
         foreach ($validator->field($fieldName)->rules() as $rule) {
-            if ($rule->get('rule') == 'maxLength') {
+            if ($rule->get('rule') === 'maxLength') {
                 return $rule->get('pass')[0] ?? null;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\View\Form;
 
 use Cake\Http\ServerRequest;
@@ -105,7 +106,6 @@ class FormContext implements ContextInterface
      * Get default value from form schema for given field.
      *
      * @param string $field Field name.
-
      * @return mixed
      */
     protected function _schemaDefault($field)
@@ -141,15 +141,15 @@ class FormContext implements ContextInterface
     {
         $validator = $this->_form->getValidator();
         if (!$validator->hasField($field)) {
-            return false;
+            return null;
         }
-        foreach($validator->field($field)->rules() as $rule){
-            if($rule->get('rule') == 'maxLength'){
-                return $rule->get('pass')[0] ?? false;
+        foreach ($validator->field($field)->rules() as $rule) {
+            if ($rule->get('rule') == 'maxLength') {
+                return $rule->get('pass')[0] ?? null;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -144,7 +144,7 @@ class FormContext implements ContextInterface
             return null;
         }
         foreach ($validator->field($field)->rules() as $rule) {
-            if ($rule->get('rule') == 'maxLength') {
+            if ($rule->get('rule') === 'maxLength') {
                 return $rule->get('pass')[0] ?? null;
             }
         }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -137,6 +137,24 @@ class FormContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
+    public function getMaxLength($field)
+    {
+        $validator = $this->_form->getValidator();
+        if (!$validator->hasField($field)) {
+            return false;
+        }
+        foreach($validator->field($field)->rules() as $rule){
+            if($rule->get('rule') == 'maxLength'){
+                return $rule->get('pass')[0] ?? false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function fieldNames()
     {
         return $this->_form->schema()->fields();

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\View\Form;
 
 use Cake\Http\ServerRequest;

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -86,6 +86,14 @@ class NullContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
+    public function getMaxLength($field)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function fieldNames()
     {
         return [];

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -88,7 +88,7 @@ class NullContext implements ContextInterface
      */
     public function getMaxLength($field)
     {
-        return false;
+        return null;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1477,7 +1477,11 @@ class FormHelper extends Helper
         }
 
         $validationLength = $context->getMaxLength($fieldName);
+<<<<<<< 892251dd39a1c5c9a91c83d1a6b50a402ed59a37
         if($fieldDef['length'] && $validationLength){
+=======
+        if(!empty($fieldDef['length']) && $validationLength){
+>>>>>>> Form Helper maxlength attribute uses validation
             $fieldDef['length'] = min($fieldDef['length'], $validationLength);
         }else if($validationLength){
             $fieldDef['length'] = $validationLength;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1477,7 +1477,11 @@ class FormHelper extends Helper
         }
 
         $validationLength = $context->getMaxLength($fieldName);
-        $fieldDef['length'] = $fieldDef['length'] ?? $validationLength;
+        if($fieldDef['length'] && $validationLength){
+            $fieldDef['length'] = min($fieldDef['length'], $validationLength);
+        }else if($validationLength){
+            $fieldDef['length'] = $validationLength;
+        }
 
         $autoLength = !array_key_exists('maxlength', $options)
             && !empty($fieldDef['length'])
@@ -1485,7 +1489,7 @@ class FormHelper extends Helper
 
         $allowedTypes = ['text', 'textarea', 'email', 'tel', 'url', 'search'];
         if ($autoLength && in_array($options['type'], $allowedTypes)) {
-            $options['maxlength'] = min($fieldDef['length'], 100000);
+            $options['maxlength'] = $fieldDef['length'];
         }
 
         if (in_array($options['type'], ['datetime', 'date', 'time', 'select'])) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1476,6 +1476,10 @@ class FormHelper extends Helper
             unset($options['step']);
         }
 
+
+        $validationLength = $context->getMaxLength($fieldName);
+        $fieldDef['length'] = $fieldDef['length'] ?? $validationLength;
+
         $autoLength = !array_key_exists('maxlength', $options)
             && !empty($fieldDef['length'])
             && $options['type'] !== 'select';

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1477,11 +1477,8 @@ class FormHelper extends Helper
         }
 
         $validationLength = $context->getMaxLength($fieldName);
-<<<<<<< 892251dd39a1c5c9a91c83d1a6b50a402ed59a37
-        if($fieldDef['length'] && $validationLength){
-=======
+
         if(!empty($fieldDef['length']) && $validationLength){
->>>>>>> Form Helper maxlength attribute uses validation
             $fieldDef['length'] = min($fieldDef['length'], $validationLength);
         }else if($validationLength){
             $fieldDef['length'] = $validationLength;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1476,7 +1476,6 @@ class FormHelper extends Helper
             unset($options['step']);
         }
 
-
         $validationLength = $context->getMaxLength($fieldName);
         $fieldDef['length'] = $fieldDef['length'] ?? $validationLength;
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -12,6 +12,7 @@
  * @since         1.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Collection\Collection;
@@ -1744,24 +1745,24 @@ class FormHelperTest extends TestCase
         $result = $this->Form->secure($this->Form->fields);
         $hash = '43c4db25e4162c5e4edd9dea51f5f9d9d92215ec%3AAddresses.0.id%7CAddresses.1.id';
         $tokenDebug = urlencode(json_encode([
-                '/articles/add',
-                [
-                    'Addresses.0.id' => '123456',
-                    'Addresses.0.title',
-                    'Addresses.0.last_name',
-                    'Addresses.0.city',
-                    'Addresses.0.phone',
-                    'Addresses.1.id' => '654321',
-                    'Addresses.1.title',
-                    'Addresses.1.last_name',
-                    'Addresses.1.city',
-                    'Addresses.1.phone'
-                ],
-                [
-                    'first_name',
-                    'address'
-                ]
-            ]));
+            '/articles/add',
+            [
+                'Addresses.0.id' => '123456',
+                'Addresses.0.title',
+                'Addresses.0.last_name',
+                'Addresses.0.city',
+                'Addresses.0.phone',
+                'Addresses.1.id' => '654321',
+                'Addresses.1.title',
+                'Addresses.1.last_name',
+                'Addresses.1.city',
+                'Addresses.1.phone'
+            ],
+            [
+                'first_name',
+                'address'
+            ]
+        ]));
 
         $expected = [
             'div' => ['style' => 'display:none;'],
@@ -1822,19 +1823,19 @@ class FormHelperTest extends TestCase
 
         $hash = 'f98315a7d5515e5ae32e35f7d680207c085fae69%3AAddresses.id';
         $tokenDebug = urlencode(json_encode([
-                '/articles/add',
-                [
-                    'Addresses.id' => '123456',
-                    'Addresses.title',
-                    'Addresses.last_name',
-                    'Addresses.city',
-                    'Addresses.phone'
-                ],
-                [
-                    'first_name',
-                    'address'
-                ]
-            ]));
+            '/articles/add',
+            [
+                'Addresses.id' => '123456',
+                'Addresses.title',
+                'Addresses.last_name',
+                'Addresses.city',
+                'Addresses.phone'
+            ],
+            [
+                'first_name',
+                'address'
+            ]
+        ]));
 
         $expected = [
             'div' => ['style' => 'display:none;'],
@@ -2274,14 +2275,14 @@ class FormHelperTest extends TestCase
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
-                'type' => 'hidden',
-                'value' => 'some text',
+            'type' => 'hidden',
+            'value' => 'some text',
         ]);
         $expected = ['text_val' => 'some text'];
         $this->assertEquals($expected, $this->Form->fields);
 
         $this->Form->control('text_val', [
-                'type' => 'text',
+            'type' => 'text',
         ]);
         $expected = ['text_val'];
         $this->assertEquals($expected, $this->Form->fields);
@@ -3641,7 +3642,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-            'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
+                'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3665,7 +3666,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-            'options' => ['First', 'Second'], 'empty' => true]
+                'options' => ['First', 'Second'], 'empty' => true]
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3771,22 +3772,22 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input select']],
-                ['label' => ['for' => 'publisher-id']],
-                'Publisher',
-                '/label',
-                'input' => ['type' => 'hidden', 'name' => 'Publisher[id]', 'value' => ''],
-                ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'publisher-id-value-1']],
-                ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1']],
-                'Label 1',
-                '/label',
-                '/div',
-                ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'publisher-id-value-2']],
-                ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2']],
-                'Label 2',
-                '/label',
-                '/div',
+            ['label' => ['for' => 'publisher-id']],
+            'Publisher',
+            '/label',
+            'input' => ['type' => 'hidden', 'name' => 'Publisher[id]', 'value' => ''],
+            ['div' => ['class' => 'checkbox']],
+            ['label' => ['for' => 'publisher-id-value-1']],
+            ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1']],
+            'Label 1',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['label' => ['for' => 'publisher-id-value-2']],
+            ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2']],
+            'Label 2',
+            '/label',
+            '/div',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -4813,18 +4814,18 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-                '<label',
-                'Test',
-                '/label',
-                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-                ['label' => ['for' => 'test-0']],
-                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-                    'A',
-                '/label',
-                ['label' => ['for' => 'test-1']],
-                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-                    'B',
-                '/label',
+            '<label',
+            'Test',
+            '/label',
+            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+            ['label' => ['for' => 'test-0']],
+            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+            'A',
+            '/label',
+            ['label' => ['for' => 'test-1']],
+            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+            'B',
+            '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4836,18 +4837,18 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-                '<label',
-                'Test',
-                '/label',
-                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-                ['label' => ['for' => 'test-0']],
-                    ['input' => ['type' => 'radio', 'checked' => 'checked', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-                    'A',
-                '/label',
-                ['label' => ['for' => 'test-1']],
-                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-                    'B',
-                '/label',
+            '<label',
+            'Test',
+            '/label',
+            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+            ['label' => ['for' => 'test-0']],
+            ['input' => ['type' => 'radio', 'checked' => 'checked', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+            'A',
+            '/label',
+            ['label' => ['for' => 'test-1']],
+            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+            'B',
+            '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4859,15 +4860,15 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-                ['label' => ['for' => 'test-0']],
-                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-                    'A',
-                '/label',
-                ['label' => ['for' => 'test-1']],
-                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-                    'B',
-                '/label',
+            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+            ['label' => ['for' => 'test-0']],
+            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+            'A',
+            '/label',
+            ['label' => ['for' => 'test-1']],
+            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+            'B',
+            '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4914,22 +4915,22 @@ class FormHelperTest extends TestCase
                 'value' => ''
             ]],
             ['label' => ['for' => 'model-field-0']],
-                ['input' => [
-                    'type' => 'radio',
-                    'name' => 'Model[field]',
-                    'value' => '0',
-                    'id' => 'model-field-0'
-                ]],
-                'option A',
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'Model[field]',
+                'value' => '0',
+                'id' => 'model-field-0'
+            ]],
+            'option A',
             '/label',
             ['label' => ['for' => 'model-field-1']],
-                ['input' => [
-                    'type' => 'radio',
-                    'name' => 'Model[field]',
-                    'value' => '1',
-                    'id' => 'model-field-1'
-                ]],
-                'option B',
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'Model[field]',
+                'value' => '1',
+                'id' => 'model-field-1'
+            ]],
+            'option B',
             '/label',
         ];
         //@codingStandardsIgnoreEnd
@@ -5180,15 +5181,15 @@ class FormHelperTest extends TestCase
             'Two',
             '/option',
             ['optgroup' => ['label' => 'Three']],
-                ['option' => ['value' => 3]],
-                'Three',
-                '/option',
-                ['option' => ['value' => 4]],
-                'Four',
-                '/option',
-                ['option' => ['value' => 5]],
-                'Five',
-                '/option',
+            ['option' => ['value' => 3]],
+            'Three',
+            '/option',
+            ['option' => ['value' => 4]],
+            'Four',
+            '/option',
+            ['option' => ['value' => 5]],
+            'Five',
+            '/option',
             '/optgroup',
             '/select'
         ];
@@ -5789,16 +5790,16 @@ class FormHelperTest extends TestCase
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'fish', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'fish-0']],
-                    ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
-                    '1',
-                '/label',
+            ['label' => ['for' => 'fish-0']],
+            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
+            '1',
+            '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'fish-1']],
-                    ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
-                    '2',
-                '/label',
+            ['label' => ['for' => 'fish-1']],
+            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
+            '2',
+            '/label',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -5836,16 +5837,16 @@ class FormHelperTest extends TestCase
             '/label',
             'input' => ['type' => 'hidden', 'name' => 'category', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'category-0']],
-                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'category-0']],
-                    '1',
-                '/label',
+            ['label' => ['for' => 'category-0']],
+            ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'category-0']],
+            '1',
+            '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'category-1']],
-                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'category-1']],
-                    '2',
-                '/label',
+            ['label' => ['for' => 'category-1']],
+            ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'category-1']],
+            '2',
+            '/label',
             '/div',
             '/div',
         ];
@@ -7124,10 +7125,10 @@ class FormHelperTest extends TestCase
         ]);
         $this->Form->create($this->article);
         $result = $this->Form->control('month_year', [
-                'label' => false,
-                'type' => 'date',
-                'minYear' => 2006,
-                'maxYear' => 2008
+            'label' => false,
+            'type' => 'date',
+            'minYear' => 2006,
+            'maxYear' => 2008
         ]);
         $this->assertContains('value="' . date('m') . '" selected="selected"', $result);
         $this->assertNotContains('value="2008" selected="selected"', $result);
@@ -7531,10 +7532,10 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
-                '/posts/delete/1',
-                [],
-                []
-            ]));
+            '/posts/delete/1',
+            [],
+            []
+        ]));
 
         $expected = [
             'form' => [
@@ -8286,15 +8287,15 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
-                'label' => ['for' => '0-comments-1-comment'],
-                    'Comment',
-                '/label',
-                'textarea' => [
-                    'name',
-                    'id' => '0-comments-1-comment',
-                    'rows' => 5
-                ],
-                '/textarea',
+            'label' => ['for' => '0-comments-1-comment'],
+            'Comment',
+            '/label',
+            'textarea' => [
+                'name',
+                'id' => '0-comments-1-comment',
+                'rows' => 5
+            ],
+            '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8304,16 +8305,16 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
-                'label' => ['for' => '0-comments-0-comment'],
-                    'Comment',
-                '/label',
-                'textarea' => [
-                    'name',
-                    'id' => '0-comments-0-comment',
-                    'rows' => 5
-                ],
-                'Value',
-                '/textarea',
+            'label' => ['for' => '0-comments-0-comment'],
+            'Comment',
+            '/label',
+            'textarea' => [
+                'name',
+                'id' => '0-comments-0-comment',
+                'rows' => 5
+            ],
+            'Value',
+            '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8324,20 +8325,20 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea error'],
-                'label' => ['for' => '0-comments-0-comment'],
-                    'Comment',
-                '/label',
-                'textarea' => [
-                    'name',
-                    'class' => 'form-error',
-                    'id' => '0-comments-0-comment',
-                    'rows' => 5
-                ],
-                'Value',
-                '/textarea',
-                ['div' => ['class' => 'error-message']],
-                'Not valid',
-                '/div',
+            'label' => ['for' => '0-comments-0-comment'],
+            'Comment',
+            '/label',
+            'textarea' => [
+                'name',
+                'class' => 'form-error',
+                'id' => '0-comments-0-comment',
+                'rows' => 5
+            ],
+            'Value',
+            '/textarea',
+            ['div' => ['class' => 'error-message']],
+            'Not valid',
+            '/div',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8350,16 +8351,16 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea required'],
-                'label' => ['for' => '0-comments-1-comment'],
-                    'Comment',
-                '/label',
-                'textarea' => [
-                    'name',
-                    'required' => 'required',
-                    'id' => '0-comments-1-comment',
-                    'rows' => 5
-                ],
-                '/textarea',
+            'label' => ['for' => '0-comments-1-comment'],
+            'Comment',
+            '/label',
+            'textarea' => [
+                'name',
+                'required' => 'required',
+                'id' => '0-comments-1-comment',
+                'rows' => 5
+            ],
+            '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8507,7 +8508,7 @@ class FormHelperTest extends TestCase
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
             ['input' => ['type' => 'checkbox', 'name' => 'foo', 'id' => 'foo', 'value' => '1']],
             'label' => ['for' => 'foo'],
-                'Foo',
+            'Foo',
             '/label',
             '/div'
         ];
@@ -8551,16 +8552,16 @@ class FormHelperTest extends TestCase
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'fish', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-                ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
-                ['label' => ['for' => 'fish-0']],
-                    '1',
-                '/label',
+            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
+            ['label' => ['for' => 'fish-0']],
+            '1',
+            '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-                ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
-                ['label' => ['for' => 'fish-1']],
-                    '2',
-                '/label',
+            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
+            ['label' => ['for' => 'fish-1']],
+            '2',
+            '/label',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -8712,23 +8713,23 @@ class FormHelperTest extends TestCase
                 'type' => 'hidden', 'name' => 'multi_field', 'value' => ''
             ],
             ['div' => ['class' => 'checkbox']],
-                ['label' => ['for' => 'multi-field-0']],
-                    ['input' => [
-                        'type' => 'checkbox', 'name' => 'multi_field[]',
-                        'value' => '0', 'id' => 'multi-field-0'
-                    ]],
-                    'first',
-                    '/label',
-                    '/div',
-                    ['div' => ['class' => 'checkbox']],
-                    ['label' => ['for' => 'multi-field-1']],
-                    ['input' => [
-                        'type' => 'checkbox', 'name' => 'multi_field[]',
-                        'value' => '1', 'id' => 'multi-field-1'
-                    ]],
-                    'second',
-                    '/label',
-                    '/div',
+            ['label' => ['for' => 'multi-field-0']],
+            ['input' => [
+                'type' => 'checkbox', 'name' => 'multi_field[]',
+                'value' => '0', 'id' => 'multi-field-0'
+            ]],
+            'first',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['label' => ['for' => 'multi-field-1']],
+            ['input' => [
+                'type' => 'checkbox', 'name' => 'multi_field[]',
+                'value' => '1', 'id' => 'multi-field-1'
+            ]],
+            'second',
+            '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -9408,7 +9409,8 @@ class FormHelperTest extends TestCase
                     'validator' => $validator
                 ])
 
-            ]);
+            ]
+        );
 
         $this->Form->create($article);
         $result = $this->Form->control('title');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -9446,7 +9446,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($form);
         $result = $this->Form->control('title');
-        debug($result);
+
         $expected = [
             'div' => ['class'],
             'label' => ['for'],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -23,6 +23,8 @@ use Cake\ORM\Table;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
+use Cake\Validation\Validator;
+use Cake\View\Form\EntityContext;
 use Cake\View\Helper\FormHelper;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
@@ -9349,6 +9351,116 @@ class FormHelperTest extends TestCase
             '/label',
             '/div',
             '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testControlMaxLengthArrayContext method
+     *
+     * Test control() with maxlength attribute in Array Context.
+     *
+     * @return void
+     */
+    public function testControlMaxLengthArrayContext()
+    {
+        $this->article['schema'] = [
+            'title' => ['length' => 10]
+        ];
+
+        $this->Form->create($this->article);
+        $result = $this->Form->control('title');
+        $expected = [
+            'div' => ['class'],
+            'label' => ['for'],
+            'Title',
+            '/label',
+            'input' => [
+                'id',
+                'name' => 'title',
+                'type' => 'text',
+                'required' => 'required',
+                'maxlength' => 10,
+            ],
+            '/div',
+
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testControlMaxLengthEntityContext method
+     *
+     * Test control() with maxlength attribute in Entity Context.
+     *
+     * @return void
+     */
+    public function testControlMaxLengthEntityContext()
+    {
+        $validator = new Validator();
+        $validator->maxLength('title', 10);
+        $article = new EntityContext(
+            new ServerRequest(),
+            [
+                'entity' => new Entity($this->article),
+                'table' => new Table([
+                    'schema' => $this->article['schema'],
+                    'validator' => $validator
+                ])
+
+            ]);
+
+        $this->Form->create($article);
+        $result = $this->Form->control('title');
+        $expected = [
+            'div' => ['class'],
+            'label' => ['for'],
+            'Title',
+            '/label',
+            'input' => [
+                'id',
+                'name' => 'title',
+                'type' => 'text',
+                'required' => 'required',
+                'maxlength' => 10,
+            ],
+            '/div',
+
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testControlMaxLengthFormContext method
+     *
+     * Test control() with maxlength attribute in Form Context.
+     *
+     * @return void
+     */
+    public function testControlMaxLengthFormContext()
+    {
+        $validator = new Validator();
+        $validator->maxLength('title', 10);
+        $form = new Form();
+        $form->setValidator('default', $validator);
+
+        $this->Form->create($form);
+        $result = $this->Form->control('title');
+        debug($result);
+        $expected = [
+            'div' => ['class'],
+            'label' => ['for'],
+            'Title',
+            '/label',
+            'input' => [
+                'id',
+                'name' => 'title',
+                'type' => 'text',
+                'required' => 'required',
+                'maxlength' => 10,
+            ],
+            '/div',
+
         ];
         $this->assertHtml($expected, $result);
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -12,7 +12,6 @@
  * @since         1.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Collection\Collection;
@@ -1745,24 +1744,24 @@ class FormHelperTest extends TestCase
         $result = $this->Form->secure($this->Form->fields);
         $hash = '43c4db25e4162c5e4edd9dea51f5f9d9d92215ec%3AAddresses.0.id%7CAddresses.1.id';
         $tokenDebug = urlencode(json_encode([
-            '/articles/add',
-            [
-                'Addresses.0.id' => '123456',
-                'Addresses.0.title',
-                'Addresses.0.last_name',
-                'Addresses.0.city',
-                'Addresses.0.phone',
-                'Addresses.1.id' => '654321',
-                'Addresses.1.title',
-                'Addresses.1.last_name',
-                'Addresses.1.city',
-                'Addresses.1.phone'
-            ],
-            [
-                'first_name',
-                'address'
-            ]
-        ]));
+                '/articles/add',
+                [
+                    'Addresses.0.id' => '123456',
+                    'Addresses.0.title',
+                    'Addresses.0.last_name',
+                    'Addresses.0.city',
+                    'Addresses.0.phone',
+                    'Addresses.1.id' => '654321',
+                    'Addresses.1.title',
+                    'Addresses.1.last_name',
+                    'Addresses.1.city',
+                    'Addresses.1.phone'
+                ],
+                [
+                    'first_name',
+                    'address'
+                ]
+            ]));
 
         $expected = [
             'div' => ['style' => 'display:none;'],
@@ -1823,19 +1822,19 @@ class FormHelperTest extends TestCase
 
         $hash = 'f98315a7d5515e5ae32e35f7d680207c085fae69%3AAddresses.id';
         $tokenDebug = urlencode(json_encode([
-            '/articles/add',
-            [
-                'Addresses.id' => '123456',
-                'Addresses.title',
-                'Addresses.last_name',
-                'Addresses.city',
-                'Addresses.phone'
-            ],
-            [
-                'first_name',
-                'address'
-            ]
-        ]));
+                '/articles/add',
+                [
+                    'Addresses.id' => '123456',
+                    'Addresses.title',
+                    'Addresses.last_name',
+                    'Addresses.city',
+                    'Addresses.phone'
+                ],
+                [
+                    'first_name',
+                    'address'
+                ]
+            ]));
 
         $expected = [
             'div' => ['style' => 'display:none;'],
@@ -2275,14 +2274,14 @@ class FormHelperTest extends TestCase
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
-            'type' => 'hidden',
-            'value' => 'some text',
+                'type' => 'hidden',
+                'value' => 'some text',
         ]);
         $expected = ['text_val' => 'some text'];
         $this->assertEquals($expected, $this->Form->fields);
 
         $this->Form->control('text_val', [
-            'type' => 'text',
+                'type' => 'text',
         ]);
         $expected = ['text_val'];
         $this->assertEquals($expected, $this->Form->fields);
@@ -3642,7 +3641,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-                'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
+            'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3666,7 +3665,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-                'options' => ['First', 'Second'], 'empty' => true]
+            'options' => ['First', 'Second'], 'empty' => true]
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3772,22 +3771,22 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input select']],
-            ['label' => ['for' => 'publisher-id']],
-            'Publisher',
-            '/label',
-            'input' => ['type' => 'hidden', 'name' => 'Publisher[id]', 'value' => ''],
-            ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'publisher-id-value-1']],
-            ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1']],
-            'Label 1',
-            '/label',
-            '/div',
-            ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'publisher-id-value-2']],
-            ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2']],
-            'Label 2',
-            '/label',
-            '/div',
+                ['label' => ['for' => 'publisher-id']],
+                'Publisher',
+                '/label',
+                'input' => ['type' => 'hidden', 'name' => 'Publisher[id]', 'value' => ''],
+                ['div' => ['class' => 'checkbox']],
+                ['label' => ['for' => 'publisher-id-value-1']],
+                ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1']],
+                'Label 1',
+                '/label',
+                '/div',
+                ['div' => ['class' => 'checkbox']],
+                ['label' => ['for' => 'publisher-id-value-2']],
+                ['input' => ['type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2']],
+                'Label 2',
+                '/label',
+                '/div',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -4814,18 +4813,18 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-            '<label',
-            'Test',
-            '/label',
-            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-            ['label' => ['for' => 'test-0']],
-            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-            'A',
-            '/label',
-            ['label' => ['for' => 'test-1']],
-            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-            'B',
-            '/label',
+                '<label',
+                'Test',
+                '/label',
+                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+                ['label' => ['for' => 'test-0']],
+                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+                    'A',
+                '/label',
+                ['label' => ['for' => 'test-1']],
+                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+                    'B',
+                '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4837,18 +4836,18 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-            '<label',
-            'Test',
-            '/label',
-            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-            ['label' => ['for' => 'test-0']],
-            ['input' => ['type' => 'radio', 'checked' => 'checked', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-            'A',
-            '/label',
-            ['label' => ['for' => 'test-1']],
-            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-            'B',
-            '/label',
+                '<label',
+                'Test',
+                '/label',
+                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+                ['label' => ['for' => 'test-0']],
+                    ['input' => ['type' => 'radio', 'checked' => 'checked', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+                    'A',
+                '/label',
+                ['label' => ['for' => 'test-1']],
+                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+                    'B',
+                '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4860,15 +4859,15 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
-            ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
-            ['label' => ['for' => 'test-0']],
-            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-            'A',
-            '/label',
-            ['label' => ['for' => 'test-1']],
-            ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-            'B',
-            '/label',
+                ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+                ['label' => ['for' => 'test-0']],
+                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+                    'A',
+                '/label',
+                ['label' => ['for' => 'test-1']],
+                    ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+                    'B',
+                '/label',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4915,22 +4914,22 @@ class FormHelperTest extends TestCase
                 'value' => ''
             ]],
             ['label' => ['for' => 'model-field-0']],
-            ['input' => [
-                'type' => 'radio',
-                'name' => 'Model[field]',
-                'value' => '0',
-                'id' => 'model-field-0'
-            ]],
-            'option A',
+                ['input' => [
+                    'type' => 'radio',
+                    'name' => 'Model[field]',
+                    'value' => '0',
+                    'id' => 'model-field-0'
+                ]],
+                'option A',
             '/label',
             ['label' => ['for' => 'model-field-1']],
-            ['input' => [
-                'type' => 'radio',
-                'name' => 'Model[field]',
-                'value' => '1',
-                'id' => 'model-field-1'
-            ]],
-            'option B',
+                ['input' => [
+                    'type' => 'radio',
+                    'name' => 'Model[field]',
+                    'value' => '1',
+                    'id' => 'model-field-1'
+                ]],
+                'option B',
             '/label',
         ];
         //@codingStandardsIgnoreEnd
@@ -5181,15 +5180,15 @@ class FormHelperTest extends TestCase
             'Two',
             '/option',
             ['optgroup' => ['label' => 'Three']],
-            ['option' => ['value' => 3]],
-            'Three',
-            '/option',
-            ['option' => ['value' => 4]],
-            'Four',
-            '/option',
-            ['option' => ['value' => 5]],
-            'Five',
-            '/option',
+                ['option' => ['value' => 3]],
+                'Three',
+                '/option',
+                ['option' => ['value' => 4]],
+                'Four',
+                '/option',
+                ['option' => ['value' => 5]],
+                'Five',
+                '/option',
             '/optgroup',
             '/select'
         ];
@@ -5790,16 +5789,16 @@ class FormHelperTest extends TestCase
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'fish', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'fish-0']],
-            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
-            '1',
-            '/label',
+                ['label' => ['for' => 'fish-0']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
+                    '1',
+                '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'fish-1']],
-            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
-            '2',
-            '/label',
+                ['label' => ['for' => 'fish-1']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
+                    '2',
+                '/label',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -5837,16 +5836,16 @@ class FormHelperTest extends TestCase
             '/label',
             'input' => ['type' => 'hidden', 'name' => 'category', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'category-0']],
-            ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'category-0']],
-            '1',
-            '/label',
+                ['label' => ['for' => 'category-0']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'category-0']],
+                    '1',
+                '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'category-1']],
-            ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'category-1']],
-            '2',
-            '/label',
+                ['label' => ['for' => 'category-1']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'category-1']],
+                    '2',
+                '/label',
             '/div',
             '/div',
         ];
@@ -7125,10 +7124,10 @@ class FormHelperTest extends TestCase
         ]);
         $this->Form->create($this->article);
         $result = $this->Form->control('month_year', [
-            'label' => false,
-            'type' => 'date',
-            'minYear' => 2006,
-            'maxYear' => 2008
+                'label' => false,
+                'type' => 'date',
+                'minYear' => 2006,
+                'maxYear' => 2008
         ]);
         $this->assertContains('value="' . date('m') . '" selected="selected"', $result);
         $this->assertNotContains('value="2008" selected="selected"', $result);
@@ -7532,10 +7531,10 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
-            '/posts/delete/1',
-            [],
-            []
-        ]));
+                '/posts/delete/1',
+                [],
+                []
+            ]));
 
         $expected = [
             'form' => [
@@ -8287,15 +8286,15 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
-            'label' => ['for' => '0-comments-1-comment'],
-            'Comment',
-            '/label',
-            'textarea' => [
-                'name',
-                'id' => '0-comments-1-comment',
-                'rows' => 5
-            ],
-            '/textarea',
+                'label' => ['for' => '0-comments-1-comment'],
+                    'Comment',
+                '/label',
+                'textarea' => [
+                    'name',
+                    'id' => '0-comments-1-comment',
+                    'rows' => 5
+                ],
+                '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8305,16 +8304,16 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
-            'label' => ['for' => '0-comments-0-comment'],
-            'Comment',
-            '/label',
-            'textarea' => [
-                'name',
-                'id' => '0-comments-0-comment',
-                'rows' => 5
-            ],
-            'Value',
-            '/textarea',
+                'label' => ['for' => '0-comments-0-comment'],
+                    'Comment',
+                '/label',
+                'textarea' => [
+                    'name',
+                    'id' => '0-comments-0-comment',
+                    'rows' => 5
+                ],
+                'Value',
+                '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8325,20 +8324,20 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea error'],
-            'label' => ['for' => '0-comments-0-comment'],
-            'Comment',
-            '/label',
-            'textarea' => [
-                'name',
-                'class' => 'form-error',
-                'id' => '0-comments-0-comment',
-                'rows' => 5
-            ],
-            'Value',
-            '/textarea',
-            ['div' => ['class' => 'error-message']],
-            'Not valid',
-            '/div',
+                'label' => ['for' => '0-comments-0-comment'],
+                    'Comment',
+                '/label',
+                'textarea' => [
+                    'name',
+                    'class' => 'form-error',
+                    'id' => '0-comments-0-comment',
+                    'rows' => 5
+                ],
+                'Value',
+                '/textarea',
+                ['div' => ['class' => 'error-message']],
+                'Not valid',
+                '/div',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8351,16 +8350,16 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea required'],
-            'label' => ['for' => '0-comments-1-comment'],
-            'Comment',
-            '/label',
-            'textarea' => [
-                'name',
-                'required' => 'required',
-                'id' => '0-comments-1-comment',
-                'rows' => 5
-            ],
-            '/textarea',
+                'label' => ['for' => '0-comments-1-comment'],
+                    'Comment',
+                '/label',
+                'textarea' => [
+                    'name',
+                    'required' => 'required',
+                    'id' => '0-comments-1-comment',
+                    'rows' => 5
+                ],
+                '/textarea',
             '/div'
         ];
         //@codingStandardsIgnoreEnd
@@ -8508,7 +8507,7 @@ class FormHelperTest extends TestCase
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
             ['input' => ['type' => 'checkbox', 'name' => 'foo', 'id' => 'foo', 'value' => '1']],
             'label' => ['for' => 'foo'],
-            'Foo',
+                'Foo',
             '/label',
             '/div'
         ];
@@ -8552,16 +8551,16 @@ class FormHelperTest extends TestCase
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'fish', 'value' => ''],
             ['div' => ['class' => 'checkbox']],
-            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
-            ['label' => ['for' => 'fish-0']],
-            '1',
-            '/label',
+                ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0']],
+                ['label' => ['for' => 'fish-0']],
+                    '1',
+                '/label',
             '/div',
             ['div' => ['class' => 'checkbox']],
-            ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
-            ['label' => ['for' => 'fish-1']],
-            '2',
-            '/label',
+                ['input' => ['type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1']],
+                ['label' => ['for' => 'fish-1']],
+                    '2',
+                '/label',
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -8713,23 +8712,23 @@ class FormHelperTest extends TestCase
                 'type' => 'hidden', 'name' => 'multi_field', 'value' => ''
             ],
             ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'multi-field-0']],
-            ['input' => [
-                'type' => 'checkbox', 'name' => 'multi_field[]',
-                'value' => '0', 'id' => 'multi-field-0'
-            ]],
-            'first',
-            '/label',
-            '/div',
-            ['div' => ['class' => 'checkbox']],
-            ['label' => ['for' => 'multi-field-1']],
-            ['input' => [
-                'type' => 'checkbox', 'name' => 'multi_field[]',
-                'value' => '1', 'id' => 'multi-field-1'
-            ]],
-            'second',
-            '/label',
-            '/div',
+                ['label' => ['for' => 'multi-field-0']],
+                    ['input' => [
+                        'type' => 'checkbox', 'name' => 'multi_field[]',
+                        'value' => '0', 'id' => 'multi-field-0'
+                    ]],
+                    'first',
+                    '/label',
+                    '/div',
+                    ['div' => ['class' => 'checkbox']],
+                    ['label' => ['for' => 'multi-field-1']],
+                    ['input' => [
+                        'type' => 'checkbox', 'name' => 'multi_field[]',
+                        'value' => '1', 'id' => 'multi-field-1'
+                    ]],
+                    'second',
+                    '/label',
+                    '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -9448,7 +9447,6 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($form);
         $result = $this->Form->control('title');
-
         $expected = [
             'div' => ['class'],
             'label' => ['for'],


### PR DESCRIPTION
Improvement for 
https://github.com/cakephp/cakephp/issues/12773

Form helper now supports maxlength attribute from validation directly.