### PR TITLE
Use validator for prefer-lowest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,11 @@ before_install:
 before_script:
   - if [[ $PREFER_LOWEST != 1 ]]; then composer install --prefer-source --no-interaction; fi
   - if [[ $PREFER_LOWEST == 1 ]]; then composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then composer require --dev dereuromark/composer-prefer-lowest; fi
 
 script:
   - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then vendor/bin/validate-prefer-lowest; fi
 
   - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 


### PR DESCRIPTION
Using the validator we get info for free about where we cannot promise/test the minimum versions declared.

Fow now, this only issues a warning output (build still passes) as require-dev raises the chronos dependency ( https://travis-ci.org/cakephp/cakephp/jobs/475716058#L766 ):
```
1 warning (impossible to test minimum version here):
 - cakephp/chronos: Defined `1.0.1.0` as minimum, but is `1.2.1.0`
```

Hopefully, we can clean this up in the future (just requiring `^1.2.1` right away).
Until then this helps as a reminder.