### PR TITLE
Better grouping in CLI for commands.

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -134,7 +134,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     }
 
     /**
-     * @param string[] $names
+     * @param string[] $names Names
      *
      * @return string|null
      */
@@ -150,7 +150,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
     }
 
     /**
-     * @param string[] $names
+     * @param string[] $names Names
      * @return string
      */
     protected function getShortestName(array $names)

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -101,7 +101,8 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
         foreach ($invert as $class => $names) {
             $prefixedName = $this->findPrefixedName($names);
             if (!$prefixedName) {
-                $prefixed['[app]'][] = $this->getShortestName($names);
+                $prefix = preg_match('#^Cake\\\\(Command|Shell)\\\\#', $class) ? '[core]' : '[app]';
+                $prefixed[$prefix][] = $this->getShortestName($names);
                 continue;
             }
 

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -106,16 +106,17 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
             }
 
             list ($prefix, $name) = explode('.', $prefixedName, 2);
-            $prefix = Inflector::camelize($prefix);debug($names);
+            $prefix = Inflector::camelize($prefix);
+            debug($names);
 
             $shortestName = $this->getShortestName($names);
             if (strpos($shortestName, '.') !== false) {
                 list (, $shortestName) = explode('.', $shortestName, 2);
             }
-            
+
             $prefixed[$prefix][] = $shortestName;
         }
-        
+
         ksort($prefixed);
 
         foreach ($prefixed as $prefix => $names) {
@@ -143,7 +144,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
                 return $name;
             }
         }
-        
+
         return null;
     }
 
@@ -151,16 +152,16 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      * @param string[] $names
      * @return string
      */
-    protected function getShortestName(array $names) 
+    protected function getShortestName(array $names)
     {
         if (count($names) <= 1) {
             return array_shift($names);
         }
-        
+
         usort($names, function ($a, $b) {
             return strlen($a) - strlen($b);
         });
-        
+
         return array_shift($names);
     }
 

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -21,8 +21,8 @@ use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\ConsoleOutput;
-use SimpleXMLElement;
 use Cake\Utility\Inflector;
+use SimpleXMLElement;
 
 /**
  * Print out command list

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -108,7 +108,6 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
 
             list ($prefix, $name) = explode('.', $prefixedName, 2);
             $prefix = Inflector::camelize($prefix);
-            debug($names);
 
             $shortestName = $this->getShortestName($names);
             if (strpos($shortestName, '.') !== false) {

--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -90,7 +90,6 @@ class HelpCommandTest extends ConsoleIntegrationTestCase
             'only short alias for plugin command.'
         );
         $this->assertOutputContains('- sample', 'app shell');
-        $this->assertOutputContains('- test_plugin.sample', 'Long plugin name');
         $this->assertOutputContains('- routes', 'core shell');
         $this->assertOutputContains('- example', 'short plugin name');
         $this->assertOutputContains('- abort', 'command object');


### PR DESCRIPTION
[WIP]

Partial Issue of https://github.com/cakephp/cakephp/issues/12123

The output so far is millions of randomly ordered rows (for many shells => even way more many commands):
```
- annotations
- asset_compress
- bake
- benchmark
- cache
- cache.cache
- clear
- code_completion
- completion
- current_config
- database_log
- db_backup
- db_maintenance
- db_migration
- whitespace
- fixture_check
- generator
- help
- i18n
- phpstorm
- indent
- inflect
- mailmap
- main
- maintenance_mode
- migrations
- notification
- orm_cache
- own_plugins
- plugin
- queue
- reset
- routes
- schema_cache
- server
- superfluous_whitespace
- test_cli
- user
- vendor_plugins
- test_helper.fixture_check
- tiny_auth_sync
- undisposable
- translate
- update
- version
...
```
Try to find what you are looking for, almost impossible.

Also: There is a bug for single prefixed ones (test_helper.fixture_check etc) that keep their prefix wrongly it seems. Also cache and cache.cache is duplicate in 3.7+.

With this, they would at least have their semantic high level grouping again as in 3.5:
```
AssetCompress:
 - asset_compress
Bake:
 - bake
Cache:
 - cache
DatabaseLog:
 - database_log
DebugKit:
 - benchmark
 - whitespace
IdeHelper:
 - annotations
 - code_completion
 - phpstorm
Migrations:
 - migrations
Queue:
 - queue
Setup:
 - clear
 - current_config
 - db_maintenance
 - db_migration
 - indent
 - mailmap
 - maintenance_mode
 - reset
 - superfluous_whitespace
 - test_cli
 - user
TestHelper:
 - fixture_check
TinyAuth:
 - tiny_auth_sync
Tools:
 - inflect
ToolsExtra:
 - undisposable
Translate:
 - translate
[app]:
 - cache
 - completion
 - help
 - i18n
 - main
 - notification
 - orm_cache
 - plugin
 - routes
 - schema_cache
 - server
 - update
 - version
...
```
This is important as most shells (/their tasks) or commands are not possible to be prefixed always with the plugin and as such are otherwise randomly shuffeled in the list.

Any better ideas?
How could we separate core from project?
by checking the "Cake" prefix in the command maybe?