### PR TITLE
Collection trait: instantiate new collections through overridable method

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -48,7 +48,7 @@ trait CollectionTrait
      * Allows classes which use this trait to determine their own
      * type of returned collection interface
      *
-     * @param mixed ...$args
+     * @param mixed $args,.. Constructor arguments.
      * @return CollectionInterface
      */
     protected function newCollection(...$args)

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -49,7 +49,7 @@ trait CollectionTrait
      * type of returned collection interface
      *
      * @param mixed $args,.. Constructor arguments.
-     * @return CollectionInterface
+     * @return \Cake\Collection\CollectionInterface
      */
     protected function newCollection(...$args)
     {

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -48,7 +48,7 @@ trait CollectionTrait
      * Allows classes which use this trait to determine their own
      * type of returned collection interface
      *
-     * @param mixed $args,.. Constructor arguments.
+     * @param mixed ...$args Constructor arguments.
      * @return \Cake\Collection\CollectionInterface
      */
     protected function newCollection(...$args)

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -545,7 +545,7 @@ trait CollectionTrait
      */
     public function prepend($items)
     {
-        return ($this->newCollection($items))->append($this);
+        return $this->newCollection($items)->append($this);
     }
 
     /**
@@ -645,7 +645,7 @@ trait CollectionTrait
             $parents[$key][$nestingKey] = $children;
         };
 
-        return ($this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer)))
+        return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer))
             ->map(function ($value) use (&$isObject) {
                 /** @var \ArrayIterator $value */
                 return $isObject ? $value : $value->getArrayCopy();

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -521,7 +521,7 @@ trait CollectionTrait
     {
         $list = new AppendIterator();
         $list->append($this->unwrap());
-        $list->append(($this->newCollection($items))->unwrap());
+        $list->append($this->newCollection($items)->unwrap());
 
         return $this->newCollection($list);
     }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -35,12 +35,26 @@ use RecursiveIteratorIterator;
 use Traversable;
 
 /**
- * Offers a handful of method to manipulate iterators
+ * Offers a handful of methods to manipulate iterators
  */
 trait CollectionTrait
 {
 
     use ExtractTrait;
+
+    /**
+     * Returns a new collection.
+     *
+     * Allows classes which use this trait to determine their own
+     * type of returned collection interface
+     *
+     * @param mixed ...$args
+     * @return CollectionInterface
+     */
+    protected function newCollection(...$args)
+    {
+        return new Collection(...$args);
+    }
 
     /**
      * {@inheritDoc}
@@ -258,7 +272,7 @@ trait CollectionTrait
             $group[$callback($value)][] = $value;
         }
 
-        return new Collection($group);
+        return $this->newCollection($group);
     }
 
     /**
@@ -272,7 +286,7 @@ trait CollectionTrait
             $group[$callback($value)] = $value;
         }
 
-        return new Collection($group);
+        return $this->newCollection($group);
     }
 
     /**
@@ -292,7 +306,7 @@ trait CollectionTrait
             $mr->emit(count($values), $key);
         };
 
-        return new Collection(new MapReduce($this->unwrap(), $mapper, $reducer));
+        return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer));
     }
 
     /**
@@ -321,7 +335,7 @@ trait CollectionTrait
         $elements = $this->toArray();
         shuffle($elements);
 
-        return new Collection($elements);
+        return $this->newCollection($elements);
     }
 
     /**
@@ -329,7 +343,7 @@ trait CollectionTrait
      */
     public function sample($size = 10)
     {
-        return new Collection(new LimitIterator($this->shuffle(), 0, $size));
+        return $this->newCollection(new LimitIterator($this->shuffle(), 0, $size));
     }
 
     /**
@@ -337,7 +351,7 @@ trait CollectionTrait
      */
     public function take($size = 1, $from = 0)
     {
-        return new Collection(new LimitIterator($this, $from, $size));
+        return $this->newCollection(new LimitIterator($this, $from, $size));
     }
 
     /**
@@ -345,7 +359,7 @@ trait CollectionTrait
      */
     public function skip($howMany)
     {
-        return new Collection(new LimitIterator($this, $howMany));
+        return $this->newCollection(new LimitIterator($this, $howMany));
     }
 
     /**
@@ -412,19 +426,19 @@ trait CollectionTrait
 
         $iterator = $this->optimizeUnwrap();
         if (is_array($iterator)) {
-            return new Collection(array_slice($iterator, $howMany * -1));
+            return $this->newCollection(array_slice($iterator, $howMany * -1));
         }
 
         if ($iterator instanceof Countable) {
             $count = count($iterator);
 
             if ($count === 0) {
-                return new Collection([]);
+                return $this->newCollection([]);
             }
 
             $iterator = new LimitIterator($iterator, max(0, $count - $howMany), $howMany);
 
-            return new Collection($iterator);
+            return $this->newCollection($iterator);
         }
 
         $generator = function ($iterator, $howMany) {
@@ -497,7 +511,7 @@ trait CollectionTrait
             }
         };
 
-        return new Collection($generator($iterator, $howMany));
+        return $this->newCollection($generator($iterator, $howMany));
     }
 
     /**
@@ -507,9 +521,9 @@ trait CollectionTrait
     {
         $list = new AppendIterator();
         $list->append($this->unwrap());
-        $list->append((new Collection($items))->unwrap());
+        $list->append(($this->newCollection($items))->unwrap());
 
-        return new Collection($list);
+        return $this->newCollection($list);
     }
 
     /**
@@ -531,7 +545,7 @@ trait CollectionTrait
      */
     public function prepend($items)
     {
-        return (new Collection($items))->append($this);
+        return ($this->newCollection($items))->append($this);
     }
 
     /**
@@ -586,7 +600,7 @@ trait CollectionTrait
             $mapReduce->emit($result, $key);
         };
 
-        return new Collection(new MapReduce($this->unwrap(), $mapper, $reducer));
+        return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer));
     }
 
     /**
@@ -631,7 +645,7 @@ trait CollectionTrait
             $parents[$key][$nestingKey] = $children;
         };
 
-        return (new Collection(new MapReduce($this->unwrap(), $mapper, $reducer)))
+        return ($this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer)))
             ->map(function ($value) use (&$isObject) {
                 /** @var \ArrayIterator $value */
                 return $isObject ? $value : $value->getArrayCopy();
@@ -689,7 +703,7 @@ trait CollectionTrait
      */
     public function compile($preserveKeys = true)
     {
-        return new Collection($this->toArray($preserveKeys));
+        return $this->newCollection($this->toArray($preserveKeys));
     }
 
     /**
@@ -703,7 +717,7 @@ trait CollectionTrait
             }
         };
 
-        return new Collection($generator());
+        return $this->newCollection($generator());
     }
 
     /**
@@ -761,7 +775,7 @@ trait CollectionTrait
             };
         }
 
-        return new Collection(
+        return $this->newCollection(
             new RecursiveIteratorIterator(
                 new UnfoldIterator($this->unwrap(), $transformer),
                 RecursiveIteratorIterator::LEAVES_ONLY
@@ -776,7 +790,7 @@ trait CollectionTrait
     {
         $result = $handler($this);
 
-        return $result instanceof CollectionInterface ? $result : new Collection($result);
+        return $result instanceof CollectionInterface ? $result : $this->newCollection($result);
     }
 
     /**
@@ -900,7 +914,7 @@ trait CollectionTrait
     public function cartesianProduct(callable $operation = null, callable $filter = null)
     {
         if ($this->isEmpty()) {
-            return new Collection([]);
+            return $this->newCollection([]);
         }
 
         $collectionArrays = [];
@@ -942,7 +956,7 @@ trait CollectionTrait
             }
         }
 
-        return new Collection($result);
+        return $this->newCollection($result);
     }
 
     /**
@@ -966,7 +980,7 @@ trait CollectionTrait
             $result[] = array_column($arrayValue, $column);
         }
 
-        return new Collection($result);
+        return $this->newCollection($result);
     }
 
     /**


### PR DESCRIPTION
When using the collection trait in any class, appending items or using other methods which return new collections will always return a Collection object.

If I for example wish to create my own ResultSetInterface implementation, containing its own collection the following will happen:

```
$resultSet = new ResultSet();
$a = $resultSet->append('item');
// $a is now a Collection object, but I want it to remain a ResultSet object
```

With the changes proposed, I can implement the following in my ResultSet class:
```
protected $myItems;
public function __construct($myFirstArgument, $myItems){
      $this->myItems = $myItems;
      // do something else with other arguments
}
protected function newCollection(...$args){
   return new static($this->getMyFirstArgument(), ...$args);
}
```
