### PR TITLE
4.x Associations should use finder for replace operations

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -854,11 +854,9 @@ abstract class Association
      */
     public function exists($conditions): bool
     {
-        if ($this->_conditions) {
-            $conditions = $this
-                ->find('all', ['conditions' => $conditions])
-                ->clause('where');
-        }
+        $conditions = $this->find()
+            ->where($conditions)
+            ->clause('where');
 
         return $this->getTarget()->exists($conditions);
     }
@@ -874,13 +872,11 @@ abstract class Association
      */
     public function updateAll(array $fields, $conditions): int
     {
-        $target = $this->getTarget();
-        $expression = $target->query()
-            ->where($this->getConditions())
+        $expression = $this->find()
             ->where($conditions)
             ->clause('where');
 
-        return $target->updateAll($fields, $expression);
+        return $this->getTarget()->updateAll($fields, $expression);
     }
 
     /**
@@ -893,13 +889,11 @@ abstract class Association
      */
     public function deleteAll($conditions): int
     {
-        $target = $this->getTarget();
-        $expression = $target->query()
-            ->where($this->getConditions())
+        $expression = $this->find()
             ->where($conditions)
             ->clause('where');
 
-        return $target->deleteAll($expression);
+        return $this->getTarget()->deleteAll($expression);
     }
 
     /**

--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -52,8 +52,7 @@ class DependentDeleteHelper
 
             return true;
         }
-        $conditions = array_merge($conditions, $association->getConditions());
 
-        return (bool)$table->deleteAll($conditions);
+        return (bool)$association->deleteAll($conditions);
     }
 }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -509,7 +509,7 @@ class HasMany extends Association
                         $entry->setField($target->aliasField($entry->getField()));
                     }
                 });
-                $query = $this->find('all')->where($conditions);
+                $query = $this->find()->where($conditions);
                 $ok = true;
                 foreach ($query as $assoc) {
                     $ok = $ok && $target->delete($assoc, $options);
@@ -518,15 +518,13 @@ class HasMany extends Association
                 return $ok;
             }
 
-            $conditions = array_merge($conditions, $this->getConditions());
-            $target->deleteAll($conditions);
+            $this->deleteAll($conditions);
 
             return true;
         }
 
         $updateFields = array_fill_keys($foreignKey, null);
-        $conditions = array_merge($conditions, $this->getConditions());
-        $target->updateAll($updateFields, $conditions);
+        $this->updateAll($updateFields, $conditions);
 
         return true;
     }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -287,6 +287,30 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Ensure that the `finder` option is applied to the target
+     * table.
+     *
+     * @return void
+     */
+    public function testFinderOption()
+    {
+        $this->setAppNamespace('TestApp');
+
+        $articles = $this->getTableLocator()->get('Articles');
+        $tags = $this->getTableLocator()->get('Tags');
+
+        $assoc = $tags->belongsToMany('Articles', [
+            'sourceTable' => $tags,
+            'targetTable' => $articles,
+            'finder' => 'published',
+        ]);
+        $articles->updateAll(['published' => 'N'], ['id' => 1]);
+        $entity = $tags->get(1, ['contain' => 'Articles']);
+        $this->assertCount(1, $entity->articles, 'only one article should load');
+        $this->assertSame('Y', $entity->articles[0]->published);
+    }
+
+    /**
      * Test cascading deletes.
      *
      * @return void

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -41,6 +41,7 @@ class HasManyTest extends TestCase
         'core.Articles',
         'core.Authors',
         'core.ArticlesTags',
+        'core.Tags',
     ];
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -40,6 +40,7 @@ class HasManyTest extends TestCase
         'core.Comments',
         'core.Articles',
         'core.Authors',
+        'core.ArticlesTags',
     ];
 
     /**
@@ -50,6 +51,8 @@ class HasManyTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $this->setAppNamespace('TestApp');
+
         $this->author = $this->getTableLocator()->get('Authors', [
             'schema' => [
                 'id' => ['type' => 'integer'],
@@ -457,23 +460,56 @@ class HasManyTest extends TestCase
      */
     public function testCascadeDelete()
     {
+        $articles = $this->getTableLocator()->get('Articles');
         $config = [
             'dependent' => true,
             'sourceTable' => $this->author,
-            'targetTable' => $this->article,
-            'conditions' => ['Articles.is_active' => true],
+            'targetTable' => $articles,
+            'conditions' => ['Articles.published' => 'Y'],
         ];
         $association = new HasMany('Articles', $config);
 
-        $this->article->expects($this->once())
-            ->method('deleteAll')
-            ->with([
-                'Articles.is_active' => true,
-                'Articles.author_id' => 1,
+        $entity = new Entity(['id' => 1, 'name' => 'PHP']);
+        $this->assertTrue($association->cascadeDelete($entity));
+
+        $published = $articles
+            ->find('published')
+            ->where([
+                'published' => 'Y',
+                'author_id' => 1,
             ]);
+        $this->assertCount(0, $published->all());
+    }
+
+    /**
+     * Test cascading deletes with a finder
+     *
+     * @return void
+     */
+    public function testCascadeDeleteFinder()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $config = [
+            'dependent' => true,
+            'sourceTable' => $this->author,
+            'targetTable' => $articles,
+            'finder' => 'published',
+        ];
+        // Exclude one record from the association finder
+        $articles->updateAll(
+            ['published' => 'N'],
+            ['author_id' => 1, 'title' => 'First Article']
+        );
+        $association = new HasMany('Articles', $config);
 
         $entity = new Entity(['id' => 1, 'name' => 'PHP']);
-        $association->cascadeDelete($entity);
+        $this->assertTrue($association->cascadeDelete($entity));
+
+        $published = $articles->find('published')->where(['author_id' => 1]);
+        $this->assertCount(0, $published->all(), 'Associated records should be removed');
+
+        $all = $articles->find()->where(['author_id' => 1]);
+        $this->assertCount(1, $all->all(), 'Record not in association finder should remain');
     }
 
     /**
@@ -1090,13 +1126,15 @@ class HasManyTest extends TestCase
             'dependent' => true,
         ]);
         $articles = $authors->Articles->getTarget();
+
+        // Remove an article from the association finder scope
         $articles->updateAll(['published' => 'N'], ['author_id' => 1, 'title' => 'Third Article']);
 
         $entity = $authors->get(1, ['contain' => ['Articles']]);
         $data = [
             'name' => 'updated',
             'articles' => [
-                ['title' => 'First Article', 'body' => 'New First', 'published' => 'N'],
+                ['title' => 'New First', 'body' => 'New First', 'published' => 'Y'],
             ],
         ];
         $entity = $authors->patchEntity($entity, $data, ['associated' => ['Articles']]);
@@ -1104,18 +1142,23 @@ class HasManyTest extends TestCase
 
         // Should only have one article left as we 'replaced' the others.
         $this->assertCount(1, $entity->articles);
-        $this->assertCount(1, $authors->Articles->find()->toArray());
+
+        // No additional records in db.
+        $this->assertCount(
+            1,
+            $authors->Articles->find()->where(['author_id' => 1])->toArray()
+        );
 
         $others = $articles->find('all')
-            ->where(['Articles.author_id' => 1])
+            ->where(['Articles.author_id' => 1, 'published' => 'N'])
             ->orderAsc('title')
             ->toArray();
         $this->assertCount(
             1,
             $others,
-            'Record not matching condition should stay. But does not'
+            'Record not matching association condition should stay'
         );
-        $this->assertSame('First Article', $others[0]->title);
+        $this->assertSame('Third Article', $others[0]->title);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3570,8 +3570,8 @@ class TableTest extends TestCase
                 'name' => 'Another Something',
             ]),
         ];
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags');
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags');
         $this->assertSame($entity, $table->save($entity));
         $this->assertFalse($entity->isNew());
         $this->assertFalse($entity->tags[0]->isNew());
@@ -3715,12 +3715,12 @@ class TableTest extends TestCase
      */
     public function testSaveBelongsToManyDeleteAllLinks()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags', [
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags', [
             'saveStrategy' => 'replace',
         ]);
 
-        $entity = $table->get(1, ['contain' => 'tags']);
+        $entity = $table->get(1, ['contain' => 'Tags']);
         $this->assertCount(2, $entity->tags, 'Fixture data did not change.');
 
         $entity->tags = [];
@@ -3728,7 +3728,7 @@ class TableTest extends TestCase
         $this->assertSame($result, $entity);
         $this->assertSame([], $entity->tags, 'No tags on the entity.');
 
-        $entity = $table->get(1, ['contain' => 'tags']);
+        $entity = $table->get(1, ['contain' => 'Tags']);
         $this->assertSame([], $entity->tags, 'No tags in the db either.');
     }
 
@@ -3740,12 +3740,12 @@ class TableTest extends TestCase
      */
     public function testSaveBelongsToManyDeleteSomeLinks()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags', [
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags', [
             'saveStrategy' => 'replace',
         ]);
 
-        $entity = $table->get(1, ['contain' => 'tags']);
+        $entity = $table->get(1, ['contain' => 'Tags']);
         $this->assertCount(2, $entity->tags, 'Fixture data did not change.');
 
         $tag = new Entity([
@@ -3757,7 +3757,7 @@ class TableTest extends TestCase
         $this->assertCount(1, $entity->tags, 'Only one tag left.');
         $this->assertEquals($tag, $entity->tags[0]);
 
-        $entity = $table->get(1, ['contain' => 'tags']);
+        $entity = $table->get(1, ['contain' => 'Tags']);
         $this->assertCount(1, $entity->tags, 'Only one tag in the db.');
         $this->assertEquals($tag->id, $entity->tags[0]->id);
     }
@@ -3769,8 +3769,8 @@ class TableTest extends TestCase
      */
     public function testSaveBelongsToManyIgnoreNonEntityData()
     {
-        $articles = $this->getTableLocator()->get('articles');
-        $article = $articles->get(1, ['contain' => ['tags']]);
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = $articles->get(1, ['contain' => ['Tags']]);
         $article->tags = [
             '_ids' => [2, 1],
         ];
@@ -3858,9 +3858,9 @@ class TableTest extends TestCase
      */
     public function testBelongsToManyIntegration()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags');
-        $article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags');
+        $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $tags = $article->tags;
         $this->assertNotEmpty($tags);
         $tags[] = new \TestApp\Model\Entity\Tag(['name' => 'Something New']);
@@ -4682,9 +4682,9 @@ class TableTest extends TestCase
      */
     public function testReplacelinksBelongsToMany()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags');
-        $tagsTable = $this->getTableLocator()->get('tags');
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags');
+        $tagsTable = $this->getTableLocator()->get('Tags');
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
@@ -4692,12 +4692,12 @@ class TableTest extends TestCase
         $tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
         $tags[] = new \TestApp\Model\Entity\Tag(['name' => 'foo']);
 
-        $table->getAssociation('tags')->replaceLinks($article, $tags);
+        $table->getAssociation('Tags')->replaceLinks($article, $tags);
         $this->assertEquals(2, $article->tags[0]->id);
         $this->assertEquals(3, $article->tags[1]->id);
         $this->assertEquals(4, $article->tags[2]->id);
 
-        $article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+        $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $this->assertCount(3, $article->tags);
         $this->assertEquals(2, $article->tags[0]->id);
         $this->assertEquals(3, $article->tags[1]->id);
@@ -4712,17 +4712,17 @@ class TableTest extends TestCase
      */
     public function testReplacelinksBelongsToManyWithEmpty()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags');
-        $tagsTable = $this->getTableLocator()->get('tags');
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags');
+        $tagsTable = $this->getTableLocator()->get('Tags');
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
         $tags = [];
 
-        $table->getAssociation('tags')->replaceLinks($article, $tags);
+        $table->getAssociation('Tags')->replaceLinks($article, $tags);
         $this->assertSame($tags, $article->tags);
-        $article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+        $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $this->assertEmpty($article->tags);
     }
 
@@ -4734,9 +4734,9 @@ class TableTest extends TestCase
      */
     public function testReplacelinksBelongsToManyWithJoint()
     {
-        $table = $this->getTableLocator()->get('articles');
-        $table->belongsToMany('tags');
-        $tagsTable = $this->getTableLocator()->get('tags');
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags');
+        $tagsTable = $this->getTableLocator()->get('Tags');
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
@@ -4749,9 +4749,9 @@ class TableTest extends TestCase
         ], $options);
         $tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
 
-        $table->getAssociation('tags')->replaceLinks($article, $tags);
+        $table->getAssociation('Tags')->replaceLinks($article, $tags);
         $this->assertSame($tags, $article->tags);
-        $article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+        $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $this->assertCount(2, $article->tags);
         $this->assertEquals(2, $article->tags[0]->id);
         $this->assertEquals(3, $article->tags[1]->id);


### PR DESCRIPTION
Update the `HasMany` and `BelongsToMany` associations so that their 'replace' modes use the defined finder. This reduce the need to duplicate code between finder methods and association conditions.

I've also updated the association proxy methods for `updateAll`, `deleteAll` and `exists` to use the configured finder. The net result of this should be less duplication for association conditions.