### PR TITLE
Fix .json routes not rendering error pages properly

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -125,9 +125,18 @@ class ExceptionRenderer implements ExceptionRendererInterface
      */
     protected function _getController()
     {
-        $request = $this->request ?: Router::getRequest(true);
+        $request = $this->request;
+        $routerRequest = Router::getRequest(true);
+        // Fallback to the request in the router or make a new one from
+        // $_SERVER
         if ($request === null) {
-            $request = ServerRequestFactory::fromGlobals();
+            $request = $routerRequest ?: ServerRequestFactory::fromGlobals();
+        }
+
+        // If the current request doesn't have routing data, but we
+        // found a request in the router context copy the params over
+        if ($request->getParam('controller') === false && $routerRequest !== null) {
+            $request = $request->withAttribute('params', $routerRequest->getAttribute('params'));
         }
 
         $response = new Response();

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -196,7 +196,9 @@ class ExceptionRendererTest extends TestCase
 
         $exception = new NotFoundException('Page not found');
         $request = new ServerRequest();
-        $request = $request->withParam('prefix', 'admin');
+        $request = $request
+            ->withParam('controller', 'Articles')
+            ->withParam('prefix', 'admin');
 
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception, $request);
 
@@ -903,6 +905,38 @@ class ExceptionRendererTest extends TestCase
 
         $this->assertContains('Internal Error', (string)$result->getBody());
         $this->assertEquals(500, $result->getStatusCode());
+    }
+
+    /**
+     * Test that router request parameters are applied when the passed
+     * request has no params.
+     *
+     * @return void
+     */
+    public function testRenderInheritRoutingParams()
+    {
+        $routerRequest = new ServerRequest([
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'index',
+                'plugin' => null,
+                'pass' => [],
+                '_ext' => 'json',
+            ]
+        ]);
+        // Simulate a request having routing applied and stored in router
+        Router::pushRequest($routerRequest);
+
+        $exceptionRenderer = new ExceptionRenderer(new Exception('Terrible'), new ServerRequest());
+        $exceptionRenderer->render();
+        $properties = $exceptionRenderer->__debugInfo();
+
+        foreach (['controller', 'action', '_ext'] as $key) {
+            $this->assertSame(
+                $routerRequest->getParam($key),
+                $properties['controller']->request->getParam($key)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Due to changes in #11978 the original request state was preserved. This is a good thing as it makes control flow more explicit however, it has the side-effect of parsed extensions being 'lost' as the request error handler has access to is detached from the one Router mutated.

By using the Router state to apply routing if available we can fix #12834. I'm using the `controller` param as a hint for empty params as controller is a required router output key.