### PR TITLE
Exclude more files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,3 +55,8 @@ phpunit.xml.dist export-ignore
 tests/test_app export-ignore
 tests/TestCase export-ignore
 .github export-ignore
+.mailmap export-ignore
+.varci.yml export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore
+contrib export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.

One could argue that even ``src/TestSuite/`` could be excluded
