### PR TITLE
Use field instead of property for Entity.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -129,7 +129,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
             }
 
             $this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
-            $result->unsetProperty($passwordField);
+            $result->unsetField($passwordField);
         }
         $hidden = $result->getHidden();
         if ($password === null && in_array($passwordField, $hidden)) {

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -129,7 +129,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
             }
 
             $this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
-            $result->unsetField($passwordField);
+            $result->unset($passwordField);
         }
         $hidden = $result->getHidden();
         if ($password === null && in_array($passwordField, $hidden)) {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -162,10 +162,10 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * Returns an array with the requested original fields
      * stored in this entity, indexed by field name.
      *
-     * @param array $field List of fields to be returned
+     * @param array $fields List of fields to be returned
      * @return array
      */
-    public function extractOriginal(array $field);
+    public function extractOriginal(array $fields);
 
     /**
      * Returns an array with only the original fields

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -27,57 +27,57 @@ use JsonSerializable;
 interface EntityInterface extends ArrayAccess, JsonSerializable
 {
     /**
-     * Sets hidden properties.
+     * Sets hidden fields.
      *
-     * @param array $properties An array of properties to hide from array exports.
-     * @param bool $merge Merge the new properties with the existing. By default false.
+     * @param array $fields An array of fields to hide from array exports.
+     * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
-    public function setHidden(array $properties, bool $merge = false);
+    public function setHidden(array $fields, bool $merge = false);
 
     /**
-     * Gets the hidden properties.
+     * Gets the hidden fields.
      *
      * @return array
      */
     public function getHidden(): array;
 
     /**
-     * Sets the virtual properties on this entity.
+     * Sets the virtual fields on this entity.
      *
-     * @param array $properties An array of properties to treat as virtual.
-     * @param bool $merge Merge the new properties with the existing. By default false.
+     * @param array $fields An array of fields to treat as virtual.
+     * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
-    public function setVirtual(array $properties, bool $merge = false);
+    public function setVirtual(array $fields, bool $merge = false);
 
     /**
-     * Gets the virtual properties on this entity.
+     * Gets the virtual fields on this entity.
      *
      * @return array
      */
     public function getVirtual(): array;
 
     /**
-     * Sets the dirty status of a single property.
+     * Sets the dirty status of a single field.
      *
-     * @param string $property the field to set or check status for
-     * @param bool $isDirty true means the property was changed, false means
+     * @param string $field the field to set or check status for
+     * @param bool $isDirty true means the field was changed, false means
      * it was not changed
      * @return $this
      */
-    public function setDirty(string $property, bool $isDirty);
+    public function setDirty(string $field, bool $isDirty);
 
     /**
-     * Checks if the entity is dirty or if a single property of it is dirty.
+     * Checks if the entity is dirty or if a single field of it is dirty.
      *
-     * @param string|null $property The field to check the status for. Null for the whole entity.
-     * @return bool Whether the property was changed or not
+     * @param string|null $field The field to check the status for. Null for the whole entity.
+     * @return bool Whether the field was changed or not
      */
-    public function isDirty(?string $property = null): bool;
+    public function isDirty(?string $field = null): bool;
 
     /**
-     * Gets the dirty properties.
+     * Gets the dirty fields.
      *
      * @return array
      */
@@ -126,22 +126,22 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     public function setError($field, $errors, bool $overwrite = false);
 
     /**
-     * Stores whether or not a property value can be changed or set in this entity.
+     * Stores whether or not a field value can be changed or set in this entity.
      *
-     * @param string|array $property single or list of properties to change its accessibility
-     * @param bool $set true marks the property as accessible, false will
+     * @param string|array $field single or list of fields to change its accessibility
+     * @param bool $set true marks the field as accessible, false will
      * mark it as protected.
      * @return $this
      */
-    public function setAccess($property, bool $set);
+    public function setAccess($field, bool $set);
 
     /**
-     * Checks if a property is accessible
+     * Checks if a field is accessible
      *
-     * @param string $property Property name to check
+     * @param string $field Field name to check
      * @return bool
      */
-    public function isAccessible(string $property): bool;
+    public function isAccessible(string $field): bool;
 
     /**
      * Sets the source alias
@@ -159,72 +159,72 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     public function getSource(): string;
 
     /**
-     * Returns an array with the requested original properties
-     * stored in this entity, indexed by property name.
+     * Returns an array with the requested original fields
+     * stored in this entity, indexed by field name.
      *
-     * @param array $properties List of properties to be returned
+     * @param array $field List of fields to be returned
      * @return array
      */
-    public function extractOriginal(array $properties);
+    public function extractOriginal(array $field);
 
     /**
-     * Returns an array with only the original properties
-     * stored in this entity, indexed by property name.
+     * Returns an array with only the original fields
+     * stored in this entity, indexed by field name.
      *
-     * @param array $properties List of properties to be returned
+     * @param array $fields List of fields to be returned
      * @return array
      */
-    public function extractOriginalChanged(array $properties);
+    public function extractOriginalChanged(array $fields);
 
     /**
-     * Sets one or multiple properties to the specified value
+     * Sets one or multiple fields to the specified value
      *
-     * @param string|array $property the name of property to set or a list of
-     * properties with their respective values
-     * @param mixed $value The value to set to the property or an array if the
+     * @param string|array $field the name of field to set or a list of
+     * fields with their respective values
+     * @param mixed $value The value to set to the field or an array if the
      * first argument is also an array, in which case will be treated as $options
-     * @param array $options options to be used for setting the property. Allowed option
+     * @param array $options options to be used for setting the field. Allowed option
      * keys are `setter` and `guard`
      * @return \Cake\Datasource\EntityInterface
      */
-    public function set($property, $value = null, array $options = []);
+    public function set($field, $value = null, array $options = []);
 
     /**
-     * Returns the value of a property by name
+     * Returns the value of a field by name
      *
-     * @param string $property the name of the property to retrieve
+     * @param string $field the name of the field to retrieve
      * @return mixed
      */
-    public function &get($property);
+    public function &get($field);
 
     /**
-     * Returns whether this entity contains a property named $property
+     * Returns whether this entity contains a field named $field
      * regardless of if it is empty.
      *
-     * @param string|array $property The property to check.
+     * @param string|array $field The field to check.
      * @return bool
      */
-    public function has($property);
+    public function has($field);
 
     /**
-     * Removes a property or list of properties from this entity
+     * Removes a field or list of fields from this entity
      *
-     * @param string|array $property The property to unset.
+     * @param string|array $field The field to unset.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function unsetProperty($property);
+    public function unsetField($field);
 
     /**
-     * Get the list of visible properties.
+     * Get the list of visible fields.
      *
-     * @return array A list of properties that are 'visible' in all representations.
+     * @return array A list of fields that are 'visible' in all representations.
      */
-    public function visibleProperties();
+    public function getVisible(): array;
 
     /**
-     * Returns an array with all the visible properties set in this entity.
+     * Returns an array with all the visible fields set in this entity.
      *
-     * *Note* hidden properties are not visible, and will not be output
+     * *Note* hidden fields are not visible, and will not be output
      * by toArray().
      *
      * @return array
@@ -232,18 +232,18 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     public function toArray();
 
     /**
-     * Returns an array with the requested properties
-     * stored in this entity, indexed by property name
+     * Returns an array with the requested fields
+     * stored in this entity, indexed by field name
      *
-     * @param array $properties list of properties to be returned
-     * @param bool $onlyDirty Return the requested property only if it is dirty
+     * @param array $fields list of fields to be returned
+     * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array
      */
-    public function extract(array $properties, $onlyDirty = false);
+    public function extract(array $fields, $onlyDirty = false);
 
     /**
      * Sets the entire entity as clean, which means that it will appear as
-     * no properties being modified or added at all. This is an useful call
+     * no fields being modified or added at all. This is an useful call
      * for an initial object hydration
      *
      * @return void

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -212,7 +212,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @param string|array $field The field to unset.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function unsetField($field);
+    public function unset($field);
 
     /**
      * Get the list of visible fields.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -160,7 +160,7 @@ trait EntityTrait
      */
     public function __unset($field)
     {
-        $this->unsetField($field);
+        $this->unset($field);
     }
 
     /**
@@ -314,7 +314,7 @@ trait EntityTrait
      *
      * @return array
      */
-    public function getOriginalValues()
+    public function getOriginalValues(): array
     {
         $originals = $this->_original;
         $originalKeys = array_keys($originals);
@@ -354,7 +354,7 @@ trait EntityTrait
      * @param string|array $field The field or fields to check.
      * @return bool
      */
-    public function has($field)
+    public function has($field): bool
     {
         foreach ((array)$field as $prop) {
             if ($this->get($prop) === null) {
@@ -380,7 +380,7 @@ trait EntityTrait
      * @param string $field The field to check.
      * @return bool
      */
-    public function isEmpty($field)
+    public function isEmpty($field): bool
     {
         $value = $this->get($field);
         if ($value === null
@@ -409,7 +409,7 @@ trait EntityTrait
      * @param string $field The field to check.
      * @return bool
      */
-    public function hasValue($field)
+    public function hasValue($field): bool
     {
         return !$this->isEmpty($field);
     }
@@ -420,14 +420,14 @@ trait EntityTrait
      * ### Examples:
      *
      * ```
-     * $entity->unsetField('name');
-     * $entity->unsetField(['name', 'last_name']);
+     * $entity->unset('name');
+     * $entity->unset(['name', 'last_name']);
      * ```
      *
      * @param string|array $field The field to unset.
      * @return $this
      */
-    public function unsetField($field)
+    public function unset($field)
     {
         $field = (array)$field;
         foreach ($field as $p) {
@@ -440,13 +440,13 @@ trait EntityTrait
     /**
      * Removes a field or list of fields from this entity
      *
-     * @deprecated 4.0.0 Use unsetField() instead.
+     * @deprecated 4.0.0 Use unset() instead. Will be removed in 5.0.
      * @param string|array $field The field to unset.
      * @return $this
      */
     public function unsetProperty($field)
     {
-        return $this->unsetField($field);
+        return $this->unset($field);
     }
 
     /**
@@ -531,7 +531,7 @@ trait EntityTrait
     /**
      * Gets the list of visible fields.
      *
-     * @deprecated 4.0.0 Use getVisible() instead.
+     * @deprecated 4.0.0 Use getVisible() instead. Will be removed in 5.0.
      * @return array
      */
     public function visibleProperties(): array
@@ -548,7 +548,7 @@ trait EntityTrait
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $result = [];
         foreach ($this->getVisible() as $field) {
@@ -577,7 +577,7 @@ trait EntityTrait
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->extract($this->getVisible());
     }
@@ -585,10 +585,10 @@ trait EntityTrait
     /**
      * Implements isset($entity);
      *
-     * @param mixed $offset The offset to check.
+     * @param string $offset The offset to check.
      * @return bool Success
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->has($offset);
     }
@@ -596,7 +596,7 @@ trait EntityTrait
     /**
      * Implements $entity[$offset];
      *
-     * @param mixed $offset The offset to get.
+     * @param string $offset The offset to get.
      * @return mixed
      */
     public function &offsetGet($offset)
@@ -607,7 +607,7 @@ trait EntityTrait
     /**
      * Implements $entity[$offset] = $value;
      *
-     * @param mixed $offset The offset to set.
+     * @param string $offset The offset to set.
      * @param mixed $value The value to set.
      * @return void
      */
@@ -619,12 +619,12 @@ trait EntityTrait
     /**
      * Implements unset($result[$offset]);
      *
-     * @param mixed $offset The offset to remove.
+     * @param string $offset The offset to remove.
      * @return void
      */
     public function offsetUnset($offset)
     {
-        $this->unsetField($offset);
+        $this->unset($offset);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -23,7 +23,7 @@ use Traversable;
 
 /**
  * An entity represents a single result row from a repository. It exposes the
- * methods for retrieving and storing properties associated in this row.
+ * methods for retrieving and storing fields associated in this row.
  */
 trait EntityTrait
 {
@@ -59,7 +59,7 @@ trait EntityTrait
     protected $_virtual = [];
 
     /**
-     * Holds a list of the properties that were modified or added after this object
+     * Holds a list of the fields that were modified or added after this object
      * was originally created.
      *
      * @var array
@@ -97,9 +97,9 @@ trait EntityTrait
     protected $_invalid = [];
 
     /**
-     * Map of properties in this entity that can be safely assigned, each
+     * Map of fields in this entity that can be safely assigned, each
      * field name points to a boolean indicating its status. An empty array
-     * means no properties are accessible
+     * means no fields are accessible
      *
      * The special field '\*' can also be mapped, meaning that any other field
      * not defined in the map will take its value. For example, `'\*' => true`
@@ -117,7 +117,7 @@ trait EntityTrait
     protected $_registryAlias = '';
 
     /**
-     * Magic getter to access properties that have been set in this entity
+     * Magic getter to access fields that have been set in this entity
      *
      * @param string $field Name of the field to access
      * @return mixed
@@ -128,10 +128,10 @@ trait EntityTrait
     }
 
     /**
-     * Magic setter to add or edit a property in this entity
+     * Magic setter to add or edit a field in this entity
      *
-     * @param string $field The name of the property to set
-     * @param mixed $value The value to set to the property
+     * @param string $field The name of the field to set
+     * @param mixed $value The value to set to the field
      * @return void
      */
     public function __set($field, $value)
@@ -140,10 +140,10 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a property named $property
+     * Returns whether this entity contains a field named $field
      * regardless of if it is empty.
      *
-     * @param string $field The property to check.
+     * @param string $field The field to check.
      * @return bool
      * @see \Cake\ORM\Entity::has()
      */
@@ -153,9 +153,9 @@ trait EntityTrait
     }
 
     /**
-     * Removes a property from this entity
+     * Removes a field from this entity
      *
-     * @param string $field The property to unset
+     * @param string $field The field to unset
      * @return void
      */
     public function __unset($field)
@@ -164,7 +164,7 @@ trait EntityTrait
     }
 
     /**
-     * Sets a single property inside this entity.
+     * Sets a single field inside this entity.
      *
      * ### Example:
      *
@@ -172,9 +172,9 @@ trait EntityTrait
      * $entity->set('name', 'Andrew');
      * ```
      *
-     * It is also possible to mass-assign multiple properties to this entity
-     * with one call by passing a hashed array as properties in the form of
-     * property => value pairs
+     * It is also possible to mass-assign multiple fields to this entity
+     * with one call by passing a hashed array as fields in the form of
+     * field => value pairs
      *
      * ### Example:
      *
@@ -185,7 +185,7 @@ trait EntityTrait
      * ```
      *
      * Some times it is handy to bypass setter functions in this entity when assigning
-     * properties. You can achieve this by disabling the `setter` option using the
+     * fields. You can achieve this by disabling the `setter` option using the
      * `$options` parameter:
      *
      * ```
@@ -194,25 +194,25 @@ trait EntityTrait
      * ```
      *
      * Mass assignment should be treated carefully when accepting user input, by default
-     * entities will guard all fields when properties are assigned in bulk. You can disable
+     * entities will guard all fields when fields are assigned in bulk. You can disable
      * the guarding for a single set call with the `guard` option:
      *
      * ```
      * $entity->set(['name' => 'Andrew', 'id' => 1], ['guard' => true]);
      * ```
      *
-     * You do not need to use the guard option when assigning properties individually:
+     * You do not need to use the guard option when assigning fields individually:
      *
      * ```
      * // No need to use the guard option.
      * $entity->set('name', 'Andrew');
      * ```
      *
-     * @param string|array $field the name of property to set or a list of
-     * properties with their respective values
-     * @param mixed $value The value to set to the property or an array if the
+     * @param string|array $field the name of field to set or a list of
+     * fields with their respective values
+     * @param mixed $value The value to set to the field or an array if the
      * first argument is also an array, in which case will be treated as $options
-     * @param array $options options to be used for setting the property. Allowed option
+     * @param array $options options to be used for setting the field. Allowed option
      * keys are `setter` and `guard`
      * @return $this
      * @throws \InvalidArgumentException
@@ -228,7 +228,7 @@ trait EntityTrait
         }
 
         if (!is_array($field)) {
-            throw new InvalidArgumentException('Cannot set an empty property');
+            throw new InvalidArgumentException('Cannot set an empty field');
         }
         $options += ['setter' => true, 'guard' => $guard];
 
@@ -262,16 +262,16 @@ trait EntityTrait
     }
 
     /**
-     * Returns the value of a property by name
+     * Returns the value of a field by name
      *
-     * @param string $field the name of the property to retrieve
+     * @param string $field the name of the field to retrieve
      * @return mixed
-     * @throws \InvalidArgumentException if an empty property name is passed
+     * @throws \InvalidArgumentException if an empty field name is passed
      */
     public function &get($field)
     {
         if (!strlen((string)$field)) {
-            throw new InvalidArgumentException('Cannot get an empty property');
+            throw new InvalidArgumentException('Cannot get an empty field');
         }
 
         $value = null;
@@ -291,16 +291,16 @@ trait EntityTrait
     }
 
     /**
-     * Returns the value of an original property by name
+     * Returns the value of an original field by name
      *
-     * @param string $field the name of the property for which original value is retrieved.
+     * @param string $field the name of the field for which original value is retrieved.
      * @return mixed
-     * @throws \InvalidArgumentException if an empty property name is passed.
+     * @throws \InvalidArgumentException if an empty field name is passed.
      */
     public function getOriginal($field)
     {
         if (!strlen((string)$field)) {
-            throw new InvalidArgumentException('Cannot get an empty property');
+            throw new InvalidArgumentException('Cannot get an empty field');
         }
         if (array_key_exists($field, $this->_original)) {
             return $this->_original[$field];
@@ -328,7 +328,7 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a property named $property
+     * Returns whether this entity contains a field named $field
      * that contains a non-null value.
      *
      * ### Example:
@@ -340,18 +340,18 @@ trait EntityTrait
      * $entity->has('last_name'); // false
      * ```
      *
-     * You can check multiple properties by passing an array:
+     * You can check multiple fields by passing an array:
      *
      * ```
      * $entity->has(['name', 'last_name']);
      * ```
      *
-     * All properties must not be null to get a truthy result.
+     * All fields must not be null to get a truthy result.
      *
-     * When checking multiple properties. All properties must not be null
+     * When checking multiple fields. All fields must not be null
      * in order for true to be returned.
      *
-     * @param string|array $field The property or properties to check.
+     * @param string|array $field The field or fields to check.
      * @return bool
      */
     public function has($field)
@@ -366,7 +366,7 @@ trait EntityTrait
     }
 
     /**
-     * Checks that a property is empty
+     * Checks that a field is empty
      *
      * This is not working like the PHP `empty()` function. The method will
      * return true for:
@@ -377,7 +377,7 @@ trait EntityTrait
      *
      * and false in all other cases.
      *
-     * @param string $field The property to check.
+     * @param string $field The field to check.
      * @return bool
      */
     public function isEmpty($field)
@@ -394,7 +394,7 @@ trait EntityTrait
     }
 
     /**
-     * Checks tha a property has a value.
+     * Checks tha a field has a value.
      *
      * This method will return true for
      *
@@ -406,7 +406,7 @@ trait EntityTrait
      *
      * and false in all other cases.
      *
-     * @param string $field The property to check.
+     * @param string $field The field to check.
      * @return bool
      */
     public function hasValue($field)
@@ -415,16 +415,16 @@ trait EntityTrait
     }
 
     /**
-     * Removes a property or list of properties from this entity
+     * Removes a field or list of fields from this entity
      *
      * ### Examples:
      *
      * ```
-     * $entity->unsetProperty('name');
-     * $entity->unsetProperty(['name', 'last_name']);
+     * $entity->unsetField('name');
+     * $entity->unsetField(['name', 'last_name']);
      * ```
      *
-     * @param string|array $field The property to unset.
+     * @param string|array $field The field to unset.
      * @return $this
      */
     public function unsetField($field)
@@ -438,7 +438,7 @@ trait EntityTrait
     }
 
     /**
-     * Removes a property or list of properties from this entity
+     * Removes a field or list of fields from this entity
      *
      * @deprecated 4.0.0 Use unsetField() instead.
      * @param string|array $field The field to unset.
@@ -450,10 +450,10 @@ trait EntityTrait
     }
 
     /**
-     * Sets hidden properties.
+     * Sets hidden fields.
      *
-     * @param array $fields An array of properties to hide from array exports.
-     * @param bool $merge Merge the new properties with the existing. By default false.
+     * @param array $fields An array of fields to hide from array exports.
+     * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
     public function setHidden(array $fields, bool $merge = false)
@@ -471,7 +471,7 @@ trait EntityTrait
     }
 
     /**
-     * Gets the hidden properties.
+     * Gets the hidden fields.
      *
      * @return array
      */
@@ -481,10 +481,10 @@ trait EntityTrait
     }
 
     /**
-     * Sets the virtual properties on this entity.
+     * Sets the virtual fields on this entity.
      *
-     * @param array $fields An array of properties to treat as virtual.
-     * @param bool $merge Merge the new properties with the existing. By default false.
+     * @param array $fields An array of fields to treat as virtual.
+     * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
     public function setVirtual(array $fields, bool $merge = false)
@@ -522,10 +522,10 @@ trait EntityTrait
      */
     public function getVisible(): array
     {
-        $properties = array_keys($this->_fields);
-        $properties = array_merge($properties, $this->_virtual);
+        $fields = array_keys($this->_fields);
+        $fields = array_merge($fields, $this->_virtual);
 
-        return array_diff($properties, $this->_hidden);
+        return array_diff($fields, $this->_hidden);
     }
 
     /**
@@ -573,7 +573,7 @@ trait EntityTrait
     }
 
     /**
-     * Returns the properties that will be serialized as JSON
+     * Returns the fields that will be serialized as JSON
      *
      * @return array
      */
@@ -672,11 +672,11 @@ trait EntityTrait
     }
 
     /**
-     * Returns an array with the requested properties
-     * stored in this entity, indexed by property name
+     * Returns an array with the requested fields
+     * stored in this entity, indexed by field name
      *
-     * @param array $fields list of properties to be returned
-     * @param bool $onlyDirty Return the requested property only if it is dirty
+     * @param array $fields list of fields to be returned
+     * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array
      */
     public function extract(array $fields, $onlyDirty = false)
@@ -692,13 +692,13 @@ trait EntityTrait
     }
 
     /**
-     * Returns an array with the requested original properties
-     * stored in this entity, indexed by property name.
+     * Returns an array with the requested original fields
+     * stored in this entity, indexed by field name.
      *
-     * Properties that are unchanged from their original value will be included in the
+     * Fields that are unchanged from their original value will be included in the
      * return of this method.
      *
-     * @param array $fields List of properties to be returned
+     * @param array $fields List of fields to be returned
      * @return array
      */
     public function extractOriginal(array $fields)
@@ -712,13 +712,13 @@ trait EntityTrait
     }
 
     /**
-     * Returns an array with only the original properties
-     * stored in this entity, indexed by property name.
+     * Returns an array with only the original fields
+     * stored in this entity, indexed by field name.
      *
-     * This method will only return properties that have been modified since
-     * the entity was built. Unchanged properties will be omitted.
+     * This method will only return fields that have been modified since
+     * the entity was built. Unchanged fields will be omitted.
      *
-     * @param array $fields List of properties to be returned
+     * @param array $fields List of fields to be returned
      * @return array
      */
     public function extractOriginalChanged(array $fields)
@@ -735,10 +735,10 @@ trait EntityTrait
     }
 
     /**
-     * Sets the dirty status of a single property.
+     * Sets the dirty status of a single field.
      *
      * @param string $field the field to set or check status for
-     * @param bool $isDirty true means the property was changed, false means
+     * @param bool $isDirty true means the field was changed, false means
      * it was not changed. Defaults to true.
      * @return $this
      */
@@ -757,10 +757,10 @@ trait EntityTrait
     }
 
     /**
-     * Checks if the entity is dirty or if a single property of it is dirty.
+     * Checks if the entity is dirty or if a single field of it is dirty.
      *
      * @param string|null $field The field to check the status for. Null for the whole entity.
-     * @return bool Whether the property was changed or not
+     * @return bool Whether the field was changed or not
      */
     public function isDirty(?string $field = null): bool
     {
@@ -772,7 +772,7 @@ trait EntityTrait
     }
 
     /**
-     * Gets the dirty properties.
+     * Gets the dirty fields.
      *
      * @return string[]
      */
@@ -783,7 +783,7 @@ trait EntityTrait
 
     /**
      * Sets the entire entity as clean, which means that it will appear as
-     * no properties being modified or added at all. This is an useful call
+     * no fields being modified or added at all. This is an useful call
      * for an initial object hydration
      *
      * @return void
@@ -1107,13 +1107,13 @@ trait EntityTrait
     }
 
     /**
-     * Stores whether or not a property value can be changed or set in this entity.
-     * The special property `*` can also be marked as accessible or protected, meaning
-     * that any other property specified before will take its value. For example
-     * `$entity->setAccess('*', true)` means that any property not specified already
+     * Stores whether or not a field value can be changed or set in this entity.
+     * The special field `*` can also be marked as accessible or protected, meaning
+     * that any other field specified before will take its value. For example
+     * `$entity->setAccess('*', true)` means that any field not specified already
      * will be accessible by default.
      *
-     * You can also call this method with an array of properties, in which case they
+     * You can also call this method with an array of fields, in which case they
      * will each take the accessibility value specified in the second argument.
      *
      * ### Example:
@@ -1121,12 +1121,12 @@ trait EntityTrait
      * ```
      * $entity->setAccess('id', true); // Mark id as not protected
      * $entity->setAccess('author_id', false); // Mark author_id as protected
-     * $entity->setAccess(['id', 'user_id'], true); // Mark both properties as accessible
-     * $entity->setAccess('*', false); // Mark all properties as protected
+     * $entity->setAccess(['id', 'user_id'], true); // Mark both fields as accessible
+     * $entity->setAccess('*', false); // Mark all fields as protected
      * ```
      *
-     * @param string|array $field single or list of properties to change its accessibility
-     * @param bool $set true marks the property as accessible, false will
+     * @param string|array $field Single or list of fields to change its accessibility
+     * @param bool $set True marks the field as accessible, false will
      * mark it as protected.
      * @return $this
      */
@@ -1149,7 +1149,7 @@ trait EntityTrait
     }
 
     /**
-     * Checks if a property is accessible
+     * Checks if a field is accessible
      *
      * ### Example:
      *
@@ -1157,7 +1157,7 @@ trait EntityTrait
      * $entity->isAccessible('id'); // Returns whether it can be set or not
      * ```
      *
-     * @param string $field Property name to check
+     * @param string $field Field name to check
      * @return bool
      */
     public function isAccessible(string $field): bool

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -444,7 +444,8 @@ trait EntityTrait
      * @param string|array $field The field to unset.
      * @return $this
      */
-    public function unsetProperty($field) {
+    public function unsetProperty($field)
+    {
         return $this->unsetField($field);
     }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -679,7 +679,7 @@ trait EntityTrait
      * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array
      */
-    public function extract(array $fields, $onlyDirty = false)
+    public function extract(array $fields, $onlyDirty = false): array
     {
         $result = [];
         foreach ($fields as $field) {
@@ -701,7 +701,7 @@ trait EntityTrait
      * @param array $fields List of fields to be returned
      * @return array
      */
-    public function extractOriginal(array $fields)
+    public function extractOriginal(array $fields): array
     {
         $result = [];
         foreach ($fields as $field) {
@@ -721,7 +721,7 @@ trait EntityTrait
      * @param array $fields List of fields to be returned
      * @return array
      */
-    public function extractOriginalChanged(array $fields)
+    public function extractOriginalChanged(array $fields): array
     {
         $result = [];
         foreach ($fields as $field) {
@@ -958,7 +958,7 @@ trait EntityTrait
      * @param string $field the field in this entity to check for errors
      * @return array errors in nested entity if any
      */
-    protected function _nestedErrors($field)
+    protected function _nestedErrors($field): array
     {
         $path = explode('.', $field);
 
@@ -1026,7 +1026,7 @@ trait EntityTrait
      * @param string|null $path The field name for errors.
      * @return array
      */
-    protected function _readError($object, $path = null)
+    protected function _readError($object, $path = null): array
     {
         if ($path !== null && $object instanceof EntityInterface) {
             return $object->getError($path);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -770,7 +770,7 @@ class BelongsToMany extends Association
             // or if we are updating an existing link.
             if ($changedKeys) {
                 $joint->isNew(true);
-                $joint->unsetProperty($junction->getPrimaryKey())
+                $joint->unsetField($junction->getPrimaryKey())
                     ->set(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
             }
             $saved = $junction->save($joint, $options);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -770,7 +770,7 @@ class BelongsToMany extends Association
             // or if we are updating an existing link.
             if ($changedKeys) {
                 $joint->isNew(true);
-                $joint->unsetField($junction->getPrimaryKey())
+                $joint->unset($junction->getPrimaryKey())
                     ->set(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
             }
             $saved = $junction->save($joint, $options);

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -115,7 +115,7 @@ class HasOne extends Association
         $targetEntity->set($properties, ['guard' => false]);
 
         if (!$this->getTarget()->save($targetEntity, $options)) {
-            $targetEntity->unsetField(array_keys($properties));
+            $targetEntity->unset(array_keys($properties));
 
             return false;
         }

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -115,7 +115,7 @@ class HasOne extends Association
         $targetEntity->set($properties, ['guard' => false]);
 
         if (!$this->getTarget()->save($targetEntity, $options)) {
-            $targetEntity->unsetProperty(array_keys($properties));
+            $targetEntity->unsetField(array_keys($properties));
 
             return false;
         }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -450,9 +450,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 return $row;
             }
 
+            /** @var \Cake\ORM\Entity $translation|array */
             $translation = $row['translation'];
 
-            $keys = $hydrated ? $translation->visibleProperties() : array_keys($translation);
+            $keys = $hydrated ? $translation->getVisible() : array_keys($translation);
 
             foreach ($keys as $field) {
                 if ($field === 'locale') {

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -105,12 +105,13 @@ trait TranslateStrategyTrait
      */
     protected function unsetEmptyFields($entity)
     {
+        /** @var \Cake\ORM\Entity[] $translations */
         $translations = (array)$entity->get('_translations');
         foreach ($translations as $locale => $translation) {
             $fields = $translation->extract($this->_config['fields'], false);
             foreach ($fields as $field => $value) {
                 if (strlen($value) === 0) {
-                    $translation->unsetProperty($field);
+                    $translation->unsetField($field);
                 }
             }
 
@@ -126,7 +127,7 @@ trait TranslateStrategyTrait
         // If now, the whole _translations property is empty,
         // unset it completely and return
         if (empty($entity->get('_translations'))) {
-            $entity->unsetProperty('_translations');
+            $entity->unsetField('_translations');
         }
     }
 
@@ -186,6 +187,6 @@ trait TranslateStrategyTrait
      */
     public function afterSave(EventInterface $event, EntityInterface $entity)
     {
-        $entity->unsetProperty('_i18n');
+        $entity->unsetField('_i18n');
     }
 }

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -111,7 +111,7 @@ trait TranslateStrategyTrait
             $fields = $translation->extract($this->_config['fields'], false);
             foreach ($fields as $field => $value) {
                 if (strlen($value) === 0) {
-                    $translation->unsetField($field);
+                    $translation->unset($field);
                 }
             }
 
@@ -127,7 +127,7 @@ trait TranslateStrategyTrait
         // If now, the whole _translations property is empty,
         // unset it completely and return
         if (empty($entity->get('_translations'))) {
-            $entity->unsetField('_translations');
+            $entity->unset('_translations');
         }
     }
 
@@ -187,6 +187,6 @@ trait TranslateStrategyTrait
      */
     public function afterSave(EventInterface $event, EntityInterface $entity)
     {
-        $entity->unsetField('_i18n');
+        $entity->unset('_i18n');
     }
 }

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -65,7 +65,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
         }
 
         if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
-            $this->_properties = $properties;
+            $this->_fields = $properties;
 
             return;
         }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -815,7 +815,7 @@ class Marshaller
 
             // Scalar data can't be handled
             if (!is_array($value)) {
-                $record->unsetField('_joinData');
+                $record->unset('_joinData');
                 continue;
             }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -815,7 +815,7 @@ class Marshaller
 
             // Scalar data can't be handled
             if (!is_array($value)) {
-                $record->unsetProperty('_joinData');
+                $record->unsetField('_joinData');
                 continue;
             }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1823,7 +1823,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         if (!$success && $isNew) {
-            $entity->unsetProperty($this->getPrimaryKey());
+            $entity->unsetField($this->getPrimaryKey());
             $entity->isNew(true);
         }
 
@@ -2025,9 +2025,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $isNew = [];
         $cleanup = function ($entities) use (&$isNew): void {
+            /** @var \Cake\Datasource\EntityInterface[] $entities */
             foreach ($entities as $key => $entity) {
                 if (isset($isNew[$key]) && $isNew[$key]) {
-                    $entity->unsetProperty($this->getPrimaryKey());
+                    $entity->unsetField($this->getPrimaryKey());
                     $entity->isNew(true);
                 }
             }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1823,7 +1823,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         if (!$success && $isNew) {
-            $entity->unsetField($this->getPrimaryKey());
+            $entity->unset($this->getPrimaryKey());
             $entity->isNew(true);
         }
 
@@ -2028,7 +2028,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             /** @var \Cake\Datasource\EntityInterface[] $entities */
             foreach ($entities as $key => $entity) {
                 if (isset($isNew[$key]) && $isNew[$key]) {
-                    $entity->unsetField($this->getPrimaryKey());
+                    $entity->unset($this->getPrimaryKey());
                     $entity->isNew(true);
                 }
             }

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -33,6 +33,14 @@ class TreeBehaviorTest extends TestCase
         'core.NumberTrees',
     ];
 
+    /**
+     * @var \Cake\ORM\Table|\Cake\ORM\Behavior\TreeBehavior
+     */
+    protected $table;
+
+    /**
+     * @return void
+     */
     public function setUp()
     {
         parent::setUp();
@@ -41,6 +49,9 @@ class TreeBehaviorTest extends TestCase
         $this->table->addBehavior('Tree');
     }
 
+    /**
+     * @return void
+     */
     public function tearDown()
     {
         parent::tearDown();
@@ -185,8 +196,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $node = $table->get(6);
-        $node->unsetField('lft');
-        $node->unsetField('rght');
+        $node->unset('lft');
+        $node->unset('rght');
         $count = $this->table->childCount($node, false);
         $this->assertEquals(4, $count);
     }
@@ -499,8 +510,8 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $node = $table->get(8);
-        $node->unsetField('lft');
-        $node->unsetField('rght');
+        $node->unset('lft');
+        $node->unset('rght');
         $node = $table->moveUp($node, true);
         $this->assertEquals(['lft' => 1, 'rght' => 2], $node->extract(['lft', 'rght']));
         $expected = [
@@ -629,8 +640,8 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $node = $table->get(1);
-        $node->unsetField('lft');
-        $node->unsetField('rght');
+        $node->unset('lft');
+        $node->unset('rght');
         $node = $table->moveDown($node, true);
         $this->assertEquals(['lft' => 7, 'rght' => 16], $node->extract(['lft', 'rght']));
         $expected = [
@@ -1067,8 +1078,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(6);
-        $entity->unsetField('lft');
-        $entity->unsetField('rght');
+        $entity->unset('lft');
+        $entity->unset('rght');
         $entity->parent_id = 2;
         $this->assertSame($entity, $table->save($entity));
         $this->assertEquals(9, $entity->lft);
@@ -1129,8 +1140,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(2);
-        $entity->unsetField('lft');
-        $entity->unsetField('rght');
+        $entity->unset('lft');
+        $entity->unset('rght');
         $entity->parent_id = null;
         $this->assertSame($entity, $table->save($entity));
         $this->assertEquals(15, $entity->lft);
@@ -1278,8 +1289,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(1);
-        $entity->unsetField('lft');
-        $entity->unsetField('rght');
+        $entity->unset('lft');
+        $entity->unset('rght');
         $this->assertTrue($table->delete($entity));
 
         $expected = [

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -185,8 +185,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $node = $table->get(6);
-        $node->unsetProperty('lft');
-        $node->unsetProperty('rght');
+        $node->unsetField('lft');
+        $node->unsetField('rght');
         $count = $this->table->childCount($node, false);
         $this->assertEquals(4, $count);
     }
@@ -499,8 +499,8 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $node = $table->get(8);
-        $node->unsetProperty('lft');
-        $node->unsetProperty('rght');
+        $node->unsetField('lft');
+        $node->unsetField('rght');
         $node = $table->moveUp($node, true);
         $this->assertEquals(['lft' => 1, 'rght' => 2], $node->extract(['lft', 'rght']));
         $expected = [
@@ -629,8 +629,8 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $node = $table->get(1);
-        $node->unsetProperty('lft');
-        $node->unsetProperty('rght');
+        $node->unsetField('lft');
+        $node->unsetField('rght');
         $node = $table->moveDown($node, true);
         $this->assertEquals(['lft' => 7, 'rght' => 16], $node->extract(['lft', 'rght']));
         $expected = [
@@ -1067,8 +1067,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(6);
-        $entity->unsetProperty('lft');
-        $entity->unsetProperty('rght');
+        $entity->unsetField('lft');
+        $entity->unsetField('rght');
         $entity->parent_id = 2;
         $this->assertSame($entity, $table->save($entity));
         $this->assertEquals(9, $entity->lft);
@@ -1129,8 +1129,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(2);
-        $entity->unsetProperty('lft');
-        $entity->unsetProperty('rght');
+        $entity->unsetField('lft');
+        $entity->unsetField('rght');
         $entity->parent_id = null;
         $this->assertSame($entity, $table->save($entity));
         $this->assertEquals(15, $entity->lft);
@@ -1278,8 +1278,8 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(1);
-        $entity->unsetProperty('lft');
-        $entity->unsetProperty('rght');
+        $entity->unsetField('lft');
+        $entity->unsetField('rght');
         $this->assertTrue($table->delete($entity));
 
         $expected = [

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -751,10 +751,10 @@ class EntityTest extends TestCase
         $phone = $this->getMockBuilder(Entity::class)
             ->setMethods(['jsonSerialize'])
             ->getMock();
-        $phone->expects($this->once())->method('jsonSerialize')->will($this->returnValue('12345'));
+        $phone->expects($this->once())->method('jsonSerialize')->will($this->returnValue(['something']));
         $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
         $entity = new Entity($data);
-        $expected = ['name' => 'James', 'age' => 20, 'phone' => '12345'];
+        $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something']];
         $this->assertEquals(json_encode($expected), json_encode($entity));
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -347,7 +347,7 @@ class EntityTest extends TestCase
         $entity->set('name', 'Jones');
         $this->assertEquals('Dr. Jones', $entity->get('name'));
 
-        $entity->unsetField('name');
+        $entity->unset('name');
         $this->assertEquals('Dr. ', $entity->get('name'));
     }
 
@@ -517,10 +517,10 @@ class EntityTest extends TestCase
     public function testUnset()
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
-        $entity->unsetField('id');
+        $entity->unset('id');
         $this->assertFalse($entity->has('id'));
         $this->assertTrue($entity->has('name'));
-        $entity->unsetField('name');
+        $entity->unset('name');
         $this->assertFalse($entity->has('id'));
     }
 
@@ -533,7 +533,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
         $this->assertTrue($entity->isDirty('name'));
-        $entity->unsetField('name');
+        $entity->unset('name');
         $this->assertFalse($entity->isDirty('name'), 'Removed properties are not dirty.');
     }
 
@@ -545,7 +545,7 @@ class EntityTest extends TestCase
     public function testUnsetMultiple()
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar', 'thing' => 2]);
-        $entity->unsetField(['id', 'thing']);
+        $entity->unset(['id', 'thing']);
         $this->assertFalse($entity->has('id'));
         $this->assertTrue($entity->has('name'));
         $this->assertFalse($entity->has('thing'));
@@ -573,12 +573,26 @@ class EntityTest extends TestCase
     public function testMagicUnset()
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')
-            ->setMethods(['unsetField'])
+            ->setMethods(['unset'])
             ->getMock();
         $entity->expects($this->at(0))
-            ->method('unsetField')
+            ->method('unset')
             ->with('foo');
         unset($entity->foo);
+    }
+
+    /**
+     * Tests the deprecated unsetProperty() method
+     *
+     * @return void
+     */
+    public function testUnsetDeprecated()
+    {
+        $entity = new Entity();
+        $entity->foo = 'foo';
+
+        $entity->unsetProperty('foo');
+        $this->assertNull($entity->foo);
     }
 
     /**
@@ -653,10 +667,10 @@ class EntityTest extends TestCase
     public function testUnsetArrayAccess()
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')
-            ->setMethods(['unsetField'])
+            ->setMethods(['unset'])
             ->getMock();
         $entity->expects($this->at(0))
-            ->method('unsetField')
+            ->method('unset')
             ->with('foo');
         unset($entity['foo']);
     }
@@ -1145,6 +1159,36 @@ class EntityTest extends TestCase
         $expected = ['email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
         $this->assertEquals(['name'], $entity->getHidden());
+    }
+
+    /**
+     * Tests the getVisible() method
+     *
+     * @return void
+     */
+    public function testGetVisible()
+    {
+        $entity = new Entity();
+        $entity->foo = 'foo';
+        $entity->bar = 'bar';
+
+        $expected = $entity->getVisible();
+        $this->assertSame(['foo', 'bar'], $expected);
+    }
+
+    /**
+     * Tests the deprecated visibleProperties() method
+     *
+     * @return void
+     */
+    public function testVisiblePropertiesDeprecated()
+    {
+        $entity = new Entity();
+        $entity->foo = 'foo';
+        $entity->bar = 'bar';
+
+        $expected = $entity->visibleProperties();
+        $this->assertSame(['foo', 'bar'], $expected);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -336,6 +336,7 @@ class EntityTest extends TestCase
      */
     public function testGetCacheClearedByUnset()
     {
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder('Cake\ORM\Entity')
             ->setMethods(['_getName'])
             ->getMock();
@@ -346,7 +347,7 @@ class EntityTest extends TestCase
         $entity->set('name', 'Jones');
         $this->assertEquals('Dr. Jones', $entity->get('name'));
 
-        $entity->unsetProperty('name');
+        $entity->unsetField('name');
         $this->assertEquals('Dr. ', $entity->get('name'));
     }
 
@@ -516,10 +517,10 @@ class EntityTest extends TestCase
     public function testUnset()
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
-        $entity->unsetProperty('id');
+        $entity->unsetField('id');
         $this->assertFalse($entity->has('id'));
         $this->assertTrue($entity->has('name'));
-        $entity->unsetProperty('name');
+        $entity->unsetField('name');
         $this->assertFalse($entity->has('id'));
     }
 
@@ -532,7 +533,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
         $this->assertTrue($entity->isDirty('name'));
-        $entity->unsetProperty('name');
+        $entity->unsetField('name');
         $this->assertFalse($entity->isDirty('name'), 'Removed properties are not dirty.');
     }
 
@@ -544,7 +545,7 @@ class EntityTest extends TestCase
     public function testUnsetMultiple()
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar', 'thing' => 2]);
-        $entity->unsetProperty(['id', 'thing']);
+        $entity->unsetField(['id', 'thing']);
         $this->assertFalse($entity->has('id'));
         $this->assertTrue($entity->has('name'));
         $this->assertFalse($entity->has('thing'));
@@ -572,10 +573,10 @@ class EntityTest extends TestCase
     public function testMagicUnset()
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')
-            ->setMethods(['unsetProperty'])
+            ->setMethods(['unsetField'])
             ->getMock();
         $entity->expects($this->at(0))
-            ->method('unsetProperty')
+            ->method('unsetField')
             ->with('foo');
         unset($entity->foo);
     }
@@ -652,10 +653,10 @@ class EntityTest extends TestCase
     public function testUnsetArrayAccess()
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')
-            ->setMethods(['unsetProperty'])
+            ->setMethods(['unsetField'])
             ->getMock();
         $entity->expects($this->at(0))
-            ->method('unsetProperty')
+            ->method('unsetField')
             ->with('foo');
         unset($entity['foo']);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1960,7 +1960,7 @@ class TableTest extends TestCase
         $this->assertEquals($entity->id, self::$nextUserId);
 
         $row = $table->find('all')->where(['id' => self::$nextUserId])->first();
-        $entity->unsetProperty('crazyness');
+        $entity->unsetField('crazyness');
         $this->assertEquals($entity->toArray(), $row->toArray());
     }
 
@@ -6012,7 +6012,7 @@ class TableTest extends TestCase
         $article = $table->get(1);
 
         $cloned = clone $article;
-        $cloned->unsetProperty('id');
+        $cloned->unsetField('id');
         $cloned->isNew(true);
         $this->assertSame($cloned, $table->save($cloned));
         $this->assertEquals(

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1960,7 +1960,7 @@ class TableTest extends TestCase
         $this->assertEquals($entity->id, self::$nextUserId);
 
         $row = $table->find('all')->where(['id' => self::$nextUserId])->first();
-        $entity->unsetField('crazyness');
+        $entity->unset('crazyness');
         $this->assertEquals($entity->toArray(), $row->toArray());
     }
 
@@ -6012,7 +6012,7 @@ class TableTest extends TestCase
         $article = $table->get(1);
 
         $cloned = clone $article;
-        $cloned->unsetField('id');
+        $cloned->unset('id');
         $cloned->isNew(true);
         $this->assertSame($cloned, $table->save($cloned));
         $this->assertEquals(


### PR DESCRIPTION
I would like to propose API improvement for Entities for a more consistent API here.

Main changes:

- getVisible() for visible fields (in sync with getHidden, getVirtual, getDirty, getInvalid, getOriginal method names)
- unsetField() for unsetting fields

For BC and since the interface was quite public for a long time:

- visibleProperties() kept until 5.0, but deprecated
- unsetProperty() kept until 5.0, but deprecated

still there to be used via trait, but not part of the interface contract for core.

All variable renames are BC as they are scoped inside the methods.
The protected properties have a low reach in terms of BC.

So for most people nothing changes in usability here when upgrading.

```
/**
 * An entity represents a single result row from a repository. It exposes the
 * methods for retrieving and storing fields associated in this row.
 */
```

As the entity docblock states: The main idea is to use "field" as name, in sync with DB fields.
The word property should only be used when referring to the technical part of exposing them as such on the object ("object property access" read/write). The term should not leak into the high level description of having multiple fields here in an entity. Especially since they are not even stored as single properties, but grouped as key=>value fields inside an array property here.

Follows https://github.com/cakephp/docs/pull/5961 for 3.0 now as 4.0 cleanup.

With the included deprecations this change seems to be rather harmless.
What do you think? It would make a lot of sense in terms of harmonizing the wording/naming-scheme in the public API.

Things to discuss:

- Can we split setAccess() into single and multi to add typehints? Or can we simply say setAccess() is array always, similar to some other methods?