### PR TITLE
Fix warnings from FileEngine on shutdown

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -395,7 +395,10 @@ class FileEngine extends CacheEngine
         if (!$createKey && !$path->isFile()) {
             return false;
         }
-        if (empty($this->_File) || $this->_File->getBasename() !== $key) {
+        if (empty($this->_File) ||
+            $this->_File->getBasename() !== $key ||
+            $this->_File->valid() === false
+        ) {
             $exists = file_exists($path->getPathname());
             try {
                 $this->_File = $path->openFile('c+');


### PR DESCRIPTION
Check if the current file is valid before re-using it. This fixes warnings emitted during process shutdown when DboSource is persisting the method cache.

Forward port fix for #13085 to 3.x