### PR TITLE
Change method visbility to allow easily getting just rendered contents.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1422,7 +1422,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return \Cake\Mailer\Renderer
      */
-    protected function getRenderer(): Renderer
+    public function getRenderer(): Renderer
     {
         if ($this->renderer === null) {
             $this->renderer = new Renderer($this->_appCharset);
@@ -1437,7 +1437,7 @@ class Email implements JsonSerializable, Serializable
      * @param \Cake\Mailer\Renderer $renderer Render instance.
      * @return $this
      */
-    protected function setRenderer(Renderer $renderer): self
+    public function setRenderer(Renderer $renderer): self
     {
         $this->renderer = $renderer;
 


### PR DESCRIPTION
This change avoids a bunch of reflection done in DebugKit's email previewer to get the rendered text and html content. `Email::getRenderer()` and `Email::setRenderer()` being protected was an oversight anyway, they should have been public.