### PR TITLE
Run phpcs tests parallel.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,8 @@
             "@cs-check",
             "@test"
         ],
-        "cs-check": "phpcs --colors -p src/ tests/",
-        "cs-fix": "phpcbf --colors src/ tests/",
+        "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
+        "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     }


### PR DESCRIPTION
Testing locally I got no time improvement beyond value of `4` on 2 cores. So values of `16` should suffice to use someone's 8 core CPU optimally.