### PR TITLE
Add missing autoload to make $modelClass property useful.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -63,6 +63,10 @@ class Command
         $this->modelFactory('Table', function ($alias) {
             return $this->getTableLocator()->get($alias);
         });
+
+        if (isset($this->modelClass)) {
+            $this->loadModel();
+        }
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
+use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
 
 /**
@@ -50,6 +51,17 @@ class CommandTest extends TestCase
         $command = new Command();
         $command->loadModel('Comments');
         $this->assertInstanceOf(Table::class, $command->Comments);
+    }
+
+    /**
+     * test loadModel is configured properly
+     *
+     * @return void
+     */
+    public function testConstructorAutoLoadModel()
+    {
+        $command = new AutoLoadModelCommand();
+        $this->assertInstanceOf(Table::class, $command->Posts);
     }
 
     /**

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -65,7 +65,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $expected = "/\[.*CORE.*\] cache, help, i18n, orm_cache, plugin, routes, schema_cache, server/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] abort, demo, i18m, integration, merge, sample/";
+        $expected = "/\[.*app.*\] abort, auto_load_model, demo, i18m, integration, merge, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();
@@ -86,7 +86,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $expected = "/\[.*CORE.*\] cache, help, orm_cache, plugin, routes, schema_cache, server, version/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] abort, demo, i18n, integration, merge, sample/";
+        $expected = "/\[.*app.*\] abort, auto_load_model, demo, i18n, integration, merge, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -117,7 +117,7 @@ class CompletionShellTest extends TestCase
 
         $expected = 'TestPlugin.example TestPlugin.sample TestPluginTwo.example unique welcome ' .
             'cache help i18n orm_cache plugin routes schema_cache server version ' .
-            "abort demo i18m integration merge sample shell_test testing_dispatch\n";
+            "abort auto_load_model demo i18m integration merge sample shell_test testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 

--- a/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
+++ b/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
@@ -1,0 +1,9 @@
+<?php
+namespace TestApp\Command;
+
+use Cake\Console\Command;
+
+class AutoLoadModelCommand extends Command
+{
+    public $modelClass = 'Posts';
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/13099 

This is to sync it with Shells (before) and other classes like controller.
The important part is: This is opt-in.
If you don't specify any $modelClass, it will just be as before.
But a manual loadModel() call without any args required is just bonkers here if there is a $modelClass property for it.