### PR TITLE
Simplify local phpstan usage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ script:
 
   - |
       if [[ $STATIC_ANALYSIS = 1 ]]; then
-        composer require --dev phpstan/phpstan:^0.11 vimeo/psalm:^3.0
-        vendor/bin/phpstan analyse src && vendor/bin/psalm --show-info=false
+        composer stan-setup
+        composer stan
       fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,9 @@
         "cs-check": "phpcs --colors -p src/ tests/",
         "cs-fix": "phpcbf --colors src/ tests/",
         "test": "phpunit",
-        "test-coverage": "phpunit --coverage-clover=clover.xml"
+        "test-coverage": "phpunit --coverage-clover=clover.xml",
+        "stan": "phpstan analyse src/ && psalm --show-info=false",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.11 vimeo/psalm:^3.0 && mv composer.backup composer.json"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
As long as we dont have those in require-dev directly, it is painful to work locally here.

This should make it simpler as you can now run locally

    composer stan-setup
    composer stan

etc
Travis uses the same wrappers to keep things DRY.