### PR TITLE
Make PSR7 uploaded files accessible in integration tests

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -621,7 +621,8 @@ trait IntegrationTestTrait
         $props = [
             'url' => $url,
             'session' => $session,
-            'query' => $queryData
+            'query' => $queryData,
+            'files' => [],
         ];
         if (is_string($data)) {
             $props['input'] = $data;

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -153,7 +153,8 @@ class MiddlewareDispatcher
             $environment,
             $spec['query'],
             $spec['post'],
-            $spec['cookies']
+            $spec['cookies'],
+            $spec['files']
         );
         $request = $request->withAttribute('session', $spec['session']);
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -514,6 +514,59 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     }
 
     /**
+     * Test that the uploaded files are passed correctly to the request
+     *
+     * @return void
+     */
+    public function testUploadedFiles()
+    {
+        $this->configRequest([
+            'files' => [
+                'file' => [
+                    'tmp_name' => __FILE__,
+                    'size' => 42,
+                    'error' => 0,
+                    'type' => 'text/plain',
+                    'name' => 'Uploaded file'
+                ],
+                'pictures' => [
+                    'name' => [
+                        ['file' => 'a-file.png'],
+                        ['file' => 'a-moose.png']
+                    ],
+                    'type' => [
+                        ['file' => 'image/png'],
+                        ['file' => 'image/jpg']
+                    ],
+                    'tmp_name' => [
+                        ['file' => __FILE__],
+                        ['file' => __FILE__]
+                    ],
+                    'error' => [
+                        ['file' => 0],
+                        ['file' => 0]
+                    ],
+                    'size' => [
+                        ['file' => 17188],
+                        ['file' => 2010]
+                    ],
+                ],
+                'upload' => new UploadedFile(__FILE__, 42, 0)
+            ]
+        ]);
+        $this->post('/request_action/uploaded_files');
+        $this->assertHeader('X-Middleware', 'true');
+        $data = json_decode($this->_response->getBody(), true);
+
+        $this->assertEquals([
+            'file' => 'Uploaded file',
+            'pictures.0.file' => 'a-file.png',
+            'pictures.1.file' => 'a-moose.png',
+            'upload' => null
+        ], $data);
+    }
+
+    /**
      * Test that the PSR7 requests receive encoded data.
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -188,7 +188,7 @@ class RequestActionController extends AppController
     public function uploaded_files()
     {
         $files = Hash::flatten($this->request->getUploadedFiles());
-        $names = collection($files)->map(function(UploadedFileInterface $file) {
+        $names = collection($files)->map(function (UploadedFileInterface $file) {
             return $file->getClientFilename();
         });
 

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -14,6 +14,8 @@
 namespace TestApp\Controller;
 
 use Cake\Http\Exception\NotFoundException;
+use Cake\Utility\Hash;
+use Psr\Http\Message\UploadedFileInterface;
 
 /**
  * RequestActionController class
@@ -176,5 +178,20 @@ class RequestActionController extends AppController
     public function error_method()
     {
         throw new NotFoundException('Not there or here.');
+    }
+
+    /**
+     * Tests uploaded files
+     *
+     * @return \Cake\Http\Response
+     */
+    public function uploaded_files()
+    {
+        $files = Hash::flatten($this->request->getUploadedFiles());
+        $names = collection($files)->map(function(UploadedFileInterface $file) {
+            return $file->getClientFilename();
+        });
+
+        return $this->response->withStringBody(json_encode($names));
     }
 }


### PR DESCRIPTION
This fix makes it possible to test controller actions that expect uploads are accessible from `getUploadedFiles()`. 

Unfortunately files passed as POST data body are not present in `getUploadedFiles()` and to test those properly `$_FILES` had to be injected with files directly.