### PR TITLE
FormHelper does not respect passed 'escape' option for errors

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2093,10 +2093,10 @@ class FormHelperTest extends CakeTestCase {
 		$Contact = ClassRegistry::getObject('Contact');
 		$Contact->validationErrors['password'] = array('Please provide a password');
 
-		$result = $this->Form->input('Contact.password',array(
+		$result = $this->Form->input('Contact.password', array(
 			'error' => array(
-			    'attributes' => array('class' => 'special-error-class'),
-            )
+				'attributes' => array('class' => 'special-error-class'),
+			)
 		));
 		$expected = array(
 			'div' => array('class' => 'input password error'),
@@ -2115,7 +2115,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 
 		$Contact->validationErrors['password'] = array('Please provide a password<br>otherwise you will not be able to login');
-		$result = $this->Form->input('Contact.password',array(
+		$result = $this->Form->input('Contact.password', array(
 			'error' => array(
 				'attributes' => array(
 					'class' => 'special-error-class',

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2085,6 +2085,62 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Test validation errors with error options
+ *
+ * @return void
+ */
+	public function testPasswordValidationWithOptions() {
+		$Contact = ClassRegistry::getObject('Contact');
+		$Contact->validationErrors['password'] = array('Please provide a password');
+
+		$result = $this->Form->input('Contact.password',array(
+			'error' => array(
+			    'attributes' => array('class' => 'special-error-class'),
+            )
+		));
+		$expected = array(
+			'div' => array('class' => 'input password error'),
+			'label' => array('for' => 'ContactPassword'),
+			'Password',
+			'/label',
+			'input' => array(
+				'type' => 'password', 'name' => 'data[Contact][password]',
+				'id' => 'ContactPassword', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'special-error-class')),
+			'Please provide a password',
+			'/div',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+		$Contact->validationErrors['password'] = array('Please provide a password<br>otherwise you will not be able to login');
+		$result = $this->Form->input('Contact.password',array(
+			'error' => array(
+				'attributes' => array(
+					'class' => 'special-error-class',
+					'escape' => false,
+				)
+			)
+		));
+		$expected = array(
+			'div' => array('class' => 'input password error'),
+			'label' => array('for' => 'ContactPassword'),
+			'Password',
+			'/label',
+			'input' => array(
+				'type' => 'password', 'name' => 'data[Contact][password]',
+				'id' => 'ContactPassword', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'special-error-class')),
+			'Please provide a password<br>otherwise you will not be able to login',
+			'/div',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * Test validation errors, when validation message is an empty string.
  *
  * @return void

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1095,7 +1095,7 @@ class FormHelper extends AppHelper {
 
 		$out['error'] = null;
 		if ($type !== 'hidden' && $error !== false) {
-			$errMsg = $this->error($fieldName, $error);
+			$errMsg = $this->error($fieldName, null, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, Hash::get($divOptions, 'errorClass', 'error'));
 				if ($errorMessage) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1095,7 +1095,7 @@ class FormHelper extends AppHelper {
 
 		$out['error'] = null;
 		if ($type !== 'hidden' && $error !== false) {
-			$errMsg = $this->error($fieldName, null, $error);
+			$errMsg = $this->error($fieldName, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, Hash::get($divOptions, 'errorClass', 'error'));
 				if ($errorMessage) {


### PR DESCRIPTION
See issue #13053.
