### PR TITLE
Improve console help output

### DIFF
--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -39,6 +39,7 @@ class HelpCommandTest extends TestCase
         $this->setAppNamespace();
         $this->useCommandRunner();
         Plugin::getCollection()->clear();
+
         $app = $this->getMockForAbstractClass(
             BaseApplication::class,
             ['']
@@ -89,12 +90,15 @@ class HelpCommandTest extends TestCase
      */
     protected function assertCommandList()
     {
-        $this->assertOutputContains('- widget', 'plugin command');
+        $this->assertOutputContains('<info>TestPlugin</info>', 'plugin header should appear');
+        $this->assertOutputContains('- widget', 'plugin command should appear');
         $this->assertOutputNotContains(
             '- test_plugin.widget',
             'only short alias for plugin command.'
         );
+        $this->assertOutputContains('<info>App</info>', 'app header should appear');
         $this->assertOutputContains('- sample', 'app shell');
+        $this->assertOutputContains('<info>CakePHP</info>', 'cakephp header should appear');
         $this->assertOutputContains('- routes', 'core shell');
         $this->assertOutputContains('- example', 'short plugin name');
         $this->assertOutputContains('- abort', 'command object');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5954,7 +5954,7 @@ class TableTest extends TestCase
             'Model.beforeFind',
             function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$associationBeforeFindCount) {
                 $this->assertInternalType('bool', $primary);
-                $associationBeforeFindCount ++;
+                $associationBeforeFindCount++;
             }
         );
 
@@ -5963,7 +5963,7 @@ class TableTest extends TestCase
             'Model.beforeFind',
             function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$beforeFindCount) {
                 $this->assertInternalType('bool', $primary);
-                $beforeFindCount ++;
+                $beforeFindCount++;
             }
         );
         $table->find()->contain('authors')->first();
@@ -5975,7 +5975,7 @@ class TableTest extends TestCase
             'Model.buildValidator',
             $callback = function (EventInterface $event, Validator $validator, $name) use (&$buildValidatorCount) {
                 $this->assertInternalType('string', $name);
-                $buildValidatorCount ++;
+                $buildValidatorCount++;
             }
         );
         $table->getValidator();
@@ -5989,14 +5989,14 @@ class TableTest extends TestCase
         $eventManager->on(
             'Model.buildRules',
             function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount) {
-                $buildRulesCount ++;
+                $buildRulesCount++;
             }
         );
         $eventManager->on(
             'Model.beforeRules',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation) use (&$beforeRulesCount) {
                 $this->assertInternalType('string', $operation);
-                $beforeRulesCount ++;
+                $beforeRulesCount++;
             }
         );
         $eventManager->on(
@@ -6004,19 +6004,19 @@ class TableTest extends TestCase
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation) use (&$afterRulesCount) {
                 $this->assertInternalType('bool', $result);
                 $this->assertInternalType('string', $operation);
-                $afterRulesCount ++;
+                $afterRulesCount++;
             }
         );
         $eventManager->on(
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount) {
-                $beforeSaveCount ++;
+                $beforeSaveCount++;
             }
         );
         $eventManager->on(
             'Model.afterSave',
             $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount) {
-                $afterSaveCount ++;
+                $afterSaveCount++;
             }
         );
         $entity = new Entity(['title' => 'Title']);
@@ -6032,13 +6032,13 @@ class TableTest extends TestCase
         $eventManager->on(
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount) {
-                $beforeDeleteCount ++;
+                $beforeDeleteCount++;
             }
         );
         $eventManager->on(
             'Model.afterDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount) {
-                $afterDeleteCount ++;
+                $afterDeleteCount++;
             }
         );
         $this->assertTrue($table->delete($entity, ['checkRules' => false]));


### PR DESCRIPTION
Group commands/shells based on their namespaces instead of trying to do it based on registered command name. Plugin commands can be explicitly registered with no `plugin.command` variant. These commands would end up grouped under 'app' in the previous implementation. Now
they are correctly classified under the matching plugin.

## Example output now

```
$ bin/cake -h
Current Paths:

* app:  src
* root: /Users/markstory/Sites/cake4app
* core: /Users/markstory/Sites/cake4app/vendor/cakephp/cakephp

Available Commands:

App:
 - console

Bake:
 - bake
 - bake all
 - bake behavior
 - bake cell
 - bake command
 - bake component
 - bake controller
 - bake controller all
 - bake fixture
 - bake fixture all
 - bake form
 - bake helper
 - bake mailer
 - bake middleware
 - bake model
 - bake model all
 - bake plugin
 - bake shell
 - bake shell_helper
 - bake task
 - bake template
 - bake template all
 - bake test

CakePHP:
 - cache
 - completion
 - help
 - i18n
 - plugin
 - routes
 - schema_cache
 - server
 - upgrade
 - version

To run a command, type `cake command_name [args|options]`
To get help on a specific command, type `cake command_name --help`
```