### PR TITLE
Allow assetUrl() to use CDNs easier.

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -143,9 +143,9 @@ class UrlHelper extends Helper
      *
      * Depending on options passed provides full URL with domain name. Also calls
      * `Helper::assetTimestamp()` to add timestamp to local files.
-     * 
+     *
      * ### Options:
-     * 
+     *
      * - `fullBase` Boolean true or a string (e.g. https://example) to
      *    return full URL with protocol and domain name.
      * - `pathPrefix` Path prefix for relative URLs

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -143,17 +143,21 @@ class UrlHelper extends Helper
      *
      * Depending on options passed provides full URL with domain name. Also calls
      * `Helper::assetTimestamp()` to add timestamp to local files.
+     * 
+     * ### Options:
+     * 
+     * - `fullBase` Boolean true or a string (e.g. https://example) to
+     *    return full URL with protocol and domain name.
+     * - `pathPrefix` Path prefix for relative URLs
+     * - `ext` Asset extension to append
+     * - `plugin` False value will prevent parsing path as a plugin
+     * - `timestamp` Overrides the value of `Asset.timestamp` in Configure.
+     *    Set to false to skip timestamp generation.
+     *    Set to true to apply timestamps when debug is true. Set to 'force' to always
+     *    enable timestamping regardless of debug value.
      *
      * @param string|array $path Path string or URL array
-     * @param array $options Options array. Possible keys:
-     *   `fullBase` Return full URL with domain name. Bool or string.
-     *   `pathPrefix` Path prefix for relative URLs
-     *   `ext` Asset extension to append
-     *   `plugin` False value will prevent parsing path as a plugin
-     *   `timestamp` Overrides the value of `Asset.timestamp` in Configure.
-     *        Set to false to skip timestamp generation.
-     *        Set to true to apply timestamps when debug is true. Set to 'force' to always
-     *        enable timestamping regardless of debug value.
+     * @param array $options Options array.
      * @return string Generated URL
      */
     public function assetUrl($path, array $options = [])

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -196,7 +196,7 @@ class UrlHelper extends Helper
         $path = $this->_encodeUrl($webPath);
 
         if (!empty($options['fullBase'])) {
-            $fullBaseUrl = is_string($options['fullBase']) ? $options['fullBase'] : Router::fullBaseUrl(); 
+            $fullBaseUrl = is_string($options['fullBase']) ? $options['fullBase'] : Router::fullBaseUrl();
             $path = rtrim($fullBaseUrl, '/') . '/' . ltrim($path, '/');
         }
 

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -146,7 +146,7 @@ class UrlHelper extends Helper
      *
      * @param string|array $path Path string or URL array
      * @param array $options Options array. Possible keys:
-     *   `fullBase` Return full URL with domain name
+     *   `fullBase` Return full URL with domain name. Bool or string.
      *   `pathPrefix` Path prefix for relative URLs
      *   `ext` Asset extension to append
      *   `plugin` False value will prevent parsing path as a plugin
@@ -196,7 +196,8 @@ class UrlHelper extends Helper
         $path = $this->_encodeUrl($webPath);
 
         if (!empty($options['fullBase'])) {
-            $path = rtrim(Router::fullBaseUrl(), '/') . '/' . ltrim($path, '/');
+            $fullBaseUrl = is_string($options['fullBase']) ? $options['fullBase'] : Router::fullBaseUrl(); 
+            $path = rtrim($fullBaseUrl, '/') . '/' . ltrim($path, '/');
         }
 
         return $path;

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -355,7 +355,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->assetTimestamp('/test_theme/js/non_existant.js');
         $this->assertRegExp('#/test_theme/js/non_existant.js$#', $result, 'No error on missing file');
     }
-    
+
     /**
      * test script()
      *

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -291,6 +291,20 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * Tests assetUrl() with full base URL.
+     *
+     * @return void
+     */
+    public function testAssetUrlFullBase()
+    {
+        $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => true]);
+        $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
+
+        $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => 'https://xyz/']);
+        $this->assertEquals('https://xyz/img/foo.jpg', $result);
+    }
+
+    /**
      * test assetUrl and Asset.timestamp = force
      *
      * @return void
@@ -341,7 +355,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->assetTimestamp('/test_theme/js/non_existant.js');
         $this->assertRegExp('#/test_theme/js/non_existant.js$#', $result, 'No error on missing file');
     }
-
+    
     /**
      * test script()
      *


### PR DESCRIPTION
Refs issue in IRC/Slack
People are not easily able to set a CDN host inside templating for asset URLs.
With this you about having to switch out the `Router::fullBaseUrl($new)` and reset it again afterwards.