### PR TITLE
Support multiple table locations.

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -348,7 +348,7 @@ class TableLocator implements LocatorInterface
     /**
      * Adds a namespace where tables should be looked for.
      *
-     * @param string $namespace Namespace to add.
+     * @param string $namespace Namespace to add.
      * @return $this
      */
     public function addNamespace($namespace)

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -66,7 +66,7 @@ class TableLocator implements LocatorInterface
     /**
      * Constructor.
      *
-     * @param array|null $namespaces Namespaces where tables should be located located.
+     * @param array|null $namespaces Namespaces where tables should be located.
      *   If none provided, the default `Model\Table` under your app's namespace is used.
      */
     public function __construct(array $namespaces = null)
@@ -77,7 +77,9 @@ class TableLocator implements LocatorInterface
             ];
         }
 
-        $this->_namespaces = $namespaces;
+        foreach ($namespaces as $namespace) {
+            $this->addNamespace($namespace);
+        }
     }
 
     /**
@@ -341,5 +343,19 @@ class TableLocator implements LocatorInterface
             $this->_config[$alias],
             $this->_fallbacked[$alias]
         );
+    }
+
+    /**
+     * Adds a namespace where tables should be looked for.
+     *
+     * @param string $namespace Namespace to add.
+     * @return $this
+     */
+    public function addNamespace($namespace)
+    {
+        $namespace = str_replace('\\', '/', $namespace);
+        $this->_namespaces[] = trim($namespace, '/');
+
+        return $this;
     }
 }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -32,7 +32,7 @@ class TableLocator implements LocatorInterface
      *
      * @var array
      */
-    protected $_locations = [];
+    protected $locations = [];
 
     /**
      * Configuration for aliases.
@@ -273,7 +273,7 @@ class TableLocator implements LocatorInterface
             return $options['className'];
         }
 
-        foreach ($this->_locations as $location) {
+        foreach ($this->locations as $location) {
             $class = App::className($options['className'], $location, 'Table');
             if ($class !== false) {
                 return $class;
@@ -354,7 +354,7 @@ class TableLocator implements LocatorInterface
     public function addLocation($location)
     {
         $location = str_replace('\\', '/', $location);
-        $this->_locations[] = trim($location, '/');
+        $this->locations[] = trim($location, '/');
 
         return $this;
     }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -350,6 +350,8 @@ class TableLocator implements LocatorInterface
      *
      * @param string $location Location to add.
      * @return $this
+     *
+     * @since 3.8.0
      */
     public function addLocation($location)
     {

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -269,13 +269,13 @@ class TableLocator implements LocatorInterface
             $options['className'] = Inflector::camelize($alias);
         }
 
-        if (class_exists($options['className'])) {
+        if (strpos($options['className'], '\\') !== false && class_exists($options['className'])) {
             return $options['className'];
         }
 
         foreach ($this->_namespaces as $namespace) {
             $class = App::className($options['className'], $namespace, 'Table');
-            if ($class !== null) {
+            if ($class !== false) {
                 return $class;
             }
         }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -28,11 +28,11 @@ class TableLocator implements LocatorInterface
 {
 
     /**
-     * Contains a list of namespaces where table classes should be looked for.
+     * Contains a list of locations where table classes should be looked for.
      *
      * @var array
      */
-    protected $_namespaces = [];
+    protected $_locations = [];
 
     /**
      * Configuration for aliases.
@@ -66,19 +66,19 @@ class TableLocator implements LocatorInterface
     /**
      * Constructor.
      *
-     * @param array|null $namespaces Namespaces where tables should be located.
+     * @param array|null $locations Locations where tables should be looked for.
      *   If none provided, the default `Model\Table` under your app's namespace is used.
      */
-    public function __construct(array $namespaces = null)
+    public function __construct(array $locations = null)
     {
-        if ($namespaces === null) {
-            $namespaces = [
+        if ($locations === null) {
+            $locations = [
                 'Model/Table',
             ];
         }
 
-        foreach ($namespaces as $namespace) {
-            $this->addNamespace($namespace);
+        foreach ($locations as $location) {
+            $this->addLocation($location);
         }
     }
 
@@ -273,14 +273,14 @@ class TableLocator implements LocatorInterface
             return $options['className'];
         }
 
-        foreach ($this->_namespaces as $namespace) {
-            $class = App::className($options['className'], $namespace, 'Table');
+        foreach ($this->_locations as $location) {
+            $class = App::className($options['className'], $location, 'Table');
             if ($class !== false) {
                 return $class;
             }
         }
 
-        return null;
+        return false;
     }
 
     /**
@@ -346,15 +346,15 @@ class TableLocator implements LocatorInterface
     }
 
     /**
-     * Adds a namespace where tables should be looked for.
+     * Adds a location where tables should be looked for.
      *
-     * @param string $namespace Namespace to add.
+     * @param string $location Location to add.
      * @return $this
      */
-    public function addNamespace($namespace)
+    public function addLocation($location)
     {
-        $namespace = str_replace('\\', '/', $namespace);
-        $this->_namespaces[] = trim($namespace, '/');
+        $location = str_replace('\\', '/', $location);
+        $this->_locations[] = trim($location, '/');
 
         return $this;
     }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -28,6 +28,13 @@ class TableLocator implements LocatorInterface
 {
 
     /**
+     * Contains a list of namespaces where table classes should be looked for.
+     *
+     * @var array
+     */
+    protected $_namespaces = [];
+
+    /**
      * Configuration for aliases.
      *
      * @var array
@@ -55,6 +62,23 @@ class TableLocator implements LocatorInterface
      * @var array
      */
     protected $_options = [];
+
+    /**
+     * Constructor.
+     *
+     * @param array|null $namespaces Namespaces where tables should be located located.
+     *   If none provided, the default `Model\Table` under your app's namespace is used.
+     */
+    public function __construct(array $namespaces = null)
+    {
+        if ($namespaces === null) {
+            $namespaces = [
+                'Model/Table',
+            ];
+        }
+
+        $this->_namespaces = $namespaces;
+    }
 
     /**
      * Stores a list of options to be used when instantiating an object
@@ -243,7 +267,18 @@ class TableLocator implements LocatorInterface
             $options['className'] = Inflector::camelize($alias);
         }
 
-        return App::className($options['className'], 'Model/Table', 'Table');
+        if (class_exists($options['className'])) {
+            return $options['className'];
+        }
+
+        foreach ($this->_namespaces as $namespace) {
+            $class = App::className($options['className'], $namespace, 'Table');
+            if ($class !== null) {
+                return $class;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -613,13 +613,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testCustomNamespace
+     * testCustomLocation
      *
      * Tests that the correct table is returned when non-standard namespace is defined.
      *
      * @return void
      */
-    public function testCustomNamespace()
+    public function testCustomLocation()
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -628,13 +628,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testCustomNamespacePlugin
+     * testCustomLocationPlugin
      *
      * Tests that the correct plugin table is returned when non-standard namespace is defined.
      *
      * @return void
      */
-    public function testCustomNamespacePlugin()
+    public function testCustomLocationPlugin()
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -643,13 +643,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testCustomNamespaceDefaultWhenNone
+     * testCustomLocationDefaultWhenNone
      *
      * Tests that the default table is returned when no namespace is defined.
      *
      * @return void
      */
-    public function testCustomNamespaceDefaultWhenNone()
+    public function testCustomLocationDefaultWhenNone()
     {
         $locator = new TableLocator([]);
 
@@ -658,13 +658,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testCustomNamespaceDefaultWhenMissing
+     * testCustomLocationDefaultWhenMissing
      *
      * Tests that the default table is returned when the class cannot be found in a non-standard namespace.
      *
      * @return void
      */
-    public function testCustomNamespaceDefaultWhenMissing()
+    public function testCustomLocationDefaultWhenMissing()
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -673,13 +673,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testCustomNamespaceMultiple
+     * testCustomLocationMultiple
      *
      * Tests that the correct table is returned when multiple namespaces are defined.
      *
      * @return void
      */
-    public function testCustomNamespaceMultiple()
+    public function testCustomLocationMultiple()
     {
         $locator = new TableLocator([
             'Infrastructure/Table',
@@ -691,13 +691,13 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * testAddNamespace
+     * testAddLocation
      *
      * Tests that adding a namespace takes effect.
      *
      * @return void
      */
-    public function testAddNamespace()
+    public function testAddLocation()
     {
         $locator = new TableLocator([]);
 
@@ -705,7 +705,7 @@ class TableLocatorTest extends TestCase
         $this->assertInstanceOf(Table::class, $table);
 
         $locator->clear();
-        $locator->addNamespace('Infrastructure/Table');
+        $locator->addLocation('Infrastructure/Table');
 
         $table = $locator->get('Addresses');
         $this->assertInstanceOf(AddressesTable::class, $table);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -20,6 +20,9 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use TestApp\Infrastructure\Table\AddressesTable;
+use TestApp\Model\Table\ArticlesTable;
+use TestPlugin\Infrastructure\Table\AddressesTable as PluginAddressesTable;
 
 /**
  * Used to test correct class is instantiated when using $this->_locator->get();
@@ -607,5 +610,83 @@ class TableLocatorTest extends TestCase
         $plugin3 = $this->_locator->get('TestPluginTwo.Comments');
 
         $this->assertSame($plugin, $plugin3, 'Should be the same TestPluginTwo.Comments object');
+    }
+
+    /**
+     * testCustomNamespace
+     *
+     * Tests that the correct table is returned when non-standard namespace is defined.
+     *
+     * @return void
+     */
+    public function testCustomNamespace()
+    {
+        $locator = new TableLocator(['Infrastructure/Table']);
+
+        $table = $locator->get('Addresses');
+        $this->assertInstanceOf(AddressesTable::class, $table);
+    }
+
+    /**
+     * testCustomNamespacePlugin
+     *
+     * Tests that the correct plugin table is returned when non-standard namespace is defined.
+     *
+     * @return void
+     */
+    public function testCustomNamespacePlugin()
+    {
+        $locator = new TableLocator(['Infrastructure/Table']);
+
+        $table = $locator->get('TestPlugin.Addresses');
+        $this->assertInstanceOf(PluginAddressesTable::class, $table);
+    }
+
+    /**
+     * testCustomNamespaceDefaultWhenNone
+     *
+     * Tests that the default table is returned when no namespace is defined.
+     *
+     * @return void
+     */
+    public function testCustomNamespaceDefaultWhenNone()
+    {
+        $locator = new TableLocator([]);
+
+        $table = $locator->get('Addresses');
+        $this->assertInstanceOf(Table::class, $table);
+    }
+
+    /**
+     * testCustomNamespaceDefaultWhenMissing
+     *
+     * Tests that the default table is returned when the class cannot be found in a non-standard namespace.
+     *
+     * @return void
+     */
+    public function testCustomNamespaceDefaultWhenMissing()
+    {
+        $locator = new TableLocator(['Infrastructure/Table']);
+
+        $table = $locator->get('Articles');
+        $this->assertInstanceOf(Table::class, $table);
+    }
+
+    /**
+     * testCustomNamespaceMultiple
+     *
+     * Tests that the correct table is returned when multiple namespaces are defined.
+     *
+     * @return void
+     */
+    public function testCustomNamespaceMultiple()
+    {
+        $locator = new TableLocator([
+            'Infrastructure/Table',
+            'Model/Table',
+        ]);
+
+        $table = $locator->get('Articles');
+        $this->assertInstanceOf(Table::class, $table);
     }
 }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -689,4 +689,26 @@ class TableLocatorTest extends TestCase
         $table = $locator->get('Articles');
         $this->assertInstanceOf(Table::class, $table);
     }
+
+    /**
+     * testAddNamespace
+     *
+     * Tests that adding a namespace takes effect.
+     *
+     * @return void
+     */
+    public function testAddNamespace()
+    {
+        $locator = new TableLocator([]);
+
+        $table = $locator->get('Addresses');
+        $this->assertInstanceOf(Table::class, $table);
+
+        $locator->clear();
+        $locator->addNamespace('Infrastructure/Table');
+
+        $table = $locator->get('Addresses');
+        $this->assertInstanceOf(AddressesTable::class, $table);
+
+    }
 }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -709,6 +709,5 @@ class TableLocatorTest extends TestCase
 
         $table = $locator->get('Addresses');
         $this->assertInstanceOf(AddressesTable::class, $table);
-
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
@@ -7,7 +7,7 @@
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         3.7.1
+ * @since         3.8.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestPlugin\Infrastructure\Table;

--- a/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -8,7 +7,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         3.6.9
+ * @since         3.7.1
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestPlugin\Infrastructure\Table;

--- a/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Infrastructure/Table/AddressesTable.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         3.6.9
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Infrastructure\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Addresses table class
+ */
+class AddressesTable extends Table
+{
+}

--- a/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         3.6.9
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Infrastructure\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Addresses table class
+ */
+class AddressesTable extends Table
+{
+}

--- a/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
@@ -7,7 +7,7 @@
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         3.7.1
+ * @since         3.8.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Infrastructure\Table;

--- a/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
+++ b/tests/test_app/TestApp/Infrastructure/Table/AddressesTable.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -8,7 +7,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         3.6.9
+ * @since         3.7.1
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Infrastructure\Table;


### PR DESCRIPTION
This change makes it easier to use the ORM in custom setups or outside CakePHP apps.
It allows to configure the locator to look for tables in non standard (`Model/Table`) namespace.

I'd like to use the ORM alone in the Infrastructure layer of my future app keeping the app logic and business logic free of any framework dependency.