### PR TITLE
Better getter usage for internal framework handling.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -464,7 +464,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getConnection(): Connection
     {
         if (!$this->_connection) {
-            $this->_connection = ConnectionManager::get(static::defaultConnectionName());
+            /** @var \Cake\Database\Connection $connection */
+            $connection = ConnectionManager::get(static::defaultConnectionName());
+            $this->_connection = $connection;
         }
 
         return $this->_connection;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2779,7 +2779,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'associations' => $associations ? $associations->keys() : false,
             'behaviors' => $behaviors ? $behaviors->loaded() : false,
             'defaultConnection' => static::defaultConnectionName(),
-            'connectionName' => $conn ? $conn->configName() : null,
+            'connectionName' => $conn->configName(),
         ];
     }
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -22,6 +22,7 @@ use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionInterface;
+use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\RepositoryInterface;
@@ -458,10 +459,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the connection instance.
      *
-     * @return \Cake\Database\Connection|null
+     * @return \Cake\Database\Connection
      */
-    public function getConnection(): ?Connection
+    public function getConnection(): Connection
     {
+        if (!$this->_connection) {
+            $this->_connection = ConnectionManager::get(static::defaultConnectionName());
+        }
+
         return $this->_connection;
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -138,6 +138,7 @@ class TableTest extends TestCase
         $table = new UsersTable();
         $this->assertEquals('users', $table->getTable());
 
+        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingsTable')
@@ -170,6 +171,7 @@ class TableTest extends TestCase
         $table = new UsersTable();
         $this->assertEquals('Users', $table->getAlias());
 
+        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingTable')
@@ -201,7 +203,7 @@ class TableTest extends TestCase
     public function testSetConnection()
     {
         $table = new Table(['table' => 'users']);
-        $this->assertNull($table->getConnection());
+        $this->assertSame($this->connection, $table->getConnection());
         $this->assertSame($table, $table->setConnection($this->connection));
         $this->assertSame($this->connection, $table->getConnection());
     }


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/12980

![nullpointer](https://user-images.githubusercontent.com/39854/52900514-0578d980-31f7-11e9-9fed-1dbab0573f45.png)

The whole framework code always uses getConnection() without checking for null:

    ->getConnection()->...()

as such it only seems logical to also provide more sane defaults here.