### PR TITLE
Add unit test for timezone conversion

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -966,23 +966,32 @@ class CakeTimeTest extends CakeTestCase {
  */
 	public function testFromStringWithDateTime() {
 		date_default_timezone_set('UTC');
-
 		$date = new DateTime('+1 hour', new DateTimeZone('America/New_York'));
 		$result = $this->Time->fromString($date, 'UTC');
 		$date->setTimezone(new DateTimeZone('UTC'));
 		$expected = $date->format('U') + $date->getOffset();
-
 		$this->assertWithinMargin($expected, $result, 1);
+		$this->_restoreSystemTimezone();
+	}
 
+	public function testFromStringWithDateTimeAsia() {
 		date_default_timezone_set('Australia/Melbourne');
-
 		$date = new DateTime('+1 hour', new DateTimeZone('America/New_York'));
 		$result = $this->Time->fromString($date, 'Asia/Kuwait');
-
 		$date->setTimezone(new DateTimeZone('Asia/Kuwait'));
 		$expected = $date->format('U') + $date->getOffset();
 		$this->assertWithinMargin($expected, $result, 1);
+		$this->_restoreSystemTimezone();
+	}
 
+	public function testFromStringTimezoneConversionToUTC() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
+		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
+		// Convert to UTC.
+		$actual = CakeTime::fromString($clientDateTime, 'UTC');
+		$expected = 1548900000; // '2019-01-31 03:00:00' timestamp
+		$this->assertEquals($expected, $actual);
 		$this->_restoreSystemTimezone();
 	}
 
@@ -1087,6 +1096,15 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testConvertTimezoneConversionToUTC() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$serverTime = 1548903600; // '2019-01-31 04:00:00' timestamp
+		$actual = CakeTime::convert($serverTime, 'UTC');
+		$expected = 1548900000; // '2019-01-31 03:00:00' timestamp
+		$this->assertEquals($expected, $actual);
+		$this->_restoreSystemTimezone();
+	}
+
 /**
  * test convert %e on Windows.
  *
@@ -1147,6 +1165,16 @@ class CakeTimeTest extends CakeTestCase {
 		$result = $this->Time->i18nFormat('invalid date', '%x', 'Date invalid');
 		$expected = 'Date invalid';
 		$this->assertEquals($expected, $result);
+	}
+
+	public function testI18nFormatTimezoneConversionToUTC() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
+		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
+		// Convert to UTC.
+		$actual = CakeTime::i18nFormat($clientDateTime, '%Y-%m-%d %H:%M:%S', false, 'UTC');
+		$this->assertEquals('2019-01-31 03:00:00', $actual);
+		$this->_restoreSystemTimezone();
 	}
 
 /**
@@ -1226,23 +1254,14 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected->format('Y-m-d H:i'), $converted);
 	}
 
-	public function testTimezoneConversionToUTC() {
+	public function testFormatTimezoneConversionToUTC() {
 		date_default_timezone_set('Europe/Copenhagen'); // server timezone
 		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
 		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
 		// Convert to UTC.
 		$actual = CakeTime::format($clientDateTime, '%Y-%m-%d %H:%M:%S', false, 'UTC');
 		$this->assertEquals('2019-01-31 03:00:00', $actual);
-	}
-
-	public function testTimezoneConversionToUTCPlainPHP() {
-		date_default_timezone_set('Europe/Copenhagen'); // server timezone
-		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
-		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
-		// Convert to UTC.
-		$clientDateTime->setTimezone(new DateTimeZone('UTC'));
-		$actual = $clientDateTime->format('Y-m-d H:i:s');
-		$this->assertEquals('2019-01-31 03:00:00', $actual);
+		$this->_restoreSystemTimezone();
 	}
 
 }

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -1037,7 +1037,6 @@ class CakeTimeTest extends CakeTestCase {
 		$this->_restoreSystemTimezone();
 	}
 
-
 /**
  * test converting time specifiers using a time definition localfe file
  *

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -421,6 +421,18 @@ class CakeTimeTest extends CakeTestCase {
 		$this->_restoreSystemTimezone();
 	}
 
+	public function testNiceTimezoneConversion() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
+		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
+		// Convert to UTC.
+		$actual = CakeTime::nice($clientDateTime, 'UTC', '%Y-%m-%d %H:%M:%S');
+		$clientDateTime->setTimezone(new DateTimeZone('UTC'));
+		$expected = $clientDateTime->format('Y-m-d H:i:s');
+		$this->assertEquals($expected, $actual);
+		$this->_restoreSystemTimezone();
+	}
+
 /**
  * testNiceShort method
  *

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -1235,4 +1235,14 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals('2019-01-31 03:00:00', $actual);
 	}
 
+	public function testTimezoneConversionToUTCPlainPHP() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
+		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
+		// Convert to UTC.
+		$clientDateTime->setTimezone(new DateTimeZone('UTC'));
+		$actual = $clientDateTime->format('Y-m-d H:i:s');
+		$this->assertEquals('2019-01-31 03:00:00', $actual);
+	}
+
 }

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -1226,4 +1226,13 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected->format('Y-m-d H:i'), $converted);
 	}
 
+	public function testTimezoneConversionToUTC() {
+		date_default_timezone_set('Europe/Copenhagen'); // server timezone
+		$clientTimeZone = new DateTimeZone('Asia/Bangkok');
+		$clientDateTime = new DateTime('2019-01-31 10:00:00', $clientTimeZone);
+		// Convert to UTC.
+		$actual = CakeTime::format($clientDateTime, '%Y-%m-%d %H:%M:%S', false, 'UTC');
+		$this->assertEquals('2019-01-31 03:00:00', $actual);
+	}
+
 }

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -369,7 +369,7 @@ class CakeTime {
 			$format = static::$niceFormat;
 		}
 		$convertedFormat = static::convertSpecifiers($format, $timestamp);
-		return static::__strftime($convertedFormat, $timestamp, $date, $timezone);
+		return static::__strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -394,19 +394,19 @@ class CakeTime {
 		$timestamp = static::fromString($date, $timezone);
 
 		if (static::isToday($date, $timezone)) {
-			$formattedDate = static::__strftime("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Today, %s', $formattedDate);
 		}
 		if (static::wasYesterday($date, $timezone)) {
-			$formattedDate = static::__strftime("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Yesterday, %s', $formattedDate);
 		}
 		if (static::isTomorrow($date, $timezone)) {
-			$formattedDate = static::__strftime("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Tomorrow, %s', $formattedDate);
 		}
 
-		$d = static::__strftime("%w", $timestamp, $date, $timezone);
+		$d = static::__strftimeWithTimezone("%w", $timestamp, $date, $timezone);
 		$day = array(
 			__d('cake', 'Sunday'),
 			__d('cake', 'Monday'),
@@ -417,11 +417,11 @@ class CakeTime {
 			__d('cake', 'Saturday')
 		);
 		if (static::wasWithinLast('7 days', $date, $timezone)) {
-			$formattedDate = static::__strftime(static::$niceShortFormat, $timestamp, $date, $timezone);
+			$formattedDate = static::__strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
 			return sprintf('%s %s', $day[$d], $formattedDate);
 		}
 		if (static::isWithinNext('7 days', $date, $timezone)) {
-			$formattedDate = static::__strftime(static::$niceShortFormat, $timestamp, $date, $timezone);
+			$formattedDate = static::__strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
 			return __d('cake', 'On %s %s', $day[$d], $formattedDate);
 		}
 
@@ -430,7 +430,7 @@ class CakeTime {
 			$y = ' %Y';
 		}
 		$format = static::convertSpecifiers("%b %eS{$y}, %H:%M", $timestamp);
-		return static::__strftime($format, $timestamp, $date, $timezone);
+		return static::__strftimeWithTimezone($format, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -1072,7 +1072,7 @@ class CakeTime {
 			$format = '%x';
 		}
 		$convertedFormat = static::convertSpecifiers($format, $timestamp);
-		return static::__strftime($convertedFormat, $timestamp, $date, $timezone);
+		return static::__strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -1193,7 +1193,7 @@ class CakeTime {
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object.
  * @return string Formatted date string with correct encoding.
  */
-	private static function __strftime($format, $timestamp, $date, $timezone) {
+	private static function __strftimeWithTimezone($format, $timestamp, $date, $timezone) {
 		$serverTimeZone = date_default_timezone_get();
 		if (
 			!empty($timezone) &&

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -369,7 +369,7 @@ class CakeTime {
 			$format = static::$niceFormat;
 		}
 		$convertedFormat = static::convertSpecifiers($format, $timestamp);
-		return static::__strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
+		return static::_strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -394,19 +394,19 @@ class CakeTime {
 		$timestamp = static::fromString($date, $timezone);
 
 		if (static::isToday($date, $timezone)) {
-			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::_strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Today, %s', $formattedDate);
 		}
 		if (static::wasYesterday($date, $timezone)) {
-			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::_strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Yesterday, %s', $formattedDate);
 		}
 		if (static::isTomorrow($date, $timezone)) {
-			$formattedDate = static::__strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
+			$formattedDate = static::_strftimeWithTimezone("%H:%M", $timestamp, $date, $timezone);
 			return __d('cake', 'Tomorrow, %s', $formattedDate);
 		}
 
-		$d = static::__strftimeWithTimezone("%w", $timestamp, $date, $timezone);
+		$d = static::_strftimeWithTimezone("%w", $timestamp, $date, $timezone);
 		$day = array(
 			__d('cake', 'Sunday'),
 			__d('cake', 'Monday'),
@@ -417,11 +417,11 @@ class CakeTime {
 			__d('cake', 'Saturday')
 		);
 		if (static::wasWithinLast('7 days', $date, $timezone)) {
-			$formattedDate = static::__strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
+			$formattedDate = static::_strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
 			return sprintf('%s %s', $day[$d], $formattedDate);
 		}
 		if (static::isWithinNext('7 days', $date, $timezone)) {
-			$formattedDate = static::__strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
+			$formattedDate = static::_strftimeWithTimezone(static::$niceShortFormat, $timestamp, $date, $timezone);
 			return __d('cake', 'On %s %s', $day[$d], $formattedDate);
 		}
 
@@ -430,7 +430,7 @@ class CakeTime {
 			$y = ' %Y';
 		}
 		$format = static::convertSpecifiers("%b %eS{$y}, %H:%M", $timestamp);
-		return static::__strftimeWithTimezone($format, $timestamp, $date, $timezone);
+		return static::_strftimeWithTimezone($format, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -1072,7 +1072,7 @@ class CakeTime {
 			$format = '%x';
 		}
 		$convertedFormat = static::convertSpecifiers($format, $timestamp);
-		return static::__strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
+		return static::_strftimeWithTimezone($convertedFormat, $timestamp, $date, $timezone);
 	}
 
 /**
@@ -1193,7 +1193,7 @@ class CakeTime {
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object.
  * @return string Formatted date string with correct encoding.
  */
-	private static function __strftimeWithTimezone($format, $timestamp, $date, $timezone) {
+	protected static function _strftimeWithTimezone($format, $timestamp, $date, $timezone) {
 		$serverTimeZone = date_default_timezone_get();
 		if (
 			!empty($timezone) &&

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -239,7 +239,7 @@ class CakeTime {
 /**
  * Converts given time (in server's time zone) to user's local time, given his/her timezone.
  *
- * @param integer $serverTime Server's timestamp.
+ * @param int $serverTime Server's timestamp.
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object.
  * @return int User's timezone timestamp.
  * @link https://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::convert

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -327,7 +327,7 @@ class CakeTime {
 		) {
 			$clone = clone $dateString;
 			$clone->setTimezone(new DateTimeZone(date_default_timezone_get()));
-			$date = (int)$clone->format('U') + $clone->getOffset();
+			$date = (int)$clone->format('U')/* + $clone->getOffset()*/;
 		} elseif ($dateString instanceof DateTime) {
 			$date = (int)$dateString->format('U');
 		} else {

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -1074,9 +1074,7 @@ class CakeTime {
 			date_default_timezone_set($timezone);
 		}
 		$result = static::_strftime(static::convertSpecifiers($format, $timestamp), $timestamp);
-		if (!empty($serverTimeZone)) {
-			date_default_timezone_set($serverTimeZone);
-		}
+		date_default_timezone_set($serverTimeZone);
 		return $result;
 	}
 


### PR DESCRIPTION
According to https://www.timeanddate.com/worldclock/converter.html?iso=20190131T030000&p1=28&p2=69&p3=136 '2019-01-31 10:00:00' in Bangkok is '2019-01-31 03:00:00' in UTC. Does this failing test mean that there is a bug in CakeTime class?