### PR TITLE
createFile() should create directories.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -566,6 +566,12 @@ class ConsoleIo
         }
 
         try {
+            // Create the directory using the current user permissions.
+            $directory = dirname($path);
+            if (!file_exists($directory)) {
+                mkdir($directory, 0777 ^ umask(), true);
+            }
+
             $file = new SplFileObject($path, 'w');
         } catch (RuntimeException $e) {
             $this->error("Could not write to `{$path}`. Permission denied.", 2);

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -580,6 +580,8 @@ class ConsoleIoTest extends TestCase
      */
     public function testCreateFileSuccess()
     {
+        $this->err->expects($this->never())
+            ->method('write');
         $path = TMP . 'shell_test';
         mkdir($path);
 
@@ -590,6 +592,23 @@ class ConsoleIoTest extends TestCase
         $this->assertTrue($result);
         $this->assertFileExists($file);
         $this->assertStringEqualsFile($file, $contents);
+    }
+
+    public function testCreateFileDirectoryCreation()
+    {
+        $this->err->expects($this->never())
+            ->method('write');
+
+        $directory = TMP . 'shell_test';
+        $this->assertFileNotExists($directory, 'Directory should not exist before createFile');
+
+        $path = $directory . DS . 'create.txt';
+        $contents = 'some content';
+        $result = $this->io->createFile($path, $contents);
+
+        $this->assertTrue($result, 'File should create');
+        $this->assertFileExists($path);
+        $this->assertStringEqualsFile($path, $contents);
     }
 
     /**


### PR DESCRIPTION
To improve compatibility with `Shell::createFile()` `ConsoleIo::createFile()` should also create the required directories. Because `Cake\Filesystem` is soft-deprecated I've rebuilt the directory creation logic here as Spl does not handle it.