### PR TITLE
Entity::hasErrors() should return true only if field's errors array is non-empty.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -15,6 +15,7 @@
 namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Traversable;
@@ -899,7 +900,7 @@ trait EntityTrait
      */
     public function hasErrors($includeNested = true)
     {
-        if (!empty($this->_errors)) {
+        if (Hash::filter($this->_errors)) {
             return true;
         }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1315,6 +1315,9 @@ class EntityTest extends TestCase
         $nestedEntity->clean();
         $hasErrors = $entity->hasErrors();
         $this->assertFalse($hasErrors);
+
+        $entity->setError('foo', []);
+        $this->assertFalse($entity->hasErrors());
     }
 
     /**


### PR DESCRIPTION
Fixes #12974