### PR TITLE
fix phpdoc at HtmlHelper::link

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -341,7 +341,7 @@ class HtmlHelper extends AppHelper {
  * @param string $title The content to be wrapped by `<a>` tags.
  * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
  * @param array $options Array of options and HTML attributes.
- * @param string $confirmMessage JavaScript confirmation message. This
+ * @param string|bool $confirmMessage JavaScript confirmation message. This
  *   argument is deprecated as of 2.6. Use `confirm` key in $options instead.
  * @return string An `<a />` element.
  * @link https://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::link


### PR DESCRIPTION
I fixed phpdoc at HtmlHelper::link.