### PR TITLE
Use stricter PHP internal functions.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -130,8 +130,8 @@ abstract class BaseAuthenticate implements EventListenerInterface
             $result->unset($passwordField);
         }
         $hidden = $result->getHidden();
-        if ($password === null && in_array($passwordField, $hidden)) {
-            $key = array_search($passwordField, $hidden);
+        if ($password === null && in_array($passwordField, $hidden, true)) {
+            $key = array_search($passwordField, $hidden, true);
             unset($hidden[$key]);
             $result->setHidden($hidden);
         }

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -267,7 +267,7 @@ class FileEngine extends CacheEngine
             }
 
             $path = $path->getRealPath() . DIRECTORY_SEPARATOR;
-            if (!in_array($path, $cleared)) {
+            if (!in_array($path, $cleared, true)) {
                 $this->_clearDirectory($path);
                 $cleared[] = $path;
             }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -240,7 +240,7 @@ class RedisEngine extends CacheEngine
             $result[] = $this->_Redis->delete($key) > 0;
         }
 
-        return !in_array(false, $result);
+        return !in_array(false, $result, true);
     }
 
     /**

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -111,7 +111,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
             $prefix = 'App';
             if ($namespace === 'Cake') {
                 $prefix = 'CakePHP';
-            } elseif (in_array($namespace, $plugins)) {
+            } elseif (in_array($namespace, $plugins, true)) {
                 $prefix = $namespace;
             }
             $shortestName = $this->getShortestName($names);

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -50,7 +50,7 @@ class ConsoleInputArgument
     /**
      * An array of valid choices for this argument.
      *
-     * @var array
+     * @var string[]
      */
     protected $_choices;
 
@@ -60,7 +60,7 @@ class ConsoleInputArgument
      * @param string|array $name The long name of the option, or an array with all the properties.
      * @param string $help The help text for this option
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
-     * @param array $choices Valid choices for this option.
+     * @param string[] $choices Valid choices for this option.
      */
     public function __construct($name, $help = '', $required = false, $choices = [])
     {
@@ -162,7 +162,7 @@ class ConsoleInputArgument
         if (empty($this->_choices)) {
             return true;
         }
-        if (!in_array($value, $this->_choices)) {
+        if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
                     '"%s" is not a valid value for %s. Please use one of "%s"',

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -57,7 +57,7 @@ class ConsoleInputOption
     /**
      * Default value for the option
      *
-     * @var mixed
+     * @var string|bool
      */
     protected $_default;
 
@@ -71,7 +71,7 @@ class ConsoleInputOption
     /**
      * An array of choices for the option.
      *
-     * @var array
+     * @var string[]
      */
     protected $_choices;
 
@@ -185,7 +185,7 @@ class ConsoleInputOption
     /**
      * Get the default value for this option
      *
-     * @return mixed
+     * @return string|bool
      */
     public function defaultValue()
     {
@@ -224,7 +224,7 @@ class ConsoleInputOption
         if (empty($this->_choices)) {
             return true;
         }
-        if (!in_array($value, $this->_choices)) {
+        if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
                     '"%s" is not a valid value for --%s. Please use one of "%s"',

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -418,7 +418,7 @@ class ConsoleIo
             $options
         );
         $in = '';
-        while ($in === '' || !in_array($in, $options)) {
+        while ($in === '' || !in_array($in, $options, true)) {
             $in = $this->_getInput($prompt, $printOptions, $default);
         }
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -585,7 +585,7 @@ class Shell
      */
     public function __get(string $name)
     {
-        if (empty($this->{$name}) && in_array($name, $this->taskNames)) {
+        if (empty($this->{$name}) && in_array($name, $this->taskNames, true)) {
             $properties = $this->_taskMap[$name];
             $this->{$name} = $this->Tasks->load($properties['class'], $properties['config']);
             $this->{$name}->args =& $this->args;

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -216,12 +216,12 @@ class ShellDispatcher
 
             return false;
         }
-        if (in_array($shellName, ['help', '--help', '-h'])) {
+        if (in_array($shellName, ['help', '--help', '-h'], true)) {
             $this->help();
 
             return true;
         }
-        if (in_array($shellName, ['version', '--version'])) {
+        if (in_array($shellName, ['version', '--version'], true)) {
             $this->version();
 
             return true;

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -322,7 +322,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     {
         $action = strtolower($controller->getRequest()->getParam('action'));
 
-        return in_array($action, array_map('strtolower', $this->allowedActions));
+        return in_array($action, array_map('strtolower', $this->allowedActions), true);
     }
 
     /**
@@ -614,7 +614,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
             return;
         }
         foreach ((array)$actions as $action) {
-            $i = array_search($action, $this->allowedActions);
+            $i = array_search($action, $this->allowedActions, true);
             if (is_int($i)) {
                 unset($this->allowedActions[$i]);
             }

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -171,7 +171,7 @@ class RequestHandlerComponent extends Component
         if ($request->getParam('_ext')) {
             $this->ext = $request->getParam('_ext');
         }
-        if (!$this->ext || in_array($this->ext, ['html', 'htm'])) {
+        if (!$this->ext || in_array($this->ext, ['html', 'htm'], true)) {
             $this->_setExtension($request, $response);
         }
 
@@ -253,7 +253,7 @@ class RequestHandlerComponent extends Component
         $response = $controller->getResponse();
         $request = $controller->getRequest();
 
-        if ($this->ext && !in_array($this->ext, ['html', 'htm'])) {
+        if ($this->ext && !in_array($this->ext, ['html', 'htm'], true)) {
             if (!$response->getMimeType($this->ext)) {
                 throw new NotFoundException('Invoked extension not recognized/configured: ' . $this->ext);
             }
@@ -314,7 +314,7 @@ class RequestHandlerComponent extends Component
         if (is_array($type)) {
             foreach ($type as $t) {
                 $t = $this->mapAlias($t);
-                if (in_array($t, $accepted)) {
+                if (in_array($t, $accepted, true)) {
                     return true;
                 }
             }
@@ -322,7 +322,7 @@ class RequestHandlerComponent extends Component
             return false;
         }
         if (is_string($type)) {
-            return in_array($this->mapAlias($type), $accepted);
+            return in_array($this->mapAlias($type), $accepted, true);
         }
 
         return false;
@@ -408,10 +408,10 @@ class RequestHandlerComponent extends Component
 
         if (count($types) === 1) {
             if ($this->ext) {
-                return in_array($this->ext, $types);
+                return in_array($this->ext, $types, true);
             }
 
-            return in_array($types[0], $accepts);
+            return in_array($types[0], $accepts, true);
         }
 
         $intersect = array_values(array_intersect($accepts, $types));

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -109,7 +109,7 @@ class SecurityComponent extends Component
                 ));
             }
 
-            if (!in_array($this->_action, (array)$this->_config['unlockedActions']) &&
+            if (!in_array($this->_action, (array)$this->_config['unlockedActions'], true) &&
                 $hasData &&
                 $isNotRequestAction &&
                 $this->_config['validatePost']
@@ -218,7 +218,7 @@ class SecurityComponent extends Component
         ) {
             $requireSecure = $this->_config['requireSecure'];
 
-            if (in_array($this->_action, $requireSecure) || $requireSecure === ['*']) {
+            if (in_array($this->_action, $requireSecure, true) || $requireSecure === ['*']) {
                 if (!$controller->getRequest()->is('ssl')) {
                     throw new SecurityException(
                         'Request is not SSL and the action is required to be secure'
@@ -360,7 +360,7 @@ class SecurityComponent extends Component
         );
 
         foreach ($fieldList as $i => $key) {
-            $isLocked = in_array($key, $locked);
+            $isLocked = in_array($key, $locked, true);
 
             if (!empty($unlockedFields)) {
                 foreach ($unlockedFields as $off) {
@@ -557,7 +557,7 @@ class SecurityComponent extends Component
         $messages = [];
         foreach ($dataFields as $key => $value) {
             if (is_int($key)) {
-                $foundKey = array_search($value, (array)$expectedFields);
+                $foundKey = array_search($value, (array)$expectedFields, true);
                 if ($foundKey === false) {
                     $messages[] = sprintf($intKeyMessage, $value);
                 } else {

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -131,7 +131,7 @@ class App
             'Cake',
             str_replace('\\', '/', Configure::read('App.namespace')),
         ];
-        if (in_array($pluginName, $nonPluginNamespaces)) {
+        if (in_array($pluginName, $nonPluginNamespaces, true)) {
             return $name;
         }
 

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -236,7 +236,7 @@ class BasePlugin implements PluginInterface
      */
     protected function checkHook(string $hook): void
     {
-        if (!in_array($hook, static::VALID_HOOKS)) {
+        if (!in_array($hook, static::VALID_HOOKS, true)) {
             throw new InvalidArgumentException(
                 "`$hook` is not a valid hook name. Must be one of " . implode(', ', static::VALID_HOOKS)
             );

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -272,7 +272,7 @@ class PluginCollection implements Iterator, Countable
      */
     public function with(string $hook): Generator
     {
-        if (!in_array($hook, PluginInterface::VALID_HOOKS)) {
+        if (!in_array($hook, PluginInterface::VALID_HOOKS, true)) {
             throw new InvalidArgumentException("The `{$hook}` hook is not a known plugin hook.");
         }
         foreach ($this as $plugin) {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -320,7 +320,7 @@ trait EntityTrait
         $originals = $this->_original;
         $originalKeys = array_keys($originals);
         foreach ($this->_fields as $key => $value) {
-            if (!in_array($key, $originalKeys)) {
+            if (!in_array($key, $originalKeys, true)) {
                 $originals[$key] = $value;
             }
         }

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -362,7 +362,7 @@ class Paginator implements PaginatorInterface
             if (isset($options['direction'])) {
                 $direction = strtolower($options['direction']);
             }
-            if (!in_array($direction, ['asc', 'desc'])) {
+            if (!in_array($direction, ['asc', 'desc'], true)) {
                 $direction = 'asc';
             }
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -491,7 +491,7 @@ trait QueryTrait
     public function __call($method, $arguments)
     {
         $resultSetClass = $this->_decoratorClass();
-        if (in_array($method, get_class_methods($resultSetClass))) {
+        if (in_array($method, get_class_methods($resultSetClass), true)) {
             $results = $this->all();
 
             return $results->$method(...$arguments);

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -339,7 +339,7 @@ class Debugger
                     $reference .= ')';
                 }
             }
-            if (in_array($signature, $options['exclude'])) {
+            if (in_array($signature, $options['exclude'], true)) {
                 continue;
             }
             if ($options['format'] === 'points' && $trace['file'] !== '[internal]') {

--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -58,6 +58,6 @@ class SubjectFilterDecorator extends AbstractDecorator
             $this->_options['allowedSubject'] = [$this->_options['allowedSubject']];
         }
 
-        return in_array($class, $this->_options['allowedSubject']);
+        return in_array($class, $this->_options['allowedSubject'], true);
     }
 }

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -347,7 +347,7 @@ class Folder
     public static function isRegisteredStreamWrapper(string $path): bool
     {
         return preg_match('/^[^:\/\/]+?(?=:\/\/)/', $path, $matches) &&
-            in_array($matches[0], stream_get_wrappers());
+            in_array($matches[0], stream_get_wrappers(), true);
     }
 
     /**
@@ -437,7 +437,7 @@ class Folder
      * @param string $path The path to chmod.
      * @param int|null $mode Octal value, e.g. 0755.
      * @param bool $recursive Chmod recursively, set to false to only change the current directory.
-     * @param array $exceptions Array of files, directories to skip.
+     * @param string[] $exceptions Array of files, directories to skip.
      * @return bool Success.
      */
     public function chmod(string $path, ?int $mode = null, bool $recursive = true, array $exceptions = []): bool
@@ -468,7 +468,7 @@ class Folder
                     $check = explode(DIRECTORY_SEPARATOR, $fullpath);
                     $count = count($check);
 
-                    if (in_array($check[$count - 1], $exceptions)) {
+                    if (in_array($check[$count - 1], $exceptions, true)) {
                         continue;
                     }
 
@@ -799,7 +799,7 @@ class Folder
             // phpcs:enable
             while (($item = readdir($handle)) !== false) {
                 $to = Folder::addPathElement($toDir, $item);
-                if (($options['scheme'] !== Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions)) {
+                if (($options['scheme'] !== Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions, true)) {
                     $from = Folder::addPathElement($fromDir, $item);
                     if (is_file($from) && (!is_file($to) || $options['scheme'] !== Folder::SKIP)) {
                         if (copy($from, $to)) {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -236,7 +236,7 @@ class Response extends Message implements ResponseInterface
             static::STATUS_TEMPORARY_REDIRECT,
         ];
 
-        return in_array($this->code, $codes) &&
+        return in_array($this->code, $codes, true) &&
             $this->getHeaderLine('Location');
     }
 

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -133,7 +133,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (!in_array($request->getMethod(), $this->methods)) {
+        if (!in_array($request->getMethod(), $this->methods, true)) {
             return $handler->handle($request);
         }
         [$type] = explode(';', $request->getHeaderLine('Content-Type'));

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -120,7 +120,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     protected function _validateAndUnsetTokenField(ServerRequest $request): ServerRequest
     {
-        if (in_array($request->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH']) || $request->getData()) {
+        if (in_array($request->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH'], true) || $request->getData()) {
             $this->_validateToken($request);
             $body = $request->getParsedBody();
             if (is_array($body)) {

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -230,12 +230,12 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      *
      * @throws \InvalidArgumentException Thrown when a value is invalid.
      * @param string $value Value to check
-     * @param array $allowed List of allowed values
+     * @param string[] $allowed List of allowed values
      * @return void
      */
     protected function checkValues(string $value, array $allowed): void
     {
-        if (!in_array($value, $allowed)) {
+        if (!in_array($value, $allowed, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid arg `%s`, use one of these: %s',
                 $value,

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -485,7 +485,7 @@ class Response implements ResponseInterface
      */
     protected function _setContentType(): void
     {
-        if (in_array($this->_status, [304, 204])) {
+        if (in_array($this->_status, [304, 204], true)) {
             $this->_clearHeader('Content-Type');
 
             return;
@@ -496,7 +496,7 @@ class Response implements ResponseInterface
 
         $charset = false;
         if ($this->_charset &&
-            (strpos($this->_contentType, 'text/') === 0 || in_array($this->_contentType, $whitelist))
+            (strpos($this->_contentType, 'text/') === 0 || in_array($this->_contentType, $whitelist, true))
         ) {
             $charset = true;
         }
@@ -741,7 +741,7 @@ class Response implements ResponseInterface
         }
 
         foreach ($this->_mimeTypes as $alias => $types) {
-            if (in_array($ctype, (array)$types)) {
+            if (in_array($ctype, (array)$types, true)) {
                 return $alias;
             }
         }
@@ -1098,7 +1098,7 @@ class Response implements ResponseInterface
     public function outputCompressed(): bool
     {
         return strpos(env('HTTP_ACCEPT_ENCODING'), 'gzip') !== false
-            && (ini_get('zlib.output_compression') === '1' || in_array('ob_gzhandler', ob_list_handlers()));
+            && (ini_get('zlib.output_compression') === '1' || in_array('ob_gzhandler', ob_list_handlers(), true));
     }
 
     /**
@@ -1181,7 +1181,7 @@ class Response implements ResponseInterface
         $responseTag = $this->getHeaderLine('Etag');
         $etagMatches = null;
         if ($responseTag) {
-            $etagMatches = in_array('*', $etags) || in_array($responseTag, $etags);
+            $etagMatches = in_array('*', $etags, true) || in_array($responseTag, $etags, true);
         }
 
         $modifiedSince = $request->getHeaderLine('If-Modified-Since');

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -83,7 +83,7 @@ class ResponseEmitter implements EmitterInterface
      */
     protected function emitBody(ResponseInterface $response, int $maxBufferLength): void
     {
-        if (in_array($response->getStatusCode(), [204, 304])) {
+        if (in_array($response->getStatusCode(), [204, 304], true)) {
             return;
         }
         $body = $response->getBody();

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -334,7 +334,7 @@ class ServerRequest implements ServerRequestInterface
         $method = $this->getEnv('REQUEST_METHOD');
         $override = false;
 
-        if (in_array($method, ['PUT', 'DELETE', 'PATCH']) &&
+        if (in_array($method, ['PUT', 'DELETE', 'PATCH'], true) &&
             strpos((string)$this->contentType(), 'application/x-www-form-urlencoded') === 0
         ) {
             $data = $this->input();
@@ -351,7 +351,7 @@ class ServerRequest implements ServerRequestInterface
             $override = true;
         }
 
-        if ($override && !in_array($this->_environment['REQUEST_METHOD'], ['PUT', 'POST', 'DELETE', 'PATCH'])) {
+        if ($override && !in_array($this->_environment['REQUEST_METHOD'], ['PUT', 'POST', 'DELETE', 'PATCH'], true)) {
             $data = [];
         }
 
@@ -694,7 +694,7 @@ class ServerRequest implements ServerRequestInterface
     {
         $acceptHeaders = explode(',', (string)$this->getEnv('HTTP_ACCEPT'));
         foreach ($detect['accept'] as $header) {
-            if (in_array($header, $acceptHeaders)) {
+            if (in_array($header, $acceptHeaders, true)) {
                 return true;
             }
         }
@@ -865,7 +865,7 @@ class ServerRequest implements ServerRequestInterface
     protected function normalizeHeaderName(string $name): string
     {
         $name = str_replace('-', '_', strtoupper($name));
-        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'], true)) {
             $name = 'HTTP_' . $name;
         }
 
@@ -1203,7 +1203,7 @@ class ServerRequest implements ServerRequestInterface
             return $accept;
         }
 
-        return in_array($type, $accept);
+        return in_array($type, $accept, true);
     }
 
     /**
@@ -1251,7 +1251,7 @@ class ServerRequest implements ServerRequestInterface
             return $accept;
         }
 
-        return in_array(strtolower($language), $accept);
+        return in_array(strtolower($language), $accept, true);
     }
 
     /**

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -163,7 +163,7 @@ class FileLog extends BaseLog
             $filename = $this->_file;
         } elseif ($level === 'error' || $level === 'warning') {
             $filename = 'error.log';
-        } elseif (in_array($level, $debugTypes)) {
+        } elseif (in_array($level, $debugTypes, true)) {
             $filename = 'debug.log';
         } else {
             $filename = $level . '.log';

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -350,8 +350,8 @@ class Log
     public static function write($level, $message, $context = []): bool
     {
         static::_init();
-        if (is_int($level) && in_array($level, static::$_levelMap)) {
-            $level = array_search($level, static::$_levelMap);
+        if (is_int($level) && in_array($level, static::$_levelMap, true)) {
+            $level = array_search($level, static::$_levelMap, true);
         }
 
         if (!in_array($level, static::$_levels)) {
@@ -377,7 +377,7 @@ class Log
                 $scopes = [];
             }
 
-            $correctLevel = empty($levels) || in_array($level, $levels);
+            $correctLevel = empty($levels) || in_array($level, $levels, true);
             $inScope = $scopes === false && empty($context['scope']) || $scopes === [] ||
                 is_array($scopes) && array_intersect((array)$context['scope'], $scopes);
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -609,7 +609,7 @@ class Message implements JsonSerializable, Serializable
     {
         if ($encoding !== null) {
             $encoding = strtolower($encoding);
-            if (!in_array($encoding, $this->transferEncodingAvailable)) {
+            if (!in_array($encoding, $this->transferEncodingAvailable, true)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'Transfer encoding not available. Can be : %s.',
@@ -970,7 +970,7 @@ class Message implements JsonSerializable, Serializable
      */
     public function setEmailFormat(string $format)
     {
-        if (!in_array($format, $this->emailFormatAvailable)) {
+        if (!in_array($format, $this->emailFormatAvailable, true)) {
             throw new InvalidArgumentException('Format not available.');
         }
         $this->emailFormat = $format;
@@ -1447,7 +1447,7 @@ class Message implements JsonSerializable, Serializable
     public function setBody(array $content)
     {
         foreach ($content as $type => $text) {
-            if (!in_array($type, $this->emailFormatAvailable)) {
+            if (!in_array($type, $this->emailFormatAvailable, true)) {
                 throw new InvalidArgumentException(sprintf(
                     'Invalid message type: "$s". Valid types are: "text", "html".',
                     $type
@@ -1720,7 +1720,7 @@ class Message implements JsonSerializable, Serializable
         }
 
         $charset = strtoupper($this->charset);
-        if (in_array($charset, $this->charset8bit)) {
+        if (in_array($charset, $this->charset8bit, true)) {
             return '8bit';
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -589,7 +589,7 @@ abstract class Association
     {
         if (!$this->_propertyName) {
             $this->_propertyName = $this->_propertyName();
-            if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns())) {
+            if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)) {
                 $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
                     ' You should explicitly specify the "propertyName" option.';
                 trigger_error(
@@ -625,7 +625,7 @@ abstract class Association
      */
     public function setStrategy(string $name)
     {
-        if (!in_array($name, $this->_validStrategies)) {
+        if (!in_array($name, $this->_validStrategies, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid strategy "%s" was provided. Valid options are (%s).',
                 $name,

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -596,7 +596,7 @@ class BelongsToMany extends Association
      */
     public function setSaveStrategy(string $strategy): self
     {
-        if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE])) {
+        if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
             $msg = sprintf('Invalid save strategy "%s"', $strategy);
             throw new InvalidArgumentException($msg);
         }
@@ -1000,7 +1000,7 @@ class BelongsToMany extends Association
             }
             // Assume that operators contain junction conditions.
             // Trying to manage complex conditions could result in incorrect queries.
-            if ($isString && in_array(strtoupper($field), ['OR', 'NOT', 'AND', 'XOR'])) {
+            if ($isString && in_array(strtoupper($field), ['OR', 'NOT', 'AND', 'XOR'], true)) {
                 $matching[$field] = $value;
             }
         }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -371,7 +371,7 @@ class SelectLoader
             throw new RuntimeException($msg);
         }
 
-        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY]) ?
+        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY], true) ?
             $this->foreignKey :
             $this->bindingKey;
 
@@ -460,8 +460,8 @@ class SelectLoader
     protected function _buildResultMap(Query $fetchQuery, array $options): array
     {
         $resultMap = [];
-        $singleResult = in_array($this->associationType, [Association::MANY_TO_ONE, Association::ONE_TO_ONE]);
-        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY]) ?
+        $singleResult = in_array($this->associationType, [Association::MANY_TO_ONE, Association::ONE_TO_ONE], true);
+        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY], true) ?
             $this->foreignKey :
             $this->bindingKey;
         $key = (array)$keys;

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -101,7 +101,7 @@ class TimestampBehavior extends Behavior
         $refresh = $this->_config['refreshTimestamp'];
 
         foreach ($events[$eventName] as $field => $when) {
-            if (!in_array($when, ['always', 'new', 'existing'])) {
+            if (!in_array($when, ['always', 'new', 'existing'], true)) {
                 throw new UnexpectedValueException(sprintf(
                     'When should be one of "always", "new" or "existing". The passed value "%s" is invalid',
                     $when
@@ -177,7 +177,7 @@ class TimestampBehavior extends Behavior
         $refresh = $this->_config['refreshTimestamp'];
 
         foreach ($events[$eventName] as $field => $when) {
-            if (in_array($when, ['always', 'existing'])) {
+            if (in_array($when, ['always', 'existing'], true)) {
                 $return = true;
                 $entity->setDirty($field, false);
                 $this->_updateField($entity, $field, $refresh);

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -231,10 +231,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                     return $c;
                 }
 
-                if (in_array($field, $fields)) {
+                if (in_array($field, $fields, true)) {
                     $joinRequired = true;
                     $field = "$alias.$field";
-                } elseif (in_array($field, $mainTableFields)) {
+                } elseif (in_array($field, $mainTableFields, true)) {
                     $field = "$mainTableAlias.$field";
                 }
 
@@ -280,14 +280,14 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                     return;
                 }
 
-                if (in_array($field, $fields)) {
+                if (in_array($field, $fields, true)) {
                     $joinRequired = true;
                     $expression->setField("$alias.$field");
 
                     return;
                 }
 
-                if (in_array($field, $mainTableFields)) {
+                if (in_array($field, $mainTableFields, true)) {
                     $expression->setField("$mainTableAlias.$field");
                 }
             }
@@ -413,7 +413,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         }
 
         $translatedFields = $this->translatedFields();
-        if (in_array($field, $translatedFields)) {
+        if (in_array($field, $translatedFields, true)) {
             return $this->getConfig('hasOneAlias') . '.' . $field;
         }
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -732,7 +732,7 @@ class Route
         }
         $methods = array_map('strtoupper', (array)$url['_method']);
         foreach ($methods as $value) {
-            if (in_array($value, (array)$this->defaults['_method'])) {
+            if (in_array($value, (array)$this->defaults['_method'], true)) {
                 return true;
             }
         }

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -143,7 +143,7 @@ class RoutesShell extends Shell
         foreach ($args as $arg) {
             if (strpos($arg, ':') !== false) {
                 [$key, $value] = explode(':', $arg);
-                if (in_array($value, ['true', 'false'])) {
+                if (in_array($value, ['true', 'false'], true)) {
                     $value = $value === 'true';
                 }
                 $out[$key] = $value;

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -146,9 +146,9 @@ class CommandTask extends Shell
         foreach ($shellList as $type => $commands) {
             foreach ($commands as $shell) {
                 $prefix = '';
-                if (!in_array(strtolower($type), ['app', 'core']) &&
+                if (!in_array(strtolower($type), ['app', 'core'], true) &&
                     isset($duplicates[$type]) &&
-                    in_array($shell, $duplicates[$type])
+                    in_array($shell, $duplicates[$type], true)
                 ) {
                     $prefix = $type . '.';
                 }
@@ -188,7 +188,7 @@ class CommandTask extends Shell
         $methodNames = [];
         foreach ($methods as $method) {
             $declaringClass = $method->getDeclaringClass()->getShortName();
-            if (!in_array($declaringClass, $baseClasses)) {
+            if (!in_array($declaringClass, $baseClasses, true)) {
                 $methodNames[] = $method->getName();
             }
         }
@@ -209,22 +209,22 @@ class CommandTask extends Shell
     {
         [$pluginDot, $name] = pluginSplit($commandName, true);
 
-        if (in_array(strtolower((string)$pluginDot), ['app.', 'core.'])) {
+        if (in_array(strtolower((string)$pluginDot), ['app.', 'core.'], true)) {
             $commandName = $name;
             $pluginDot = '';
         }
 
-        if (!in_array($commandName, $this->commands()) && (empty($pluginDot) && !in_array($name, $this->commands()))) {
+        if (!in_array($commandName, $this->commands(), true) && (empty($pluginDot) && !in_array($name, $this->commands(), true))) {
             return false;
         }
 
         if (empty($pluginDot)) {
             $shellList = $this->getShellList();
 
-            if (!in_array($commandName, $shellList['app']) && !in_array($commandName, $shellList['CORE'])) {
+            if (!in_array($commandName, $shellList['app']) && !in_array($commandName, $shellList['CORE'], true)) {
                 unset($shellList['CORE'], $shellList['app']);
                 foreach ($shellList as $plugin => $commands) {
-                    if (in_array($commandName, $commands)) {
+                    if (in_array($commandName, $commands, true)) {
                         $pluginDot = $plugin . '.';
                         break;
                     }

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -50,7 +50,7 @@ class MailSentWith extends MailConstraintBase
         $emails = $this->getMessages();
         foreach ($emails as $email) {
             $value = $email->{'get' . ucfirst($this->method)}();
-            if (in_array($this->method, ['to', 'cc', 'bcc', 'from']) && isset($value[$other])) {
+            if (in_array($this->method, ['to', 'cc', 'bcc', 'from'], true) && isset($value[$other])) {
                 return true;
             }
             if ($value === $other) {

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -51,7 +51,7 @@ class FixtureInjector implements TestListener
     public function __construct(FixtureManager $manager)
     {
         if (isset($_SERVER['argv'])) {
-            $manager->setDebug(in_array('--debug', $_SERVER['argv']));
+            $manager->setDebug(in_array('--debug', $_SERVER['argv'], true));
         }
         $this->_fixtureManager = $manager;
         $this->_fixtureManager->shutDown();

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -248,7 +248,7 @@ class FixtureManager
         }
 
         $table = $fixture->sourceName();
-        $exists = in_array($table, $sources);
+        $exists = in_array($table, $sources, true);
 
         $hasSchema = $fixture instanceof TableSchemaAwareInterface && $fixture->getTableSchema() instanceof TableSchema;
 
@@ -291,7 +291,7 @@ class FixtureManager
                 }
 
                 foreach ($fixtures as $fixture) {
-                    if (in_array($fixture->table, $tables)) {
+                    if (in_array($fixture->table, $tables, true)) {
                         try {
                             $fixture->dropConstraints($db);
                         } catch (PDOException $e) {
@@ -307,7 +307,7 @@ class FixtureManager
                 }
 
                 foreach ($fixtures as $fixture) {
-                    if (!in_array($fixture, $this->_insertionMap[$configName])) {
+                    if (!in_array($fixture, $this->_insertionMap[$configName], true)) {
                         $this->_setupTable($fixture, $db, $tables, $test->dropTables);
                     } else {
                         $fixture->truncate($db);
@@ -475,12 +475,13 @@ class FixtureManager
      */
     public function shutDown(): void
     {
-        $shutdown = function ($db, $fixtures): void {
+        $shutdown = function (ConnectionInterface $db, $fixtures): void {
             $connection = $db->configName();
+            /** @var \Cake\Datasource\FixtureInterface $fixture */
             foreach ($fixtures as $fixture) {
                 if ($this->isFixtureSetup($connection, $fixture)) {
                     $fixture->drop($db);
-                    $index = array_search($fixture, $this->_insertionMap[$connection]);
+                    $index = array_search($fixture, $this->_insertionMap[$connection], true);
                     unset($this->_insertionMap[$connection][$index]);
                 }
             }
@@ -497,6 +498,6 @@ class FixtureManager
      */
     public function isFixtureSetup(string $connection, FixtureInterface $fixture): bool
     {
-        return isset($this->_insertionMap[$connection]) && in_array($fixture, $this->_insertionMap[$connection]);
+        return isset($this->_insertionMap[$connection]) && in_array($fixture, $this->_insertionMap[$connection], true);
     }
 }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -249,7 +249,7 @@ class TestFixture implements FixtureInterface, TableSchemaAwareInterface
         $schemaCollection = $db->getSchemaCollection();
         $tables = $schemaCollection->listTables();
 
-        if (!in_array($this->table, $tables)) {
+        if (!in_array($this->table, $tables, true)) {
             throw new CakeException(
                 sprintf(
                     'Cannot describe schema for table `%s` for fixture `%s`: the table does not exist.',

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -622,7 +622,7 @@ trait IntegrationTestTrait
         if (isset($this->_request['headers'])) {
             foreach ($this->_request['headers'] as $k => $v) {
                 $name = strtoupper(str_replace('-', '_', $k));
-                if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+                if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'], true)) {
                     $name = 'HTTP_' . $name;
                 }
                 $env[$name] = $v;

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -79,7 +79,7 @@ trait CookieCryptTrait
      */
     protected function _checkCipher(string $encrypt): void
     {
-        if (!in_array($encrypt, $this->_validCiphers)) {
+        if (!in_array($encrypt, $this->_validCiphers, true)) {
             $msg = sprintf(
                 'Invalid encryption cipher. Must be one of %s or false.',
                 implode(', ', $this->_validCiphers)

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -558,7 +558,7 @@ class Inflector
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
             static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) .
-                substr(array_search(strtolower($regs[2]), static::$_irregular), 1);
+                substr(array_search(strtolower($regs[2]), static::$_irregular, true), 1);
 
             return static::$_cache['singularize'][$word];
         }

--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -69,7 +69,7 @@ trait MergeVariablesTrait
         $thisValue = $this->{$property};
         $isAssoc = false;
         if (isset($options['associative']) &&
-            in_array($property, (array)$options['associative'])
+            in_array($property, (array)$options['associative'], true)
         ) {
             $isAssoc = true;
         }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -66,7 +66,7 @@ class Security
         $algorithm = strtolower($algorithm);
 
         $availableAlgorithms = hash_algos();
-        if (!in_array($algorithm, $availableAlgorithms)) {
+        if (!in_array($algorithm, $availableAlgorithms, true)) {
             throw new RuntimeException(sprintf(
                 'The hash type `%s` was not found. Available algorithms are: %s',
                 $algorithm,

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -624,7 +624,7 @@ class Text
                         if (preg_match('/<[\w]+[^>]*>/', $tag[0])) {
                             array_unshift($openTags, $tag[2]);
                         } elseif (preg_match('/<\/([\w]+)[^>]*>/', $tag[0], $closeTag)) {
-                            $pos = array_search($closeTag[1], $openTags);
+                            $pos = array_search($closeTag[1], $openTags, true);
                             if ($pos !== false) {
                                 array_splice($openTags, $pos, 1);
                             }
@@ -1022,10 +1022,10 @@ class Text
         $size = strtoupper($size);
 
         $l = -2;
-        $i = array_search(substr($size, -2), ['KB', 'MB', 'GB', 'TB', 'PB']);
+        $i = array_search(substr($size, -2), ['KB', 'MB', 'GB', 'TB', 'PB'], true);
         if ($i === false) {
             $l = -1;
-            $i = array_search(substr($size, -1), ['K', 'M', 'G', 'T', 'P']);
+            $i = array_search(substr($size, -1), ['K', 'M', 'G', 'T', 'P'], true);
         }
         if ($i !== false) {
             $size = (float)substr($size, 0, $l);

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1116,7 +1116,7 @@ class Validation
             $mimeTypes[$key] = strtolower($val);
         }
 
-        return in_array($mime, $mimeTypes);
+        return in_array($mime, $mimeTypes, true);
     }
 
     /**

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -193,7 +193,7 @@ class ValidationRule
                 $this->_pass = array_slice($value, 1);
                 $value = array_shift($value);
             }
-            if (in_array($key, ['rule', 'on', 'message', 'last', 'provider', 'pass'])) {
+            if (in_array($key, ['rule', 'on', 'message', 'last', 'provider', 'pass'], true)) {
                 $this->{"_$key"} = $value;
             }
         }

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -126,7 +126,7 @@ class ArrayContext implements ContextInterface
     {
         $primaryKey = $this->primaryKey();
 
-        return in_array($field, $primaryKey);
+        return in_array($field, $primaryKey, true);
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -187,7 +187,7 @@ class EntityContext implements ContextInterface
         $table = $this->_getTable($parts);
         $primaryKey = (array)$table->getPrimaryKey();
 
-        return in_array(array_pop($parts), $primaryKey);
+        return in_array(array_pop($parts), $primaryKey, true);
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -641,10 +641,10 @@ class FormHelper extends Helper
         if ($name === null) {
             return $this->_unlockedFields;
         }
-        if (!in_array($name, $this->_unlockedFields)) {
+        if (!in_array($name, $this->_unlockedFields, true)) {
             $this->_unlockedFields[] = $name;
         }
-        $index = array_search($name, $this->fields);
+        $index = array_search($name, $this->fields, true);
         if ($index !== false) {
             unset($this->fields[$index]);
         }
@@ -685,7 +685,7 @@ class FormHelper extends Helper
         $field = preg_replace('/(\.\d+)+$/', '', $field);
 
         if ($lock) {
-            if (!in_array($field, $this->fields)) {
+            if (!in_array($field, $this->fields, true)) {
                 if ($value !== null) {
                     $this->fields[$field] = $value;
 
@@ -1260,9 +1260,9 @@ class FormHelper extends Helper
                 return 'checkbox';
             case isset($options['options']):
                 return 'select';
-            case in_array($fieldName, ['passwd', 'password']):
+            case in_array($fieldName, ['passwd', 'password'], true):
                 return 'password';
-            case in_array($fieldName, ['tel', 'telephone', 'phone']):
+            case in_array($fieldName, ['tel', 'telephone', 'phone'], true):
                 return 'tel';
             case $fieldName === 'email':
                 return 'email';
@@ -1359,8 +1359,8 @@ class FormHelper extends Helper
         }
 
         $typesWithOptions = ['text', 'number', 'radio', 'select'];
-        $magicOptions = (in_array($options['type'], ['radio', 'select']) || $allowOverride);
-        if ($magicOptions && in_array($options['type'], $typesWithOptions)) {
+        $magicOptions = (in_array($options['type'], ['radio', 'select'], true) || $allowOverride);
+        if ($magicOptions && in_array($options['type'], $typesWithOptions, true)) {
             $options = $this->_optionsOptions($fieldName, $options);
         }
 
@@ -1377,7 +1377,7 @@ class FormHelper extends Helper
 
         $typesWithMaxLength = ['text', 'textarea', 'email', 'tel', 'url', 'search'];
         if (!array_key_exists('maxlength', $options)
-            && in_array($options['type'], $typesWithMaxLength)
+            && in_array($options['type'], $typesWithMaxLength, true)
         ) {
             $maxLength = null;
             if (method_exists($context, 'getMaxLength')) {
@@ -1393,7 +1393,7 @@ class FormHelper extends Helper
             }
         }
 
-        if (in_array($options['type'], ['datetime', 'date', 'time', 'select'])) {
+        if (in_array($options['type'], ['datetime', 'date', 'time', 'select'], true)) {
             $options += ['empty' => false];
         }
 
@@ -2341,7 +2341,7 @@ class FormHelper extends Helper
             // Complex option types
             if (is_array($first)) {
                 $disabled = array_filter($options['options'], function ($i) use ($options) {
-                    return in_array($i['value'], $options['disabled']);
+                    return in_array($i['value'], $options['disabled'], true);
                 });
 
                 return count($disabled) > 0;

--- a/src/View/Helper/IdGeneratorTrait.php
+++ b/src/View/Helper/IdGeneratorTrait.php
@@ -63,7 +63,7 @@ trait IdGeneratorTrait
         $idSuffix = mb_strtolower(str_replace(['/', '@', '<', '>', ' ', '"', '\''], '-', $val));
         $count = 1;
         $check = $idSuffix;
-        while (in_array($check, $this->_idSuffixes)) {
+        while (in_array($check, $this->_idSuffixes, true)) {
             $check = $idSuffix . $count++;
         }
         $this->_idSuffixes[] = $check;


### PR DESCRIPTION
When we are now using strict typehinting and especially now the `declare(strict_types=1);` part, it is a bit sad to see that the code internally uses a lot of dirty "auto-casting" inside functions like array_search() and in_array(), potentially cloaking issues still.
I started a first batch here to harmonize the code base towards what is already used in quite a few other places. 

Maybe we also want a sniffer of some sorts in the future, as well.