### PR TITLE
Speed up ExtractTask by skipping files without translation functions

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -405,6 +405,18 @@ class ExtractTask extends Shell
         $progress->init(['total' => count($this->_files)]);
         $isVerbose = $this->param('verbose');
 
+        $functions = [
+            '__' => ['singular'],
+            '__n' => ['singular', 'plural'],
+            '__d' => ['domain', 'singular'],
+            '__dn' => ['domain', 'singular', 'plural'],
+            '__x' => ['context', 'singular'],
+            '__xn' => ['context', 'singular', 'plural'],
+            '__dx' => ['domain', 'context', 'singular'],
+            '__dxn' => ['domain', 'context', 'singular', 'plural'],
+        ];
+        $pattern = '/(' . implode('|', array_keys($functions)) . ')\s*\(/';
+
         foreach ($this->_files as $file) {
             $this->_file = $file;
             if ($isVerbose) {
@@ -412,23 +424,22 @@ class ExtractTask extends Shell
             }
 
             $code = file_get_contents($file);
-            $allTokens = token_get_all($code);
 
-            $this->_tokens = [];
-            foreach ($allTokens as $token) {
-                if (!is_array($token) || ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML)) {
-                    $this->_tokens[] = $token;
+            if (preg_match($pattern, $code) === 1) {
+                $allTokens = token_get_all($code);
+
+                $this->_tokens = [];
+                foreach ($allTokens as $token) {
+                    if (!is_array($token) || ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML)) {
+                        $this->_tokens[] = $token;
+                    }
+                }
+                unset($allTokens);
+
+                foreach ($functions as $functionName => $map) {
+                    $this->_parse($functionName, $map);
                 }
             }
-            unset($allTokens);
-            $this->_parse('__', ['singular']);
-            $this->_parse('__n', ['singular', 'plural']);
-            $this->_parse('__d', ['domain', 'singular']);
-            $this->_parse('__dn', ['domain', 'singular', 'plural']);
-            $this->_parse('__x', ['context', 'singular']);
-            $this->_parse('__xn', ['context', 'singular', 'plural']);
-            $this->_parse('__dx', ['domain', 'context', 'singular']);
-            $this->_parse('__dxn', ['domain', 'context', 'singular', 'plural']);
 
             if (!$isVerbose) {
                 $progress->increment(1);


### PR DESCRIPTION
Speed up ExtractTask 1.5-3x times by skipping files without translation functions. Regular expressions are faster than parsing file.

With `--extract-core=yes`, time taken decreased 10 seconds to 3.7 seconds, because from 633 core src/ files, only 16 uses translation functions.
Time saved in apps depends how much files can be skipped.