### PR TITLE
correct PhpDoc for Collection stopWhen()

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -868,7 +868,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
 
     /**
      * Creates a new collection that when iterated will stop yielding results if
-     * the provided condition evaluates to false.
+     * the provided condition evaluates to true.
      *
      * This is handy for dealing with infinite iterators or any generator that
      * could start returning invalid elements at a certain point. For example,
@@ -893,7 +893,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      *
      * @param callable $condition the method that will receive each of the elements and
-     * returns false when the iteration should be stopped.
+     * returns true when the iteration should be stopped.
      * If an array, it will be interpreted as a key-value list of conditions where
      * the key is a property path as accepted by `Collection::extract`,
      * and the value the condition against with each element will be matched.


### PR DESCRIPTION
The PhpDoc for the Collection stopWhen() method incorrectly state that evaluating to `false` stops yielding, whereas the correct value is `true`. This is shown by the code examples given as well, which can only perform as described if the correct yield end condition is `true`.