### PR TITLE
Allow field to be an array for validation and rules

### DIFF
--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -129,12 +129,13 @@ class RuleInvoker
         } else {
             $message = [$message];
         }
-        $errorField = $this->options['errorField'];
-        $entity->setError($errorField, $message);
-
-        if ($entity instanceof InvalidPropertyInterface && isset($entity->{$errorField})) {
-            $invalidValue = $entity->{$errorField};
-            $entity->setInvalidField($errorField, $invalidValue);
+        $errorFields = (array)$this->options['errorField'];
+        foreach ($errorFields as $errorField) {
+            $entity->setError($errorField, $message);
+            if ($entity instanceof InvalidPropertyInterface && isset($entity->{$errorField})) {
+                $invalidValue = $entity->{$errorField};
+                $entity->setInvalidField($errorField, $invalidValue);
+            }
         }
 
         return $pass === true;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -426,6 +426,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * then rules list for the field will be replaced with second argument and
      * third argument will be ignored.
      *
+     * The first argument can be an array of fields if you wish for the rule to
+     * apply to multiple fields.
+     *
      * ### Example:
      *
      * ```
@@ -437,28 +440,35 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *          'size' => ['rule' => ['lengthBetween', 8, 20]],
      *          'hasSpecialCharacter' => ['rule' => 'validateSpecialchar', 'message' => 'not valid']
      *      ]);
+     *
+     *      $validator
+     *          ->add(['title', 'description'], 'required', ['rule' => 'notBlank']);
+     *
      * ```
      *
-     * @param string $field The name of the field from which the rule will be added
+     * @param array|string $field The name of the field from which the rule will be added
      * @param array|string $name The alias for a single rule or multiple rules array
      * @param array|\Cake\Validation\ValidationRule $rule the rule to add
      * @return $this
      */
     public function add($field, $name, $rule = [])
     {
-        $validationSet = $this->field($field);
+        $fields = (array)$field;
+        foreach ($fields as $field) {
+            $validationSet = $this->field($field);
 
-        if (!is_array($name)) {
-            $rules = [$name => $rule];
-        } else {
-            $rules = $name;
-        }
-
-        foreach ($rules as $name => $rule) {
-            if (is_array($rule)) {
-                $rule += ['rule' => $name];
+            if (!is_array($name)) {
+                $rules = [$name => $rule];
+            } else {
+                $rules = $name;
             }
-            $validationSet->add($name, $rule);
+
+            foreach ($rules as $name => $rule) {
+                if (is_array($rule)) {
+                    $rule += ['rule' => $name];
+                }
+                $validationSet->add($name, $rule);
+            }
         }
 
         return $this;

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -199,4 +199,37 @@ class RulesCheckerTest extends TestCase
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
         $this->assertEmpty($entity->getErrors());
     }
+
+    /**
+     * Test that errors are present on multiple fields if errorField is
+     * passed as an array.
+     *
+     * @group mygroup
+     * @return void
+     */
+    public function testAddToMultipleFieldsUsingArray()
+    {
+        $entity = new Entity([
+            'one' => 'One',
+            'two' => 'Two',
+        ]);
+
+        $rules = new RulesChecker();
+        $rule = function () {
+            return false;
+        };
+        $msg = 'Something is wrong with both one and two.';
+        $options = [
+            'errorField' => ['one', 'two'],
+            'message' => $msg,
+        ];
+        $rules->add($rule, $options);
+        $expected = [
+            'one' => [$msg],
+            'two' => [$msg],
+        ];
+
+        $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
+        $this->assertEquals($expected, $entity->getErrors());
+    }
 }

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -204,7 +204,6 @@ class RulesCheckerTest extends TestCase
      * Test that errors are present on multiple fields if errorField is
      * passed as an array.
      *
-     * @group mygroup
      * @return void
      */
     public function testAddToMultipleFieldsUsingArray()

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -104,6 +104,38 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Testing that field can be passed as an array to apply
+     * the rule to multiple fields.
+     *
+     * @group mygroup
+     * @return void
+     */
+    public function testAddingRulesToMultipleFields()
+    {
+        $validator = new Validator();
+        $rule = function () {
+            return false;
+        };
+        $message = 'This should apply to both one and two.';
+        $options = [
+            'rule' => $rule,
+            'message' => $message,
+        ];
+        $validator->add(['one', 'two'], 'one-and-two-are-wrong', $options);
+
+        $data = [
+            'one' => '1',
+            'two' => '2',
+        ];
+        $expected = [
+            'one' => ['one-and-two-are-wrong' => $message],
+            'two' => ['one-and-two-are-wrong' => $message],
+        ];
+
+        $this->assertEquals($expected, $validator->errors($data));
+    }
+
+    /**
      * Testing addNested field rules
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -107,7 +107,6 @@ class ValidatorTest extends TestCase
      * Testing that field can be passed as an array to apply
      * the rule to multiple fields.
      *
-     * @group mygroup
      * @return void
      */
     public function testAddingRulesToMultipleFields()


### PR DESCRIPTION
Allow for multiple fields to be passed to application rules, and when creating validation rules.

Issue reference: #12676

I thought this was already possible.  When looking into it I noticed the open issue so I decided to give it a shot as it seemed easy enough.  A few concerns with this change:

- It seems like it was *too easy* which makes me think I am probably overlooking something (or a lot of things). I don't have a lot of knowledge in this area of the framework.
- This does add a performance penalty due to casting the field as an array and iterating (even if only one field is passed, iteration now occurs). Not sure if the performance penalty is negligable or not.
- Given how easy it is to achieve this in userland code, I'm honestly not sure it's a worthy addition, so take it or leave it.  For example:

```php
$fields = ['title', 'description'];
foreach ($fields as $field) {
    $rules->add(//...
}
```
