### PR TITLE
Allow more data to be counted as empty

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2339,7 +2339,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return true;
         }
 
-        $arrayTypes = (self::EMPTY_ARRAY | self::EMPTY_DATE | self::EMPTY_TIME | self::EMPTY_FILE);
+        $arrayTypes = self::EMPTY_ARRAY | self::EMPTY_DATE | self::EMPTY_TIME | self::EMPTY_FILE;
         if ($data === [] && ($flags & $arrayTypes)) {
             return true;
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2339,7 +2339,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return true;
         }
 
-        $arrayTypes = self::EMPTY_ARRAY | self::EMPTY_DATE | self::EMPTY_TIME | self::EMPTY_FILE;
+        $arrayTypes = self::EMPTY_ARRAY | self::EMPTY_DATE | self::EMPTY_TIME;
         if ($data === [] && ($flags & $arrayTypes)) {
             return true;
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2339,7 +2339,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return true;
         }
 
-        if ($data === [] && ($flags & self::EMPTY_ARRAY)) {
+        $arrayTypes = (self::EMPTY_ARRAY | self::EMPTY_DATE | self::EMPTY_TIME | self::EMPTY_FILE);
+        if ($data === [] && ($flags & $arrayTypes)) {
             return true;
         }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -913,7 +913,7 @@ class ValidatorTest extends TestCase
 
         $data = ['photo' => []];
         $result = $validator->errors($data);
-        $this->assertEmpty($result);
+        $this->assertSame($expected, $result);
 
         $validator = new Validator();
         $validator->allowEmptyArray('photo', 'update', 'message');

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -911,17 +911,9 @@ class ValidatorTest extends TestCase
         $result = $validator->errors($data);
         $this->assertSame($expected, $result);
 
-        $data = [
-            'photo' => [],
-        ];
+        $data = ['photo' => []];
         $result = $validator->errors($data);
-        $expected = [
-            'photo' => [
-                'uploadedFile' => 'The provided value is invalid'
-            ]
-        ];
-        $this->assertSame($expected, $result);
-        $this->assertNotEmpty($result);
+        $this->assertEmpty($result);
 
         $validator = new Validator();
         $validator->allowEmptyArray('photo', 'update', 'message');
@@ -973,16 +965,9 @@ class ValidatorTest extends TestCase
         $result = $validator->errors($data);
         $this->assertEmpty($result);
 
-        $data = [
-            'date' => [],
-        ];
-        $expected = [
-            'date' => [
-                'date' => 'The provided value is invalid'
-            ]
-        ];
+        $data = ['date' => []];
         $result = $validator->errors($data);
-        $this->assertSame($expected, $result);
+        $this->assertEmpty($result);
 
         $validator = new Validator();
         $validator->allowEmptyArray('date', 'update', 'message');
@@ -1000,7 +985,7 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Tests the allowEmptyDate method
+     * Tests the allowEmptyTime method
      *
      * @return void
      */
@@ -1034,16 +1019,9 @@ class ValidatorTest extends TestCase
         $result = $validator->errors($data);
         $this->assertEmpty($result);
 
-        $data = [
-            'time' => [],
-        ];
-        $expected = [
-            'time' => [
-                'time' => 'The provided value is invalid'
-            ]
-        ];
+        $data = ['time' => []];
         $result = $validator->errors($data);
-        $this->assertSame($expected, $result);
+        $this->assertEmpty($result);
 
         $validator = new Validator();
         $validator->allowEmptyArray('time', 'update', 'message');
@@ -1101,13 +1079,8 @@ class ValidatorTest extends TestCase
         $data = [
             'published' => [],
         ];
-        $expected = [
-            'published' => [
-                'dateTime' => 'The provided value is invalid'
-            ]
-        ];
         $result = $validator->errors($data);
-        $this->assertSame($expected, $result);
+        $this->assertEmpty($result);
 
         $validator = new Validator();
         $validator->allowEmptyArray('published', 'update', 'message');


### PR DESCRIPTION
date, and time fields should all allow `[]` as an empty value. This makes the behavior of the new methods compatible with `Validator::notEmpty()`'s definition of empty. This change also makes
`allowEmptyDate(..., false)` work as a complement to its other modes.

I ran across this issue while trying to build the `notEmptyDate()`, and `notEmptyDateTime()` methods. I was unable to get them to behave opposite of the `allowEmpty*()` methods and reject `[]`.

I'm targeting this for 3.7 as I think it is a mistake in the logic that creates inconsistent behavior with `allowEmpty()` and `notEmpty()`.