### PR TITLE
Cleaner API for chaining

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -946,7 +946,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
 
         $this->Flash->set($message, $this->_config['flash']);
     }
-    
+
     /**
      * Checks if there is an BaseAuthenticate instance.
      *
@@ -956,7 +956,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     {
         return $this->_authenticationProvider !== null;
     }
-    
+
     /**
      * If login was called during this request and the user was successfully
      * authenticated, this function will return the instance of the authentication
@@ -968,7 +968,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     {
         return $this->_authenticationProvider;
     }
-    
+
     /**
      * Checks if there is an BaseAuthorize instance.
      *
@@ -978,7 +978,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     {
         return $this->_authorizationProvider !== null;
     }
-    
+
     /**
      * If there was any authorization processing for the current request, this function
      * will return the instance of the Authorization object that granted access to the

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -946,27 +946,47 @@ class AuthComponent extends Component implements EventDispatcherInterface
 
         $this->Flash->set($message, $this->_config['flash']);
     }
-
+    
+    /**
+     * Checks if there is an BaseAuthenticate instance.
+     *
+     * @return bool
+     */
+    public function hasAuthenticationProvider(): bool
+    {
+        return $this->_authenticationProvider !== null;
+    }
+    
     /**
      * If login was called during this request and the user was successfully
      * authenticated, this function will return the instance of the authentication
      * object that was used for logging the user in.
      *
-     * @return \Cake\Auth\BaseAuthenticate|null
+     * @return \Cake\Auth\BaseAuthenticate
      */
-    public function authenticationProvider(): ?BaseAuthenticate
+    public function authenticationProvider(): BaseAuthenticate
     {
         return $this->_authenticationProvider;
     }
-
+    
+    /**
+     * Checks if there is an BaseAuthorize instance.
+     *
+     * @return bool
+     */
+    public function hasAuthorizationProvider(): bool
+    {
+        return $this->_authorizationProvider !== null;
+    }
+    
     /**
      * If there was any authorization processing for the current request, this function
      * will return the instance of the Authorization object that granted access to the
      * user to the current address.
      *
-     * @return \Cake\Auth\BaseAuthorize|null
+     * @return \Cake\Auth\BaseAuthorize
      */
-    public function authorizationProvider(): ?BaseAuthorize
+    public function authorizationProvider(): BaseAuthorize
     {
         return $this->_authorizationProvider;
     }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/12846

We need a cleaner API in some cases.
Here the IDE correctly warns about a dirtyness in code:

![nullpointer](https://user-images.githubusercontent.com/39854/50462525-260a7d00-0986-11e9-92aa-97fe513a1129.png)

This can easily be solved by forcing the type to be of that object or otherwise throw an exception (we could add a more meaningful message here of course).
To check on it one could use `has...()` methods then?

We could also keep the current ones and add `...OrFail()` ones?

In this case you would otherwise be forced to do this:
```php
$possibleProvider = $this->Auth->authenticationProvider();
if ($possibleProvider && $possibleProvider->needsPasswordRehash()) {
    ...
}
```

Just wanted to get some general API feedback here on how to improve things on core level here to use less return types and especially less nullable where possible/feasible.