### PR TITLE
Fix classes to standalone class files. Added missing mixin.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -32,6 +32,7 @@ use InvalidArgumentException;
  * You configure pagination when calling paginate(). See that method for more details.
  *
  * @link https://book.cakephp.org/3.0/en/controllers/components/pagination.html
+ * @mixin \Cake\Datasource\Paginator
  */
 class PaginatorComponent extends Component
 {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -21,33 +21,15 @@ use Cake\Controller\Controller;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\PageOutOfBoundsException;
-use Cake\Datasource\Paginator;
 use Cake\Datasource\RepositoryInterface;
+use Cake\Event\EventInterface;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use Cake\ORM\Entity;
+use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
 use stdClass;
-
-/**
- * PaginatorTestController class
- */
-class PaginatorTestController extends Controller
-{
-    /**
-     * components property
-     *
-     * @var array
-     */
-    public $components = ['Paginator'];
-}
-
-/**
- * Custom paginator
- */
-class CustomPaginator extends Paginator
-{
-}
+use TestApp\Datasource\CustomPaginator;
 
 class PaginatorComponentTest extends TestCase
 {
@@ -67,6 +49,26 @@ class PaginatorComponentTest extends TestCase
      * @var bool
      */
     public $autoFixtures = false;
+
+    /**
+     * @var \Cake\Controller\Controller
+     */
+    protected $controller;
+
+    /**
+     * @var \Cake\Controller\ComponentRegistry
+     */
+    protected $registry;
+
+    /**
+     * @var \Cake\Controller\Component\PaginatorComponent
+     */
+    protected $Paginator;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $Post;
 
     /**
      * setup
@@ -283,9 +285,9 @@ class PaginatorComponentTest extends TestCase
         $tags = $this->getTableLocator()->get('Tags');
         $tags->belongsToMany('Authors');
 
-        $articles->getEventManager()->on('Model.beforeFind', function ($event, $query): void {
-            $query ->matching('Tags', function ($q) {
-                return $q->matching('Authors', function ($q) {
+        $articles->getEventManager()->on('Model.beforeFind', function (EventInterface $event, Query $query): void {
+            $query ->matching('Tags', function (Query $q) {
+                return $q->matching('Authors', function (Query $q) {
                     return $q->where(['Authors.name' => 'larry']);
                 });
             });
@@ -1417,9 +1419,12 @@ class PaginatorComponentTest extends TestCase
         return $query;
     }
 
+    /**
+     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function getMockRepository()
     {
-        $model = $this->getMockBuilder('Cake\Datasource\RepositoryInterface')
+        $model = $this->getMockBuilder(RepositoryInterface::class)
             ->setMethods([
                 'getAlias', 'setAlias', 'setRegistryAlias', 'getRegistryAlias', 'hasField', 'find', 'get', 'query', 'updateAll', 'deleteAll',
                 'exists', 'save', 'delete', 'newEntity', 'newEntities', 'patchEntity', 'patchEntities',

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Controller\Component;
 
 use Cake\Controller\Component\RequestHandlerComponent;
 use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Controller;
 use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -26,22 +27,10 @@ use Cake\TestSuite\TestCase;
 use Cake\View\AjaxView;
 use Cake\View\JsonView;
 use Cake\View\XmlView;
+use TestApp\Controller\Component\RequestHandlerExtComponent;
 use TestApp\Controller\RequestHandlerTestController;
 use TestApp\View\AppView;
 use Zend\Diactoros\Stream;
-
-class RequestHandlerComponentExt extends RequestHandlerComponent
-{
-    public function getExt()
-    {
-        return $this->ext;
-    }
-
-    public function setExt($ext)
-    {
-        $this->ext = $ext;
-    }
-}
 
 /**
  * RequestHandlerComponentTest class
@@ -54,7 +43,7 @@ class RequestHandlerComponentTest extends TestCase
     public $Controller;
 
     /**
-     * @var RequestHandlerComponent
+     * @var \TestApp\Controller\Component\RequestHandlerExtComponent
      */
     public $RequestHandler;
 
@@ -91,11 +80,12 @@ class RequestHandlerComponentTest extends TestCase
     protected function _init(): void
     {
         $request = new ServerRequest(['url' => 'controller_posts/index']);
-        $response = $this->getMockBuilder('Cake\Http\Response')
+        /** @var \Cake\Http\Response|\PHPUnit\Framework\MockObject\MockObject $response */
+        $response = $this->getMockBuilder(Response::class)
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
         $this->Controller = new RequestHandlerTestController($request, $response);
-        $this->RequestHandler = $this->Controller->components()->load(RequestHandlerComponentExt::class);
+        $this->RequestHandler = $this->Controller->components()->load(RequestHandlerExtComponent::class);
         $this->request = $request;
 
         Router::scope('/', function (RouteBuilder $routes): void {
@@ -127,7 +117,8 @@ class RequestHandlerComponentTest extends TestCase
         $config = [
             'viewClassMap' => ['json' => 'MyPlugin.MyJson'],
         ];
-        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+        /** @var \Cake\Controller\Controller|\PHPUnit\Framework\MockObject\MockObject $controller */
+        $controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['redirect'])
             ->getMock();
         $collection = new ComponentRegistry($controller);
@@ -315,9 +306,12 @@ class RequestHandlerComponentTest extends TestCase
         $extensions = Router::extensions();
         Router::extensions('xml', false);
 
-        $this->Controller->setRequest($this->getMockBuilder('Cake\Http\ServerRequest')
+        /** @var \Cake\Http\ServerRequest|\PHPUnit\Framework\MockObject\MockObject $request */
+        $request = $this->getMockBuilder(ServerRequest::class)
             ->setMethods(['accepts'])
-            ->getMock());
+            ->getMock();
+
+        $this->Controller->setRequest($request);
         $this->Controller->getRequest()->expects($this->any())
             ->method('accepts')
             ->will($this->returnValue(['application/json']));

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -16,108 +16,20 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Controller\Component;
 
 use Cake\Controller\Component\SecurityComponent;
-use Cake\Controller\Controller;
 use Cake\Controller\Exception\SecurityException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
-
-/**
- * TestSecurityComponent
- */
-class TestSecurityComponent extends SecurityComponent
-{
-    /**
-     * validatePost method
-     *
-     * @param Controller $controller
-     * @return bool
-     */
-    public function validatePost(Controller $controller): bool
-    {
-        return $this->_validatePost($controller);
-    }
-
-    /**
-     * authRequired method
-     *
-     * @param Controller $controller
-     * @return bool
-     */
-    public function authRequired(Controller $controller): bool
-    {
-        return $this->_authRequired($controller);
-    }
-}
-
-/**
- * SecurityTestController
- */
-class SecurityTestController extends Controller
-{
-    /**
-     * failed property
-     *
-     * @var bool
-     */
-    public $failed = false;
-
-    /**
-     * Used for keeping track of headers in test
-     *
-     * @var array
-     */
-    public $testHeaders = [];
-
-    public function initialize(): void
-    {
-        $this->loadComponent('TestSecurity', ['className' => 'Cake\Test\TestCase\Controller\Component\TestSecurityComponent']);
-    }
-
-    /**
-     * fail method
-     *
-     * @return void
-     */
-    public function fail(): void
-    {
-        $this->failed = true;
-    }
-
-    /**
-     * redirect method
-     *
-     * @param string|array $url
-     * @param int $status
-     * @return \Cake\Http\Response|null
-     */
-    public function redirect($url, ?int $status = null): ?Response
-    {
-        return $status;
-    }
-
-    /**
-     * Convenience method for header()
-     *
-     * @param string $status
-     * @return void
-     */
-    public function header(string $status): void
-    {
-        $this->testHeaders[] = $status;
-    }
-}
+use TestApp\Controller\SecurityTestController;
 
 /**
  * SecurityComponentTest class
  *
- * @property SecurityComponent Security
- * @property SecurityTestController Controller
+ * @property \TestApp\Controller\Component\TestSecurityComponent Security
  */
 class SecurityComponentTest extends TestCase
 {
@@ -131,7 +43,7 @@ class SecurityComponentTest extends TestCase
     /**
      * Controller property
      *
-     * @var SecurityTestController
+     * @var \TestApp\Controller\SecurityTestController
      */
     public $Controller;
 

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -23,14 +23,9 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Countable;
+use TestApp\Controller\Component\FlashAliasComponent;
+use TestPlugin\Controller\Component\OtherComponent;
 use Traversable;
-
-/**
- * Extended FlashComponent
- */
-class FlashAliasComponent extends FlashComponent
-{
-}
 
 class ComponentRegistryTest extends TestCase
 {
@@ -71,8 +66,8 @@ class ComponentRegistryTest extends TestCase
     public function testLoad(): void
     {
         $result = $this->Components->load('Flash');
-        $this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $result);
-        $this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $this->Components->Flash);
+        $this->assertInstanceOf(FlashComponent::class, $result);
+        $this->assertInstanceOf(FlashComponent::class, $this->Components->Flash);
 
         $result = $this->Components->loaded();
         $this->assertEquals(['Flash'], $result, 'loaded() results are wrong.');
@@ -88,21 +83,21 @@ class ComponentRegistryTest extends TestCase
      */
     public function testLoadWithAlias(): void
     {
-        $result = $this->Components->load('Flash', ['className' => __NAMESPACE__ . '\FlashAliasComponent', 'somesetting' => true]);
-        $this->assertInstanceOf(__NAMESPACE__ . '\FlashAliasComponent', $result);
-        $this->assertInstanceOf(__NAMESPACE__ . '\FlashAliasComponent', $this->Components->Flash);
+        $result = $this->Components->load('Flash', ['className' => FlashAliasComponent::class, 'somesetting' => true]);
+        $this->assertInstanceOf(FlashAliasComponent::class, $result);
+        $this->assertInstanceOf(FlashAliasComponent::class, $this->Components->Flash);
         $this->assertTrue($this->Components->Flash->getConfig('somesetting'));
 
         $result = $this->Components->loaded();
         $this->assertEquals(['Flash'], $result, 'loaded() results are wrong.');
 
         $result = $this->Components->load('Flash');
-        $this->assertInstanceOf(__NAMESPACE__ . '\FlashAliasComponent', $result);
+        $this->assertInstanceOf(FlashAliasComponent::class, $result);
 
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Components->load('SomeOther', ['className' => 'TestPlugin.Other']);
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $result);
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $this->Components->SomeOther);
+        $this->assertInstanceOf(OtherComponent::class, $result);
+        $this->assertInstanceOf(OtherComponent::class, $this->Components->SomeOther);
 
         $result = $this->Components->loaded();
         $this->assertEquals(['Flash', 'SomeOther'], $result, 'loaded() results are wrong.');
@@ -122,8 +117,8 @@ class ComponentRegistryTest extends TestCase
         $this->Components->getController()->setEventManager($mock);
 
         $result = $this->Components->load('Flash', ['enabled' => false]);
-        $this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $result);
-        $this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $this->Components->Flash);
+        $this->assertInstanceOf(FlashComponent::class, $result);
+        $this->assertInstanceOf(FlashComponent::class, $this->Components->Flash);
     }
 
     /**
@@ -146,8 +141,8 @@ class ComponentRegistryTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Components->load('TestPlugin.Other');
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $result, 'Component class is wrong.');
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $this->Components->Other, 'Class is wrong');
+        $this->assertInstanceOf(OtherComponent::class, $result, 'Component class is wrong.');
+        $this->assertInstanceOf(OtherComponent::class, $this->Components->Other, 'Class is wrong');
     }
 
     /**
@@ -159,8 +154,8 @@ class ComponentRegistryTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Components->load('AliasedOther', ['className' => 'TestPlugin.Other']);
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $result);
-        $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $this->Components->AliasedOther);
+        $this->assertInstanceOf(OtherComponent::class, $result);
+        $this->assertInstanceOf(OtherComponent::class, $this->Components->AliasedOther);
 
         $result = $this->Components->loaded();
         $this->assertEquals(['AliasedOther'], $result, 'loaded() results are wrong.');

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -29,168 +29,6 @@ use TestApp\Controller\Admin\PostsController;
 use TestPlugin\Controller\TestPluginController;
 
 /**
- * AppController class
- */
-class ControllerTestAppController extends Controller
-{
-    /**
-     * modelClass property
-     *
-     * @var string
-     */
-    public $modelClass = 'Posts';
-}
-
-/**
- * TestController class
- */
-class TestController extends ControllerTestAppController
-{
-    /**
-     * Theme property
-     *
-     * @var string
-     */
-    public $theme = 'Foo';
-
-    /**
-     * modelClass property
-     *
-     * @var string
-     */
-    public $modelClass = 'Comments';
-
-    /**
-     * beforeFilter handler
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return \Cake\Http\Response|null
-     */
-    public function beforeFilter(EventInterface $event): ?Response
-    {
-    }
-
-    /**
-     * index method
-     *
-     * @param mixed $testId
-     * @param mixed $testTwoId
-     * @return void
-     */
-    public function index($testId, $testTwoId): void
-    {
-        $this->request = $this->request->withParsedBody([
-            'testId' => $testId,
-            'test2Id' => $testTwoId,
-        ]);
-    }
-
-    /**
-     * view method
-     *
-     * @param mixed $testId
-     * @param mixed $testTwoId
-     * @return void
-     */
-    public function view($testId, $testTwoId): void
-    {
-        $this->request = $this->request->withParsedBody([
-            'testId' => $testId,
-            'test2Id' => $testTwoId,
-        ]);
-    }
-
-    public function returner()
-    {
-        return 'I am from the controller.';
-    }
-
-    // phpcs:disable
-    protected function protected_m()
-    {
-    }
-
-    private function private_m()
-    {
-    }
-
-    public function _hidden()
-    {
-    }
-    // phpcs:enable
-
-    public function admin_add(): void
-    {
-    }
-}
-
-/**
- * TestComponent class
- */
-class TestComponent extends Component
-{
-    /**
-     * beforeRedirect method
-     *
-     * @return void
-     */
-    public function beforeRedirect(): void
-    {
-    }
-
-    /**
-     * initialize method
-     *
-     * @param array $config
-     * @return void
-     */
-    public function initialize(array $config): void
-    {
-    }
-
-    /**
-     * startup method
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return void
-     */
-    public function startup(EventInterface $event): void
-    {
-    }
-
-    /**
-     * shutdown method
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return void
-     */
-    public function shutdown(EventInterface $event): void
-    {
-    }
-
-    /**
-     * beforeRender callback
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return void
-     */
-    public function beforeRender(EventInterface $event): void
-    {
-        $controller = $event->getSubject();
-        if ($this->viewclass) {
-            $controller->viewClass = $this->viewclass;
-        }
-    }
-}
-
-/**
- * AnotherTestController class
- */
-class AnotherTestController extends ControllerTestAppController
-{
-}
-
-/**
  * ControllerTest class
  */
 class ControllerTest extends TestCase
@@ -1213,4 +1051,166 @@ class ControllerTest extends TestCase
         $this->assertSame($controller, $controller->enableAutoRender());
         $this->assertTrue($controller->isAutoRenderEnabled());
     }
+}
+
+/**
+ * AppController class
+ */
+class ControllerTestAppController extends Controller
+{
+    /**
+     * modelClass property
+     *
+     * @var string
+     */
+    public $modelClass = 'Posts';
+}
+
+/**
+ * TestController class
+ */
+class TestController extends ControllerTestAppController
+{
+    /**
+     * Theme property
+     *
+     * @var string
+     */
+    public $theme = 'Foo';
+
+    /**
+     * modelClass property
+     *
+     * @var string
+     */
+    public $modelClass = 'Comments';
+
+    /**
+     * beforeFilter handler
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @return \Cake\Http\Response|null
+     */
+    public function beforeFilter(EventInterface $event): ?Response
+    {
+    }
+
+    /**
+     * index method
+     *
+     * @param mixed $testId
+     * @param mixed $testTwoId
+     * @return void
+     */
+    public function index($testId, $testTwoId): void
+    {
+        $this->request = $this->request->withParsedBody([
+            'testId' => $testId,
+            'test2Id' => $testTwoId,
+        ]);
+    }
+
+    /**
+     * view method
+     *
+     * @param mixed $testId
+     * @param mixed $testTwoId
+     * @return void
+     */
+    public function view($testId, $testTwoId): void
+    {
+        $this->request = $this->request->withParsedBody([
+            'testId' => $testId,
+            'test2Id' => $testTwoId,
+        ]);
+    }
+
+    public function returner()
+    {
+        return 'I am from the controller.';
+    }
+
+    // phpcs:disable
+    protected function protected_m()
+    {
+    }
+
+    private function private_m()
+    {
+    }
+
+    public function _hidden()
+    {
+    }
+    // phpcs:enable
+
+    public function admin_add(): void
+    {
+    }
+}
+
+/**
+ * TestComponent class
+ */
+class TestComponent extends Component
+{
+    /**
+     * beforeRedirect method
+     *
+     * @return void
+     */
+    public function beforeRedirect(): void
+    {
+    }
+
+    /**
+     * initialize method
+     *
+     * @param array $config
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+    }
+
+    /**
+     * startup method
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @return void
+     */
+    public function startup(EventInterface $event): void
+    {
+    }
+
+    /**
+     * shutdown method
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @return void
+     */
+    public function shutdown(EventInterface $event): void
+    {
+    }
+
+    /**
+     * beforeRender callback
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @return void
+     */
+    public function beforeRender(EventInterface $event): void
+    {
+        $controller = $event->getSubject();
+        if ($this->viewclass) {
+            $controller->viewClass = $this->viewclass;
+        }
+    }
+}
+
+/**
+ * AnotherTestController class
+ */
+class AnotherTestController extends ControllerTestAppController
+{
 }

--- a/tests/test_app/TestApp/Controller/Component/FlashAliasComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/FlashAliasComponent.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Controller\Component;
+
+use Cake\Controller\Component\FlashComponent;
+
+class FlashAliasComponent extends FlashComponent
+{
+}

--- a/tests/test_app/TestApp/Controller/Component/RequestHandlerExtComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/RequestHandlerExtComponent.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Controller\Component;
+
+use Cake\Controller\Component\RequestHandlerComponent;
+
+class RequestHandlerExtComponent extends RequestHandlerComponent
+{
+    public $ext;
+
+    public function getExt()
+    {
+        return $this->ext;
+    }
+
+    public function setExt($ext)
+    {
+        $this->ext = $ext;
+    }
+}

--- a/tests/test_app/TestApp/Controller/Component/TestSecurityComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/TestSecurityComponent.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Controller\Component;
+
+use Cake\Controller\Component\SecurityComponent;
+use Cake\Controller\Controller;
+
+class TestSecurityComponent extends SecurityComponent
+{
+    /**
+     * validatePost method
+     *
+     * @param Controller $controller
+     * @return bool
+     */
+    public function validatePost(Controller $controller): bool
+    {
+        return $this->_validatePost($controller);
+    }
+}

--- a/tests/test_app/TestApp/Controller/PaginatorTestController.php
+++ b/tests/test_app/TestApp/Controller/PaginatorTestController.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class PaginatorTestController extends Controller
+{
+    /**
+     * components property
+     *
+     * @var array
+     */
+    public $components = ['Paginator'];
+}

--- a/tests/test_app/TestApp/Controller/SecurityTestController.php
+++ b/tests/test_app/TestApp/Controller/SecurityTestController.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Http\Response;
+use TestApp\Controller\Component\TestSecurityComponent;
+
+class SecurityTestController extends Controller
+{
+    /**
+     * failed property
+     *
+     * @var bool
+     */
+    public $failed = false;
+
+    /**
+     * Used for keeping track of headers in test
+     *
+     * @var array
+     */
+    public $testHeaders = [];
+
+    public function initialize(): void
+    {
+        $this->loadComponent('TestSecurity', ['className' => TestSecurityComponent::class]);
+    }
+
+    /**
+     * fail method
+     *
+     * @return void
+     */
+    public function fail(): void
+    {
+        $this->failed = true;
+    }
+
+    /**
+     * redirect method
+     *
+     * @param string|array $url
+     * @param int $status
+     * @return \Cake\Http\Response|null
+     */
+    public function redirect($url, ?int $status = null): ?Response
+    {
+        return $status;
+    }
+
+    /**
+     * Convenience method for header()
+     *
+     * @param string $status
+     * @return void
+     */
+    public function header(string $status): void
+    {
+        $this->testHeaders[] = $status;
+    }
+}

--- a/tests/test_app/TestApp/Datasource/CustomPaginator.php
+++ b/tests/test_app/TestApp/Datasource/CustomPaginator.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Datasource;
+
+use Cake\Datasource\Paginator;
+
+class CustomPaginator extends Paginator
+{
+}


### PR DESCRIPTION
Resolves the first part of https://github.com/cakephp/cakephp-codesniffer/pull/230
- Controller

also fixes some missing inline docs for typehinting, and shows the missing $mixin that is required to be added here.