### PR TITLE
Improve error messages when persistence fails

### DIFF
--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -14,6 +14,7 @@ namespace Cake\ORM\Exception;
 
 use Cake\Core\Exception\Exception;
 use Cake\Datasource\EntityInterface;
+use Cake\Utility\Hash;
 
 /**
  * Used when a strict save or delete fails
@@ -47,33 +48,15 @@ class PersistenceFailedException extends Exception
         $this->_entity = $entity;
         if (is_array($message)) {
             $errors = [];
-            foreach ($entity->getErrors() as $field => $error) {
-                $errors[] = $field . ': "' . $this->buildError($error) . '"';
+            foreach (Hash::flatten($entity->getErrors()) as $field => $error) {
+                $errors[] = $field . ': "' . $error . '"';
             }
             if ($errors) {
                 $message[] = implode(', ', $errors);
-                $this->_messageTemplate = 'Entity %s failure (%s).';
+                $this->_messageTemplate = 'Entity %s failure. Found the following errors (%s).';
             }
         }
         parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @param string|array $error Error message.
-     * @return string
-     */
-    protected function buildError($error)
-    {
-        if (!is_array($error)) {
-            return $error;
-        }
-
-        $errors = [];
-        foreach ($error as $key => $message) {
-            $errors[] = is_int($key) ? $message : $key;
-        }
-
-        return implode(', ', $errors);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6414,7 +6414,7 @@ class TableTest extends TestCase
     public function testSaveOrFailErrorDisplay()
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
-        $this->expectExceptionMessage('Entity save failure (field: "Some message", multiple: "one, two")');
+        $this->expectExceptionMessage('Entity save failure. Found the following errors (field.0: "Some message", multiple.one: "One", multiple.two: "Two")');
 
         $entity = new Entity([
             'foo' => 'bar'
@@ -6422,6 +6422,30 @@ class TableTest extends TestCase
         $entity->setError('field', 'Some message');
         $entity->setError('multiple', ['one' => 'One', 'two' => 'Two']);
         $table = $this->getTableLocator()->get('users');
+
+        $table->saveOrFail($entity);
+    }
+
+    /**
+     * Tests that saveOrFail with nested errors
+     *
+     * @return void
+     */
+    public function testSaveOrFailNestedError()
+    {
+        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectExceptionMessage('Entity save failure. Found the following errors (articles.0.title.0: "Bad value")');
+
+        $entity = new Entity([
+            'username' => 'bad',
+            'articles' => [
+                new Entity(['title' => 'not an entity'])
+            ]
+        ]);
+        $entity->articles[0]->setError('title', 'Bad value');
+
+        $table = $this->getTableLocator()->get('Users');
+        $table->hasMany('Articles');
 
         $table->saveOrFail($entity);
     }


### PR DESCRIPTION
When persistence fails error messages should include all the validation errors recursively.

Fixes #12931