### PR TITLE
Ensure precision is not lost in DecimalType.

### DIFF
--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -86,8 +86,8 @@ class DecimalType extends Type implements TypeInterface, BatchCastingInterface
                 getTypeName($value)
             ));
         }
-        if (is_string($value) && is_numeric($value)) {
-            return $value;
+        if (is_numeric($value)) {
+            return strval($value);
         }
 
         return sprintf('%F', $value);

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -131,13 +131,16 @@ class DecimalTypeTest extends TestCase
         $this->assertSame('0.000000', $result);
 
         $result = $this->type->toDatabase(2, $this->driver);
-        $this->assertSame('2.000000', $result);
+        $this->assertSame('2', $result);
 
         $result = $this->type->toDatabase(2.99, $this->driver);
-        $this->assertSame('2.990000', $result);
+        $this->assertSame('2.99', $result);
 
         $result = $this->type->toDatabase('2.51', $this->driver);
         $this->assertSame('2.51', $result);
+
+        $result = $this->type->toDatabase(0.12345678, $this->driver);
+        $this->assertSame('0.12345678', $result);
     }
 
     /**


### PR DESCRIPTION
Closes #10233 

While the tests have changed I don't think it will make any practical difference when values are saved to db and this change should be safe for bugfix release.