### PR TITLE
Remove bad chaining typehints and fix up RepositoryInterface methods.

### DIFF
--- a/src/Core/PluginApplicationInterface.php
+++ b/src/Core/PluginApplicationInterface.php
@@ -37,9 +37,9 @@ interface PluginApplicationInterface extends EventDispatcherInterface
      *
      * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
      * @param array $config The configuration data for the plugin if using a string for $name
-     * @return \Cake\Core\PluginApplicationInterface
+     * @return $this
      */
-    public function addPlugin($name, array $config = []): self;
+    public function addPlugin($name, array $config = []);
 
     /**
      * Run bootstrap logic for loaded plugins.

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -334,7 +334,7 @@ abstract class Driver implements DriverInterface
     /**
      * @inheritDoc
      */
-    public function enableAutoQuoting(bool $enable = true): DriverInterface
+    public function enableAutoQuoting(bool $enable = true)
     {
         $this->_autoQuoting = (bool)$enable;
 

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -227,9 +227,9 @@ interface DriverInterface
      * in queries.
      *
      * @param bool $enable Whether to enable auto quoting
-     * @return \Cake\Database\DriverInterface
+     * @return $this
      */
-    public function enableAutoQuoting(bool $enable = true): self;
+    public function enableAutoQuoting(bool $enable = true);
 
     /**
      * Returns whether or not this driver should automatically quote identifiers

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1877,7 +1877,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param callable $callback the function to be executed for each ExpressionInterface
      *   found inside this query.
-     * @return $this|null
+     * @return $this
      */
     public function traverseExpressions(callable $callback)
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -686,7 +686,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function setTemporary(bool $temporary): TableSchemaInterface
+    public function setTemporary(bool $temporary)
     {
         $this->_temporary = (bool)$temporary;
 

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -154,9 +154,9 @@ interface TableSchemaInterface extends SchemaInterface
      * Sets whether the table is temporary in the database.
      *
      * @param bool $temporary Whether or not the table is to be temporary.
-     * @return \Cake\Database\Schema\TableSchemaInterface
+     * @return $this
      */
-    public function setTemporary(bool $temporary): self;
+    public function setTemporary(bool $temporary);
 
     /**
      * Gets whether the table is temporary in the database.

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -18,9 +18,6 @@ namespace Cake\Datasource;
 /**
  * Describes the methods that any class representing a data storage should
  * comply with.
- *
- * @method $this setRegistryAlias(string $alias)
- * @method string getRegistryAlias()
  */
 interface RepositoryInterface
 {
@@ -38,6 +35,21 @@ interface RepositoryInterface
      * @return string
      */
     public function getAlias(): string;
+
+    /**
+     * Sets the table registry key used to create this table instance.
+     *
+     * @param string $registryAlias The key used to access this object.
+     * @return $this
+     */
+    public function setRegistryAlias(string $registryAlias);
+
+    /**
+     * Returns the table registry key used to create this table instance.
+     *
+     * @return string
+     */
+    public function getRegistryAlias(): string;
 
     /**
      * Test to see if a Repository has a specific field/column.

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -95,7 +95,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
-    public function on($eventKey = null, $options = [], $callable = null): EventManagerInterface
+    public function on($eventKey = null, $options = [], $callable = null)
     {
         if ($eventKey instanceof EventListenerInterface) {
             $this->_attachSubscriber($eventKey);
@@ -178,7 +178,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
-    public function off($eventKey, $callable = null): EventManagerInterface
+    public function off($eventKey, $callable = null)
     {
         if ($eventKey instanceof EventListenerInterface) {
             $this->_detachSubscriber($eventKey);

--- a/src/Event/EventManagerInterface.php
+++ b/src/Event/EventManagerInterface.php
@@ -53,11 +53,11 @@ interface EventManagerInterface
      *
      * @param callable|null $callable The callable function you want invoked.
      *
-     * @return \Cake\Event\EventManagerInterface
+     * @return $this
      * @throws \InvalidArgumentException When event key is missing or callable is not an
      *   instance of Cake\Event\EventListenerInterface.
      */
-    public function on($eventKey = null, $options = [], $callable = null): self;
+    public function on($eventKey = null, $options = [], $callable = null);
 
     /**
      * Remove a listener from the active listeners.
@@ -89,9 +89,9 @@ interface EventManagerInterface
      * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name
      *   with which the callback has been associated, or the $listener you want to remove.
      * @param callable|null $callable The callback you want to detach.
-     * @return \Cake\Event\EventManagerInterface
+     * @return $this
      */
-    public function off($eventKey, $callable = null): self;
+    public function off($eventKey, $callable = null);
 
     /**
      * Dispatches a new event to all configured listeners

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -92,7 +92,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
-    public function addPlugin($name, array $config = []): PluginApplicationInterface
+    public function addPlugin($name, array $config = [])
     {
         if (is_string($name)) {
             $plugin = $this->makePlugin($name, $config);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -423,7 +423,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *   if associations is an array, a bool on whether to override previous list
      *   with the one passed
      * defaults to merging previous list with the new one.
-     * @return array|$this
+     * @return $this
      */
     public function contain($associations, $override = false)
     {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -1420,7 +1420,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\Datasource\RepositoryInterface')
             ->setMethods([
-                'getAlias', 'setAlias', 'hasField', 'find', 'get', 'query', 'updateAll', 'deleteAll',
+                'getAlias', 'setAlias', 'setRegistryAlias', 'getRegistryAlias', 'hasField', 'find', 'get', 'query', 'updateAll', 'deleteAll',
                 'exists', 'save', 'delete', 'newEntity', 'newEntities', 'patchEntity', 'patchEntities',
             ])
             ->getMock();

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Paginator;
+use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 
@@ -971,9 +972,9 @@ class PaginatorTest extends TestCase
      */
     protected function getMockRepository()
     {
-        $model = $this->getMockBuilder('Cake\Datasource\RepositoryInterface')
+        $model = $this->getMockBuilder(RepositoryInterface::class)
             ->setMethods([
-                'getAlias', 'setAlias', 'hasField', 'find', 'get', 'query', 'updateAll', 'deleteAll',
+                'getAlias', 'setAlias', 'setRegistryAlias', 'getRegistryAlias', 'hasField', 'find', 'get', 'query', 'updateAll', 'deleteAll',
                 'exists', 'save', 'delete', 'newEntity', 'newEntities', 'patchEntity', 'patchEntities',
             ])
             ->getMock();


### PR DESCRIPTION
As discussed, this brings extendability and chaining back for $this methods.
Also fixed up RepositoryInterface methods.

A sniffer ( https://github.com/spryker/code-sniffer/pull/149 ) then can assert this is done properly and consistently, and also helps to avoid bugs here. 

Also: Chainable methods (return $this) must never have a 2nd return type, we still violate this in a few places afaik (2x):
- TranslateTrait::translation()
- Mailer::__call()