### PR TITLE
Fix classes to standalone class files.

### DIFF
--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -21,6 +21,8 @@ use Cake\Event\EventList;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use TestApp\TestCase\Event\CustomTestEventListenerInterface;
+use TestApp\TestCase\Event\EventTestListener;
 
 /**
  * Tests the Cake\Event\EventManager class functionality
@@ -217,9 +219,9 @@ class EventManagerTest extends TestCase
     public function testDispatch()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $listener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
-        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $anotherListener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
         $manager->on('fake.event', [$listener, 'listenerFunction']);
         $manager->on('fake.event', [$anotherListener, 'listenerFunction']);
@@ -256,9 +258,9 @@ class EventManagerTest extends TestCase
     public function testDispatchReturnValue()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $listener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
-        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $anotherListener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
         $manager->on('fake.event', [$listener, 'listenerFunction']);
         $manager->on('fake.event', [$anotherListener, 'listenerFunction']);
@@ -283,9 +285,9 @@ class EventManagerTest extends TestCase
     public function testDispatchFalseStopsEvent()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $listener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
-        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+        $anotherListener = $this->getMockBuilder(EventTestListener::class)
             ->getMock();
         $manager->on('fake.event', [$listener, 'listenerFunction']);
         $manager->on('fake.event', [$anotherListener, 'listenerFunction']);
@@ -329,7 +331,7 @@ class EventManagerTest extends TestCase
     public function testOnSubscriber()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+        $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
             ->setMethods(['secondListenerFunction'])
             ->getMock();
         $manager->on($listener);
@@ -356,7 +358,7 @@ class EventManagerTest extends TestCase
     public function testOnSubscriberMultiple()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+        $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
             ->setMethods(['listenerFunction', 'thirdListenerFunction'])
             ->getMock();
         $manager->on($listener);
@@ -378,7 +380,7 @@ class EventManagerTest extends TestCase
     public function testDetachSubscriber()
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+        $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
             ->setMethods(['secondListenerFunction'])
             ->getMock();
         $manager->on($listener);
@@ -816,72 +818,5 @@ class EventManagerTest extends TestCase
 
         $returnValue = $eventManager->unsetEventList();
         $this->assertSame($eventManager, $returnValue);
-    }
-}
-
-/**
- * Mock class used to test event dispatching
- */
-class EventTestListener
-{
-    public $callList = [];
-
-    /**
-     * Test function to be used in event dispatching
-     *
-     * @return void
-     */
-    public function listenerFunction()
-    {
-        $this->callList[] = __FUNCTION__;
-    }
-
-    /**
-     * Test function to be used in event dispatching
-     *
-     * @return void
-     */
-    public function secondListenerFunction()
-    {
-        $this->callList[] = __FUNCTION__;
-    }
-
-    /**
-     * Auxiliary function to help in stopPropagation testing
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return void
-     */
-    public function stopListener($event)
-    {
-        $event->stopPropagation();
-    }
-}
-
-/**
- * Mock used for testing the subscriber objects
- */
-class CustomTestEventListenerInterface extends EventTestListener implements EventListenerInterface
-{
-    public function implementedEvents(): array
-    {
-        return [
-            'fake.event' => 'listenerFunction',
-            'another.event' => ['callable' => 'secondListenerFunction'],
-            'multiple.handlers' => [
-                ['callable' => 'listenerFunction'],
-                ['callable' => 'thirdListenerFunction'],
-            ],
-        ];
-    }
-
-    /**
-     * Test function to be used in event dispatching
-     *
-     * @return void
-     */
-    public function thirdListenerFunction()
-    {
-        $this->callList[] = __FUNCTION__;
     }
 }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 
 /**
@@ -136,8 +137,8 @@ class AssociationTest extends TestCase
     public function testSetClassNameBeforeTarget()
     {
         $this->assertEquals(TestTable::class, $this->association->getClassName());
-        $this->assertSame($this->association, $this->association->setClassName('\TestApp\Model\Table\AuthorsTable'));
-        $this->assertEquals('\TestApp\Model\Table\AuthorsTable', $this->association->getClassName());
+        $this->assertSame($this->association, $this->association->setClassName(AuthorsTable::class));
+        $this->assertEquals(AuthorsTable::class, $this->association->getClassName());
     }
 
     /**
@@ -148,9 +149,9 @@ class AssociationTest extends TestCase
     public function testSetClassNameAfterTarget()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The class name "\TestApp\Model\Table\AuthorsTable" doesn\'t match the target table class name of');
+        $this->expectExceptionMessage('The class name "' . AuthorsTable::class . '" doesn\'t match the target table class name of');
         $this->association->getTarget();
-        $this->association->setClassName('\TestApp\Model\Table\AuthorsTable');
+        $this->association->setClassName(AuthorsTable::class);
     }
 
     /**
@@ -187,7 +188,7 @@ class AssociationTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
 
-        $this->association->setClassName('\TestApp\Model\Table\AuthorsTable');
+        $this->association->setClassName(AuthorsTable::class);
         $className = get_class($this->association->getTarget());
         $this->assertEquals('TestApp\Model\Table\AuthorsTable', $className);
         $this->association->setClassName('Authors');

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -23,6 +23,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use TestApp\Model\Entity\TranslateArticle;
+use TestApp\Model\Table\I18nTable;
 
 /**
  * Translate behavior test case
@@ -81,15 +82,15 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
 
         $table->addBehavior('Translate', [
-            'translationTable' => '\TestApp\Model\Table\I18nTable',
+            'translationTable' => I18nTable::class,
             'fields' => ['title', 'body'],
         ]);
 
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->getName());
-        $this->assertInstanceOf('TestApp\Model\Table\I18nTable', $i18n->getTarget());
+        $this->assertEquals(I18nTable::class, $i18n->getName());
+        $this->assertInstanceOf(I18nTable::class, $i18n->getTarget());
         $this->assertEquals('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
         $this->assertEquals('custom_i18n_table', $i18n->getTarget()->getTable());
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -41,6 +41,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use TestApp\Model\Entity\ProtectedEntity;
+use TestApp\Model\Entity\VirtualUser;
 use TestApp\Model\Table\UsersTable;
 
 /**
@@ -1322,7 +1323,7 @@ class TableTest extends TestCase
         $table = new Table([
             'table' => 'users',
             'connection' => $this->connection,
-            'entityClass' => '\TestApp\Model\Entity\VirtualUser',
+            'entityClass' => VirtualUser::class,
         ]);
         $table->setDisplayField('bonus');
 

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -20,6 +20,7 @@ use Cake\Event\Event;
 use Cake\Event\EventList;
 use Cake\Event\EventManager;
 use Cake\ORM\Entity;
+use Cake\ORM\Table;
 use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
@@ -423,11 +424,11 @@ class TestCaseTest extends TestCase
         $Mock = $this->getMockForModel(
             'Table',
             ['save'],
-            ['alias' => 'Comments', 'className' => 'Cake\ORM\Table']
+            ['alias' => 'Comments', 'className' => Table::class]
         );
 
         $result = $this->getTableLocator()->get('Comments');
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertInstanceOf(Table::class, $result);
         $this->assertEquals('Comments', $Mock->getAlias());
 
         $Mock->expects($this->at(0))
@@ -444,19 +445,19 @@ class TestCaseTest extends TestCase
         $allMethodsStubs = $this->getMockForModel(
             'Table',
             [],
-            ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
+            ['alias' => 'Comments', 'className' => Table::class]
         );
         $result = $this->getTableLocator()->get('Comments');
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertInstanceOf(Table::class, $result);
         $this->assertEmpty([], $allMethodsStubs->getAlias());
 
         $allMethodsMocks = $this->getMockForModel(
             'Table',
             null,
-            ['alias' => 'Comments', 'className' => '\Cake\ORM\Table']
+            ['alias' => 'Comments', 'className' => Table::class]
         );
         $result = $this->getTableLocator()->get('Comments');
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertInstanceOf(Table::class, $result);
         $this->assertEquals('Comments', $allMethodsMocks->getAlias());
 
         $this->assertNotEquals($allMethodsStubs, $allMethodsMocks);

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -23,24 +23,9 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
+use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\ArticlesTag;
 use TestApp\Model\Entity\Tag;
-
-/**
- * Test stub.
- */
-class Article extends Entity
-{
-    /**
-     * Testing stub method.
-     *
-     * @return bool
-     */
-    public function isRequired()
-    {
-        return true;
-    }
-}
 
 /**
  * Entity context test case.
@@ -53,6 +38,11 @@ class EntityContextTest extends TestCase
      * @var array
      */
     public $fixtures = ['core.Articles', 'core.Comments', 'core.ArticlesTags', 'core.Tags'];
+
+    /**
+     * @var \Cake\Http\ServerRequest
+     */
+    protected $request;
 
     /**
      * setup method.
@@ -1321,7 +1311,7 @@ class EntityContextTest extends TestCase
         $articles->belongsTo('Users');
         $articles->belongsToMany('Tags');
         $articles->hasMany('Comments');
-        $articles->setEntityClass(__NAMESPACE__ . '\Article');
+        $articles->setEntityClass(Article::class);
 
         $articlesTags = $this->getTableLocator()->get('ArticlesTags');
         $comments = $this->getTableLocator()->get('Comments');

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -19,31 +19,11 @@ namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-use Cake\View\Helper\NumberHelper;
 use Cake\View\View;
-
-/**
- * NumberHelperTestObject class
- */
-class NumberHelperTestObject extends NumberHelper
-{
-    public function attach(NumberMock $cakeNumber)
-    {
-        $this->_engine = $cakeNumber;
-    }
-
-    public function engine()
-    {
-        return $this->_engine;
-    }
-}
-
-/**
- * NumberMock class
- */
-class NumberMock
-{
-}
+use TestApp\Utility\NumberMock;
+use TestApp\Utility\TestAppEngine;
+use TestApp\View\Helper\NumberHelperTestObject;
+use TestPlugin\Utility\TestPluginEngine;
 
 /**
  * NumberHelperTest class
@@ -105,10 +85,10 @@ class NumberHelperTest extends TestCase
      */
     public function testNumberHelperProxyMethodCalls($method)
     {
-        $number = $this->getMockBuilder(__NAMESPACE__ . '\NumberMock')
+        $number = $this->getMockBuilder(NumberMock::class)
             ->setMethods([$method])
             ->getMock();
-        $helper = new NumberHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\NumberMock']);
+        $helper = new NumberHelperTestObject($this->View, ['engine' => NumberMock::class]);
         $helper->attach($number);
         $number->expects($this->at(0))
             ->method($method)
@@ -125,11 +105,11 @@ class NumberHelperTest extends TestCase
     public function testEngineOverride()
     {
         $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
-        $this->assertInstanceOf('TestApp\Utility\TestAppEngine', $Number->engine());
+        $this->assertInstanceOf(TestAppEngine::class, $Number->engine());
 
         $this->loadPlugins(['TestPlugin']);
         $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);
-        $this->assertInstanceOf('TestPlugin\Utility\TestPluginEngine', $Number->engine());
+        $this->assertInstanceOf(TestPluginEngine::class, $Number->engine());
         $this->removePlugins(['TestPlugin']);
     }
 }

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -19,29 +19,10 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\TextHelper;
 use Cake\View\View;
-
-/**
- * TextHelperTestObject
- */
-class TextHelperTestObject extends TextHelper
-{
-    public function attach(StringMock $string)
-    {
-        $this->_engine = $string;
-    }
-
-    public function engine()
-    {
-        return $this->_engine;
-    }
-}
-
-/**
- * StringMock class
- */
-class StringMock
-{
-}
+use TestApp\Utility\TestAppEngine;
+use TestApp\Utility\TextMock;
+use TestApp\View\Helper\TextHelperTestObject;
+use TestPlugin\Utility\TestPluginEngine;
 
 /**
  * TextHelperTest class
@@ -90,10 +71,10 @@ class TextHelperTest extends TestCase
         $methods = [
             'stripLinks', 'toList',
         ];
-        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+        $String = $this->getMockBuilder(TextMock::class)
             ->setMethods($methods)
             ->getMock();
-        $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
+        $Text = new TextHelperTestObject($this->View, ['engine' => TextMock::class]);
         $Text->attach($String);
         foreach ($methods as $method) {
             $String->expects($this->at(0))->method($method)->willReturn('');
@@ -103,10 +84,10 @@ class TextHelperTest extends TestCase
         $methods = [
             'excerpt',
         ];
-        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+        $String = $this->getMockBuilder(TextMock::class)
             ->setMethods($methods)
             ->getMock();
-        $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
+        $Text = new TextHelperTestObject($this->View, ['engine' => TextMock::class]);
         $Text->attach($String);
         foreach ($methods as $method) {
             $String->expects($this->at(0))->method($method)->willReturn('');
@@ -116,10 +97,10 @@ class TextHelperTest extends TestCase
         $methods = [
             'highlight',
         ];
-        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+        $String = $this->getMockBuilder(TextMock::class)
             ->setMethods($methods)
             ->getMock();
-        $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
+        $Text = new TextHelperTestObject($this->View, ['engine' => TextMock::class]);
         $Text->attach($String);
         foreach ($methods as $method) {
             $String->expects($this->at(0))->method($method)->willReturn('');
@@ -129,10 +110,10 @@ class TextHelperTest extends TestCase
         $methods = [
             'tail', 'truncate',
         ];
-        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+        $String = $this->getMockBuilder(TextMock::class)
             ->setMethods($methods)
             ->getMock();
-        $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
+        $Text = new TextHelperTestObject($this->View, ['engine' => TextMock::class]);
         $Text->attach($String);
         foreach ($methods as $method) {
             $String->expects($this->at(0))->method($method)->willReturn('');
@@ -148,11 +129,11 @@ class TextHelperTest extends TestCase
     public function testEngineOverride()
     {
         $Text = new TextHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
-        $this->assertInstanceOf('TestApp\Utility\TestAppEngine', $Text->engine());
+        $this->assertInstanceOf(TestAppEngine::class, $Text->engine());
 
         $this->loadPlugins(['TestPlugin']);
         $Text = new TextHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);
-        $this->assertInstanceOf('TestPlugin\Utility\TestPluginEngine', $Text->engine());
+        $this->assertInstanceOf(TestPluginEngine::class, $Text->engine());
         $this->clearPlugins();
     }
 

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View;
 
 use Cake\TestSuite\TestCase;
+use Cake\View\Helper\FormHelper;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\HelperRegistry;
 use Cake\View\View;
@@ -36,6 +37,11 @@ class HelperRegistryTest extends TestCase
      * @var \Cake\Event\EventManager
      */
     public $Events;
+
+    /**
+     * @var \Cake\View\View
+     */
+    public $View;
 
     /**
      * setUp
@@ -88,7 +94,7 @@ class HelperRegistryTest extends TestCase
         $this->assertInstanceOf(HtmlHelper::class, $result);
 
         $result = $this->Helpers->Form;
-        $this->assertInstanceOf('Cake\View\Helper\FormHelper', $result);
+        $this->assertInstanceOf(FormHelper::class, $result);
 
         $this->View->setPlugin('TestPlugin');
         $this->loadPlugins(['TestPlugin']);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -16,19 +16,11 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View;
 
 use Cake\TestSuite\TestCase;
-use Cake\View\Helper;
+use Cake\View\Helper\HtmlHelper;
 use Cake\View\HelperRegistry;
 use Cake\View\View;
-
-/**
- * Extended HtmlHelper
- */
-class HtmlAliasHelper extends Helper
-{
-    public function afterRender($viewFile)
-    {
-    }
-}
+use TestApp\View\Helper\HtmlAliasHelper;
+use TestPlugin\View\Helper\OtherHelperHelper;
 
 /**
  * HelperRegistryTest
@@ -78,8 +70,8 @@ class HelperRegistryTest extends TestCase
     public function testLoad()
     {
         $result = $this->Helpers->load('Html');
-        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $result);
-        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $this->Helpers->Html);
+        $this->assertInstanceOf(HtmlHelper::class, $result);
+        $this->assertInstanceOf(HtmlHelper::class, $this->Helpers->Html);
 
         $result = $this->Helpers->loaded();
         $this->assertEquals(['Html'], $result, 'loaded() results are wrong.');
@@ -93,7 +85,7 @@ class HelperRegistryTest extends TestCase
     public function testLazyLoad()
     {
         $result = $this->Helpers->Html;
-        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $result);
+        $this->assertInstanceOf(HtmlHelper::class, $result);
 
         $result = $this->Helpers->Form;
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $result);
@@ -101,7 +93,7 @@ class HelperRegistryTest extends TestCase
         $this->View->setPlugin('TestPlugin');
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Helpers->OtherHelper;
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result);
+        $this->assertInstanceOf(OtherHelperHelper::class, $result);
     }
 
     /**
@@ -122,7 +114,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadSubscribeEvents()
     {
-        $this->Helpers->load('Html', ['className' => __NAMESPACE__ . '\HtmlAliasHelper']);
+        $this->Helpers->load('Html', ['className' => HtmlAliasHelper::class]);
         $result = $this->Events->listeners('View.afterRender');
         $this->assertCount(1, $result);
     }
@@ -134,15 +126,15 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadWithAlias()
     {
-        $result = $this->Helpers->load('Html', ['className' => __NAMESPACE__ . '\HtmlAliasHelper']);
-        $this->assertInstanceOf(__NAMESPACE__ . '\HtmlAliasHelper', $result);
-        $this->assertInstanceOf(__NAMESPACE__ . '\HtmlAliasHelper', $this->Helpers->Html);
+        $result = $this->Helpers->load('Html', ['className' => HtmlAliasHelper::class]);
+        $this->assertInstanceOf(HtmlAliasHelper::class, $result);
+        $this->assertInstanceOf(HtmlAliasHelper::class, $this->Helpers->Html);
 
         $result = $this->Helpers->loaded();
         $this->assertEquals(['Html'], $result, 'loaded() results are wrong.');
 
         $result = $this->Helpers->load('Html');
-        $this->assertInstanceOf(__NAMESPACE__ . '\HtmlAliasHelper', $result);
+        $this->assertInstanceOf(HtmlAliasHelper::class, $result);
     }
 
     /**
@@ -154,8 +146,8 @@ class HelperRegistryTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Helpers->load('SomeOther', ['className' => 'TestPlugin.OtherHelper']);
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result);
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $this->Helpers->SomeOther);
+        $this->assertInstanceOf(OtherHelperHelper::class, $result);
+        $this->assertInstanceOf(OtherHelperHelper::class, $this->Helpers->SomeOther);
 
         $result = $this->Helpers->loaded();
         $this->assertEquals(['SomeOther'], $result, 'loaded() results are wrong.');
@@ -169,8 +161,8 @@ class HelperRegistryTest extends TestCase
     public function testLoadWithEnabledFalse()
     {
         $result = $this->Helpers->load('Html', ['enabled' => false]);
-        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $result);
-        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $this->Helpers->Html);
+        $this->assertInstanceOf(HtmlHelper::class, $result);
+        $this->assertInstanceOf(HtmlHelper::class, $this->Helpers->Html);
 
         $this->assertEmpty($this->Events->listeners('View.beforeRender'));
     }
@@ -196,8 +188,8 @@ class HelperRegistryTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $result = $this->Helpers->load('TestPlugin.OtherHelper');
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result, 'Helper class is wrong.');
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $this->Helpers->OtherHelper, 'Class is wrong');
+        $this->assertInstanceOf(OtherHelperHelper::class, $result, 'Helper class is wrong.');
+        $this->assertInstanceOf(OtherHelperHelper::class, $this->Helpers->OtherHelper, 'Class is wrong');
     }
 
     /**
@@ -212,9 +204,9 @@ class HelperRegistryTest extends TestCase
         $result = $this->Helpers->load('thing.helper', [
             'className' => 'TestPlugin.OtherHelper',
         ]);
-        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result, 'Helper class is wrong.');
+        $this->assertInstanceOf(OtherHelperHelper::class, $result, 'Helper class is wrong.');
         $this->assertInstanceOf(
-            'TestPlugin\View\Helper\OtherHelperHelper',
+            OtherHelperHelper::class,
             $this->Helpers->get('thing.helper'),
             'Class is wrong'
         );

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -20,28 +20,8 @@ namespace Cake\Test\TestCase\View;
 use Cake\Core\Configure;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use Cake\View\Helper;
 use Cake\View\View;
-
-class TestHelper extends Helper
-{
-    /**
-     * Settings for this helper.
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [
-        'key1' => 'val1',
-        'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'val2.2'],
-    ];
-
-    /**
-     * Helpers for this helper.
-     *
-     * @var array
-     */
-    public $helpers = ['Html', 'TestPlugin.OtherHelper'];
-}
+use TestApp\View\Helper\TestHelper;
 
 /**
  * HelperTest class

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -15,25 +15,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
-use Cake\Core\InstanceConfigTrait;
 use Cake\TestSuite\TestCase;
-use Cake\View\StringTemplateTrait;
-
-/**
- * TestStringTemplate
- */
-class TestStringTemplate
-{
-    use InstanceConfigTrait;
-    use StringTemplateTrait;
-
-    /**
-     * _defaultConfig
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [];
-}
+use Cake\View\StringTemplate;
+use TestApp\View\TestStringTemplate;
 
 /**
  * StringTemplateTraitTest class
@@ -41,7 +25,7 @@ class TestStringTemplate
 class StringTemplateTraitTest extends TestCase
 {
     /**
-     * @var TestStringTemplate
+     * @var \TestApp\View\TestStringTemplate
      */
     public $Template;
 
@@ -130,6 +114,6 @@ class StringTemplateTraitTest extends TestCase
         ];
         $this->Template->setTemplates($templates);
         $result = $this->Template->templater();
-        $this->assertInstanceOf('Cake\View\StringTemplate', $result);
+        $this->assertInstanceOf(StringTemplate::class, $result);
     }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -21,244 +21,16 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Event\EventInterface;
-use Cake\Event\EventListenerInterface;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use Cake\View\Helper;
 use Cake\View\View;
-use TestApp\View\AppView;
-
-/**
- * ViewPostsController class
- */
-class ViewPostsController extends Controller
-{
-    /**
-     * name property
-     *
-     * @var string
-     */
-    public $name = 'Posts';
-
-    /**
-     * index method
-     *
-     * @return void
-     */
-    public function index()
-    {
-        $this->set([
-            'testData' => 'Some test data',
-            'test2' => 'more data',
-            'test3' => 'even more data',
-        ]);
-    }
-
-    /**
-     * nocache_tags_with_element method
-     *
-     * @return void
-     */
-    public function nocache_multiple_element()
-    {
-        $this->set('foo', 'this is foo var');
-        $this->set('bar', 'this is bar var');
-    }
-}
-
-/**
- * ThemePostsController class
- */
-class ThemePostsController extends Controller
-{
-    /**
-     * index method
-     *
-     * @return void
-     */
-    public function index()
-    {
-        $this->set('testData', 'Some test data');
-        $test2 = 'more data';
-        $test3 = 'even more data';
-        $this->set(compact('test2', 'test3'));
-    }
-}
-
-/**
- * TestView class
- */
-class TestView extends AppView
-{
-    public function initialize(): void
-    {
-        $this->loadHelper('Html', ['mykey' => 'myval']);
-    }
-
-    /**
-     * getViewFileName method
-     *
-     * @param string $name Controller action to find template filename for
-     * @return string Template filename
-     */
-    public function getViewFileName($name = null)
-    {
-        return $this->_getViewFileName($name);
-    }
-
-    /**
-     * getLayoutFileName method
-     *
-     * @param string $name The name of the layout to find.
-     * @return string Filename for layout file (.php).
-     */
-    public function getLayoutFileName($name = null)
-    {
-        return $this->_getLayoutFileName($name);
-    }
-
-    /**
-     * paths method
-     *
-     * @param string $plugin Optional plugin name to scan for view files.
-     * @param bool $cached Set to true to force a refresh of view paths.
-     * @return array paths
-     */
-    public function paths($plugin = null, $cached = true)
-    {
-        return $this->_paths($plugin, $cached);
-    }
-
-    /**
-     * Setter for extension.
-     *
-     * @param string $ext The extension
-     * @return void
-     */
-    public function ext($ext)
-    {
-        $this->_ext = $ext;
-    }
-}
-
-/**
- * TestBeforeAfterHelper class
- */
-class TestBeforeAfterHelper extends Helper
-{
-    /**
-     * property property
-     *
-     * @var string
-     */
-    public $property = '';
-
-    /**
-     * beforeLayout method
-     *
-     * @param string $viewFile View file name.
-     * @return void
-     */
-    public function beforeLayout($viewFile)
-    {
-        $this->property = 'Valuation';
-    }
-
-    /**
-     * afterLayout method
-     *
-     * @param string $layoutFile Layout file name.
-     * @return void
-     */
-    public function afterLayout($layoutFile)
-    {
-        $this->_View->append('content', 'modified in the afterlife');
-    }
-}
-
-/**
- * TestObjectWithToString
- *
- * An object with the magic method __toString() for testing with view blocks.
- */
-class TestObjectWithToString
-{
-    /**
-     * Return string value.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return "I'm ObjectWithToString";
-    }
-}
-
-/**
- * TestObjectWithoutToString
- *
- * An object without the magic method __toString() for testing with view blocks.
- */
-class TestObjectWithoutToString
-{
-}
-
-/**
- * TestViewEventListenerInterface
- *
- * An event listener to test cakePHP events
- */
-class TestViewEventListenerInterface implements EventListenerInterface
-{
-    /**
-     * type of view before rendering has occurred
-     *
-     * @var string
-     */
-    public $beforeRenderViewType;
-
-    /**
-     * type of view after rendering has occurred
-     *
-     * @var string
-     */
-    public $afterRenderViewType;
-
-    /**
-     * implementedEvents method
-     *
-     * @return array
-     */
-    public function implementedEvents(): array
-    {
-        return [
-            'View.beforeRender' => 'beforeRender',
-            'View.afterRender' => 'afterRender',
-        ];
-    }
-
-    /**
-     * beforeRender method
-     *
-     * @param \Cake\Event\EventInterface $event the event being sent
-     * @return void
-     */
-    public function beforeRender(EventInterface $event)
-    {
-        $this->beforeRenderViewType = $event->getSubject()->getCurrentType();
-    }
-
-    /**
-     * afterRender method
-     *
-     * @param \Cake\Event\EventInterface $event the event being sent
-     * @return void
-     */
-    public function afterRender(EventInterface $event)
-    {
-        $this->afterRenderViewType = $event->getSubject()->getCurrentType();
-    }
-}
+use TestApp\Controller\ThemePostsController;
+use TestApp\Controller\ViewPostsController;
+use TestApp\View\Helper\TestBeforeAfterHelper;
+use TestApp\View\Object\TestObjectWithoutToString;
+use TestApp\View\Object\TestObjectWithToString;
+use TestApp\View\TestView;
+use TestApp\View\TestViewEventListenerInterface;
 
 /**
  * ViewTest class
@@ -278,9 +50,14 @@ class ViewTest extends TestCase
     public $View;
 
     /**
-     * @var ViewPostsController
+     * @var \TestApp\Controller\ViewPostsController
      */
     public $PostsController;
+
+    /**
+     * @var \TestApp\Controller\ThemePostsController
+     */
+    public $ThemePostsController;
 
     /**
      * setUp method
@@ -1255,7 +1032,7 @@ class ViewTest extends TestCase
     public function testBeforeLayout()
     {
         $this->PostsController->viewBuilder()->setHelpers([
-            'TestBeforeAfter' => ['className' => __NAMESPACE__ . '\TestBeforeAfterHelper'],
+            'TestBeforeAfter' => ['className' => TestBeforeAfterHelper::class],
             'Html',
         ]);
         $View = $this->PostsController->createView();
@@ -1272,7 +1049,7 @@ class ViewTest extends TestCase
     public function testAfterLayout()
     {
         $this->PostsController->viewBuilder()->setHelpers([
-            'TestBeforeAfter' => ['className' => __NAMESPACE__ . '\TestBeforeAfterHelper'],
+            'TestBeforeAfter' => ['className' => TestBeforeAfterHelper::class],
             'Html',
         ]);
         $this->PostsController->set('variable', 'values');
@@ -1294,7 +1071,7 @@ class ViewTest extends TestCase
     public function testRenderLoadHelper()
     {
         $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number']);
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
@@ -1307,7 +1084,7 @@ class ViewTest extends TestCase
         $this->PostsController->viewBuilder()->setHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
         );
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
@@ -1325,7 +1102,7 @@ class ViewTest extends TestCase
      */
     public function testRender()
     {
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
@@ -1333,7 +1110,7 @@ class ViewTest extends TestCase
         $this->assertRegExp("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
         $this->assertRegExp("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
 
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $result = $View->render(false, 'ajax2');
 
         $this->assertRegExp('/Ajax\!/', $result);
@@ -1344,7 +1121,7 @@ class ViewTest extends TestCase
         );
         Configure::write('Cache.check', true);
 
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
@@ -1359,7 +1136,7 @@ class ViewTest extends TestCase
      */
     public function testRenderUsingViewProperty()
     {
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
         $View->setTemplate('cache_form');
 
@@ -1380,7 +1157,7 @@ class ViewTest extends TestCase
         $error->queryString = 'this is sql string';
         $message = 'it works';
 
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView(TestView::class);
         $View->set(compact('error', 'message'));
         $View->setTemplatePath('Error');
 
@@ -1399,7 +1176,8 @@ class ViewTest extends TestCase
     {
         $this->PostsController->setPlugin('TestPlugin');
         $this->PostsController->setName('Posts');
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        /** @var \TestApp\View\TestView $View */
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath('element');
 
         $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
@@ -1433,7 +1211,8 @@ class ViewTest extends TestCase
      */
     public function testViewFileName()
     {
-        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        /** @var \TestApp\View\TestView $View */
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath('Posts');
 
         $result = $View->getViewFileName('index');

--- a/tests/test_app/TestApp/Controller/ThemePostsController.php
+++ b/tests/test_app/TestApp/Controller/ThemePostsController.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class ThemePostsController extends Controller
+{
+    /**
+     * index method
+     *
+     * @return void
+     */
+    public function index()
+    {
+        $this->set('testData', 'Some test data');
+        $test2 = 'more data';
+        $test3 = 'even more data';
+        $this->set(compact('test2', 'test3'));
+    }
+}

--- a/tests/test_app/TestApp/Controller/ViewPostsController.php
+++ b/tests/test_app/TestApp/Controller/ViewPostsController.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class ViewPostsController extends Controller
+{
+    /**
+     * name property
+     *
+     * @var string
+     */
+    public $name = 'Posts';
+
+    /**
+     * index method
+     *
+     * @return void
+     */
+    public function index()
+    {
+        $this->set([
+            'testData' => 'Some test data',
+            'test2' => 'more data',
+            'test3' => 'even more data',
+        ]);
+    }
+
+    /**
+     * nocache_tags_with_element method
+     *
+     * @return void
+     */
+    public function nocache_multiple_element()
+    {
+        $this->set('foo', 'this is foo var');
+        $this->set('bar', 'this is bar var');
+    }
+}

--- a/tests/test_app/TestApp/Model/Entity/Article.php
+++ b/tests/test_app/TestApp/Model/Entity/Article.php
@@ -9,4 +9,13 @@ use Cake\ORM\Entity;
  */
 class Article extends Entity
 {
+    /**
+     * Testing stub method.
+     *
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return true;
+    }
 }

--- a/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\TestCase\Event;
+
+use Cake\Event\EventListenerInterface;
+
+/**
+ * Mock used for testing the subscriber objects
+ */
+class CustomTestEventListenerInterface extends EventTestListener implements EventListenerInterface
+{
+    /**
+     * @return array
+     */
+    public function implementedEvents(): array
+    {
+        return [
+            'fake.event' => 'listenerFunction',
+            'another.event' => ['callable' => 'secondListenerFunction'],
+            'multiple.handlers' => [
+                ['callable' => 'listenerFunction'],
+                ['callable' => 'thirdListenerFunction'],
+            ],
+        ];
+    }
+
+    /**
+     * Test function to be used in event dispatching
+     *
+     * @return void
+     */
+    public function thirdListenerFunction()
+    {
+        $this->callList[] = __FUNCTION__;
+    }
+}

--- a/tests/test_app/TestApp/TestCase/Event/EventTestListener.php
+++ b/tests/test_app/TestApp/TestCase/Event/EventTestListener.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\TestCase\Event;
+
+/**
+ * Mock class used to test event dispatching
+ */
+class EventTestListener
+{
+    public $callList = [];
+
+    /**
+     * Test function to be used in event dispatching
+     *
+     * @return void
+     */
+    public function listenerFunction()
+    {
+        $this->callList[] = __FUNCTION__;
+    }
+
+    /**
+     * Test function to be used in event dispatching
+     *
+     * @return void
+     */
+    public function secondListenerFunction()
+    {
+        $this->callList[] = __FUNCTION__;
+    }
+
+    /**
+     * Auxiliary function to help in stopPropagation testing
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @return void
+     */
+    public function stopListener($event)
+    {
+        $event->stopPropagation();
+    }
+}

--- a/tests/test_app/TestApp/Utility/NumberMock.php
+++ b/tests/test_app/TestApp/Utility/NumberMock.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Utility;
+
+class NumberMock
+{
+}

--- a/tests/test_app/TestApp/Utility/TextMock.php
+++ b/tests/test_app/TestApp/Utility/TextMock.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\Utility;
+
+class TextMock
+{
+}

--- a/tests/test_app/TestApp/View/Helper/HtmlAliasHelper.php
+++ b/tests/test_app/TestApp/View/Helper/HtmlAliasHelper.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Helper;
+
+use Cake\View\Helper;
+
+/**
+ * Extended HtmlHelper
+ */
+class HtmlAliasHelper extends Helper
+{
+    /**
+     * @param string $viewFile
+     * @return void
+     */
+    public function afterRender($viewFile)
+    {
+    }
+}

--- a/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
+++ b/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Helper;
+
+use Cake\View\Helper\NumberHelper;
+use TestApp\Utility\NumberMock;
+
+/**
+ * NumberHelperTestObject class
+ */
+class NumberHelperTestObject extends NumberHelper
+{
+    public function attach(NumberMock $cakeNumber)
+    {
+        $this->_engine = $cakeNumber;
+    }
+
+    public function engine()
+    {
+        return $this->_engine;
+    }
+}

--- a/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
+++ b/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Helper;
+
+use Cake\View\Helper;
+
+class TestBeforeAfterHelper extends Helper
+{
+    /**
+     * property property
+     *
+     * @var string
+     */
+    public $property = '';
+
+    /**
+     * beforeLayout method
+     *
+     * @param string $viewFile View file name.
+     * @return void
+     */
+    public function beforeLayout($viewFile)
+    {
+        $this->property = 'Valuation';
+    }
+
+    /**
+     * afterLayout method
+     *
+     * @param string $layoutFile Layout file name.
+     * @return void
+     */
+    public function afterLayout($layoutFile)
+    {
+        $this->_View->append('content', 'modified in the afterlife');
+    }
+}

--- a/tests/test_app/TestApp/View/Helper/TestHelper.php
+++ b/tests/test_app/TestApp/View/Helper/TestHelper.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Helper;
+
+use Cake\View\Helper;
+
+class TestHelper extends Helper
+{
+    /**
+     * Settings for this helper.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'key1' => 'val1',
+        'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'val2.2'],
+    ];
+
+    /**
+     * Helpers for this helper.
+     *
+     * @var array
+     */
+    public $helpers = ['Html', 'TestPlugin.OtherHelper'];
+}

--- a/tests/test_app/TestApp/View/Helper/TextHelperTestObject.php
+++ b/tests/test_app/TestApp/View/Helper/TextHelperTestObject.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Helper;
+
+use Cake\View\Helper\TextHelper;
+use TestApp\Utility\TextMock;
+
+class TextHelperTestObject extends TextHelper
+{
+    public function attach(TextMock $string)
+    {
+        $this->_engine = $string;
+    }
+
+    public function engine()
+    {
+        return $this->_engine;
+    }
+}

--- a/tests/test_app/TestApp/View/Object/TestObjectWithToString.php
+++ b/tests/test_app/TestApp/View/Object/TestObjectWithToString.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Object;
+
+/**
+ * TestObjectWithToString
+ *
+ * An object with the magic method __toString() for testing with view blocks.
+ */
+class TestObjectWithToString
+{
+    /**
+     * Return string value.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return "I'm ObjectWithToString";
+    }
+}

--- a/tests/test_app/TestApp/View/Object/TestObjectWithoutToString.php
+++ b/tests/test_app/TestApp/View/Object/TestObjectWithoutToString.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View\Object;
+
+/**
+ * TestObjectWithoutToString
+ *
+ * An object without the magic method __toString() for testing with view blocks.
+ */
+class TestObjectWithoutToString
+{
+}

--- a/tests/test_app/TestApp/View/TestStringTemplate.php
+++ b/tests/test_app/TestApp/View/TestStringTemplate.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\View\StringTemplateTrait;
+
+class TestStringTemplate
+{
+    use InstanceConfigTrait;
+    use StringTemplateTrait;
+
+    /**
+     * @var array
+     */
+    protected $_defaultConfig = [];
+}

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View;
+
+class TestView extends AppView
+{
+    public function initialize(): void
+    {
+        $this->loadHelper('Html', ['mykey' => 'myval']);
+    }
+
+    /**
+     * getViewFileName method
+     *
+     * @param string $name Controller action to find template filename for
+     * @return string Template filename
+     */
+    public function getViewFileName($name = null)
+    {
+        return $this->_getViewFileName($name);
+    }
+
+    /**
+     * getLayoutFileName method
+     *
+     * @param string $name The name of the layout to find.
+     * @return string Filename for layout file (.php).
+     */
+    public function getLayoutFileName($name = null)
+    {
+        return $this->_getLayoutFileName($name);
+    }
+
+    /**
+     * paths method
+     *
+     * @param string $plugin Optional plugin name to scan for view files.
+     * @param bool $cached Set to true to force a refresh of view paths.
+     * @return array paths
+     */
+    public function paths($plugin = null, $cached = true)
+    {
+        return $this->_paths($plugin, $cached);
+    }
+
+    /**
+     * Setter for extension.
+     *
+     * @param string $ext The extension
+     * @return void
+     */
+    public function ext($ext)
+    {
+        $this->_ext = $ext;
+    }
+}

--- a/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
+++ b/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+namespace TestApp\View;
+
+use Cake\Event\EventInterface;
+use Cake\Event\EventListenerInterface;
+
+/**
+ * TestViewEventListenerInterface
+ *
+ * An event listener to test cakePHP events
+ */
+class TestViewEventListenerInterface implements EventListenerInterface
+{
+    /**
+     * type of view before rendering has occurred
+     *
+     * @var string
+     */
+    public $beforeRenderViewType;
+
+    /**
+     * type of view after rendering has occurred
+     *
+     * @var string
+     */
+    public $afterRenderViewType;
+
+    /**
+     * implementedEvents method
+     *
+     * @return array
+     */
+    public function implementedEvents(): array
+    {
+        return [
+            'View.beforeRender' => 'beforeRender',
+            'View.afterRender' => 'afterRender',
+        ];
+    }
+
+    /**
+     * beforeRender method
+     *
+     * @param \Cake\Event\EventInterface $event the event being sent
+     * @return void
+     */
+    public function beforeRender(EventInterface $event)
+    {
+        $this->beforeRenderViewType = $event->getSubject()->getCurrentType();
+    }
+
+    /**
+     * afterRender method
+     *
+     * @param \Cake\Event\EventInterface $event the event being sent
+     * @return void
+     */
+    public function afterRender(EventInterface $event)
+    {
+        $this->afterRenderViewType = $event->getSubject()->getCurrentType();
+    }
+}


### PR DESCRIPTION
Part 4/4 of https://github.com/cakephp/cakephp-codesniffer/pull/230 

No more `__NAMESPACE__` usage anymore in tests, clean use statements for classes.

CS rule: Now all green too.