### PR TITLE
 Fix `FileCacheEngine` removing files in parent of configured path.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,4 +98,4 @@ before_test:
 test_script:
   - sqlcmd -S ".\SQL2012SP1" -U sa -P Password12! -Q "create database cakephp;"
   - cd C:\projects\cakephp
-  - php vendor\bin\phpunit
+  - vendor\bin\phpunit.bat

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -269,7 +269,10 @@ class FileEngine extends CacheEngine
 
         $this->_clearDirectory($this->_config['path'], $now, $threshold);
 
-        $directory = new RecursiveDirectoryIterator($this->_config['path']);
+        $directory = new RecursiveDirectoryIterator(
+            $this->_config['path'],
+            \FilesystemIterator::SKIP_DOTS
+        );
         $contents = new RecursiveIteratorIterator(
             $directory,
             RecursiveIteratorIterator::SELF_FIRST

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -641,4 +641,31 @@ class FileEngineTest extends TestCase
         $result = Cache::add('test_add_key', 'test data 2', 'file_test');
         $this->assertFalse($result);
     }
+
+    /**
+     * Tests that only files inside of the configured path are being deleted.
+     *
+     * @return void
+     */
+    public function testClearIsRestrictedToConfiguredPath()
+    {
+        $this->_configCache([
+            'prefix' => '',
+            'path' => TMP . 'tests',
+        ]);
+
+        $unrelatedFile = tempnam(TMP, 'file_test');
+        file_put_contents($unrelatedFile, 'data');
+        $this->assertFileExists($unrelatedFile);
+
+        Cache::write('key', 'data', 'file_test');
+        $this->assertFileExists(TMP . 'tests/key');
+
+        $result = Cache::clear(false, 'file_test');
+        $this->assertTrue($result);
+        $this->assertFileNotExists(TMP . 'tests/key');
+
+        $this->assertFileExists($unrelatedFile);
+        $this->assertTrue(unlink($unrelatedFile));
+    }
 }


### PR DESCRIPTION
When processing dot files, `..` will expand to the parent of the configured base path, causing unrelated files to be deleted.

This seems to be what caused AppVeyor to fail, it was triggered in `SimpleCacheEngineTest` when it tried to clear the cache. With a prefix of `''`, the inner `FileCacheEngine` deleted all files in the configured path's parent path, which happens to be the OS temp folder, where probably some AppVeyor internal `.bat` file is located, resulting in an error when the batch script terminates and the file doesn't exist anymore.
