### PR TITLE
Get just the header_size instead of all curl options

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -144,9 +144,9 @@ class Curl implements AdapterInterface
      */
     protected function createResponse($handle, $responseData)
     {
-        $meta = curl_getinfo($handle);
-        $headers = trim(substr($responseData, 0, $meta['header_size']));
-        $body = substr($responseData, $meta['header_size']);
+        $headerSize = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+        $headers = trim(substr($responseData, 0, $headerSize));
+        $body = substr($responseData, $headerSize);
         $response = new Response(explode("\r\n", $headers), $body);
 
         return [$response];


### PR DESCRIPTION
We only use the one option so this saves us allocating a big array when we only need one integer. It also improves compatibility with php-vcr.