### PR TITLE
Remove unused constant.

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -16,13 +16,6 @@ declare(strict_types=1);
 
 use Cake\Core\Configure;
 
-if (!defined('DS')) {
-    /**
-     * Define DS as short form of DIRECTORY_SEPARATOR.
-     */
-    define('DS', DIRECTORY_SEPARATOR);
-}
-
 if (!function_exists('h')) {
     /**
      * Convenience method for htmlspecialchars.


### PR DESCRIPTION
The constant is not used in core anymore.

It's still defined in app skeleton in `config/paths.php` so shouldn't affect app code, though I would like to remove it from app too.