### PR TITLE
3.7 cell - exception

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -198,6 +198,7 @@ abstract class Cell
             if (!$builder->getTemplatePath()) {
                 $builder->setTemplatePath('Cell' . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $name));
             }
+            $template = $builder->getTemplate();
 
             $this->View = $this->createView();
             try {


### PR DESCRIPTION
before this ( cake 3.6)  we had this line to set correct file name into `$template` var 
https://github.com/cakephp/cakephp/blob/98d559c6071555bba26fdae8fc9c87acfb169eca/src/View/Cell.php#L215
but now ( cake 3.7 ) it changed( removed)
this PR can help us to revert functionality 

cake 3.6 : `Could not render cell - Cell view file "test" is missing.`
cake 3.7 : `Could not render cell - Cell view file "" is missing.`