### PR TITLE
Patching search data in findOrCreate to ensure valid entity

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1730,7 +1730,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         $entity = $this->newEntity();
         if ($options['defaults'] && is_array($search)) {
-            $entity->set($search, ['guard' => false]);
+            $entity = $this->patchEntity($entity, $search, ['guard' => false]);
         }
         if ($callback !== null) {
             $entity = $callback($entity) ?: $entity;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1730,7 +1730,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         $entity = $this->newEntity();
         if ($options['defaults'] && is_array($search)) {
-            $entity = $this->patchEntity($entity, $search, ['guard' => false]);
+            $accessibleFields = array_combine(array_keys($search), array_fill(0, count($search), true));
+            $entity = $this->patchEntity($entity, $search, ['accessibleFields' => $accessibleFields]);
         }
         if ($callback !== null) {
             $entity = $callback($entity) ?: $entity;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1737,7 +1737,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         unset($options['defaults']);
 
-        return $this->save($entity, $options) ?: $entity;
+        $result = $this->save($entity, $options);
+
+        if ($result === false) {
+            throw new PersistenceFailedException($entity, ['findOrCreate']);
+        }
+
+        return $entity;
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -53,6 +53,7 @@ class ProtectedEntity extends Entity
 {
     protected $_accessible = [
         'id' => true,
+        'title' => false,
     ];
 }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -49,6 +49,13 @@ class UsersTable extends Table
 
 }
 
+class ProtectedEntity extends Entity
+{
+    protected $_accessible = [
+        'id' => true,
+    ];
+}
+
 /**
  * Tests Table class
  */
@@ -5857,6 +5864,24 @@ class TableTest extends TestCase
         $articles->setValidator('default', $validator);
 
         $articles->findOrCreate(['title' => '']);
+    }
+
+    /**
+     * Test that findOrCreate allows patching of all $search keys
+     *
+     * @return void
+     */
+    public function testFindOrCreateAccessibleFields()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->setEntityClass(ProtectedEntity::class);
+        $validator = new Validator();
+        $validator->notBlank('title');
+        $articles->setValidator('default', $validator);
+
+        $article = $articles->findOrCreate(['title' => 'test']);
+        $this->assertInstanceOf(ProtectedEntity::class, $article);
+        $this->assertSame('test', $article->title);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5840,6 +5840,24 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test that findOrCreate creates a new valid entity with the search data
+     *
+     * @return void
+     */
+    public function testFindOrCreateValidatesNewEntity()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $validator = new Validator();
+        $validator->notBlank('title');
+        $articles->setValidator('default', $validator);
+
+        $article = $articles->findOrCreate(['title' => '']);
+        $this->assertTrue($article->isNew());
+        $this->assertNotEmpty($article->getError('title'));
+        $this->assertNull($article->id);
+    }
+
+    /**
      * Test that creating a table fires the initialize event.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -32,6 +32,7 @@ use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
+use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\SaveOptionsBuilder;
@@ -5840,21 +5841,22 @@ class TableTest extends TestCase
     }
 
     /**
-     * Test that findOrCreate creates a new valid entity with the search data
+     * Test that findOrCreate throws a PersistenceFailedException when it cannot save
+     * an entity created from $search
      *
      * @return void
      */
-    public function testFindOrCreateValidatesNewEntity()
+    public function testFindOrCreateWithInvalidEntity()
     {
+        $this->expectException(PersistenceFailedException::class);
+        $this->expectExceptionMessage('Entity findOrCreate failure (title: "_empty").');
+
         $articles = $this->getTableLocator()->get('Articles');
         $validator = new Validator();
         $validator->notBlank('title');
         $articles->setValidator('default', $validator);
 
-        $article = $articles->findOrCreate(['title' => '']);
-        $this->assertTrue($article->isNew());
-        $this->assertNotEmpty($article->getError('title'));
-        $this->assertNull($article->id);
+        $articles->findOrCreate(['title' => '']);
     }
 
     /**


### PR DESCRIPTION
`Table::findOrCreate` can create and persist invalid entities as it doesn't apply any validation when creating a new entity from the `$search`.

I'm not sure if this is a bug or a feature. I personally see it as a bug, but I can see how `findOrCreate` not returning a persisted entity could be seen as a bug too. It's also a behavior change, so it might be that this needs to go in 3.next.