### PR TITLE
4.x - Middleware queue updates

### DIFF
--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -97,6 +97,10 @@ class MiddlewareQueue implements Countable, SeekableIterator
             $middleware = new $className();
         }
 
+        if ($middleware instanceof MiddlewareInterface) {
+            return $middleware;
+        }
+
         if (!$middleware instanceof Closure) {
             return new DoublePassDecoratorMiddleware($middleware);
         }

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -252,7 +252,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \SeekableIterator::seek()
      */
-    public function seek($position) {
+    public function seek($position)
+    {
         if (!isset($this->queue[$position])) {
             throw new OutOfBoundsException("Invalid seek position ($position)");
         }
@@ -266,7 +267,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \Iterator::rewind()
      */
-    public function rewind() {
+    public function rewind()
+    {
         $this->position = 0;
     }
 
@@ -276,7 +278,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return \Psr\Http\Server\MiddlewareInterface
      * @see \Iterator::current()
      */
-    public function current() {
+    public function current()
+    {
         return $this->get($this->position);
     }
 
@@ -286,7 +289,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return int
      * @see \Iterator::key()
      */
-    public function key() {
+    public function key()
+    {
         return $this->position;
     }
 
@@ -296,7 +300,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \Iterator::next()
      */
-    public function next() {
+    public function next()
+    {
         ++$this->position;
     }
 
@@ -306,7 +311,8 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return bool
      * @see \Iterator::valid()
      */
-    public function valid() {
+    public function valid()
+    {
         return isset($this->queue[$this->position]);
     }
 }

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -58,26 +58,6 @@ class MiddlewareQueue implements Countable, SeekableIterator
     }
 
     /**
-     * Get the middleware at the provided index.
-     *
-     * @param int $index The index to fetch.
-     * @return \Psr\Http\Server\MiddlewareInterface|null Either the middleware or null
-     *   if the index is undefined.
-     */
-    public function get(int $index): ?MiddlewareInterface
-    {
-        if (!isset($this->queue[$index])) {
-            return null;
-        }
-
-        if ($this->queue[$index] instanceof MiddlewareInterface) {
-            return $this->queue[$index];
-        }
-
-        return $this->queue[$index] = $this->resolve($this->queue[$index]);
-    }
-
-    /**
      * Resolve middleware name to a PSR 15 compliant middleware instance.
      *
      * @param string|callable $middleware The middleware to resolve.
@@ -279,12 +259,20 @@ class MiddlewareQueue implements Countable, SeekableIterator
     /**
      *  Returns the current middleware.
      *
-     * @return \Psr\Http\Server\MiddlewareInterface
+     * @return \Psr\Http\Server\MiddlewareInterface|null
      * @see \Iterator::current()
      */
     public function current()
     {
-        return $this->get($this->position);
+        if (!isset($this->queue[$this->position])) {
+            return null;
+        }
+
+        if ($this->queue[$this->position] instanceof MiddlewareInterface) {
+            return $this->queue[$this->position];
+        }
+
+        return $this->queue[$this->position] = $this->resolve($this->queue[$this->position]);
     }
 
     /**

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -29,7 +29,7 @@ use SeekableIterator;
 
 /**
  * Provides methods for creating and manipulating a "queue" of middleware callables.
- * This queue is used to process a request and response via \Cake\Http\Runner.
+ * This queue is used to process a request and generate response via \Cake\Http\Runner.
  */
 class MiddlewareQueue implements Countable, SeekableIterator
 {

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -26,13 +26,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 class Runner implements RequestHandlerInterface
 {
     /**
-     * The current index in the middleware queue.
-     *
-     * @var int
-     */
-    protected $index = 0;
-
-    /**
      * The middleware queue being run.
      *
      * @var \Cake\Http\MiddlewareQueue
@@ -58,7 +51,7 @@ class Runner implements RequestHandlerInterface
         ?RequestHandlerInterface $fallbackHandler = null
     ): ResponseInterface {
         $this->queue = $queue;
-        $this->index = 0;
+        $this->queue->rewind();
         $this->fallbackHandler = $fallbackHandler;
 
         return $this->handle($request);
@@ -72,9 +65,10 @@ class Runner implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $middleware = $this->queue->get($this->index++);
+        if ($this->queue->valid()) {
+            $middleware = $this->queue->current();
+            $this->queue->next();
 
-        if ($middleware) {
             return $middleware->process($request, $this);
         }
 

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -42,7 +42,7 @@ class Runner implements RequestHandlerInterface
     /**
      * @param \Cake\Http\MiddlewareQueue $queue The middleware queue
      * @param \Psr\Http\Message\ServerRequestInterface $request The Server Request
-     * @param \Psr\Http\Server\RequestHandlerInterface $fallbackHandler Fallback request handler.
+     * @param \Psr\Http\Server\RequestHandlerInterface|null $fallbackHandler Fallback request handler.
      * @return \Psr\Http\Message\ResponseInterface A response object
      */
     public function run(

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -56,7 +56,7 @@ class MiddlewareQueueTest extends TestCase
         };
         $queue = new MiddlewareQueue([$cb]);
         $this->assertCount(1, $queue);
-        $this->assertSame($cb, $queue->get(0)->getCallable());
+        $this->assertSame($cb, $queue->current()->getCallable());
     }
 
     /**
@@ -70,8 +70,9 @@ class MiddlewareQueueTest extends TestCase
         $cb = function () {
         };
         $queue->add($cb);
-        $this->assertSame($cb, $queue->get(0)->getCallable());
-        $this->assertNull($queue->get(1));
+        $this->assertSame($cb, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertNull($queue->current());
     }
 
     /**
@@ -108,8 +109,9 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($two);
         $this->assertCount(2, $queue);
 
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($two, $queue->get(1)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
     }
 
     /**
@@ -146,8 +148,9 @@ class MiddlewareQueueTest extends TestCase
         $queue->prepend($two);
         $this->assertCount(2, $queue);
 
-        $this->assertSame($two, $queue->get(0)->getCallable());
-        $this->assertSame($one, $queue->get(1)->getCallable());
+        $this->assertSame($two, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($one, $queue->current()->getCallable());
     }
 
     /**
@@ -161,8 +164,8 @@ class MiddlewareQueueTest extends TestCase
         $queue->add('Sample');
         $queue->prepend('TestApp\Middleware\SampleMiddleware');
 
-        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(0)->getCallable());
-        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(1)->getCallable());
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->current()->getCallable());
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->current()->getCallable());
     }
 
     /**
@@ -179,8 +182,9 @@ class MiddlewareQueueTest extends TestCase
         $queue->add([$one]);
         $queue->prepend(['TestApp\Middleware\SampleMiddleware']);
 
-        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(0)->getCallable());
-        $this->assertSame($one, $queue->get(1)->getCallable());
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($one, $queue->current()->getCallable());
     }
 
     /**
@@ -200,16 +204,21 @@ class MiddlewareQueueTest extends TestCase
 
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertAt(0, $three)->insertAt(2, $four);
-        $this->assertSame($three, $queue->get(0)->getCallable());
-        $this->assertSame($one, $queue->get(1)->getCallable());
-        $this->assertSame($four, $queue->get(2)->getCallable());
-        $this->assertSame($two, $queue->get(3)->getCallable());
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($four, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
 
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertAt(1, $three);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($three, $queue->get(1)->getCallable());
-        $this->assertSame($two, $queue->get(2)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
     }
 
     /**
@@ -228,8 +237,9 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($one)->insertAt(99, $two);
 
         $this->assertCount(2, $queue);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($two, $queue->get(1)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
     }
 
     /**
@@ -249,9 +259,11 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($one)->insertAt(-1, $two)->insertAt(-1, $three);
 
         $this->assertCount(3, $queue);
-        $this->assertSame($two, $queue->get(0)->getCallable());
-        $this->assertSame($three, $queue->get(1)->getCallable());
-        $this->assertSame($one, $queue->get(2)->getCallable());
+        $this->assertSame($two, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($one, $queue->current()->getCallable());
     }
 
     /**
@@ -272,10 +284,13 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($one)->add($two)->insertBefore(SampleMiddleware::class, $three)->insertBefore(SampleMiddleware::class, $four);
 
         $this->assertCount(4, $queue);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($three, $queue->get(1)->getCallable());
-        $this->assertSame($four, $queue->get(2)->getCallable());
-        $this->assertSame($two, $queue->get(3)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($four, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
 
         $two = SampleMiddleware::class;
         $queue = new MiddlewareQueue();
@@ -285,9 +300,11 @@ class MiddlewareQueueTest extends TestCase
             ->insertBefore(SampleMiddleware::class, $three);
 
         $this->assertCount(3, $queue);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($three, $queue->get(1)->getCallable());
-        $this->assertInstanceOf(SampleMiddleware::class, $queue->get(2)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertInstanceOf(SampleMiddleware::class, $queue->current()->getCallable());
     }
 
     /**
@@ -329,10 +346,13 @@ class MiddlewareQueueTest extends TestCase
             ->insertAfter(SampleMiddleware::class, $four);
 
         $this->assertCount(4, $queue);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($four, $queue->get(1)->getCallable());
-        $this->assertSame($three, $queue->get(2)->getCallable());
-        $this->assertSame($two, $queue->get(3)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($four, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
 
         $one = 'Sample';
         $queue = new MiddlewareQueue();
@@ -342,9 +362,11 @@ class MiddlewareQueueTest extends TestCase
             ->insertAfter('Sample', $three);
 
         $this->assertCount(3, $queue);
-        $this->assertInstanceOf(SampleMiddleware::class, $queue->get(0)->getCallable());
-        $this->assertSame($three, $queue->get(1)->getCallable());
-        $this->assertSame($two, $queue->get(2)->getCallable());
+        $this->assertInstanceOf(SampleMiddleware::class, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
     }
 
     /**
@@ -363,8 +385,10 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($one)->add($two)->insertAfter('InvalidClass', $three);
 
         $this->assertCount(3, $queue);
-        $this->assertSame($one, $queue->get(0)->getCallable());
-        $this->assertSame($two, $queue->get(1)->getCallable());
-        $this->assertSame($three, $queue->get(2)->getCallable());
+        $this->assertSame($one, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($two, $queue->current()->getCallable());
+        $queue->next();
+        $this->assertSame($three, $queue->current()->getCallable());
     }
 }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -243,7 +243,8 @@ class ServerTest extends TestCase
         });
         $server->run();
         $this->assertTrue($this->called, 'Middleware added in the event was not triggered.');
-        $this->assertInstanceOf('Closure', $this->middleware->get(3)->getCallable(), '2nd last middleware is a closure');
+        $this->middleware->seek(3);
+        $this->assertInstanceOf('Closure', $this->middleware->current()->getCallable(), '2nd last middleware is a closure');
     }
 
     /**


### PR DESCRIPTION
- `MiddlewareQueue` now implements `SeekableIterator` to avoid having to maintain iteration index in `Runner`.
- Using a separate array to maintain resolved middleware instances seemed unnecessary, so I got rid of `MiddlewareQueue::$middlewares` and `MiddlewareQueue::$queue` is directly updated now.