### PR TITLE
Enable subcommands to use spaces.

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -64,6 +64,12 @@ class CommandCollection implements IteratorAggregate, Countable
                 "Cannot use '$class' for command '$name' it is not a subclass of Cake\Console\Shell or Cake\Console\Command."
             );
         }
+        if (!preg_match('/^[\p{L}\p{N}\-_:.]+(?:(?: [\p{L}\p{N}\-_:.]+){1,2})?$/ui', $name)) {
+            throw new InvalidArgumentException(
+                "The command name `{$name}` is invalid. " .
+                'Names must use only letters/numbers + punctuation characters and be 3 words or fewer.'
+            );
+        }
 
         $this->commands[$name] = $command;
 

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -64,10 +64,9 @@ class CommandCollection implements IteratorAggregate, Countable
                 "Cannot use '$class' for command '$name' it is not a subclass of Cake\Console\Shell or Cake\Console\Command."
             );
         }
-        if (!preg_match('/^[\p{L}\p{N}\-_:.]+(?:(?: [\p{L}\p{N}\-_:.]+){1,2})?$/ui', $name)) {
+        if (!preg_match('/^[^\s]+(?:(?: [^\s]+){1,2})?$/ui', $name)) {
             throw new InvalidArgumentException(
-                "The command name `{$name}` is invalid. " .
-                'Names must use only letters/numbers + punctuation characters and be 3 words or fewer.'
+                "The command name `{$name}` is invalid. Names can only be a maximum of three words."
             );
         }
 

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -137,6 +137,39 @@ class CommandCollectionTest extends TestCase
     }
 
     /**
+     * Provider for invalid names.
+     *
+     * @return array
+     */
+    public function invalidNameProvider()
+    {
+        return [
+            // Empty
+            [''],
+            // Leading spaces
+            [' spaced'],
+            // Trailing spaces
+            ['spaced '],
+            // Too many words
+            ['one two three four'],
+        ];
+    }
+
+    /**
+     * test adding a command instance.
+     *
+     * @dataProvider invalidNameProvider
+     * @return void
+     */
+    public function testAddCommandInvalidName($name)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid command name');
+        $collection = new CommandCollection();
+        $collection->add($name, DemoCommand::class);
+    }
+
+    /**
      * Class names that are not shells should fail
      *
      */

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Plugin;
 use Cake\Shell\I18nShell;
 use Cake\Shell\RoutesShell;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use stdClass;
 use TestApp\Command\DemoCommand;
 
@@ -164,7 +165,7 @@ class CommandCollectionTest extends TestCase
     public function testAddCommandInvalidName($name)
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid command name');
+        $this->expectExceptionMessage("The command name `$name` is invalid.");
         $collection = new CommandCollection();
         $collection->add($name, DemoCommand::class);
     }

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -27,6 +27,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
 use TestApp\Shell\SampleShell;
 
@@ -373,6 +374,48 @@ class CommandRunnerTest extends TestCase
 
         $runner = new CommandRunner($app, 'cake');
         $result = $runner->run(['cake', 'ex'], $this->getMockIo($output));
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
+
+        $messages = implode("\n", $output->messages());
+        $this->assertContains('Demo Command!', $messages);
+    }
+
+    /**
+     * Test running a valid command with spaces in the name
+     *
+     * @return void
+     */
+    public function testRunValidCommandSubcommandName()
+    {
+        $app = $this->makeAppWithCommands([
+            'tool build' => DemoCommand::class,
+            'tool' => AbortCommand::class
+        ]);
+        $output = new ConsoleOutput();
+
+        $runner = new CommandRunner($app, 'cake');
+        $result = $runner->run(['cake', 'tool', 'build'], $this->getMockIo($output));
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
+
+        $messages = implode("\n", $output->messages());
+        $this->assertContains('Demo Command!', $messages);
+    }
+
+    /**
+     * Test running a valid command with spaces in the name
+     *
+     * @return void
+     */
+    public function testRunValidCommandNestedName()
+    {
+        $app = $this->makeAppWithCommands([
+            'tool build assets' => DemoCommand::class,
+            'tool' => AbortCommand::class
+        ]);
+        $output = new ConsoleOutput();
+
+        $runner = new CommandRunner($app, 'cake');
+        $result = $runner->run(['cake', 'tool', 'build', 'assets'], $this->getMockIo($output));
         $this->assertSame(Shell::CODE_SUCCESS, $result);
 
         $messages = implode("\n", $output->messages());


### PR DESCRIPTION
Right now explicit subcommands must use a non-space character. For example `bake:test` and `bake.test` work, however `bake test` will not work. This change enables commands up with up to 3 spaces to work. I limited to 3 as I don't think more than 3 will be frequently used and I wanted to cut down on wasted work.
