### PR TITLE
Add previous exception in BaseErrorHandler logging

### DIFF
--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\Error;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Error\ErrorHandler;
 use Cake\Error\PHP7ErrorException;
 use Cake\Http\Exception\ForbiddenException;
@@ -342,6 +343,32 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->handleException($error);
 
         Configure::write('debug', false);
+        $errorHandler->handleException($error);
+    }
+
+    /**
+     * test logging attributes with previous exception
+     *
+     * @return void
+     */
+    public function testHandleExceptionLogPrevious()
+    {
+        $errorHandler = new TestErrorHandler([
+            'log' => true,
+            'trace' => true,
+        ]);
+
+        $previous = new \Cake\Datasource\Exception\RecordNotFoundException('Previous logged');
+        $error = new \Cake\Http\Exception\NotFoundException('Kaboom!', null, $previous);
+
+        $this->_logger->expects($this->at(0))
+            ->method('log')
+            ->with('error', $this->logicalAnd(
+                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
+                $this->stringContains('Caused by: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged'),
+                $this->stringContains('ErrorHandlerTest->testHandleExceptionLogPrevious')
+            ));
+
         $errorHandler->handleException($error);
     }
 


### PR DESCRIPTION
Add previous exceptions to BaseErrorHandler logs. Previously added in #12738 and #12673 for ErrorHandlerMiddleware. This PR implementes the same in BaseErrorHandler.