### PR TITLE
Create controller instance if one is not provided to constructor.

### DIFF
--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -44,17 +44,15 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function __construct(?Controller $controller = null)
     {
-        if ($controller) {
-            $this->setController($controller);
-        }
+        $this->setController($controller ?: new Controller());
     }
 
     /**
      * Get the controller associated with the collection.
      *
-     * @return \Cake\Controller\Controller|null Controller instance
+     * @return \Cake\Controller\Controller Controller instance
      */
-    public function getController(): ?Controller
+    public function getController(): Controller
     {
         return $this->_Controller;
     }

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -17,6 +17,7 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\App;
+use Cake\Core\Exception\Exception;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -33,7 +34,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     /**
      * The controller that this collection was initialized with.
      *
-     * @var \Cake\Controller\Controller
+     * @var \Cake\Controller\Controller|null
      */
     protected $_Controller;
 
@@ -44,7 +45,9 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function __construct(?Controller $controller = null)
     {
-        $this->setController($controller ?: new Controller());
+        if ($controller) {
+            $this->setController($controller);
+        }
     }
 
     /**
@@ -54,6 +57,10 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function getController(): Controller
     {
+        if ($this->_Controller === null) {
+            throw new Exception('Controller not set for ComponentRegistry');
+        }
+
         return $this->_Controller;
     }
 

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -61,12 +61,14 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * Set the controller associated with the collection.
      *
      * @param \Cake\Controller\Controller $controller Controller instance.
-     * @return void
+     * @return $this
      */
-    public function setController(Controller $controller): void
+    public function setController(Controller $controller)
     {
         $this->_Controller = $controller;
         $this->setEventManager($controller->getEventManager());
+
+        return $this;
     }
 
     /**

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Controller;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
+use Cake\Core\Exception\Exception;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Controller\Component\AppleComponent;
@@ -49,7 +50,7 @@ class ComponentTest extends TestCase
      */
     public function testInnerComponentConstruction(): void
     {
-        $Collection = new ComponentRegistry();
+        $Collection = new ComponentRegistry(new Controller());
         $Component = new AppleComponent($Collection);
 
         $this->assertInstanceOf(OrangeComponent::class, $Component->Orange, 'class is wrong');
@@ -62,7 +63,7 @@ class ComponentTest extends TestCase
      */
     public function testNestedComponentLoading(): void
     {
-        $Collection = new ComponentRegistry();
+        $Collection = new ComponentRegistry(new Controller());
         $Apple = new AppleComponent($Collection);
 
         $this->assertInstanceOf(OrangeComponent::class, $Apple->Orange, 'class is wrong');
@@ -99,7 +100,7 @@ class ComponentTest extends TestCase
      */
     public function testMultipleComponentInitialize(): void
     {
-        $Collection = new ComponentRegistry();
+        $Collection = new ComponentRegistry(new Controller());
         $Banana = $Collection->load('Banana');
         $Orange = $Collection->load('Orange');
 
@@ -197,7 +198,11 @@ class ComponentTest extends TestCase
      */
     public function testLazyLoading(): void
     {
-        $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['Apple', 'Banana', 'Orange']);
+        $Component = new ConfiguredComponent(
+            new ComponentRegistry(new Controller()),
+            [],
+            ['Apple', 'Banana', 'Orange']
+        );
         $this->assertInstanceOf(AppleComponent::class, $Component->Apple, 'class is wrong');
         $this->assertInstanceOf(OrangeComponent::class, $Component->Orange, 'class is wrong');
         $this->assertInstanceOf(BananaComponent::class, $Component->Banana, 'class is wrong');
@@ -267,5 +272,19 @@ class ComponentTest extends TestCase
 
         $Component = new ConfiguredComponent($Collection, [], ['Apple' => ['enabled' => false]]);
         $this->assertInstanceOf(AppleComponent::class, $Component->Apple, 'class is wrong');
+    }
+
+    /**
+     * Test that calling getController() without setting a controller throws exception
+     *
+     * @return void
+     */
+    public function testGetControllerException()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Controller not set for ComponentRegistry');
+
+        $collection = new ComponentRegistry();
+        $collection->getController();
     }
 }


### PR DESCRIPTION
This ensures static analyzers/IDE don't complain about calling methods on possibly null values.

Fixes error this thrown by psalm
```
INFO: PossiblyNullReference - src/Controller/Component/PaginatorComponent.php:196:55 - Cannot call method getRequest on possibly null value
        $request = $this->_registry->getController()->getRequest();
```