### PR TITLE
Separates derivation of conditions for cascaded deletion of HABTM records to a protected method #13046

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2801,7 +2801,7 @@ class Model extends CakeObject implements CakeEventListener {
 			list(, $joinModel) = pluginSplit($data['with']);
 			$Model = $this->{$joinModel};
 			$records = $Model->find('all', array(
-				'conditions' => array($Model->escapeField($data['foreignKey']) => $id),
+				'conditions' => $this->_getConditionsForDeletingLinks($Model, $id, $data),
 				'fields' => $Model->primaryKey,
 				'recursive' => -1,
 				'callbacks' => false
@@ -2813,6 +2813,19 @@ class Model extends CakeObject implements CakeEventListener {
 				}
 			}
 		}
+	}
+
+/**
+ * Returns the conditions to be applied to Model::find() when determining which HABTM records should be deleted via
+ * Model::_deleteLinks()
+ *
+ * @param Model $Model HABTM join model instance
+ * @param mixed $id The ID of the primary model which is being deleted
+ * @param array $relationshipConfig The relationship config defined on the primary model
+ * @return array
+ */
+	protected function _getConditionsForDeletingLinks(Model $Model, $id, array $relationshipConfig) {
+		return array($Model->escapeField($relationshipConfig['foreignKey']) => $id);
 	}
 
 /**


### PR DESCRIPTION
Allows overriding of the default behaviour without having to override `_deleteLinks()` entirely, as discussed in #13046 