### PR TITLE
Use annotitations for integration trait setup/teardown

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -196,11 +196,11 @@ trait IntegrationTestTrait
     /**
      * Auto-detect if the HTTP middleware stack should be used.
      *
+     * @before
      * @return void
      */
-    public function setUp()
+    public function setupServer()
     {
-        parent::setUp();
         $namespace = Configure::read('App.namespace');
         $this->_useHttpServer = class_exists($namespace . '\Application');
     }
@@ -208,11 +208,11 @@ trait IntegrationTestTrait
     /**
      * Clears the state used for requests.
      *
+     * @after
      * @return void
      */
-    public function tearDown()
+    public function cleanup()
     {
-        parent::tearDown();
         $this->_request = [];
         $this->_session = [];
         $this->_cookie = [];


### PR DESCRIPTION
Using setup/teardown as the method names means that implementing classes lose the setup/teardown logic defined in the trait when they redeclare those methods. By using different method names and annotations phpunit will run the implementing class's setup and ours.

Targeting this to master as we recommend people use the trait in our docs and bake now generates tests using the trait.

Refs #9794