### PR TITLE
Fix Comparison expression cloning.

### DIFF
--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -195,7 +195,7 @@ class Comparison implements ExpressionInterface, FieldInterface
     public function __clone()
     {
         foreach (['_value', '_field'] as $prop) {
-            if ($prop instanceof ExpressionInterface) {
+            if ($this->{$prop} instanceof ExpressionInterface) {
                 $this->{$prop} = clone $this->{$prop};
             }
         }


### PR DESCRIPTION
Found this while working on phpstan checks on 4.x.