### PR TITLE
remove useless `SET NAMES`, it because chaset is set in dsn

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -79,9 +79,6 @@ class Mysql extends Driver
         if (!empty($config['timezone'])) {
             $config['init'][] = sprintf("SET time_zone = '%s'", $config['timezone']);
         }
-        if (!empty($config['encoding'])) {
-            $config['init'][] = sprintf('SET NAMES %s', $config['encoding']);
-        }
 
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
@@ -100,7 +97,7 @@ class Mysql extends Driver
         if (empty($config['unix_socket'])) {
             $dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']};charset={$config['encoding']}";
         } else {
-            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']};charset={$config['encoding']}";
         }
 
         $this->_connect($dsn, $config);

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -57,7 +57,7 @@ class MysqlTest extends TestCase
             'flags' => [],
             'encoding' => 'utf8mb4',
             'timezone' => null,
-            'init' => ['SET NAMES utf8mb4'],
+            'init' => []
         ];
 
         $expected['flags'] += [
@@ -107,7 +107,6 @@ class MysqlTest extends TestCase
         $dsn = 'mysql:host=foo;port=3440;dbname=bar;charset=some-encoding';
         $expected = $config;
         $expected['init'][] = "SET time_zone = 'Antarctica'";
-        $expected['init'][] = 'SET NAMES some-encoding';
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => false,
             PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
@@ -120,8 +119,7 @@ class MysqlTest extends TestCase
         $connection->expects($this->at(0))->method('exec')->with('Execute this');
         $connection->expects($this->at(1))->method('exec')->with('this too');
         $connection->expects($this->at(2))->method('exec')->with("SET time_zone = 'Antarctica'");
-        $connection->expects($this->at(3))->method('exec')->with('SET NAMES some-encoding');
-        $connection->expects($this->exactly(4))->method('exec');
+        $connection->expects($this->exactly(3))->method('exec');
 
         $driver->expects($this->once())->method('_connect')
             ->with($dsn, $expected);


### PR DESCRIPTION
I found too many executed queris when I have profiled my app.
Most of queries are `SET NAMES utf8`.  This query sets charset, but MySQL can set charset in dsn.

`SET NAMES ${encoding}` query is already useless, charset is et in dsn.
https://github.com/cakephp/cakephp/blob/master/src/Database/Driver/Mysql.php#L101

`chaset` option  can use grater than PHP 5.3.6, cakephp 3.x compatible `>=5.6.0` , therefore nothing problem.
http://www.php.net/manual/en/ref.pdo-mysql.connection.php


BTW, I want to port this changes to 2.x branch. (My app still 2.x 😿 
But, 2.x branch supports  `>= 5.3.0`
https://github.com/cakephp/cakephp/blob/2.x/composer.json#L21
I have 2 way.
first, apply same patch to 2.x and update support php version '>= 5.3.6'.
second, branch for each version like below
```
		if (version_compare(PHP_VERSION, '5.3.6', '<') && !empty($config['encoding'])) {
			$flags[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $config['encoding'];
		}
                ~~
		if (empty($config['unix_socket'])) {
                         // charset was silently ignored,  < 5.3.6 
			$dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']};charset={$config['encoding']}";
		} else {
			$dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']};charset={$config['encoding']}";
		}
```

Which do you think more better?


