### PR TITLE
Fix nested errors generation for missing layout.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -27,6 +27,7 @@ use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
+use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
 use Exception;
 use PDOException;
@@ -359,7 +360,10 @@ class ExceptionRenderer implements ExceptionRendererInterface
             return $this->_shutdown();
         } catch (MissingTemplateException $e) {
             $attributes = $e->getAttributes();
-            if (isset($attributes['file']) && strpos($attributes['file'], 'error500') !== false) {
+            if (
+                $e instanceof MissingLayoutException ||
+                (isset($attributes['file']) && strpos($attributes['file'], 'error500') !== false)
+            ) {
                 return $this->_outputMessageSafe('error500');
             }
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -360,8 +360,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
             return $this->_shutdown();
         } catch (MissingTemplateException $e) {
             $attributes = $e->getAttributes();
-            if (
-                $e instanceof MissingLayoutException ||
+            if ($e instanceof MissingLayoutException ||
                 (isset($attributes['file']) && strpos($attributes['file'], 'error500') !== false)
             ) {
                 return $this->_outputMessageSafe('error500');

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -790,8 +790,8 @@ class ExceptionRendererTest extends TestCase
         $this->assertEquals('text/html', $response->getType());
         $this->assertContains('Not Found', (string)$response->getBody());
         $this->assertTrue($this->called, 'Listener added was not triggered.');
-        $this->assertEquals('', $controller->viewBuilder()->getLayoutPath());
-        $this->assertEquals('Error', $controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('', $controller->viewBuilder()->getLayoutPath());
+        $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
     }
 
     /**


### PR DESCRIPTION
Since MissingLayoutException now extends MissingTemplateException
explicit check is required for it when catching MissingTemplateException.