### PR TITLE
 Improve generated .pot references compatibility with PO editors

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -519,16 +519,18 @@ class ExtractTask extends Shell
                 foreach ($contexts as $context => $details) {
                     $plural = $details['msgid_plural'];
                     $files = $details['references'];
-                    $occurrences = [];
-                    foreach ($files as $file => $lines) {
-                        $lines = array_unique($lines);
-                        foreach ($lines as $line) {
-                            $occurrences[] = $file . ':' . $line;
-                        }
-                    }
-                    $occurrences = implode("\n#: ", $occurrences);
                     $header = '';
+
                     if (!$this->param('no-location')) {
+                        $occurrences = [];
+                        foreach ($files as $file => $lines) {
+                            $lines = array_unique($lines);
+                            foreach ($lines as $line) {
+                                $occurrences[] = $file . ':' . $line;
+                            }
+                        }
+                        $occurrences = implode("\n#: ", $occurrences);
+
                         $header = '#: ' . str_replace(DIRECTORY_SEPARATOR, '/', str_replace($paths, '', $occurrences)) . "\n";
                     }
 

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -522,7 +522,9 @@ class ExtractTask extends Shell
                     $occurrences = [];
                     foreach ($files as $file => $lines) {
                         $lines = array_unique($lines);
-                        $occurrences[] = $file . ':' . implode(';', $lines);
+                        foreach ($lines as $line) {
+                            $occurrences[] = $file . ':' . $line;
+                        }
                     }
                     $occurrences = implode("\n#: ", $occurrences);
                     $header = '';

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -93,7 +93,8 @@ class ExtractTaskTest extends TestCase
         $this->assertFileNotExists($this->path . DS . 'cake.pot');
 
         // extract.ctp
-        $pattern = '/\#: Template[\/\\\\]Pages[\/\\\\]extract\.ctp:\d+;\d+\n';
+        $pattern = '/\#: Template[\/\\\\]Pages[\/\\\\]extract\.ctp:\d+\n';
+        $pattern .= '\#: Template[\/\\\\]Pages[\/\\\\]extract\.ctp:\d+\n';
         $pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
         $this->assertRegExp($pattern, $result);
 


### PR DESCRIPTION
Any PO editor I tried does not support references like `File.php:23;56`, each line must be listed separately to support _Go to source_ function.


```
#: ./vendor/cakephp/cakephp/src/I18n/RelativeTimeFormatter.php:47;126;316
msgid "{0} year"
```
 will become

```
#: ./vendor/cakephp/cakephp/src/I18n/RelativeTimeFormatter.php:47
#: ./vendor/cakephp/cakephp/src/I18n/RelativeTimeFormatter.php:126
#: ./vendor/cakephp/cakephp/src/I18n/RelativeTimeFormatter.php:316
msgid "{0} year"
```

Generated file size will increase a bit, but it will be possible to look at message with context in source code.