### PR TITLE
4.x Make a QueryInterface::getRepository() a real method

### DIFF
--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -21,7 +21,6 @@ namespace Cake\Datasource;
  *
  * @method $this andWhere($conditions, $types = [])
  * @method $this select($fields = [], $overwrite = false)
- * @method \Cake\Datasource\RepositoryInterface getRepository()
  */
 interface QueryInterface
 {
@@ -258,13 +257,21 @@ interface QueryInterface
     public function toArray(): array;
 
     /**
-     * Returns the default repository object that will be used by this query,
-     * that is, the repository that will appear in the from clause.
+     * Set the default Table object that will be used by this query
+     * and form the `FROM` clause.
      *
      * @param \Cake\Datasource\RepositoryInterface $repository The default repository object to use
      * @return $this
      */
     public function repository(RepositoryInterface $repository);
+
+    /**
+     * Returns the default repository object that will be used by this query,
+     * that is, the repository that will appear in the from clause.
+     *
+     * @return \Cake\Datasource\RepositoryInterface|mixed $repository The default repository object to use
+     */
+    public function getRepository();
 
     /**
      * Adds a condition or set of conditions to be used in the WHERE clause for this

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -269,7 +269,7 @@ interface QueryInterface
      * Returns the default repository object that will be used by this query,
      * that is, the repository that will appear in the from clause.
      *
-     * @return \Cake\Datasource\RepositoryInterface|mixed $repository The default repository object to use
+     * @return \Cake\Datasource\RepositoryInterface|null $repository The default repository object to use
      */
     public function getRepository();
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -82,11 +82,8 @@ trait QueryTrait
     protected $_eagerLoaded = false;
 
     /**
-     * Returns the default table object that will be used by this query,
-     * that is, the table that will appear in the from clause.
-     *
-     * When called with a Table argument, the default table object will be set
-     * and this query object will be returned for chaining.
+     * Set the default Table object that will be used by this query
+     * and form the `FROM` clause.
      *
      * @param \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table $table The default table object to use
      * @return $this


### PR DESCRIPTION
This method was marked as a virtual method but there isn't a good reason it can't be a real method in 4.x