### PR TITLE
Wrap index reference in empty() check - closes cakephp#13001

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -228,7 +228,7 @@ class RedisEngine extends CacheEngine {
  * Disconnects from the redis server
  */
 	public function __destruct() {
-		if (empty($this->settings['persistent']) && !is_null($this->_Redis)) {
+		if (empty($this->settings['persistent']) && $this->_Redis !== null) {
 			$this->_Redis->close();
 		}
 	}

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -228,7 +228,7 @@ class RedisEngine extends CacheEngine {
  * Disconnects from the redis server
  */
 	public function __destruct() {
-		if (!$this->settings['persistent']) {
+		if (empty($this->settings['persistent'])) {
 			$this->_Redis->close();
 		}
 	}

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -228,7 +228,7 @@ class RedisEngine extends CacheEngine {
  * Disconnects from the redis server
  */
 	public function __destruct() {
-		if (empty($this->settings['persistent'])) {
+		if (empty($this->settings['persistent']) && !is_null($this->_Redis)) {
 			$this->_Redis->close();
 		}
 	}


### PR DESCRIPTION
Avoid direct array index reference without checking isset() first – thus we can wrap in empty() check instead. Closes issue #13001.