### PR TITLE
Save fails if associated HasMany entities array is indexed by string keys

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -484,7 +484,7 @@ class HasMany extends Association
                 return !in_array(null, $v, true);
             }
         )
-        ->toArray();
+        ->toList();
 
         $conditions = $foreignKeyReference;
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -1141,7 +1141,7 @@ class HasManyTest extends TestCase
             ]
         ], ['associated' => ['Articles']]);
 
-        $entity = $authors->save($entity, ['associated' => ['Articles']]);
+        $entity = $authors->saveOrFail($entity, ['associated' => ['Articles']]);
         $sizeArticles = count($entity->articles);
         $this->assertSame($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -24,7 +24,6 @@ use Cake\ORM\Association;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
 
 /**
  * Tests HasMany class
@@ -1144,7 +1143,7 @@ class HasManyTest extends TestCase
 
         $entity = $authors->save($entity, ['associated' => ['Articles']]);
         $sizeArticles = count($entity->articles);
-        $this->assertEquals($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
+        $this->assertSame($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
 
         $articleId = $entity->articles[0]->id;
         $entity->articles = [
@@ -1152,9 +1151,9 @@ class HasManyTest extends TestCase
             'two' => $entity->articles[2],
         ];
 
-        $authors->save($entity, ['associated' => ['Articles']]);
+        $authors->saveOrFail($entity, ['associated' => ['Articles']]);
 
-        $this->assertEquals($sizeArticles - 1, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
+        $this->assertSame($sizeArticles - 1, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
         $this->assertFalse($authors->Articles->exists(['id' => $articleId]));
     }
 


### PR DESCRIPTION
When associated entities are indexed by string keys and save strategy is SAVE_REPLACE, saving fails because generated `'OR'` conditions. Array keys should be ignored.

Ex. in test case when saving entity, unused dependent articles are deleted by generated condition
```php
[
        'NOT' => [
                'OR' => [
                        'one' => ['id' => 5],
                        'two' => ['id' => 6],
                ]
        ],
        ['author_id' => 5]
]
```
which generates 
```sql
DELETE FROM articles
WHERE (NOT ((one = :c0 OR two = :c1)) AND author_id = :c2)
```

Or even worse if keys has spaces, generated delete condition is

```php
[
        'NOT' => [
                'OR' => [
                        'Another Random Post' => ['id' => 5],
                        'One more random post' => ['id' => 6],
                ]
        ],
        ['author_id' => 5]
]
```
which generates invalid
```sql
DELETE FROM articles
WHERE (NOT ((Another random post :c0 OR One more random post :c1)) AND author_id = :c2)
```

It should be deleted by generated condition
```php
[
        'NOT' => [
                'OR' => [
                        ['id' => 5],
                        ['id' => 6],
                ]
        ],
        ['author_id' => 5]
]
```
which generates 
```sql
DELETE FROM articles
WHERE (NOT ((id = :c0 OR id = :c1)) AND author_id = :c2)
```