### PR TITLE
Offload phpcs and static analysis checks to Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,10 +12,7 @@ build:
     phpcs:
       tests:
         override:
-          - command: vendor/bin/phpcs --report=checkstyle src/ tests/ > phpcs-checks.xml
-            analysis:
-              file: phpcs-checks.xml
-              format: "php-cs-checkstyle"
+          - phpcs-run src/ tests/
 
     static-analysis:
       environment:
@@ -35,4 +32,5 @@ build:
           - vendor/bin/psalm --show-info=false
 
 build_failure_conditions:
-- 'project.metric_change("scrutinizer.test_coverage", < -0.01)'
+  - 'issues.label("coding-style").exists'
+  - 'project.metric_change("scrutinizer.test_coverage", < -0.01)'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -32,5 +32,5 @@ build:
           - vendor/bin/psalm --show-info=false
 
 build_failure_conditions:
-  - 'issues.label("coding-style").exists'
+  - 'issues.count > 0'
   - 'project.metric_change("scrutinizer.test_coverage", < -0.01)'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,21 @@
-checks:
-  php: true
+tools:
+  external_code_coverage:
+    timeout: 1800
+    runs: 3
 
-filter:
-  paths: ['src/*']
+build:
+  environment:
+    php:
+      version: 7.1
+
+  nodes:
+    phpcs:
+      tests:
+        override:
+          - command: vendor/bin/phpcs --report=checkstyle src/ tests/ > phpcs-checks.xml
+            analysis:
+              file: phpcs-checks.xml
+              format: "php-cs-checkstyle"
+
+build_failure_conditions:
+- 'project.metric_change("scrutinizer.test_coverage", < -0.01)'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,5 +17,22 @@ build:
               file: phpcs-checks.xml
               format: "php-cs-checkstyle"
 
+    static-analysis:
+      environment:
+        php:
+          ini:
+            'memory_limit': -1
+          pecl_extensions:
+            - redis
+            - memcached
+            - apcu
+      dependencies:
+        override:
+          - composer stan-setup
+      tests:
+        override:
+          - vendor/bin/phpstan analyse src/
+          - vendor/bin/psalm --show-info=false
+
 build_failure_conditions:
 - 'project.metric_change("scrutinizer.test_coverage", < -0.01)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - if [[ $CODECOVERAGE == 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $CODECOVERAGE != 1 ]]; then vendor/bin/phpunit; fi
 
-after_success:
+after_script:
   - |
       if [[ $CODECOVERAGE == 1 ]]; then
         wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-
 dist: trusty
 
 env:
-  matrix:
-    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
-    - DEFAULT=1
-    - PHPCS=0
+    - CODECOVERAGE=0
 
 services:
   - memcached
@@ -33,6 +23,26 @@ cache:
 matrix:
   fast_finish: true
 
+  include:
+    - php: 7.1
+      env: CODECOVERAGE=1 DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    - php: 7.1
+      env: CODECOVERAGE=1 DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - php: 7.1
+      env: CODECOVERAGE=1 DB=sqlite db_dsn='sqlite:///:memory:'
+    - php: 7.2
+      env: DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    - php: 7.2
+      env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - php: 7.2
+      env: DB=sqlite db_dsn='sqlite:///:memory:'
+    - php: 7.3
+      env: DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    - php: 7.3
+      env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - php: 7.3
+      env: DB=sqlite db_dsn='sqlite:///:memory:'
+
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
   - phpenv config-rm xdebug.ini
@@ -46,12 +56,12 @@ before_install:
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
   - |
-      if [[ ${TRAVIS_PHP_VERSION} != "7.3" ]]; then
+      if [[ $TRAVIS_PHP_VERSION != "7.3" ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
       fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $PHPCS = 0 ]] ; then echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
   - sudo locale-gen da_DK
 
@@ -59,12 +69,12 @@ before_script:
   - composer install --prefer-dist --no-interaction
 
 script:
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION == 7.1 ]]; then CODECOVERAGE=1 phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
+  - if [[ $CODECOVERAGE == 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $CODECOVERAGE != 1 ]]; then vendor/bin/phpunit; fi
 
 after_success:
   - |
-      if [[ -f clover.xml ]]; then
+      if [[ $CODECOVERAGE == 1 ]]; then
         wget https://scrutinizer-ci.com/ocular.phar
         php ocular.phar code-coverage:upload --format=php-clover clover.xml
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ cache:
 matrix:
   fast_finish: true
 
-  include:
-    - php: 7.1
-      env: STATIC_ANALYSIS=1 DEFAULT=0
-
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
   - phpenv config-rm xdebug.ini
@@ -50,7 +46,7 @@ before_install:
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
   - |
-      if [[ ${TRAVIS_PHP_VERSION} != "7.3" && $PHPCS = 0 ]]; then
+      if [[ ${TRAVIS_PHP_VERSION} != "7.3" ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
       fi
   - if [[ $PHPCS = 0 ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
@@ -65,12 +61,6 @@ before_script:
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION == 7.1 ]]; then CODECOVERAGE=1 phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
-
-  - |
-      if [[ $STATIC_ANALYSIS = 1 ]]; then
-        composer stan-setup
-        composer stan
-      fi
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
     - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
-    - CODECOVERAGE=0
     - PHPCS=0
 
 services:
@@ -35,12 +34,6 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.2
-      env: CODECOVERAGE=1 DEFAULT=0
-
-    - php: 7.2
-      env: PHPCS=1 DEFAULT=0
-
     - php: 7.1
       env: STATIC_ANALYSIS=1 DEFAULT=0
 
@@ -70,10 +63,8 @@ before_script:
   - composer install --prefer-dist --no-interaction
 
 script:
-  - if [[ $CODECOVERAGE = 1 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
-  - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
-
-  - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION == 7.1 ]]; then CODECOVERAGE=1 phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
 
   - |
       if [[ $STATIC_ANALYSIS = 1 ]]; then
@@ -82,7 +73,11 @@ script:
       fi
 
 after_success:
-  - if [[ $CODECOVERAGE == 1 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - |
+      if [[ -f clover.xml ]]; then
+        wget https://scrutinizer-ci.com/ocular.phar
+        php ocular.phar code-coverage:upload --format=php-clover clover.xml
+      fi
 
 notifications:
   email: false


### PR DESCRIPTION
- Moved phpcs and static analysis checks from travis to Scrutinizer so that overall time to run all checks is reduced. I had to make the travis' job matrix a more verbose to ensure all jobs for code coverage with each db type are run first.
- Coverage report is also now submitted to scrutinizer instead of codecov.
- The various other checks that were done by scrutinizer by default have been disabled. In all these years I don't think anyone has actually checked them and made updates as per it's recommendations.