### PR TITLE
Add missing docblock for typehint.

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -306,6 +306,7 @@ class Number
             static::$_formatters[$locale][$type] = new NumberFormatter($locale, $type);
         }
 
+        /** @var \NumberFormatter $formatter */
         $formatter = static::$_formatters[$locale][$type];
 
         $options = array_intersect_key($options, [


### PR DESCRIPTION
Should solve https://travis-ci.org/cakephp/cakephp/jobs/467691956#L687

> ERROR: InvalidClone - src/I18n/Number.php:321:22 - Cannot clone null
        $formatter = clone $formatter;

The

> ERROR: EmptyArrayAccess - src/View/Helper/HtmlHelper.php:832:21 - Cannot access value on empty array variable $cellOptions
                    $cellOptions['class'] .= ' column-' . $i;

should be reported to Psalm as bug, since here the tool is wrong.
//Update: https://github.com/vimeo/psalm/issues/1126