### PR TITLE
Remove noise docblock annotations.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -22,12 +22,9 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 
 /**
  * Base Authentication class with common methods and properties.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseAuthenticate implements EventListenerInterface
 {
-
     use InstanceConfigTrait;
     use LocatorAwareTrait;
 

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -22,11 +22,9 @@ use Cake\Http\ServerRequest;
  * Abstract base authorization adapter for AuthComponent.
  *
  * @see \Cake\Controller\Component\AuthComponent::$authenticate
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseAuthorize
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -20,12 +20,9 @@ use Cake\Http\ServerRequest;
 
 /**
  * Session based persistent storage for authenticated user record.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class SessionStorage implements StorageInterface
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -19,12 +19,9 @@ use InvalidArgumentException;
 
 /**
  * Storage engine for CakePHP caching
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class CacheEngine
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -55,11 +55,9 @@ use Cake\Log\LogTrait;
  *
  * @link https://book.cakephp.org/3.0/en/controllers/components.html
  * @see \Cake\Controller\Controller::$components
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Component implements EventListenerInterface
 {
-
     use InstanceConfigTrait;
     use LogTrait;
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -30,8 +30,6 @@ use Throwable;
  *
  * Traps exceptions and converts them into HTML or content-type appropriate
  * error pages using the CakePHP ExceptionRenderer.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class ErrorHandlerMiddleware
 {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -93,12 +93,9 @@ use Zend\Diactoros\Uri;
  * a proxy if you need to use one. The type sub option can be used to
  * specify which authentication strategy you want to use.
  * CakePHP comes with built-in support for basic authentication.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Client
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -21,12 +21,9 @@ use Psr\Log\AbstractLogger;
 
 /**
  * Base log engine class.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseLog extends AbstractLogger
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -18,12 +18,9 @@ use Cake\Core\InstanceConfigTrait;
 
 /**
  * Abstract transport for sending email
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class AbstractTransport
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -24,12 +24,9 @@ use InvalidArgumentException;
  * CakePHP network socket connection class.
  *
  * Core base class for network communication.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Socket
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -109,7 +109,6 @@ use ReflectionMethod;
  *
  * @see \Cake\ORM\Table::addBehavior()
  * @see \Cake\Event\EventManager
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Behavior implements EventListenerInterface
 {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -66,11 +66,9 @@ use RuntimeException;
  *   with the first rows of the query and each of the items, then the second rows and so on.
  * @method \Cake\Collection\CollectionInterface chunk($size) Groups the results in arrays of $size rows each.
  * @method bool isEmpty() Returns true if this query found no results.
- * @mixin \Cake\Datasource\QueryTrait
  */
 class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
 {
-
     use QueryTrait {
         cache as private _cache;
         all as private _all;

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -62,12 +62,9 @@ use InvalidArgumentException;
  *
  * When using the `for` or `when` matchers, conditions will be re-checked on the before and after
  * callback as the conditions could change during the dispatch cycle.
- *
- * @mixin \Cake\Core\InstanceConfigTrait
  */
 class DispatcherFilter implements EventListenerInterface
 {
-
     use InstanceConfigTrait;
 
     /**


### PR DESCRIPTION
These annotations shouldn't be needed, and the other trait usage proofs this.
The tools understand the "use ..." already, so adding this on top is duplicate info. 
Let's remove this noise then.
