### PR TITLE
3.next - Add notEmpty* validator methods

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -809,8 +809,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     protected function sortMessageAndWhen($first, $second, $method)
     {
         // Called with `$message, $when`. No order change necessary
-        if (
-            (
+        if ((
                 in_array($second, [true, false, 'create', 'update'], true) ||
                 is_callable($second)
             ) && (
@@ -847,6 +846,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function allowEmptyString($field, $message = null, $when = true)
     {
         list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING, $when, $message);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -812,11 +812,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Opposite to allowEmptyString()
      *
      * @param string $field The name of the field.
-     * @param string|null $message The message to show if the field is not
+     * @param string|null $message The message to show if the field is empty.
      * @param bool|string|callable $when Indicates when the field is not allowed
-     *   to be empty. Valid values are false (always), 'create', 'update'. If a
-     *   callable is passed then the field will allowed to be empty only when
-     *   the callback returns false.
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
      * @see \Cake\Validation\Validator::allowEmptyString()
      * @since 3.8.0
@@ -853,10 +853,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Opposite to allowEmptyArray()
      *
      * @param string $field The name of the field.
-     * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     * @param string|null $message The message to show if the field is not
-     * Valid values are false (always), 'create', 'update'. If a callable is passed then
-     * the field will allowed to be empty only when the callback returns false.
+     * @param string|null $message The message to show if the field is empty.
+     * @param bool|string|callable $when Indicates when the field is not allowed
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
      * @see \Cake\Validation\Validator::allowEmptyArray()
      * @since 3.8.0
@@ -894,12 +895,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Opposite to allowEmptyFile()
      *
      * @param string $field The name of the field.
-     * @param string|null $message The message to show if the field is not
-     * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     *   Valid values are false (always), 'create', 'update'. If a callable is passed then
-     *   the field will required to be not empty when the callback returns false.
+     * @param string|null $message The message to show if the field is empty.
+     * @param bool|string|callable $when Indicates when the field is not allowed
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
-     * @since 3.7.0
+     * @since 3.8.0
      * @see \Cake\Validation\Validator::allowEmptyFile()
      */
     public function notEmptyFile($field, $message = null, $when = false)
@@ -932,12 +934,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Require a non-empty date value
      *
      * @param string $field The name of the field.
-     * @param string|null $message The message to show if the field is not
-     * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     *   Valid values are false, 'create', 'update'. If a callable is passed then
-     *   the field will allowed to be empty only when the callback returns false.
+     * @param string|null $message The message to show if the field is empty.
+     * @param bool|string|callable $when Indicates when the field is not allowed
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
-     * @since 3.7.0
+     * @since 3.8.0
      * @see \Cake\Validation\Validator::allowEmptyDate() For detail usage
      */
     public function notEmptyDate($field, $message = null, $when = false)
@@ -975,10 +978,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Opposite to allowEmptyTime()
      *
      * @param string $field The name of the field.
-     * @param string|null $message The message to show if the field is not
-     * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     *   Valid values are false, 'create', 'update'. If a callable is passed then
-     *   the field will allowed to be empty only when the callback returns true.
+     * @param string|null $message The message to show if the field is empty.
+     * @param bool|string|callable $when Indicates when the field is not allowed
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
      * @since 3.8.0
      * @see \Cake\Validation\Validator::allowEmptyTime()
@@ -1018,10 +1022,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Opposite to allowEmptyDateTime
      *
      * @param string $field The name of the field.
-     * @param string|null $message The message to show if the field is not
-     * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     *   Valid values are false, 'create', 'update'. If a callable is passed then
-     *   the field will allowed to be empty only when the callback returns false.
+     * @param string|null $message The message to show if the field is empty.
+     * @param bool|string|callable $when Indicates when the field is not allowed
+     *   to be empty. Valid values are false (never), 'create', 'update'. If a
+     *   callable is passed then the field will be required to be not empty when
+     *   the callback returns true.
      * @return $this
      * @since 3.8.0
      * @see \Cake\Validation\Validator::allowEmptyDateTime()

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1119,9 +1119,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Because this and `allowEmpty()` modify the same internal state, the last
      * method called will take precedence.
      *
-     * @deprecated 3.7.0 Use allowEmptyString(), allowEmptyArray(), allowEmptyFile(),
-     *   allowEmptyDate(), allowEmptyTime() or allowEmptyDateTime() with reversed
-     *   conditions instead.
+     * @deprecated 3.7.0 Use notEmptyString(), notEmptyArray(), notEmptyFile(),
+     *   notEmptyDate(), notEmptyTime() or notEmptyDateTime() instead.
      * @param string|array $field the name of the field or list of fields
      * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is not allowed

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1013,6 +1013,26 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Require a field to be a non empty date/time.
+     *
+     * Opposite to allowEmptyDateTime
+     *
+     * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
+     * @param bool|string|callable $when Indicates when the field is allowed to be empty
+     *   Valid values are false, 'create', 'update'. If a callable is passed then
+     *   the field will allowed to be empty only when the callback returns false.
+     * @return $this
+     * @since 3.8.0
+     * @see \Cake\Validation\Validator::allowEmptyDateTime()
+     */
+    public function notEmptyDateTime($field, $message = null, $when = true)
+    {
+        $when = $this->invertWhenClause($when);
+        return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE | self::EMPTY_TIME, $when, $message);
+    }
+
+    /**
      * Converts validator to fieldName => $settings array
      *
      * @param int|string $fieldName name of field

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -879,16 +879,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * EMPTY_ARRAY flags.
      *
      * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
-     * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
-     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyFor() for examples.
      */
-    public function allowEmptyArray($field, $when = true, $message = null)
+    public function allowEmptyArray($field, $message = null, $when = true)
     {
+        list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_ARRAY, $when, $message);
     }
 
@@ -922,16 +924,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * upload with `error` equal to `UPLOAD_ERR_NO_FILE` will be treated as empty.
      *
      * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      *   Valid values are true, 'create', 'update'. If a callable is passed then
      *   the field will allowed to be empty only when the callback returns true.
-     * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
      * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
      */
-    public function allowEmptyFile($field, $when = true, $message = null)
+    public function allowEmptyFile($field, $message = null, $when = true)
     {
+        list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_FILE, $when, $message);
     }
 
@@ -964,16 +968,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * and the `year` key is present.
      *
      * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
-     * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
-     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyFor() for examples
      */
-    public function allowEmptyDate($field, $when = true, $message = null)
+    public function allowEmptyDate($field, $message = null, $when = true)
     {
+        list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE, $when, $message);
     }
 
@@ -988,7 +994,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   the callback returns true.
      * @return $this
      * @since 3.8.0
-     * @see \Cake\Validation\Validator::allowEmptyDate() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyDate() for examples
      */
     public function notEmptyDate($field, $message = null, $when = false)
     {
@@ -1007,16 +1013,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * EMPTY_TIME flags.
      *
      * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
-     * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
-     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyFor() for examples.
      */
-    public function allowEmptyTime($field, $when = true, $message = null)
+    public function allowEmptyTime($field, $message = null, $when = true)
     {
+        list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_TIME, $when, $message);
     }
 
@@ -1052,16 +1060,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * EMPTY_DATE + EMPTY_TIME flags.
      *
      * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      *   Valid values are true, false, 'create', 'update'. If a callable is passed then
      *   the field will allowed to be empty only when the callback returns false.
-     * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
-     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyFor() for examples.
      */
-    public function allowEmptyDateTime($field, $when = true, $message = null)
+    public function allowEmptyDateTime($field, $message = null, $when = true)
     {
+        list($message, $when) = $this->sortMessageAndWhen($message, $when, __METHOD__);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE | self::EMPTY_TIME, $when, $message);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -824,6 +824,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyString($field, $message = null, $when = false)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING, $when, $message);
     }
 
@@ -865,6 +866,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyArray($field, $message = null, $when = false)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_ARRAY, $when, $message);
     }
 
@@ -907,6 +909,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyFile($field, $message = null, $when = false)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_FILE, $when, $message);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -886,6 +886,27 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Require a field to be a not-empty file.
+     *
+     * Empty string, and empty array values will not be caught as empty
+     * and you should use additional validators to check uploaded files.
+     *
+     * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
+     * @param bool|string|callable $when Indicates when the field is allowed to be empty
+     *   Valid values are false (always), 'create', 'update'. If a callable is passed then
+     *   the field will required to be not empty when the callback returns false.
+     * @return $this
+     * @since 3.7.0
+     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     */
+    public function notEmptyFile($field, $message = null, $when = false)
+    {
+        $when = $this->invertWhenClause($when);
+        return $this->allowEmptyFor($field, self::EMPTY_FILE, $when, $message);
+    }
+
+    /**
      * Allows a field to be an empty date.
      *
      * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -847,6 +847,26 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Require a field to be a non-empty array
+     *
+     * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +
+     * EMPTY_ARRAY flags.
+     *
+     * @param string $field The name of the field.
+     * @param bool|string|callable $when Indicates when the field is allowed to be empty
+     * @param string|null $message The message to show if the field is not
+     * Valid values are false (always), 'create', 'update'. If a callable is passed then
+     * the field will allowed to be empty only when the callback returns false.
+     * @return $this
+     * @since 3.8.0
+     */
+    public function notEmptyArray($field, $message = null, $when = false)
+    {
+        $when = $this->invertWhenClause($when);
+        return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_ARRAY, $when, $message);
+    }
+
+    /**
      * Allows a field to be an empty file.
      *
      * This method is equivalent to calling allowEmptyFor() with EMPTY_FILE flag.

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -809,7 +809,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Requires a field to be not be an empty string.
      *
-     * Creates rules that are complements to allowEmptyString()
+     * Opposite to allowEmptyString()
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
@@ -818,6 +818,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   callable is passed then the field will allowed to be empty only when
      *   the callback returns false.
      * @return $this
+     * @see \Cake\Validation\Validator::allowEmptyString()
      * @since 3.8.0
      */
     public function notEmptyString($field, $message = null, $when = false)
@@ -849,8 +850,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Require a field to be a non-empty array
      *
-     * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +
-     * EMPTY_ARRAY flags.
+     * Opposite to allowEmptyArray()
      *
      * @param string $field The name of the field.
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
@@ -858,6 +858,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Valid values are false (always), 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns false.
      * @return $this
+     * @see \Cake\Validation\Validator::allowEmptyArray()
      * @since 3.8.0
      */
     public function notEmptyArray($field, $message = null, $when = false)
@@ -870,11 +871,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Allows a field to be an empty file.
      *
      * This method is equivalent to calling allowEmptyFor() with EMPTY_FILE flag.
+     * File fields will not accept `''`, or `[]` as empty values. Only `null` and a file
+     * upload with `error` equal to `UPLOAD_ERR_NO_FILE` will be treated as empty.
      *
      * @param string $field The name of the field.
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     * Valid values are true, false, 'create', 'update'. If a callable is passed then
-     * the field will allowed to be empty only when the callback returns true.
+     *   Valid values are true, 'create', 'update'. If a callable is passed then
+     *   the field will allowed to be empty only when the callback returns true.
      * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0
@@ -888,8 +891,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Require a field to be a not-empty file.
      *
-     * Empty string, and empty array values will not be caught as empty
-     * and you should use additional validators to check uploaded files.
+     * Opposite to allowEmptyFile()
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
@@ -898,7 +900,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   the field will required to be not empty when the callback returns false.
      * @return $this
      * @since 3.7.0
-     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
+     * @see \Cake\Validation\Validator::allowEmptyFile()
      */
     public function notEmptyFile($field, $message = null, $when = false)
     {
@@ -909,8 +911,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Allows a field to be an empty date.
      *
-     * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +
-     * EMPTY_DATE flags.
+     * Empty date values are `null`, `''`, `[]` and arrays where all values are `''`
+     * and the `year` key is present.
      *
      * @param string $field The name of the field.
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
@@ -928,6 +930,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
     /**
      * Allows a field to be an empty time.
+     *
+     * Empty date values are `null`, `''`, `[]` and arrays where all values are `''`
+     * and the `hour` key is present.
      *
      * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +
      * EMPTY_TIME flags.
@@ -948,6 +953,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
     /**
      * Allows a field to be an empty date/time.
+     *
+     * Empty date values are `null`, `''`, `[]` and arrays where all values are `''`
+     * and the `year` and `hour` keys are present.
      *
      * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING +
      * EMPTY_DATE + EMPTY_TIME flags.

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -949,6 +949,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyDate($field, $message = null, $when = false)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE, $when, $message);
     }
 
@@ -993,6 +994,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyTime($field, $message = null, $when = false)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_TIME, $when, $message);
     }
 
@@ -1037,6 +1039,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function notEmptyDateTime($field, $message = null, $when = true)
     {
         $when = $this->invertWhenClause($when);
+
         return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE | self::EMPTY_TIME, $when, $message);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -929,6 +929,24 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Require a non-empty date value
+     *
+     * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
+     * @param bool|string|callable $when Indicates when the field is allowed to be empty
+     *   Valid values are false, 'create', 'update'. If a callable is passed then
+     *   the field will allowed to be empty only when the callback returns false.
+     * @return $this
+     * @since 3.7.0
+     * @see \Cake\Validation\Validator::allowEmptyDate() For detail usage
+     */
+    public function notEmptyDate($field, $message = null, $when = false)
+    {
+        $when = $this->invertWhenClause($when);
+        return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_DATE, $when, $message);
+    }
+
+    /**
      * Allows a field to be an empty time.
      *
      * Empty date values are `null`, `''`, `[]` and arrays where all values are `''`

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -970,6 +970,26 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Require a field to be a non-empty time.
+     *
+     * Opposite to allowEmptyTime()
+     *
+     * @param string $field The name of the field.
+     * @param string|null $message The message to show if the field is not
+     * @param bool|string|callable $when Indicates when the field is allowed to be empty
+     *   Valid values are false, 'create', 'update'. If a callable is passed then
+     *   the field will allowed to be empty only when the callback returns true.
+     * @return $this
+     * @since 3.8.0
+     * @see \Cake\Validation\Validator::allowEmptyTime()
+     */
+    public function notEmptyTime($field, $message = null, $when = false)
+    {
+        $when = $this->invertWhenClause($when);
+        return $this->allowEmptyFor($field, self::EMPTY_STRING | self::EMPTY_TIME, $when, $message);
+    }
+
+    /**
      * Allows a field to be an empty date/time.
      *
      * Empty date values are `null`, `''`, `[]` and arrays where all values are `''`
@@ -980,8 +1000,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
-     * Valid values are true, false, 'create', 'update'. If a callable is passed then
-     * the field will allowed to be empty only when the callback returns true.
+     *   Valid values are true, false, 'create', 'update'. If a callable is passed then
+     *   the field will allowed to be empty only when the callback returns false.
      * @param string|null $message The message to show if the field is not
      * @return $this
      * @since 3.7.0

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -783,7 +783,31 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->errors($data));
 
         $validator = new Validator();
-        $validator->allowEmptyString('title', 'update', 'message');
+        $validator->allowEmptyString('title', 'message', 'update');
+        $this->assertFalse($validator->isEmptyAllowed('title', true));
+        $this->assertTrue($validator->isEmptyAllowed('title', false));
+
+        $data = [
+            'title' => null,
+        ];
+        $expected = [
+            'title' => ['_empty' => 'message'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Ensure that allowEmptyString() works with deprecated arguments
+     *
+     * @return void
+     */
+    public function testAllowEmptyStringDeprecatedArguments()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyString('title', 'update', 'message');
+        });
         $this->assertFalse($validator->isEmptyAllowed('title', true));
         $this->assertTrue($validator->isEmptyAllowed('title', false));
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1203,6 +1203,71 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the notEmptyDate method
+     *
+     * @return void
+     */
+    public function testNotEmptyDate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyDate('date', 'required field');
+
+        $this->assertFalse($validator->isEmptyAllowed('date', true));
+        $this->assertFalse($validator->isEmptyAllowed('date', false));
+
+        $error = ['date' => ['_empty' => 'required field']];
+        $data = [
+            'date' => [
+                'year' => '',
+                'month' => '',
+                'day' => ''
+            ],
+        ];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['date' => ''];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['date' => null];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['date' => []];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = [
+            'date' => [
+                'year' => 2019,
+                'month' => 2,
+                'day' => 17
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test notEmptyDate with update mode
+     *
+     * @return void
+     */
+    public function testNotEmptyDateUpdate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyDate('date', 'message', 'update');
+        $this->assertTrue($validator->isEmptyAllowed('date', true));
+        $this->assertFalse($validator->isEmptyAllowed('date', false));
+
+        $data = ['date' => null];
+        $expected = ['date' => ['_empty' => 'message']];
+        $this->assertSame($expected, $validator->errors($data, false));
+        $this->assertEmpty($validator->errors($data, true));
+    }
+
+    /**
      * Tests the allowEmptyDate method
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -805,7 +805,7 @@ class ValidatorTest extends TestCase
     public function testNotEmptyString()
     {
         $validator = new Validator();
-        $validator->notEmptyString('title');
+        $validator->notEmptyString('title', 'not empty');
 
         $this->assertFalse($validator->isEmptyAllowed('title', true));
         $this->assertFalse($validator->isEmptyAllowed('title', false));
@@ -819,6 +819,12 @@ class ValidatorTest extends TestCase
 
         $data = ['title' => []];
         $this->assertEmpty($validator->errors($data), 'empty array is no good');
+
+        $expected = [
+            'title' => ['_empty' => 'not empty'],
+        ];
+        $data = ['title' => ''];
+        $this->assertSame($expected, $validator->errors($data, true));
     }
 
     /**
@@ -887,7 +893,15 @@ class ValidatorTest extends TestCase
         ];
         $result = $validator->errors($data);
         $this->assertSame($expected, $result);
+    }
 
+    /**
+     * Test allowEmptyArray with update mode
+     *
+     * @return void
+     */
+    public function testAllowEmptyArrayUpdate()
+    {
         $validator = new Validator();
         $validator->allowEmptyArray('items', 'update', 'message');
         $this->assertFalse($validator->isEmptyAllowed('items', true));
@@ -901,6 +915,40 @@ class ValidatorTest extends TestCase
         ];
         $this->assertSame($expected, $validator->errors($data, true));
         $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Tests the notEmptyArray method
+     *
+     * @return void
+     */
+    public function testNotEmptyArray()
+    {
+        $validator = new Validator();
+        $validator->notEmptyArray('items', 'not empty');
+
+        $this->assertFalse($validator->field('items')->isEmptyAllowed());
+
+        $error = [
+            'items' => ['_empty' => 'not empty']
+        ];
+        $data = ['items' => ''];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['items' => null];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['items' => []];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = [
+            'items' => [1],
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -853,6 +853,34 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Test notEmptyString with callback
+     *
+     * @return void
+     */
+    public function testNotEmptyStringCallbackWhen()
+    {
+        $validator = new Validator();
+        $validator->notEmptyString('title', 'message', function ($context) {
+            if (!isset($context['data']['emptyOk'])) {
+                return true;
+            }
+            return $context['data']['emptyOk'];
+        });
+
+        $error = [
+            'title' => ['_empty' => 'message'],
+        ];
+        $data = ['title' => ''];
+        $this->assertSame($error, $validator->errors($data));
+
+        $data = ['title' => '', 'emptyOk' => false];
+        $this->assertEmpty($validator->errors($data));
+
+        $data = ['title' => '', 'emptyOk' => true];
+        $this->assertSame($error, $validator->errors($data));
+    }
+
+    /**
      * Tests the allowEmptyArray method
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -798,6 +798,55 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the notEmptyString method
+     *
+     * @return void
+     */
+    public function testNotEmptyString()
+    {
+        $validator = new Validator();
+        $validator->notEmptyString('title');
+
+        $this->assertFalse($validator->isEmptyAllowed('title', true));
+        $this->assertFalse($validator->isEmptyAllowed('title', false));
+
+        $data = ['title' => '0'];
+        $this->assertEmpty($validator->errors($data));
+
+        $data = ['title' => 0];
+        $this->assertEmpty($validator->errors($data), 'empty ok on create');
+        $this->assertEmpty($validator->errors($data, false), 'empty ok on update');
+
+        $data = ['title' => []];
+        $this->assertEmpty($validator->errors($data), 'empty array is no good');
+    }
+
+    /**
+     * Test notEmptyString with explicit create.
+     *
+     * @return void
+     */
+    public function testNotEmptyStringCreate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyString('title', 'message', 'create');
+        $this->assertFalse($validator->isEmptyAllowed('title', true));
+        $this->assertTrue($validator->isEmptyAllowed('title', false));
+
+        $expected = [
+            'title' => ['_empty' => 'message'],
+        ];
+        $data = ['title' => null];
+        $this->assertSame($expected, $validator->errors($data, true));
+
+        $data = ['title' => ''];
+        $this->assertSame($expected, $validator->errors($data, true));
+
+        $data = ['title' => ''];
+        $this->assertEmpty($validator->errors($data, false), 'empty allowed on update');
+    }
+
+    /**
      * Tests the allowEmptyArray method
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1028,6 +1028,73 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the notEmptyFile method
+     *
+     * @return void
+     */
+    public function testNotEmptyFile()
+    {
+        $validator = new Validator();
+        $validator->notEmptyFile('photo', 'required field');
+
+        $this->assertFalse($validator->isEmptyAllowed('photo', true));
+        $this->assertFalse($validator->isEmptyAllowed('photo', false));
+
+        $data = [
+            'photo' => [
+                'name' => '',
+                'type' => '',
+                'tmp_name' => '',
+                'error' => UPLOAD_ERR_NO_FILE,
+            ]
+        ];
+        $error = ['photo' => ['_empty' => 'required field']];
+        $this->assertSame($error, $validator->errors($data));
+
+        $data = ['photo' => null];
+        $this->assertSame($error, $validator->errors($data));
+
+        // Empty string and empty array don't trigger errors
+        // as rejecting them here would mean accepting them in
+        // allowEmptyFile() which is not desirable.
+        $data = ['photo' => ''];
+        $this->assertEmpty($validator->errors($data));
+
+        $data = ['photo' => []];
+        $this->assertEmpty($validator->errors($data));
+
+        $data = [
+            'photo' => [
+                'name' => '',
+                'type' => '',
+                'tmp_name' => '',
+                'error' => UPLOAD_ERR_FORM_SIZE,
+            ]
+        ];
+        $this->assertEmpty($validator->errors($data));
+    }
+
+    /**
+     * Test notEmptyFile with update mode.
+     *
+     * @retrn void
+     */
+    public function testNotEmptyFileUpdate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyArray('photo', 'message', 'update');
+        $this->assertTrue($validator->isEmptyAllowed('photo', true));
+        $this->assertFalse($validator->isEmptyAllowed('photo', false));
+
+        $data = ['photo' => null];
+        $expected = [
+            'photo' => ['_empty' => 'message'],
+        ];
+        $this->assertEmpty($validator->errors($data, true));
+        $this->assertSame($expected, $validator->errors($data, false));
+    }
+
+    /**
      * Tests the allowEmptyDate method
      *
      * @return void
@@ -1173,11 +1240,8 @@ class ValidatorTest extends TestCase
         $result = $validator->errors($data);
         $this->assertEmpty($result);
 
-        $data = [
-            'published' => [],
-        ];
-        $result = $validator->errors($data);
-        $this->assertEmpty($result);
+        $data = ['published' => []];
+        $this->assertEmpty($validator->errors($data));
 
         $validator = new Validator();
         $validator->allowEmptyArray('published', 'update', 'message');

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1149,60 +1149,6 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Tests the allowEmptyTime method
-     *
-     * @return void
-     */
-    public function testAllowEmptyTime()
-    {
-        $validator = new Validator();
-        $validator->allowEmptyTime('time')
-            ->time('time');
-
-        $this->assertTrue($validator->field('time')->isEmptyAllowed());
-
-        $data = [
-            'time' => [
-                'hour' => '',
-                'minute' => '',
-                'second' => '',
-            ],
-        ];
-        $result = $validator->errors($data);
-        $this->assertEmpty($result);
-
-        $data = [
-            'time' => '',
-        ];
-        $result = $validator->errors($data);
-        $this->assertEmpty($result);
-
-        $data = [
-            'time' => null,
-        ];
-        $result = $validator->errors($data);
-        $this->assertEmpty($result);
-
-        $data = ['time' => []];
-        $result = $validator->errors($data);
-        $this->assertEmpty($result);
-
-        $validator = new Validator();
-        $validator->allowEmptyArray('time', 'update', 'message');
-        $this->assertFalse($validator->isEmptyAllowed('time', true));
-        $this->assertTrue($validator->isEmptyAllowed('time', false));
-
-        $data = [
-            'time' => null,
-        ];
-        $expected = [
-            'time' => ['_empty' => 'message'],
-        ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
-    }
-
-    /**
      * Tests the notEmptyDate method
      *
      * @return void
@@ -1265,6 +1211,119 @@ class ValidatorTest extends TestCase
         $expected = ['date' => ['_empty' => 'message']];
         $this->assertSame($expected, $validator->errors($data, false));
         $this->assertEmpty($validator->errors($data, true));
+    }
+
+    /**
+     * Tests the allowEmptyTime method
+     *
+     * @return void
+     */
+    public function testAllowEmptyTime()
+    {
+        $validator = new Validator();
+        $validator->allowEmptyTime('time')
+            ->time('time');
+
+        $this->assertTrue($validator->field('time')->isEmptyAllowed());
+
+        $data = [
+            'time' => [
+                'hour' => '',
+                'minute' => '',
+                'second' => '',
+            ],
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+
+        $data = [
+            'time' => '',
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+
+        $data = [
+            'time' => null,
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+
+        $data = ['time' => []];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+
+        $validator = new Validator();
+        $validator->allowEmptyArray('time', 'update', 'message');
+        $this->assertFalse($validator->isEmptyAllowed('time', true));
+        $this->assertTrue($validator->isEmptyAllowed('time', false));
+
+        $data = [
+            'time' => null,
+        ];
+        $expected = [
+            'time' => ['_empty' => 'message'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Tests the notEmptyTime method
+     *
+     * @return void
+     */
+    public function testNotEmptyTime()
+    {
+        $validator = new Validator();
+        $validator->notEmptyTime('time', 'required field');
+
+        $this->assertFalse($validator->isEmptyAllowed('time', true));
+        $this->assertFalse($validator->isEmptyAllowed('time', false));
+
+        $error = ['time' => ['_empty' => 'required field']];
+        $data = [
+            'time' => [
+                'hour' => '',
+                'minute' => '',
+                'second' => '',
+            ],
+        ];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['time' => ''];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['time' => null];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['time' => []];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['time' => ['hour' => 12, 'minute' => 12, 'second' => 12]];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test notEmptyTime with update mode
+     *
+     * @return void
+     */
+    public function testNotEmptyTimeUpdate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyTime('time', 'message', 'update');
+        $this->assertTrue($validator->isEmptyAllowed('time', true));
+        $this->assertFalse($validator->isEmptyAllowed('time', false));
+
+        $data = ['time' => null];
+        $expected = ['time' => ['_empty' => 'message']];
+        $this->assertEmpty($validator->errors($data, true));
+        $this->assertSame($expected, $validator->errors($data, false));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -864,6 +864,7 @@ class ValidatorTest extends TestCase
             if (!isset($context['data']['emptyOk'])) {
                 return true;
             }
+
             return $context['data']['emptyOk'];
         });
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1327,7 +1327,7 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Tests the allowEmptyDate method
+     * Tests the allowEmptyDateTime method
      *
      * @return void
      */
@@ -1380,6 +1380,75 @@ class ValidatorTest extends TestCase
         ];
         $this->assertSame($expected, $validator->errors($data, true));
         $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Tests the notEmptyDateTime method
+     *
+     * @return void
+     */
+    public function testNotEmptyDateTime()
+    {
+        $validator = new Validator();
+        $validator->notEmptyDate('published', 'required field');
+
+        $this->assertFalse($validator->isEmptyAllowed('published', true));
+        $this->assertFalse($validator->isEmptyAllowed('published', false));
+
+        $error = ['published' => ['_empty' => 'required field']];
+        $data = [
+            'published' => [
+                'year' => '',
+                'month' => '',
+                'day' => '',
+                'hour' => '',
+                'minute' => '',
+                'second' => '',
+            ],
+        ];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['published' => ''];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['published' => null];
+        $result = $validator->errors($data);
+        $this->assertSame($error, $result);
+
+        $data = ['published' => []];
+        $this->assertSame($error, $validator->errors($data));
+
+        $data = [
+            'published' => [
+                'year' => '2018',
+                'month' => '2',
+                'day' => '17',
+                'hour' => '14',
+                'minute' => '32',
+                'second' => '33',
+            ],
+        ];
+        $this->assertEmpty($validator->errors($data));
+    }
+
+    /**
+     * Test notEmptyDateTime with update mode
+     *
+     * @return voi
+     */
+    public function testNotEmptyDateTimeUpdate()
+    {
+        $validator = new Validator();
+        $validator->notEmptyDatetime('published', 'message', 'update');
+        $this->assertTrue($validator->isEmptyAllowed('published', true));
+        $this->assertFalse($validator->isEmptyAllowed('published', false));
+
+        $data = ['published' => null];
+        $expected = ['published' => ['_empty' => 'message']];
+        $this->assertSame($expected, $validator->errors($data, false));
+        $this->assertEmpty($validator->errors($data, true));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -956,7 +956,31 @@ class ValidatorTest extends TestCase
     public function testAllowEmptyArrayUpdate()
     {
         $validator = new Validator();
-        $validator->allowEmptyArray('items', 'update', 'message');
+        $validator->allowEmptyArray('items', 'message', 'update');
+        $this->assertFalse($validator->isEmptyAllowed('items', true));
+        $this->assertTrue($validator->isEmptyAllowed('items', false));
+
+        $data = [
+            'items' => null,
+        ];
+        $expected = [
+            'items' => ['_empty' => 'message'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Test allowEmptyArray with update mode
+     *
+     * @return void
+     */
+    public function testAllowEmptyArrayUpdateDeprecatedOrder()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyArray('items', 'update', 'message');
+        });
         $this->assertFalse($validator->isEmptyAllowed('items', true));
         $this->assertTrue($validator->isEmptyAllowed('items', false));
 
@@ -1066,7 +1090,31 @@ class ValidatorTest extends TestCase
         $this->assertSame($expected, $result);
 
         $validator = new Validator();
-        $validator->allowEmptyArray('photo', 'update', 'message');
+        $validator->allowEmptyFile('photo', 'message', 'update');
+        $this->assertFalse($validator->isEmptyAllowed('photo', true));
+        $this->assertTrue($validator->isEmptyAllowed('photo', false));
+
+        $data = [
+            'photo' => null,
+        ];
+        $expected = [
+            'photo' => ['_empty' => 'message'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * Test deprecated argument order for allowEmptyFile
+     *
+     * @return void
+     */
+    public function testAllowEmptyFileDeprecated()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyFile('photo', 'update', 'message');
+        });
         $this->assertFalse($validator->isEmptyAllowed('photo', true));
         $this->assertTrue($validator->isEmptyAllowed('photo', false));
 
@@ -1185,9 +1233,17 @@ class ValidatorTest extends TestCase
         $data = ['date' => []];
         $result = $validator->errors($data);
         $this->assertEmpty($result);
+    }
 
+    /**
+     * test allowEmptyDate() with an update condition
+     *
+     * @return void
+     */
+    public function testAllowEmptyDateUpdate()
+    {
         $validator = new Validator();
-        $validator->allowEmptyArray('date', 'update', 'message');
+        $validator->allowEmptyArray('date', 'be valid', 'update');
         $this->assertFalse($validator->isEmptyAllowed('date', true));
         $this->assertTrue($validator->isEmptyAllowed('date', false));
 
@@ -1195,7 +1251,31 @@ class ValidatorTest extends TestCase
             'date' => null,
         ];
         $expected = [
-            'date' => ['_empty' => 'message'],
+            'date' => ['_empty' => 'be valid'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * test allowEmptyDate() with an update condition
+     *
+     * @return void
+     */
+    public function testAllowEmptyDateUpdateDeprecatedArguments()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyArray('date', 'update', 'be valid');
+        });
+        $this->assertFalse($validator->isEmptyAllowed('date', true));
+        $this->assertTrue($validator->isEmptyAllowed('date', false));
+
+        $data = [
+            'date' => null,
+        ];
+        $expected = [
+            'date' => ['_empty' => 'be valid'],
         ];
         $this->assertSame($expected, $validator->errors($data, true));
         $this->assertEmpty($validator->errors($data, false));
@@ -1304,9 +1384,17 @@ class ValidatorTest extends TestCase
         $data = ['time' => []];
         $result = $validator->errors($data);
         $this->assertEmpty($result);
+    }
 
+    /**
+     * test allowEmptyTime with condition
+     *
+     * @return void
+     */
+    public function testAllowEmptyTimeCondition()
+    {
         $validator = new Validator();
-        $validator->allowEmptyArray('time', 'update', 'message');
+        $validator->allowEmptyTime('time', 'valid time', 'update');
         $this->assertFalse($validator->isEmptyAllowed('time', true));
         $this->assertTrue($validator->isEmptyAllowed('time', false));
 
@@ -1314,7 +1402,31 @@ class ValidatorTest extends TestCase
             'time' => null,
         ];
         $expected = [
-            'time' => ['_empty' => 'message'],
+            'time' => ['_empty' => 'valid time'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * test allowEmptyTime with deprecated argument order
+     *
+     * @return void
+     */
+    public function testAllowEmptyTimeConditionDeprecated()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyTime('time', 'update', 'valid time');
+        });
+        $this->assertFalse($validator->isEmptyAllowed('time', true));
+        $this->assertTrue($validator->isEmptyAllowed('time', false));
+
+        $data = [
+            'time' => null,
+        ];
+        $expected = [
+            'time' => ['_empty' => 'valid time'],
         ];
         $this->assertSame($expected, $validator->errors($data, true));
         $this->assertEmpty($validator->errors($data, false));
@@ -1419,9 +1531,17 @@ class ValidatorTest extends TestCase
 
         $data = ['published' => []];
         $this->assertEmpty($validator->errors($data));
+    }
 
+    /**
+     * test allowEmptyDateTime with a condition
+     *
+     * @return void
+     */
+    public function testAllowEmptyDateTimeCondition()
+    {
         $validator = new Validator();
-        $validator->allowEmptyArray('published', 'update', 'message');
+        $validator->allowEmptyDateTime('published', 'datetime required', 'update');
         $this->assertFalse($validator->isEmptyAllowed('published', true));
         $this->assertTrue($validator->isEmptyAllowed('published', false));
 
@@ -1429,7 +1549,31 @@ class ValidatorTest extends TestCase
             'published' => null,
         ];
         $expected = [
-            'published' => ['_empty' => 'message'],
+            'published' => ['_empty' => 'datetime required'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
+     * test allowEmptyDateTime with deprecated argument order
+     *
+     * @return void
+     */
+    public function testAllowEmptyDateTimeDeprecated()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyDateTime('published', 'datetime required', 'update');
+        });
+        $this->assertFalse($validator->isEmptyAllowed('published', true));
+        $this->assertTrue($validator->isEmptyAllowed('published', false));
+
+        $data = [
+            'published' => null,
+        ];
+        $expected = [
+            'published' => ['_empty' => 'datetime required'],
         ];
         $this->assertSame($expected, $validator->errors($data, true));
         $this->assertEmpty($validator->errors($data, false));


### PR DESCRIPTION
A few folks have found the current `allowEmpty*` methods to be clunky to use when trying to port `notEmpty()` to the stricter methods. I've added the missing methods now to make migration easier.

I've kept the signatures of these methods consistent with `notEmpty()` instead of being consistent with the `allowEmpty*()` methods as I think having the message first is a better default than having the condition first as the condition is used less frequently and when it is a callback it is nice to have the callback at the end of the arguments instead of in the middle. With that said I'm open to changing the argument order if people feel consistency across all the new methods is better. 