### PR TITLE
Fix session data not saved on fastcgi servers on slower session backends

### DIFF
--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -33,6 +33,9 @@ use Zend\Diactoros\Response\EmitterInterface;
  *
  * - It logs headers sent using CakePHP's logging tools.
  * - Cookies are emitted using setcookie() to not conflict with ext/session
+ * - For fastcgi servers with PHP-FPM session_write_close() is called just 
+ *   before fastcgi_finish_request() to make sure session data is saved 
+ *   correctly (especially on slower session backends).
  */
 class ResponseEmitter implements EmitterInterface
 {
@@ -63,6 +66,7 @@ class ResponseEmitter implements EmitterInterface
         }
 
         if (function_exists('fastcgi_finish_request')) {
+            session_write_close(); 
             fastcgi_finish_request();
         }
     }


### PR DESCRIPTION
This PR resolves the following issues: #13018 and #11162. The point of the change is to call `session_write_close()` just before `fastcgi_finish_request()` on setups where fastcgi is used with PHP-FPM. 

When using slower session backends (like a database) then on fastcgi it's possible to not have session data saved on quick requests (it works when changing it from for example MySQL to Redis). By adding an explicit `session_write_close()` here we are removing the possible race condition for fastcgi/PHP-FPM users. 