### PR TITLE
Add FlashComponent Session getter.

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -35,7 +35,7 @@ class FlashComponent extends Component
      * The Session object instance
      *
      * @var \Cake\Http\Session
-     * @deprecated 3.8.0 This property will be removed in 4.0.0 in favor of `getSession()` method.
+     * @deprecated 3.7.5 This property will be removed in 4.0.0 in favor of `getSession()` method.
      */
     protected $_session;
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -35,6 +35,7 @@ class FlashComponent extends Component
      * The Session object instance
      *
      * @var \Cake\Http\Session
+     * @deprecated 3.8.0 This property will be removed in 4.0.0 in favor of `getSession()` method.
      */
     protected $_session;
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -15,7 +15,6 @@
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Controller\ComponentRegistry;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Utility\Inflector;
 use Exception;
@@ -32,13 +31,6 @@ class FlashComponent extends Component
 {
 
     /**
-     * The Session object instance
-     *
-     * @var \Cake\Http\Session
-     */
-    protected $_session;
-
-    /**
      * Default configuration
      *
      * @var array
@@ -50,18 +42,6 @@ class FlashComponent extends Component
         'clear' => false,
         'duplicate' => true
     ];
-
-    /**
-     * Constructor
-     *
-     * @param \Cake\Controller\ComponentRegistry $registry A ComponentRegistry for this component
-     * @param array $config Array of config.
-     */
-    public function __construct(ComponentRegistry $registry, array $config = [])
-    {
-        parent::__construct($registry, $config);
-        $this->_session = $registry->getController()->getRequest()->getSession();
-    }
 
     /**
      * Used to set a session variable that can be used to output messages in the view.
@@ -109,7 +89,7 @@ class FlashComponent extends Component
 
         $messages = [];
         if (!$options['clear']) {
-            $messages = (array)$this->_session->read('Flash.' . $options['key']);
+            $messages = (array)$this->getSession()->read('Flash.' . $options['key']);
         }
 
         if (!$options['duplicate']) {
@@ -127,7 +107,7 @@ class FlashComponent extends Component
             'params' => $options['params']
         ];
 
-        $this->_session->write('Flash.' . $options['key'], $messages);
+        $this->getSession()->write('Flash.' . $options['key'], $messages);
     }
 
     /**
@@ -171,5 +151,15 @@ class FlashComponent extends Component
         }
 
         $this->set($args[0], $options);
+    }
+
+    /**
+     * Returns current session object from a controller request.
+     *
+     * @return Session
+     */
+    protected function getSession()
+    {
+        return $this->getController()->getRequest()->getSession();
     }
 }

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -15,6 +15,7 @@
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Controller\ComponentRegistry;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Utility\Inflector;
 use Exception;
@@ -31,6 +32,13 @@ class FlashComponent extends Component
 {
 
     /**
+     * The Session object instance
+     *
+     * @var \Cake\Http\Session
+     */
+    protected $_session;
+
+    /**
      * Default configuration
      *
      * @var array
@@ -42,6 +50,18 @@ class FlashComponent extends Component
         'clear' => false,
         'duplicate' => true
     ];
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Controller\ComponentRegistry $registry A ComponentRegistry for this component
+     * @param array $config Array of config.
+     */
+    public function __construct(ComponentRegistry $registry, array $config = [])
+    {
+        parent::__construct($registry, $config);
+        $this->_session = $registry->getController()->getRequest()->getSession();
+    }
 
     /**
      * Used to set a session variable that can be used to output messages in the view.
@@ -156,7 +176,7 @@ class FlashComponent extends Component
     /**
      * Returns current session object from a controller request.
      *
-     * @return Session
+     * @return \Cake\Http\Session
      */
     protected function getSession()
     {


### PR DESCRIPTION
Refs #12958

This prevents a situation when the outdated session object is referenced by a controller.
Since PSR-7 request and response objects are immutable, request may be changed at runtime along with the session object.