### PR TITLE
[2.x]Enable php-memcached on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,7 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]] ; then pecl install timezonedb ; fi
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require 'cakephp/cakephp-codesniffer:1.*'; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendors/bin/phpcs --config-set installed_paths vendors/cakephp/cakephp-codesniffer; fi"
-  - |
-      if [[ ${TRAVIS_PHP_VERSION} != "7.3" ]]; then
-        echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
-      fi
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]] ; then echo "yes" | pecl install apcu-5.1.3 || true; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]] ; then echo "yes" | pecl install apcu-4.0.11 || true; fi
   - echo -e "extension = apcu.so\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
php-memcached supports PHP 7.3 now.(https://pecl.php.net/package/memcached)
So I activated it in CI.

The reason why [the latest build](https://travis-ci.org/cakephp/cakephp/jobs/473064425) is not executed is that mcrypt could not be installed.
But since mcrypt is also compatible with PHP 7.3(https://pecl.php.net/package/mcrypt), it will be built.

