### PR TITLE
Fix handling of `html` and `htm` extensions.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -332,15 +332,11 @@ class RequestHandlerComponent extends Component
         $response = $controller->getResponse();
         $request = $controller->getRequest();
 
-        $isRecognized = (
-            !in_array($this->ext, ['html', 'htm']) &&
-            $response->getMimeType($this->ext)
-        );
-        if ($this->ext && !$isRecognized) {
-            throw new NotFoundException('Invoked extension not recognized/configured: ' . $this->ext);
-        }
+        if ($this->ext && !in_array($this->ext, ['html', 'htm'])) {
+            if (!$response->getMimeType($this->ext)) {
+                throw new NotFoundException('Invoked extension not recognized/configured: ' . $this->ext);
+            }
 
-        if ($this->ext) {
             $this->renderAs($controller, $this->ext);
             $response = $controller->response;
         } else {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -27,6 +27,7 @@ use Cake\View\AjaxView;
 use Cake\View\JsonView;
 use Cake\View\XmlView;
 use TestApp\Controller\RequestHandlerTestController;
+use TestApp\View\AppView;
 use Zend\Diactoros\Stream;
 
 /**
@@ -439,6 +440,66 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->request = $this->Controller->request->withParam('_ext', 'js');
         $this->RequestHandler->startup($event);
         $this->assertNotEquals(AjaxView::class, $this->Controller->viewBuilder()->getClassName());
+    }
+
+    /**
+     * @return array
+     */
+    public function defaultExtensionsProvider()
+    {
+        return [['html'], ['htm']];
+    }
+
+    /**
+     * Tests that the default extensions are using the default view.
+     *
+     * @param string $extension Extension to test.
+     * @dataProvider defaultExtensionsProvider
+     * @return void
+     */
+    public function testDefaultExtensions($extension)
+    {
+        Router::extensions([$extension], false);
+
+        $this->Controller->request = $this->Controller->request->withParam('_ext', $extension);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
+        $this->RequestHandler->beforeRender(new Event('Controller.beforeRender', $this->Controller));
+
+        $this->assertEquals($extension, $this->RequestHandler->ext);
+        $this->assertEquals('text/html', $this->Controller->response->getType());
+
+        $view = $this->Controller->createView();
+        $this->assertInstanceOf(AppView::class, $view);
+        $this->assertEmpty($view->getLayoutPath());
+        $this->assertEmpty($view->getSubDir());
+    }
+
+    /**
+     * Tests that the default extensions can be overwritten by the accept header.
+     *
+     * @param string $extension Extension to test.
+     * @dataProvider defaultExtensionsProvider
+     * @return void
+     */
+    public function testDefaultExtensionsOverwrittenByAcceptHeader($extension)
+    {
+        Router::extensions([$extension], false);
+
+        $this->Controller->request = $this->request->withHeader(
+            'Accept',
+            'application/xml'
+        );
+        $this->Controller->request = $this->Controller->request->withParam('_ext', $extension);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
+        $this->RequestHandler->beforeRender(new Event('Controller.beforeRender', $this->Controller));
+
+        $this->assertEquals('xml', $this->RequestHandler->ext);
+        $this->assertEquals('application/xml', $this->Controller->response->getType());
+
+        $view = $this->Controller->createView();
+        $this->assertInstanceOf(XmlView::class, $view);
+        $this->assertEquals('xml', $view->getLayoutPath());
+        $this->assertEquals('xml', $view->getSubDir());
     }
 
     /**


### PR DESCRIPTION
As mentioned in https://github.com/cakephp/cakephp/issues/12585#issuecomment-437549557, the changes in #12586 broke how the special `html` and `htm` extensions are being treated. Before the change they would be "ignored", so that the rendering using the default application view would take place, and now an exception is being thrown.

This PR restores the old behavior for these extensions.