### PR TITLE
Add callable typehint to QueryExpression methods and_ & or_

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -467,7 +467,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "OR"
      *
-     * @param string|array|\Cake\Database\ExpressionInterface $conditions to be joined with OR
+     * @param callable|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with OR
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -449,7 +449,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *
-     * @param string|array|\Cake\Database\ExpressionInterface $conditions to be joined with AND
+     * @param callable|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with AND
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression


### PR DESCRIPTION
Addresses #12868

phpstan raises an error when using a [sample from the documentation](https://book.cakephp.org/3.0/en/orm/query-builder.html#advanced-conditions):

```php
$query = $articles->find()
    ->where(function (QueryExpression $exp) {
        $orConditions = $exp->or_(function ($or) {
            return $or->eq('author_id', 2)
                ->eq('author_id', 5);
        });
        return $exp
            ->not($orConditions)
            ->lte('view_count', 10);
    });
```

phpstan error:
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   file.php                                                                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  xxx    Parameter #1 $conditions of method Cake\Database\Expression\QueryExpression::or_() expects array|Cake\Database\ExpressionInterface|string, Closure(mixed):  
         mixed given. 
```