### PR TITLE
Added missing mixin for Paginator.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -30,6 +30,7 @@ use InvalidArgumentException;
  * You configure pagination when calling paginate(). See that method for more details.
  *
  * @link https://book.cakephp.org/3.0/en/controllers/components/pagination.html
+ * @mixin \Cake\Datasource\Paginator
  */
 class PaginatorComponent extends Component
 {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -69,6 +69,11 @@ class PaginatorComponentTest extends TestCase
     public $autoFixtures = false;
 
     /**
+     * @var \Cake\Controller\Component\PaginatorComponent
+     */
+    protected $Paginator;
+
+    /**
      * setup
      *
      * @return void


### PR DESCRIPTION
Backport of mixin part of https://github.com/cakephp/cakephp/pull/12961
Now $paginatorComponent->validateSort() is properly found, as this can be called via __call magic.