### PR TITLE
Trait annotations

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -106,12 +106,11 @@ trait ConsoleIntegrationTestTrait
     /**
      * Cleans state to get ready for the next test
      *
+     * @after
      * @return void
      */
-    public function tearDown()
+    public function cleanupConsoleTrait()
     {
-        parent::tearDown();
-
         $this->_exitCode = null;
         $this->_out = null;
         $this->_err = null;

--- a/src/TestSuite/EmailTrait.php
+++ b/src/TestSuite/EmailTrait.php
@@ -26,30 +26,33 @@ use Cake\TestSuite\Constraint\Email\NoMailSent;
 /**
  * Make assertions on emails sent through the Cake\TestSuite\TestEmailTransport
  *
- * After adding the trait to your test case, replace all mail transports with the
- * TestEmailTransport:
- *
- * **tests/bootstrap.php**
- * ```
- * use Cake\TestSuite\TestEmailTransport;
- *
- * // replaces existing transports with the TestEmailTransport for email assertions
- * TestEmailTransport::replaceAllTransports();
- * ```
- *
- * Then, in your test case's tearDown method, clean up previously sent emails:
- *
- * ```
- * public function tearDown()
- * {
- *     // other cleanup
- *     parent::tearDown();
- *     TestEmailTransport::clearEmails();
- * }
- * ```
+ * After adding the trait to your test case, all mail transports will be replaced
+ * with TestEmailTransport which is used for making assertions and will *not* actually
+ * send emails.
  */
 trait EmailTrait
 {
+    /**
+     * Replaces all transports with the test transport during test setup
+     *
+     * @before
+     * @return void
+     */
+    public function setupTransports()
+    {
+        TestEmailTransport::replaceAllTransports();
+    }
+
+    /**
+     * Resets transport state
+     *
+     * @after
+     * @return void
+     */
+    public function cleanupEmailTrait()
+    {
+        TestEmailTransport::clearEmails();
+    }
 
     /**
      * Asserts an expected number of emails were sent

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -51,8 +51,6 @@ class EmailTraitTest extends TestCase
         TransportFactory::setConfig('test_tools', [
             'className' => TestEmailTransport::class
         ]);
-
-        TestEmailTransport::replaceAllTransports();
     }
 
     /**
@@ -67,8 +65,6 @@ class EmailTraitTest extends TestCase
         Email::drop('default');
         Email::drop('alternate');
         TransportFactory::drop('test_tools');
-
-        TestEmailTransport::clearEmails();
     }
 
     /**


### PR DESCRIPTION
Follows https://github.com/cakephp/cakephp/pull/12822

I didn't know about these annotations and I think this will make things easier, not to mention fixing the original issue in regards to ConsoleIntegrationTestCase.

For EmailTrait, I added both `@before` and `@after` to handle everything transparently when the trait is added. The reason I think this is safe is because using it requires replacing *all* transports to start anyway. If someone is replacing a single transport manually and expecting another one to use the actual transport, this could cause issues and I can revert those changes.

I'll make a PR to the docs to reflect these changes.