### PR TITLE
Include ArrayEngine in DSN and docblock

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -47,8 +47,8 @@ use RuntimeException;
  * There are 7 built-in caching engines:
  *
  * - `ApcuEngine` - Uses the APCu object cache, one of the fastest caching engines.
- * - `ArrayEngine` - Uses only memory to store all data, not actually a persistent engin.
- *    Can be useful in test or CLI enviroment.
+ * - `ArrayEngine` - Uses only memory to store all data, not actually a persistent engine.
+ *    Can be useful in test or CLI environment.
  * - `FileEngine` - Uses simple files to store content. Poor performance, but good for
  *    storing large objects, or things that are not IO sensitive. Well suited to development
  *    as it is an easy cache to inspect and manually flush.

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -44,7 +44,7 @@ use RuntimeException;
  * In general all Cache operations are supported by all cache engines.
  * However, Cache::increment() and Cache::decrement() are not supported by File caching.
  *
- * There are 6 built-in caching engines:
+ * There are 7 built-in caching engines:
  *
  * - `ApcuEngine` - Uses the APCu object cache, one of the fastest caching engines.
  * - `ArrayEngine` - Uses only memory to store all data, not actually a persistent engin.

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -46,16 +46,18 @@ use RuntimeException;
  *
  * There are 6 built-in caching engines:
  *
+ * - `ApcuEngine` - Uses the APCu object cache, one of the fastest caching engines.
+ * - `ArrayEngine` - Uses only memory to store all data, not actually a persistent engin.
+ *    Can be useful in test or CLI enviroment.
  * - `FileEngine` - Uses simple files to store content. Poor performance, but good for
  *    storing large objects, or things that are not IO sensitive. Well suited to development
  *    as it is an easy cache to inspect and manually flush.
- * - `ApcuEngine` - Uses the APCu object cache, one of the fastest caching engines.
  * - `MemcacheEngine` - Uses the PECL::Memcache extension and Memcached for storage.
  *    Fast reads/writes, and benefits from memcache being distributed.
- * - `XcacheEngine` - Uses the Xcache extension, an alternative to APCu.
+ * - `RedisEngine` - Uses redis and php-redis extension to store cache data.
  * - `WincacheEngine` - Uses Windows Cache Extension for PHP. Supports wincache 1.1.0 and higher.
  *    This engine is recommended to people deploying on windows with IIS.
- * - `RedisEngine` - Uses redis and php-redis extension to store cache data.
+ * - `XcacheEngine` - Uses the Xcache extension, an alternative to APCu.
  *
  * See Cache engine documentation for expected configuration keys.
  *
@@ -73,6 +75,7 @@ class Cache
      * @var array
      */
     protected static $_dsnClassMap = [
+        'array' => 'Cake\Cache\Engine\ArrayEngine',
         'apc' => 'Cake\Cache\Engine\ApcuEngine', // @deprecated Since 3.6. Use apcu instead.
         'apcu' => 'Cake\Cache\Engine\ApcuEngine',
         'file' => 'Cake\Cache\Engine\FileEngine',


### PR DESCRIPTION
Although ArrayEngine is included in CakePHP 3.7.x, there's no mention for it in the Cache source, neither support using DSN notation.

I'm also putting the engines list in alphabetical order.