### PR TITLE
Fix notice error on missing argument

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -117,7 +117,7 @@ class Arguments
     public function getArgument($name)
     {
         $offset = array_search($name, $this->argNames, true);
-        if ($offset === false) {
+        if ($offset === false || !isset($this->args[$offset])) {
             return null;
         }
 

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -97,6 +97,20 @@ class ArgumentsTest extends TestCase
     }
 
     /**
+     * get arguments missing value
+     *
+     * @return void
+     */
+    public function testGetArgumentMissing()
+    {
+        $values = [];
+        $names = ['size', 'color'];
+        $args = new Arguments($values, [], $names);
+        $this->assertNull($args->getArgument('size'));
+        $this->assertNull($args->getArgument('color'));
+    }
+
+    /**
      * test getOptions()
      *
      * @return void


### PR DESCRIPTION
If an argument was defined by had no value a notice error would be emitted.