### PR TITLE
Remove version number from composer require command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ recommend using the [app skeleton](https://github.com/cakephp/app) as
 a starting point. For existing applications you can run the following:
 
 ``` bash
-$ composer require cakephp/cakephp:"~3.6"
+$ composer require cakephp/cakephp
 ```
 
 ## Running Tests


### PR DESCRIPTION
This avoids having to update README with each minor/major release.