### PR TITLE
Remove redundant check in FileEngine

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -194,7 +194,7 @@ class FileEngine extends CacheEngine
         $time = time();
         $cachetime = (int)$this->_File->current();
 
-        if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
+        if ($cachetime < $time) {
             if ($this->_config['lock']) {
                 $this->_File->flock(LOCK_UN);
             }


### PR DESCRIPTION
This check was added back when Cache::settings() existed and served to invalidate cache data when duration settings change. This is no longer the case, and this code actively thwarts PSR6 per-key TTL operation.

Fixes #12827