### PR TITLE
Add missing convenience method for string body of response

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2099,11 +2099,23 @@ class Response implements ResponseInterface
      *
      * @return string
      */
-    public function __toString()
+    public function getStringBody()
     {
         $this->stream->rewind();
 
         return (string)$this->stream->getContents();
+    }
+
+    /**
+     * String conversion. Fetches the response body as a string.
+     * Does *not* send headers.
+     * If body is a callable, a blank string is returned.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getStringBody();
     }
 
     /**


### PR DESCRIPTION
It is bad to have devs rely on the internals of the stream wrapper here for simple unit testing

e.g.
```php
$this->assertEquals('Hello world!', $this>_response->getBody()->getContents());
// passes
```

BUT

```php
$content = $this->_response->getBody()->getContents();
$this->assertEquals('Hello world!', $content);
// FAILS (as the stream is not rewound)
```

You would have to know that you need to use internal casting here:
```php
$content = (string)$this->_response->getBody(); // magic
$this->assertEquals('Hello world!', $content);
// now passes
```
Or use the _getBodyAsString() method on the integration test case trait, if you are in that scenario. In other tests you also wouldnt have access here.

Having a simple convenience wrapper for this helps a lot to keep the behavior consistent as expected from dev side:

```php
$content = $this->_response->getStringBody();
$this->assertEquals('Hello world!', $content);
// passes now with simple and auto-completed/clear API
```

We can also call it `asString()`. Either way, not just the magic cast should properly rewind to have the expected string representation IMO.

//EDIT
This is also consistent with Client `$response->getStringBody()` then by the way :)