### PR TITLE
Fix shutdown warnings in PHP7.2+

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -352,7 +352,11 @@ class FileEngine extends CacheEngine {
 		if (!$createKey && !$path->isFile()) {
 			return false;
 		}
-		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
+		if (
+			empty($this->_File) ||
+			$this->_File->getBaseName() !== $key ||
+			$this->_File->valid() === false
+		) {
 			$exists = file_exists($path->getPathname());
 			try {
 				$this->_File = $path->openFile('c+');


### PR DESCRIPTION
Check if the current file is valid before re-using it. This fixes warnings emitted during process shutdown when DboSource is persisting the method cache.

Fixes #13085