### PR TITLE
Return responses from blackhole callbacks.

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -121,10 +121,10 @@ class SecurityComponent extends Component
                 $isNotRequestAction &&
                 $this->_config['validatePost']
             ) {
-                    $this->_validatePost($controller);
+                $this->_validatePost($controller);
             }
         } catch (SecurityException $se) {
-            $this->blackHole($controller, $se->getType(), $se);
+            return $this->blackHole($controller, $se->getType(), $se);
         }
 
         $request = $this->generateToken($request);

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -19,6 +19,7 @@ use Cake\Controller\Controller;
 use Cake\Controller\Exception\SecurityException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
+use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\Routing\Router;
@@ -249,6 +250,34 @@ class SecurityComponentTest extends TestCase
         $this->assertFalse($this->Controller->failed);
         $this->Controller->Security->startup($event);
         $this->assertTrue($this->Controller->failed, 'Request was blackholed.');
+    }
+
+    /**
+     * test blackholeCallback returning a response
+     *
+     * @return void
+     */
+    public function testBlackholeReturnResponse()
+    {
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'session' => $this->Security->session,
+            'method' => 'POST',
+            'params' => [
+                'controller' => 'posts',
+                'action' => 'index'
+            ],
+            'post' => [
+                'key' => 'value'
+            ]
+        ]);
+        $Controller = new \TestApp\Controller\SomePagesController($request);
+        $event = new Event('Controller.startup', $Controller);
+        $Security = new SecurityComponent($Controller->components());
+        $Security->setConfig('blackHoleCallback', 'responseGenerator');
+
+        $result = $Security->startup($event);
+        $this->assertInstanceOf(Response::class, $result);
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/SomePagesController.php
+++ b/tests/test_app/TestApp/Controller/SomePagesController.php
@@ -49,9 +49,7 @@ class SomePagesController extends Controller
      */
     public function responseGenerator()
     {
-        $this->response->body('new response');
-
-        return $this->response;
+        return $this->response->withStringBody('new response');
     }
 
     protected function _fail()


### PR DESCRIPTION
Restore behavior lost in 21cf791461756f31ae056dbfa3f0fd9bc3aaf30c that enables blackhole callbacks to return responses with additional headers.

Fixes #13036
