### PR TITLE
Add string|array|null typehint for data

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -404,7 +404,7 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     * @param array $data The data for the request.
+     * @param string|array|null $data The data for the request.
      * @return void
      * @throws \PHPUnit\Exception
      */
@@ -421,7 +421,7 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     * @param array $data The data for the request.
+     * @param string|array|null $data The data for the request.
      * @return void
      * @throws \PHPUnit\Exception
      */
@@ -438,7 +438,7 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     * @param array $data The data for the request.
+     * @param string|array|null $data The data for the request.
      * @return void
      * @throws \PHPUnit\Exception
      */
@@ -502,7 +502,7 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL
      * @param string $method The HTTP method
-     * @param array|null $data The request data.
+     * @param string|array|null $data The request data.
      * @return void
      * @throws \PHPUnit\Exception
      */
@@ -600,7 +600,7 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL
      * @param string $method The HTTP method
-     * @param array|null $data The request data.
+     * @param string|array|null $data The request data.
      * @return array The request context
      */
     protected function _buildRequest($url, $method, $data)


### PR DESCRIPTION
This PR addresses #12867 by improving the phpdoc typehint for `$data` param that it's being used in the following methods:

- `IntegrationTestTrait::post`
- `IntegrationTestTrait::patch`
- `IntegrationTestTrait::put`
- `IntegrationTestTrait::_sendRequest`
- `IntegrationTestTrait::_buildRequest`

With the above additions, it is defined that these methods can also accept a string (or null) as `$data` which is already supported by `IntegrationTestTrait::_buildRequest` 
