### PR TITLE
Remove redundant conditional checks.

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,7 +32,19 @@
         <MissingClosureParamType errorLevel="info" />
         <MissingParamType errorLevel="info" />
 
-        <RedundantCondition errorLevel="info" />
+        <RedundantCondition>
+            <errorLevel type="suppress">
+                <file name="src/Console/ConsoleErrorHandler.php" />
+                <file name="src/Database/Expression/Comparison.php" />
+                <file name="src/Datasource/EntityTrait.php" />
+                <file name="src/Http/Client/Adapter/Curl.php" />
+                <file name="src/Http/Client/Request.php" />
+                <file name="src/I18n/DateFormatTrait.php" />
+                <file name="src/ORM/Association.php" />
+                <file name="src/ORM/BehaviorRegistry.php" />
+                <file name="src/Utility/Hash.php" />
+            </errorLevel>
+        </RedundantCondition>
 
         <DocblockTypeContradiction errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
@@ -200,6 +212,12 @@
                 <file name="src/Core/functions.php" />
             </errorLevel>
         </InvalidCast>
+
+        <InvalidArrayOffset>
+            <errorLevel type="suppress">
+                <file name="src/Datasource/EntityTrait.php" />
+            </errorLevel>
+        </InvalidArrayOffset>
 
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,7 +41,6 @@
                 <file name="src/Http/Client/Request.php" />
                 <file name="src/I18n/DateFormatTrait.php" />
                 <file name="src/ORM/Association.php" />
-                <file name="src/ORM/BehaviorRegistry.php" />
                 <file name="src/Utility/Hash.php" />
             </errorLevel>
         </RedundantCondition>

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -21,7 +21,6 @@ use Cake\Datasource\ModelAwareTrait;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Base class for console commands.

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -113,16 +113,7 @@ class Command
         $parser = new ConsoleOptionParser($name);
         $parser->setRootName($root);
 
-        $parser = $this->buildOptionParser($parser);
-        if (!($parser instanceof ConsoleOptionParser)) {
-            throw new RuntimeException(sprintf(
-                "Invalid option parser returned from buildOptionParser(). Expected %s, got %s",
-                ConsoleOptionParser::class,
-                getTypeName($parser)
-            ));
-        }
-
-        return $parser;
+        return $this->buildOptionParser($parser);
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -429,7 +429,7 @@ class ConsoleOptionParser
         }
         $this->_options[$name] = $option;
         asort($this->_options);
-        if ($option->short() !== null) {
+        if ($option->short()) {
             $this->_shortOptions[$option->short()] = $name;
             asort($this->_shortOptions);
         }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -181,7 +181,7 @@ class SecurityComponent extends Component
     protected function _throwException(?SecurityException $exception = null): void
     {
         if ($exception !== null) {
-            if (!Configure::read('debug') && $exception instanceof SecurityException) {
+            if (!Configure::read('debug')) {
                 $exception->setReason($exception->getMessage());
                 $exception->setMessage(self::DEFAULT_EXCEPTION_MESSAGE);
             }
@@ -359,7 +359,7 @@ class SecurityComponent extends Component
         );
 
         foreach ($fieldList as $i => $key) {
-            $isLocked = (is_array($locked) && in_array($key, $locked));
+            $isLocked = in_array($key, $locked);
 
             if (!empty($unlockedFields)) {
                 foreach ($unlockedFields as $off) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -74,7 +74,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      */
     public function load(string $objectName, array $config = [])
     {
-        if (is_array($config) && isset($config['className'])) {
+        if (isset($config['className'])) {
             $name = $objectName;
             $objectName = $config['className'];
         } else {

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -190,10 +190,6 @@ trait StaticConfigTrait
             return [];
         }
 
-        if (!is_string($dsn)) {
-            throw new InvalidArgumentException('Only strings can be passed to parseDsn');
-        }
-
         $pattern = <<<'REGEXP'
 {
     ^

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -247,6 +247,7 @@ trait SqlserverDialectTrait
                 $expression->setName('')->setConjunction(' +');
                 break;
             case 'DATEDIFF':
+                /** @var bool $hasDay */
                 $hasDay = false;
                 $visitor = function ($value) use (&$hasDay) {
                     if ($value === 'day') {

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -351,10 +351,8 @@ class MysqlSchema extends BaseSchema
                         break;
                     }
 
-                    if ($isKnownLength) {
-                        $length = array_search($data['length'], TableSchema::$columnLengths);
-                        $out .= ' ' . strtoupper($length) . 'TEXT';
-                    }
+                    $length = array_search($data['length'], TableSchema::$columnLengths);
+                    $out .= ' ' . strtoupper($length) . 'TEXT';
 
                     break;
                 case TableSchema::TYPE_BINARY:

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -86,7 +86,7 @@ class SqlserverCompiler extends QueryCompiler
      */
     protected function _buildLimitPart(int $limit, Query $query): string
     {
-        if ($limit === null || $query->clause('offset') === null) {
+        if ($query->clause('offset') === null) {
             return '';
         }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
+use Cake\ORM\Entity;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Traversable;
@@ -623,7 +624,7 @@ trait EntityTrait
             return static::$_accessors[$class][$type][$property] = '';
         }
 
-        if ($class === 'Cake\ORM\Entity') {
+        if ($class === Entity::class) {
             return '';
         }
 

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -83,22 +83,10 @@ class Server implements EventDispatcherInterface
             $middleware = $this->app->pluginMiddleware($middleware);
         }
 
-        if (!($middleware instanceof MiddlewareQueue)) {
-            throw new RuntimeException('The application `middleware` method did not return a middleware queue.');
-        }
         $this->dispatchEvent('Server.buildMiddleware', ['middleware' => $middleware]);
         $middleware->add($this->app);
 
-        $response = $this->runner->run($middleware, $request, $response);
-
-        if (!($response instanceof ResponseInterface)) {
-            throw new RuntimeException(sprintf(
-                'Application did not create a response. Got "%s" instead.',
-                is_object($response) ? get_class($response) : $response
-            ));
-        }
-
-        return $response;
+        return $this->runner->run($middleware, $request, $response);
     }
 
     /**

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -24,7 +24,6 @@ use Cake\Event\EventManagerInterface;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use RuntimeException;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
 /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -386,9 +386,6 @@ class ServerRequest implements ServerRequestInterface
      */
     protected function _processFiles($post, array $files)
     {
-        if (!is_array($files)) {
-            return $post;
-        }
         $fileData = [];
         foreach ($files as $key => $value) {
             if ($value instanceof UploadedFileInterface) {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -75,10 +75,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     public function setTable(Table $table): void
     {
         $this->_table = $table;
-        $eventManager = $table->getEventManager();
-        if ($eventManager !== null) {
-            $this->setEventManager($eventManager);
-        }
+        $this->setEventManager($table->getEventManager());
     }
 
     /**

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -654,7 +654,7 @@ class Marshaller
             }
 
             $key = implode(';', $entity->extract($primary));
-            if ($key === null || !isset($indexed[$key])) {
+            if (!isset($indexed[$key])) {
                 continue;
             }
 
@@ -822,7 +822,7 @@ class Marshaller
             // Marshal data into the old object, or make a new joinData object.
             if (isset($extra[$hash])) {
                 $record->set('_joinData', $marshaller->merge($extra[$hash], $value, $nested));
-            } elseif (is_array($value)) {
+            } else {
                 $joinData = $marshaller->one($value, $nested);
                 $record->set('_joinData', $joinData);
             }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1283,8 +1283,8 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             'buffered' => $this->_useBufferedResults,
             'formatters' => count($this->_formatters),
             'mapReducers' => count($this->_mapReduce),
-            'contain' => $eagerLoader ? $eagerLoader->getContain() : [],
-            'matching' => $eagerLoader ? $eagerLoader->getMatching() : [],
+            'contain' => $eagerLoader->getContain(),
+            'matching' => $eagerLoader->getMatching(),
             'extraOptions' => $this->_options,
             'repository' => $this->_repository,
         ];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1455,7 +1455,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _transactionCommitted(bool $atomic, bool $primary): bool
     {
-        return !$this->getConnection()->inTransaction() && ($atomic || (!$atomic && $primary));
+        return !$this->getConnection()->inTransaction() && ($atomic || ($primary && !$atomic));
     }
 
     /**

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -538,7 +538,7 @@ class Route
         $args = explode('/', $args);
 
         foreach ($args as $param) {
-            if (empty($param) && $param !== '0' && $param !== 0) {
+            if (empty($param) && !($param === '0' || $param === 0)) {
                 continue;
             }
             $pass[] = rawurldecode($param);

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -107,7 +107,7 @@ class TableHelper extends Helper
      */
     public function output(array $rows): void
     {
-        if (!is_array($rows) || count($rows) === 0) {
+        if (empty($rows)) {
             return;
         }
 

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -849,7 +849,7 @@ class Hash
     public static function maxDimensions(array $data): int
     {
         $depth = [];
-        if (is_array($data) && !empty($data)) {
+        if (!empty($data)) {
             foreach ($data as $value) {
                 if (is_array($value)) {
                     $depth[] = static::maxDimensions($value) + 1;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -491,7 +491,7 @@ class Validation
             $dateFormat = 'ymd';
         }
         $parts = explode(' ', $check);
-        if (!empty($parts) && count($parts) > 1) {
+        if (count($parts) > 1) {
             $date = rtrim(array_shift($parts), ',');
             $time = implode(' ', $parts);
             $valid = static::date($date, $dateFormat, $regex) && static::time($time);
@@ -1040,7 +1040,7 @@ class Validation
      */
     protected static function _check($check, string $regex): bool
     {
-        return is_string($regex) && is_scalar($check) && preg_match($regex, (string)$check);
+        return is_scalar($check) && preg_match($regex, (string)$check);
     }
 
     /**

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -45,7 +45,7 @@ class AjaxView extends View
         ?EventManager $eventManager = null,
         array $viewOptions = []
     ) {
-        if ($response && $response instanceof Response) {
+        if ($response) {
             $response = $response->withType('ajax');
         }
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Http\ServerRequest;
+use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
@@ -142,7 +143,7 @@ class EntityContext implements ContextInterface
             if ($isEntity) {
                 $table = $entity->getSource();
             }
-            if (!$table && $isEntity && get_class($entity) !== 'Cake\ORM\Entity') {
+            if (!$table && $isEntity && get_class($entity) !== Entity::class) {
                 list(, $entityClass) = namespaceSplit(get_class($entity));
                 $table = Inflector::pluralize($entityClass);
             }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -709,7 +709,7 @@ class FormHelper extends Helper
 
                     return;
                 }
-                if (isset($this->fields[$field]) && $value === null) {
+                if (isset($this->fields[$field])) {
                     unset($this->fields[$field]);
                 }
                 $this->fields[] = $field;
@@ -1915,7 +1915,7 @@ class FormHelper extends Helper
      */
     public function submit(?string $caption = null, array $options = []): string
     {
-        if (!is_string($caption) && empty($caption)) {
+        if ($caption === null) {
             $caption = __d('cake', 'Submit');
         }
         $options += [

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -21,7 +21,6 @@ use Cake\View\Helper;
 use Cake\View\StringTemplate;
 use Cake\View\StringTemplateTrait;
 use Cake\View\View;
-use InvalidArgumentException;
 
 /**
  * Pagination Helper class for easy generation of pagination links.

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -648,12 +648,6 @@ class PaginatorHelper extends Helper
      */
     public function hasPage(int $page = 1, ?string $model = null): bool
     {
-        if (!is_numeric($page)) {
-            throw new InvalidArgumentException(
-                'First argument "page" has to be int. Note that argument order switched from 3.x to 4.x.'
-            );
-        }
-
         $paging = $this->params($model);
         if ($paging === []) {
             return false;


### PR DESCRIPTION
Addition of type hints has made quite a few checks redundant and some other unnecessary ones were found by psalm.

I also found and reported a few issues with psalm while working on this.

https://github.com/vimeo/psalm/issues/1148
https://github.com/vimeo/psalm/issues/1147
https://github.com/vimeo/psalm/issues/1149
https://github.com/vimeo/psalm/issues/1152