### PR TITLE
Fix docblock and typehint for getControllerClass()

### DIFF
--- a/src/Http/ControllerFactory.php
+++ b/src/Http/ControllerFactory.php
@@ -54,9 +54,9 @@ class ControllerFactory
      * Determine the controller class name based on current request and controller param
      *
      * @param \Cake\Http\ServerRequest $request The request to build a controller for.
-     * @return string|false
+     * @return string|null
      */
-    public function getControllerClass(ServerRequest $request)
+    public function getControllerClass(ServerRequest $request): ?string
     {
         $pluginPath = $controller = null;
         $namespace = 'Controller';


### PR DESCRIPTION
Based on App::className() this method can only return string or null.