### PR TITLE
restrict __ functions to return string (not null)

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -21,13 +21,13 @@ if (!function_exists('__')) {
      *
      * @param string $singular Text to translate.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null The translated text, or null if invalid.
+     * @return string The translated text.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__
      */
-    function __(string $singular, ...$args): ?string
+    function __(string $singular, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -47,13 +47,13 @@ if (!function_exists('__n')) {
      * @param string $plural Plural text.
      * @param int $count Count.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Plural form of translated string, or null if invalid.
+     * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__n
      */
-    function __n(string $singular, string $plural, int $count, ...$args): ?string
+    function __n(string $singular, string $plural, int $count, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -74,13 +74,13 @@ if (!function_exists('__d')) {
      * @param string $domain Domain.
      * @param string $msg String to translate.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Translated string.
+     * @return string Translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__d
      */
-    function __d(string $domain, string $msg, ...$args): ?string
+    function __d(string $domain, string $msg, ...$args): string
     {
         if (!$msg) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -102,13 +102,13 @@ if (!function_exists('__dn')) {
      * @param string $plural Plural.
      * @param int $count Count.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Plural form of translated string.
+     * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dn
      */
-    function __dn(string $domain, string $singular, string $plural, int $count, ...$args): ?string
+    function __dn(string $domain, string $singular, string $plural, int $count, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -131,13 +131,13 @@ if (!function_exists('__x')) {
      * @param string $context Context of the text.
      * @param string $singular Text to translate.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Translated string.
+     * @return string Translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__x
      */
-    function __x(string $context, string $singular, ...$args): ?string
+    function __x(string $context, string $singular, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -160,13 +160,13 @@ if (!function_exists('__xn')) {
      * @param string $plural Plural text.
      * @param int $count Count.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Plural form of translated string.
+     * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__xn
      */
-    function __xn(string $context, string $singular, string $plural, int $count, ...$args): ?string
+    function __xn(string $context, string $singular, string $plural, int $count, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -190,13 +190,13 @@ if (!function_exists('__dx')) {
      * @param string $context Context of the text.
      * @param string $msg String to translate.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Translated string.
+     * @return string Translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dx
      */
-    function __dx(string $domain, string $context, string $msg, ...$args): ?string
+    function __dx(string $domain, string $context, string $msg, ...$args): string
     {
         if (!$msg) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
@@ -223,13 +223,13 @@ if (!function_exists('__dxn')) {
      * @param string $plural Plural text.
      * @param int $count Count.
      * @param array ...$args Array with arguments or multiple arguments in function.
-     * @return string|null Plural form of translated string.
+     * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dxn
      */
-    function __dxn(string $domain, string $context, string $singular, string $plural, int $count, ...$args): ?string
+    function __dxn(string $domain, string $context, string $singular, string $plural, int $count, ...$args): string
     {
         if (!$singular) {
-            return null;
+            return '';
         }
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];


### PR DESCRIPTION
Restricts __ functions to return string according to #12944