### PR TITLE
Add getName() to View

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1305,7 +1305,6 @@ class View implements EventDispatcherInterface
             'response' => 'setResponse',
             'subDir' => 'setSubDir',
             'plugin' => 'setPlugin',
-            'name' => 'setName',
             'elementCache' => 'setElementCache',
         ];
         if (isset($protected[$name])) {
@@ -1328,6 +1327,13 @@ class View implements EventDispatcherInterface
             );
 
             return $this->helpers = $value;
+        }
+
+        if ($name === 'name') {
+            deprecationWarning(
+                'View::$name is protected now. ' .
+                'You can use viewBuilder()->setName() to change the name a view uses before building it.'
+            );
         }
 
         $this->{$name} = $value;
@@ -1470,6 +1476,17 @@ class View implements EventDispatcherInterface
     public function getSubDir()
     {
         return $this->subDir;
+    }
+
+    /**
+     * Returns the View's controller name.
+     *
+     * @return string|null
+     * @since 3.7.7
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -2152,6 +2152,20 @@ TEXT;
     }
 
     /**
+     * Test getName() and getPlugin().
+     *
+     * @return void
+     */
+    public function testGetNamePlugin()
+    {
+        $this->assertSame('Posts', $this->View->getName());
+        $this->assertNull($this->View->getPlugin());
+
+        $this->assertSame($this->View, $this->View->setPlugin('TestPlugin'));
+        $this->assertSame('TestPlugin', $this->View->getPlugin());
+    }
+
+    /**
      * Test testHasRendered property
      *
      * @return void


### PR DESCRIPTION
We were emitting deprecation warnings telling folks to use methods that didn't exist. Make the required methods exist, and emit a better deprecation warning when trying to mutate View::$name.

Fixes #13110
