### PR TITLE
Fix visibility for session method for outside use

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -179,7 +179,7 @@ class FlashComponent extends Component
      *
      * @return \Cake\Http\Session
      */
-    protected function getSession()
+    public function getSession()
     {
         return $this->getController()->getRequest()->getSession();
     }


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/12991

Follow up on the support of outside usage after https://github.com/cakephp/cakephp/pull/12970

Makes this work again:

    $this->Flash->success(__('The feature has been saved.'));
    $session = $this->Flash->getSession();

Not sure though if we need this at all.