### PR TITLE
Remove invalid chainable typehints as per cs assert.

### DIFF
--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -103,7 +103,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
-    public function unload(string $name): ObjectRegistry
+    public function unload(string $name)
     {
         unset($this->_loaded[$name]);
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -80,7 +80,7 @@ class Command
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setName(string $name): self
+    public function setName(string $name)
     {
         if (strpos($name, ' ') < 1) {
             throw new InvalidArgumentException(

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -55,7 +55,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string|\Cake\Console\Shell|\Cake\Console\Command $command The command to map.
      * @return $this
      */
-    public function add(string $name, $command): self
+    public function add(string $name, $command)
     {
         // Once we have a new Command class this should check
         // against that interface.
@@ -85,7 +85,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @return $this
      * @see \Cake\Console\CommandCollection::add()
      */
-    public function addMany(array $commands): self
+    public function addMany(array $commands)
     {
         foreach ($commands as $name => $class) {
             $this->add($name, $class);
@@ -100,7 +100,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param string $name The named shell.
      * @return $this
      */
-    public function remove(string $name): self
+    public function remove(string $name)
     {
         unset($this->commands[$name]);
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -103,7 +103,7 @@ class CommandRunner implements EventDispatcherInterface
      * @param array $aliases The map of aliases to replace.
      * @return $this
      */
-    public function setAliases(array $aliases): self
+    public function setAliases(array $aliases)
     {
         $this->aliases = $aliases;
 
@@ -210,8 +210,9 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @param \Cake\Event\EventManagerInterface $events The event manager to set.
      * @return $this
+     * @throws \InvalidArgumentException
      */
-    public function setEventManager(EventManagerInterface $events): EventDispatcherInterface
+    public function setEventManager(EventManagerInterface $events)
     {
         if ($this->app instanceof PluginApplicationInterface) {
             $this->app->setEventManager($events);

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -291,7 +291,7 @@ class ConsoleOptionParser
      * @param string $text The text to set.
      * @return $this
      */
-    public function setCommand(string $text): self
+    public function setCommand(string $text)
     {
         $this->_command = Inflector::underscore($text);
 
@@ -315,7 +315,7 @@ class ConsoleOptionParser
      *   text will be imploded with "\n".
      * @return $this
      */
-    public function setDescription($text): self
+    public function setDescription($text)
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -343,7 +343,7 @@ class ConsoleOptionParser
      *   be imploded with "\n".
      * @return $this
      */
-    public function setEpilog($text): self
+    public function setEpilog($text)
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -369,7 +369,7 @@ class ConsoleOptionParser
      * @param bool $value Whether or not to sort subcommands
      * @return $this
      */
-    public function enableSubcommandSort(bool $value = true): self
+    public function enableSubcommandSort(bool $value = true)
     {
         $this->_subcommandSort = (bool)$value;
 
@@ -410,7 +410,7 @@ class ConsoleOptionParser
      * @param array $options An array of parameters that define the behavior of the option
      * @return $this
      */
-    public function addOption($name, array $options = []): self
+    public function addOption($name, array $options = [])
     {
         if ($name instanceof ConsoleInputOption) {
             $option = $name;
@@ -443,7 +443,7 @@ class ConsoleOptionParser
      * @param string $name The option name to remove.
      * @return $this
      */
-    public function removeOption(string $name): self
+    public function removeOption(string $name)
     {
         unset($this->_options[$name]);
 
@@ -772,7 +772,7 @@ class ConsoleOptionParser
      * @param string $name The root command name
      * @return $this
      */
-    public function setRootName(string $name): self
+    public function setRootName(string $name)
     {
         $this->rootName = (string)$name;
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -209,7 +209,7 @@ class Shell
      * @param string $name The name of the root command.
      * @return $this
      */
-    public function setRootName(string $name): self
+    public function setRootName(string $name)
     {
         $this->rootName = $name;
 

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -198,7 +198,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
-    public function enable(string $hook): PluginInterface
+    public function enable(string $hook)
     {
         $this->checkHook($hook);
         $this->{"{$hook}Enabled}"} = true;
@@ -209,7 +209,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
-    public function disable(string $hook): PluginInterface
+    public function disable(string $hook)
     {
         $this->checkHook($hook);
         $this->{"{$hook}Enabled"} = false;

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -297,7 +297,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      *
      * @return $this
      */
-    public function reset(): self
+    public function reset()
     {
         foreach (array_keys($this->_loaded) as $name) {
             $this->unload($name);
@@ -316,7 +316,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @param object $object instance to store in the registry
      * @return $this
      */
-    public function set(string $objectName, $object): self
+    public function set(string $objectName, $object)
     {
         [, $name] = pluginSplit($objectName);
 
@@ -340,7 +340,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @param string $objectName The name of the object to remove from the registry.
      * @return $this
      */
-    public function unload(string $objectName): self
+    public function unload(string $objectName)
     {
         if (empty($this->_loaded[$objectName])) {
             [$plugin, $objectName] = pluginSplit($objectName);

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -137,7 +137,7 @@ class PluginCollection implements Iterator, Countable
      * @param \Cake\Core\PluginInterface $plugin The plugin to load.
      * @return $this
      */
-    public function add(PluginInterface $plugin): self
+    public function add(PluginInterface $plugin)
     {
         $name = $plugin->getName();
         $this->plugins[$name] = $plugin;
@@ -152,7 +152,7 @@ class PluginCollection implements Iterator, Countable
      * @param string $name The named plugin.
      * @return $this
      */
-    public function remove(string $name): self
+    public function remove(string $name)
     {
         unset($this->plugins[$name]);
         $this->names = array_keys($this->plugins);

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -107,17 +107,17 @@ interface PluginInterface
      * Disables the named hook
      *
      * @param string $hook The hook to disable
-     * @return \Cake\Core\PluginInterface
+     * @return $this
      */
-    public function disable(string $hook): PluginInterface;
+    public function disable(string $hook);
 
     /**
      * Enables the named hook
      *
      * @param string $hook The hook to disable
-     * @return \Cake\Core\PluginInterface
+     * @return $this
      */
-    public function enable(string $hook): PluginInterface;
+    public function enable(string $hook);
 
     /**
      * Check if the named hook is enabled

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -795,7 +795,7 @@ class Connection implements ConnectionInterface
      * @param bool $value Enable/disable query logging
      * @return $this
      */
-    public function enableQueryLogging(bool $value): ConnectionInterface
+    public function enableQueryLogging(bool $value)
     {
         $this->_logQueries = $value;
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -584,10 +584,10 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $method The method name.
      * @param array $args The arguments to pass to the method.
-     * @return \Cake\Database\Expression\QueryExpression
+     * @return $this
      * @throws \BadMethodCallException
      */
-    public function __call(string $method, array $args): self
+    public function __call(string $method, array $args)
     {
         if (in_array($method, ['and', 'or'])) {
             return call_user_func_array([$this, $method . '_'], $args);

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -95,7 +95,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
-    public function unload(string $name): ObjectRegistry
+    public function unload(string $name)
     {
         unset($this->_loaded[$name]);
 

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -78,7 +78,7 @@ class RuleInvoker
      * @param array $options The options to set.
      * @return $this
      */
-    public function setOptions(array $options): self
+    public function setOptions(array $options)
     {
         $this->options = $options + $this->options;
 
@@ -93,7 +93,7 @@ class RuleInvoker
      * @param string $name The name to set.
      * @return $this
      */
-    public function setName(string $name): self
+    public function setName(string $name)
     {
         if ($name) {
             $this->name = $name;

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -136,7 +136,7 @@ class Event implements EventInterface
      * @param mixed $value The value to set.
      * @return $this
      */
-    public function setResult($value = null): self
+    public function setResult($value = null)
     {
         $this->result = $value;
 
@@ -166,7 +166,7 @@ class Event implements EventInterface
      * @param mixed $value The value to set.
      * @return $this
      */
-    public function setData($key, $value = null): self
+    public function setData($key, $value = null)
     {
         if (is_array($key)) {
             $this->_data = $key;

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -48,9 +48,9 @@ interface EventDispatcherInterface
      * object events, or create your own events and trigger them at will.
      *
      * @param \Cake\Event\EventManagerInterface $eventManager the eventManager to set
-     * @return \Cake\Event\EventDispatcherInterface
+     * @return $this
      */
-    public function setEventManager(EventManagerInterface $eventManager): EventDispatcherInterface;
+    public function setEventManager(EventManagerInterface $eventManager);
 
     /**
      * Returns the Cake\Event\EventManager manager instance for this object.

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -61,7 +61,7 @@ trait EventDispatcherTrait
      * @param \Cake\Event\EventManagerInterface $eventManager the eventManager to set
      * @return $this
      */
-    public function setEventManager(EventManagerInterface $eventManager): EventDispatcherInterface
+    public function setEventManager(EventManagerInterface $eventManager)
     {
         $this->_eventManager = $eventManager;
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -204,7 +204,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      * @param array $errors Errors list.
      * @return $this
      */
-    public function setErrors(array $errors): self
+    public function setErrors(array $errors)
     {
         $this->_errors = $errors;
 
@@ -267,7 +267,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      * @param array $data Data array.
      * @return $this
      */
-    public function setData(array $data): self
+    public function setData(array $data)
     {
         $this->_data = $data;
 

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -45,7 +45,7 @@ class Schema
      * @param array $fields The fields to add.
      * @return $this
      */
-    public function addFields(array $fields): self
+    public function addFields(array $fields)
     {
         foreach ($fields as $name => $attrs) {
             $this->addField($name, $attrs);
@@ -62,7 +62,7 @@ class Schema
      *   as a string.
      * @return $this
      */
-    public function addField($name, $attrs): self
+    public function addField($name, $attrs)
     {
         if (is_string($attrs)) {
             $attrs = ['type' => $attrs];
@@ -79,7 +79,7 @@ class Schema
      * @param string $name The field to remove.
      * @return $this
      */
-    public function removeField($name): self
+    public function removeField($name)
     {
         unset($this->_fields[$name]);
 

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -95,7 +95,7 @@ class FormData implements Countable
      * @param mixed $value The value for the part.
      * @return $this
      */
-    public function add($name, $value = null): self
+    public function add($name, $value = null)
     {
         if (is_array($value)) {
             $this->addRecursive($name, $value);
@@ -119,7 +119,7 @@ class FormData implements Countable
      * @param array $data Array of data to add.
      * @return $this
      */
-    public function addMany(array $data): self
+    public function addMany(array $data)
     {
         foreach ($data as $name => $value) {
             $this->add((string)$name, $value);

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -85,7 +85,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      * @param array $methods The methods to parse data on.
      * @return $this
      */
-    public function setMethods(array $methods): self
+    public function setMethods(array $methods)
     {
         $this->methods = $methods;
 
@@ -112,7 +112,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      *   into the request.
      * @return $this
      */
-    public function addParser(array $types, callable $parser): self
+    public function addParser(array $types, callable $parser)
     {
         foreach ($types as $type) {
             $type = strtolower($type);

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -109,7 +109,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
      * @return $this
      */
-    public function noSniff(): self
+    public function noSniff()
     {
         $this->headers['x-content-type-options'] = self::NOSNIFF;
 
@@ -124,7 +124,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      * @link https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
      * @return $this
      */
-    public function noOpen(): self
+    public function noOpen()
     {
         $this->headers['x-download-options'] = self::NOOPEN;
 
@@ -139,7 +139,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      *     'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
      * @return $this
      */
-    public function setReferrerPolicy($policy = self::SAME_ORIGIN): self
+    public function setReferrerPolicy($policy = self::SAME_ORIGIN)
     {
         $available = [
             self::NO_REFERRER,
@@ -166,7 +166,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      * @param string $url URL if mode is `allow-from`
      * @return $this
      */
-    public function setXFrameOptions($option = self::SAMEORIGIN, ?string $url = null): self
+    public function setXFrameOptions($option = self::SAMEORIGIN, ?string $url = null)
     {
         $this->checkValues($option, [self::DENY, self::SAMEORIGIN, self::ALLOW_FROM]);
 
@@ -189,7 +189,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      * @param string $mode Mode value. Available Values: '1', '0', 'block'
      * @return $this
      */
-    public function setXssProtection(string $mode = self::XSS_BLOCK): self
+    public function setXssProtection(string $mode = self::XSS_BLOCK)
     {
         $mode = (string)$mode;
 
@@ -211,7 +211,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      *     'by-ftp-filename'
      * @return $this
      */
-    public function setCrossDomainPolicy($policy = self::ALL): self
+    public function setCrossDomainPolicy($policy = self::ALL)
     {
         $this->checkValues($policy, [
             self::ALL,

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -99,7 +99,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param callable|string|array $middleware The middleware(s) to append.
      * @return $this
      */
-    public function add($middleware): self
+    public function add($middleware)
     {
         if (is_array($middleware)) {
             $this->queue = array_merge($this->queue, $middleware);
@@ -118,7 +118,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return $this
      * @see MiddlewareQueue::add()
      */
-    public function push($middleware): self
+    public function push($middleware)
     {
         return $this->add($middleware);
     }
@@ -129,7 +129,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param callable|string|array $middleware The middleware(s) to prepend.
      * @return $this
      */
-    public function prepend($middleware): self
+    public function prepend($middleware)
     {
         if (is_array($middleware)) {
             $this->queue = array_merge($middleware, $this->queue);
@@ -151,7 +151,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param callable|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAt(int $index, $middleware): self
+    public function insertAt(int $index, $middleware)
     {
         array_splice($this->queue, $index, 0, [$middleware]);
 
@@ -169,7 +169,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return $this
      * @throws \LogicException If middleware to insert before is not found.
      */
-    public function insertBefore(string $class, $middleware): self
+    public function insertBefore(string $class, $middleware)
     {
         $found = false;
         $i = null;
@@ -198,7 +198,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param callable|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAfter(string $class, $middleware): self
+    public function insertAfter(string $class, $middleware)
     {
         $found = false;
         $i = null;

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -135,7 +135,7 @@ class Server implements EventDispatcherInterface
      * @param \Cake\Http\Runner $runner The runner to use.
      * @return $this
      */
-    public function setRunner(Runner $runner): self
+    public function setRunner(Runner $runner)
     {
         $this->runner = $runner;
 
@@ -163,8 +163,9 @@ class Server implements EventDispatcherInterface
      *
      * @param \Cake\Event\EventManagerInterface $eventManager The event manager to set.
      * @return $this
+     * @throws \InvalidArgumentException
      */
-    public function setEventManager(EventManagerInterface $eventManager): EventDispatcherInterface
+    public function setEventManager(EventManagerInterface $eventManager)
     {
         if ($this->app instanceof PluginApplicationInterface) {
             $this->app->setEventManager($eventManager);

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -74,7 +74,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param int $timeout The timeout duration.
      * @return $this
      */
-    public function setTimeout(int $timeout): self
+    public function setTimeout(int $timeout)
     {
         $this->_timeout = $timeout;
 

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -98,7 +98,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param string $name The logger name.
      * @return $this
      */
-    public function unload(string $name): ObjectRegistry
+    public function unload(string $name)
     {
         unset($this->_loaded[$name]);
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -189,7 +189,7 @@ class Email implements JsonSerializable, Serializable
      * @param string $viewClass View class name.
      * @return $this
      */
-    public function setViewRenderer(string $viewClass): self
+    public function setViewRenderer(string $viewClass)
     {
         $this->getRenderer()->viewBuilder()->setClassName($viewClass);
 
@@ -214,7 +214,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $viewVars Variables to set for view.
      * @return $this
      */
-    public function setViewVars(array $viewVars): self
+    public function setViewVars(array $viewVars)
     {
         $this->getRenderer()->viewBuilder()->setVars($viewVars);
 
@@ -243,7 +243,7 @@ class Email implements JsonSerializable, Serializable
      * @throws \LogicException When the chosen transport lacks a send method.
      * @throws \InvalidArgumentException When $name is neither a string nor an object.
      */
-    public function setTransport($name): self
+    public function setTransport($name)
     {
         if (is_string($name)) {
             $transport = TransportFactory::get($name);
@@ -296,7 +296,7 @@ class Email implements JsonSerializable, Serializable
      *    an array with config.
      * @return $this
      */
-    public function setProfile($config): self
+    public function setProfile($config)
     {
         if (is_string($config)) {
             $name = $config;
@@ -445,7 +445,7 @@ class Email implements JsonSerializable, Serializable
      * @param \Cake\Mailer\Renderer $renderer Render instance.
      * @return $this
      */
-    public function setRenderer(Renderer $renderer): self
+    public function setRenderer(Renderer $renderer)
     {
         $this->renderer = $renderer;
 
@@ -545,7 +545,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @return $this
      */
-    public function reset(): self
+    public function reset()
     {
         $this->message->reset();
         $this->_transport = null;

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -221,7 +221,7 @@ abstract class Mailer implements EventListenerInterface
      * @param mixed $value View variable value.
      * @return $this
      */
-    public function set($key, $value = null): self
+    public function set($key, $value = null)
     {
         $this->_email->setViewVars(is_string($key) ? [$key => $value] : $key);
 
@@ -268,7 +268,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @return $this
      */
-    protected function reset(): self
+    protected function reset()
     {
         $this->_email = clone $this->_clonedEmail;
 

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -92,7 +92,7 @@ class TransportRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
-    public function unload(string $name): ObjectRegistry
+    public function unload(string $name)
     {
         unset($this->_loaded[$name]);
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -594,7 +594,7 @@ class BelongsToMany extends Association
      * @throws \InvalidArgumentException if an invalid strategy name is passed
      * @return $this
      */
-    public function setSaveStrategy(string $strategy): self
+    public function setSaveStrategy(string $strategy)
     {
         if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
             $msg = sprintf('Invalid save strategy "%s"', $strategy);
@@ -927,7 +927,7 @@ class BelongsToMany extends Association
      * @param string|\Cake\ORM\Table $through Name of the Table instance or the instance itself
      * @return $this
      */
-    public function setThrough($through): self
+    public function setThrough($through)
     {
         $this->_through = $through;
 

--- a/src/ORM/Behavior/Translate/TranslateStrategyInterface.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyInterface.php
@@ -50,7 +50,7 @@ interface TranslateStrategyInterface extends PropertyMarshalInterface
      *   the behavior fall back to using the globally configured locale.
      * @return $this
      */
-    public function setLocale(?string $locale): TranslateStrategyInterface;
+    public function setLocale(?string $locale);
 
     /**
      * Returns the current locale.

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -73,7 +73,7 @@ trait TranslateStrategyTrait
      *   the behavior fall back to using the globally configured locale.
      * @return $this
      */
-    public function setLocale(?string $locale): TranslateStrategyInterface
+    public function setLocale(?string $locale)
     {
         $this->locale = $locale;
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -220,7 +220,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @link https://book.cakephp.org/3.0/en/orm/behaviors/translate.html#retrieving-one-language-without-using-i18n-locale
      * @link https://book.cakephp.org/3.0/en/orm/behaviors/translate.html#saving-in-another-language
      */
-    public function setLocale(?string $locale): self
+    public function setLocale(?string $locale)
     {
         $this->getStrategy()->setLocale($locale);
 

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -209,7 +209,7 @@ class EagerLoadable
      * @param bool $possible The value to set.
      * @return $this
      */
-    public function setCanBeJoined(bool $possible): self
+    public function setCanBeJoined(bool $possible)
     {
         $this->_canBeJoined = (bool)$possible;
 
@@ -233,7 +233,7 @@ class EagerLoadable
      * @param array $config The value to set.
      * @return $this
      */
-    public function setConfig(array $config): self
+    public function setConfig(array $config)
     {
         $this->_config = $config;
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -192,7 +192,7 @@ class EagerLoader
      * @param bool $enable The value to set.
      * @return $this
      */
-    public function enableAutoFields(bool $enable = true): self
+    public function enableAutoFields(bool $enable = true)
     {
         $this->_autoFields = (bool)$enable;
 
@@ -238,7 +238,7 @@ class EagerLoader
      * @param array $options Extra options for the association matching.
      * @return $this
      */
-    public function setMatching(string $assoc, ?callable $builder = null, array $options = []): self
+    public function setMatching(string $assoc, ?callable $builder = null, array $options = [])
     {
         if ($this->_matching === null) {
             $this->_matching = new static();

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -212,7 +212,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
-    public function select($fields = [], $overwrite = false): self
+    public function select($fields = [], $overwrite = false)
     {
         if ($fields instanceof Association) {
             $fields = $fields->getTarget();
@@ -237,10 +237,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\ORM\Table|\Cake\ORM\Association $table The table to use to get an array of columns
      * @param array $excludedFields The un-aliased column names you do not want selected from $table
      * @param bool $overwrite Whether to reset/remove previous selected fields
-     * @return \Cake\ORM\Query
+     * @return $this
      * @throws \InvalidArgumentException If Association|Table is not passed in first argument
      */
-    public function selectAllExcept($table, array $excludedFields, $overwrite = false): Query
+    public function selectAllExcept($table, array $excludedFields, $overwrite = false)
     {
         if ($table instanceof Association) {
             $table = $table->getTarget();
@@ -267,7 +267,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\ORM\Table $table The table to pull types from
      * @return $this
      */
-    public function addDefaultTypes(Table $table): self
+    public function addDefaultTypes(Table $table)
     {
         $alias = $table->getAlias();
         $map = $table->getSchema()->typeMap();
@@ -287,7 +287,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\ORM\EagerLoader $instance The eager loader to use.
      * @return $this
      */
-    public function setEagerLoader(EagerLoader $instance): self
+    public function setEagerLoader(EagerLoader $instance)
     {
         $this->_eagerLoader = $instance;
 
@@ -461,7 +461,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return $this
      */
-    public function clearContain(): self
+    public function clearContain()
     {
         $this->getEagerLoader()->clearContain();
         $this->_dirty();
@@ -547,7 +547,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function matching(string $assoc, ?callable $builder = null): self
+    public function matching(string $assoc, ?callable $builder = null)
     {
         $result = $this->getEagerLoader()->setMatching($assoc, $builder)->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
@@ -619,7 +619,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function leftJoinWith(string $assoc, ?callable $builder = null): self
+    public function leftJoinWith(string $assoc, ?callable $builder = null)
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -668,7 +668,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @return $this
      * @see \Cake\ORM\Query::matching()
      */
-    public function innerJoinWith(string $assoc, ?callable $builder = null): self
+    public function innerJoinWith(string $assoc, ?callable $builder = null)
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -732,7 +732,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
-    public function notMatching(string $assoc, ?callable $builder = null): self
+    public function notMatching(string $assoc, ?callable $builder = null)
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
@@ -954,7 +954,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param callable|null $counter The counter value
      * @return $this
      */
-    public function counter(?callable $counter): self
+    public function counter(?callable $counter)
     {
         $this->_counter = $counter;
 
@@ -969,7 +969,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $enable Use a boolean to set the hydration mode.
      * @return $this
      */
-    public function enableHydration(bool $enable = true): self
+    public function enableHydration(bool $enable = true)
     {
         $this->_dirty();
         $this->_hydrate = (bool)$enable;
@@ -1009,7 +1009,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @return $this
      * @throws \RuntimeException When you attempt to cache a non-select query.
      */
-    public function cache(string $key, $config = 'default'): self
+    public function cache(string $key, $config = 'default')
     {
         if ($this->_type !== 'select' && $this->_type !== null) {
             throw new RuntimeException('You cannot cache the results of non-select queries.');
@@ -1246,7 +1246,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param array $types A map between columns & their datatypes.
      * @return $this
      */
-    public function insert(array $columns, array $types = []): self
+    public function insert(array $columns, array $types = [])
     {
         /** @var \Cake\ORM\Table $repository */
         $repository = $this->getRepository();
@@ -1312,7 +1312,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $value Set true to enable, false to disable.
      * @return $this
      */
-    public function enableAutoFields(bool $value = true): self
+    public function enableAutoFields(bool $value = true)
     {
         $this->_autoFields = (bool)$value;
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -828,9 +828,9 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * This method creates query clones that are useful when working with subqueries.
      *
-     * @return \Cake\ORM\Query
+     * @return static
      */
-    public function cleanCopy(): Query
+    public function cleanCopy(): self
     {
         $clone = clone $this;
         $clone->setEagerLoader(clone $this->getEagerLoader());

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -65,9 +65,9 @@ class SaveOptionsBuilder extends ArrayObject
      *
      * @throws \InvalidArgumentException If a given option key does not exist.
      * @param array $array Options array.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function parseArrayOptions(array $array): SaveOptionsBuilder
+    public function parseArrayOptions(array $array)
     {
         foreach ($array as $key => $value) {
             $this->{$key}($value);
@@ -80,9 +80,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Set associated options.
      *
      * @param string|array $associated String or array of associations.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function associated($associated): SaveOptionsBuilder
+    public function associated($associated)
     {
         $associated = $this->_normalizeAssociations($associated);
         $this->_associated($this->_table, $associated);
@@ -136,9 +136,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Set the guard option.
      *
      * @param bool $guard Guard the properties or not.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function guard(bool $guard): SaveOptionsBuilder
+    public function guard(bool $guard)
     {
         $this->_options['guard'] = (bool)$guard;
 
@@ -149,9 +149,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Set the validation rule set to use.
      *
      * @param string $validate Name of the validation rule set to use.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function validate(string $validate): SaveOptionsBuilder
+    public function validate(string $validate)
     {
         $this->_table->getValidator($validate);
         $this->_options['validate'] = $validate;
@@ -163,9 +163,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Set check existing option.
      *
      * @param bool $checkExisting Guard the properties or not.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function checkExisting(bool $checkExisting): SaveOptionsBuilder
+    public function checkExisting(bool $checkExisting)
     {
         $this->_options['checkExisting'] = (bool)$checkExisting;
 
@@ -176,9 +176,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Option to check the rules.
      *
      * @param bool $checkRules Check the rules or not.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function checkRules(bool $checkRules): SaveOptionsBuilder
+    public function checkRules(bool $checkRules)
     {
         $this->_options['checkRules'] = (bool)$checkRules;
 
@@ -189,9 +189,9 @@ class SaveOptionsBuilder extends ArrayObject
      * Sets the atomic option.
      *
      * @param bool $atomic Atomic or not.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function atomic(bool $atomic): SaveOptionsBuilder
+    public function atomic(bool $atomic)
     {
         $this->_options['atomic'] = (bool)$atomic;
 
@@ -211,9 +211,9 @@ class SaveOptionsBuilder extends ArrayObject
      *
      * @param string $option Option key.
      * @param mixed $value Option value.
-     * @return \Cake\ORM\SaveOptionsBuilder
+     * @return $this
      */
-    public function set(string $option, $value): SaveOptionsBuilder
+    public function set(string $option, $value)
     {
         if (method_exists($this, $option)) {
             return $this->{$option}($value);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -598,7 +598,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string|array $field Name to be used as display field.
      * @return $this
      */
-    public function setDisplayField($field): self
+    public function setDisplayField($field)
     {
         $this->_displayField = $field;
 
@@ -667,7 +667,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
      * @return $this
      */
-    public function setEntityClass(string $name): self
+    public function setEntityClass(string $name)
     {
         $class = App::className($name, 'Model/Entity');
         if (!$class) {
@@ -703,7 +703,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \RuntimeException If a behavior is being reloaded.
      * @see \Cake\ORM\Behavior
      */
-    public function addBehavior(string $name, array $options = []): self
+    public function addBehavior(string $name, array $options = [])
     {
         $this->_behaviors->load($name, $options);
 
@@ -726,7 +726,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return $this
      * @throws \RuntimeException If a behavior is being reloaded.
      */
-    public function addBehaviors(array $behaviors): self
+    public function addBehaviors(array $behaviors)
     {
         foreach ($behaviors as $name => $options) {
             if (is_int($name)) {
@@ -914,7 +914,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @see \Cake\ORM\Table::hasMany()
      * @see \Cake\ORM\Table::belongsToMany()
      */
-    public function addAssociations(array $params): self
+    public function addAssociations(array $params)
     {
         foreach ($params as $assocType => $tables) {
             foreach ($tables as $associated => $options) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -138,7 +138,7 @@ class Route
      * @param array $extensions The extensions to set.
      * @return $this
      */
-    public function setExtensions(array $extensions): self
+    public function setExtensions(array $extensions)
     {
         $this->_extensions = [];
         foreach ($extensions as $ext) {
@@ -165,7 +165,7 @@ class Route
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function setMethods(array $methods): self
+    public function setMethods(array $methods)
     {
         $methods = array_map('strtoupper', $methods);
         $diff = array_diff($methods, static::VALID_METHODS);
@@ -188,7 +188,7 @@ class Route
      * @param array $patterns The patterns to apply to routing elements
      * @return $this
      */
-    public function setPatterns(array $patterns): self
+    public function setPatterns(array $patterns)
     {
         $patternValues = implode("", $patterns);
         if (mb_strlen($patternValues) < strlen($patternValues)) {
@@ -205,7 +205,7 @@ class Route
      * @param string $host The host name this route is bound to
      * @return $this
      */
-    public function setHost(string $host): self
+    public function setHost(string $host)
     {
         $this->options['_host'] = $host;
 
@@ -218,7 +218,7 @@ class Route
      * @param array $names The names of the parameters that should be passed.
      * @return $this
      */
-    public function setPass(array $names): self
+    public function setPass(array $names)
     {
         $this->options['pass'] = $names;
 
@@ -240,7 +240,7 @@ class Route
      * @param array $names The names of the parameters that should be passed.
      * @return $this
      */
-    public function setPersist(array $names): self
+    public function setPersist(array $names)
     {
         $this->options['persist'] = $names;
 

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -150,7 +150,7 @@ class RouteBuilder
      * @param string $routeClass Class name.
      * @return $this
      */
-    public function setRouteClass(string $routeClass): self
+    public function setRouteClass(string $routeClass)
     {
         $this->_routeClass = $routeClass;
 
@@ -176,7 +176,7 @@ class RouteBuilder
      * @param string|array $extensions The extensions to set.
      * @return $this
      */
-    public function setExtensions($extensions): self
+    public function setExtensions($extensions)
     {
         $this->_extensions = (array)$extensions;
 
@@ -973,7 +973,7 @@ class RouteBuilder
      * @return $this
      * @see \Cake\Routing\RouteCollection
      */
-    public function registerMiddleware(string $name, $middleware): self
+    public function registerMiddleware(string $name, $middleware)
     {
         $this->_collection->registerMiddleware($name, $middleware);
 
@@ -989,7 +989,7 @@ class RouteBuilder
      * @return $this
      * @see \Cake\Routing\RouteCollection::addMiddlewareToScope()
      */
-    public function applyMiddleware(string ...$names): self
+    public function applyMiddleware(string ...$names)
     {
         foreach ($names as $name) {
             if (!$this->_collection->middlewareExists($name)) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -385,7 +385,7 @@ class RouteCollection
      *   Defaults to `true`.
      * @return $this
      */
-    public function setExtensions(array $extensions, bool $merge = true): self
+    public function setExtensions(array $extensions, bool $merge = true)
     {
         if ($merge) {
             $extensions = array_unique(array_merge(
@@ -408,7 +408,7 @@ class RouteCollection
      * @param callable|string $middleware The middleware callable or class name to register.
      * @return $this
      */
-    public function registerMiddleware(string $name, $middleware): self
+    public function registerMiddleware(string $name, $middleware)
     {
         $this->_middleware[$name] = $middleware;
 
@@ -422,7 +422,7 @@ class RouteCollection
      * @param array $middlewareNames Names of the middleware
      * @return $this
      */
-    public function middlewareGroup(string $name, array $middlewareNames): self
+    public function middlewareGroup(string $name, array $middlewareNames)
     {
         if ($this->hasMiddleware($name)) {
             $message = "Cannot add middleware group '$name'. A middleware by this name has already been registered.";
@@ -481,7 +481,7 @@ class RouteCollection
      * @param string[] $middleware The middleware names to add for the path.
      * @return $this
      */
-    public function applyMiddleware(string $path, array $middleware): self
+    public function applyMiddleware(string $path, array $middleware)
     {
         foreach ($middleware as $name) {
             if (!$this->hasMiddleware($name) && !$this->hasMiddlewareGroup($name)) {

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -99,7 +99,7 @@ class ProgressHelper extends Helper
      * @param array $args The initialization data.
      * @return $this
      */
-    public function init(array $args = []): self
+    public function init(array $args = [])
     {
         $args += ['total' => 100, 'width' => 80];
         $this->_progress = 0;
@@ -115,7 +115,7 @@ class ProgressHelper extends Helper
      * @param int $num The amount of progress to advance by.
      * @return $this
      */
-    public function increment($num = 1): self
+    public function increment($num = 1)
     {
         $this->_progress = min(max(0, $this->_progress + $num), $this->_total);
 
@@ -127,7 +127,7 @@ class ProgressHelper extends Helper
      *
      * @return $this
      */
-    public function draw(): self
+    public function draw()
     {
         $numberLen = strlen(' 100%');
         $complete = round($this->_progress / $this->_total, 2);

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -51,7 +51,7 @@ class ContextFactory
      *
      * @param array $providers Array of provider callables. Each element should
      *   be of form `['type' => 'a-string', 'callable' => ..]`
-     * @return \Cake\View\Form\ContextFactory
+     * @return static
      */
     public static function createWithDefaults(array $providers = []): self
     {
@@ -109,7 +109,7 @@ class ContextFactory
      *   when the form context is the correct type.
      * @return $this
      */
-    public function addProvider(string $type, callable $check): self
+    public function addProvider(string $type, callable $check)
     {
         $this->providers = [$type => ['type' => $type, 'callable' => $check]]
             + $this->providers;

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -74,7 +74,7 @@ class BreadcrumbsHelper extends Helper
      * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      */
-    public function add($title, $url = null, array $options = []): self
+    public function add($title, $url = null, array $options = [])
     {
         if (is_array($title)) {
             foreach ($title as $crumb) {
@@ -107,7 +107,7 @@ class BreadcrumbsHelper extends Helper
      * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      */
-    public function prepend($title, $url = null, array $options = []): self
+    public function prepend($title, $url = null, array $options = [])
     {
         if (is_array($title)) {
             $crumbs = [];
@@ -144,7 +144,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the index is out of bound
      */
-    public function insertAt(int $index, string $title, $url = null, array $options = []): self
+    public function insertAt(int $index, string $title, $url = null, array $options = [])
     {
         if (!isset($this->crumbs[$index])) {
             throw new LogicException(sprintf("No crumb could be found at index '%s'", $index));
@@ -173,7 +173,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the matching crumb can not be found
      */
-    public function insertBefore(string $matchingTitle, string $title, $url = null, array $options = []): self
+    public function insertBefore(string $matchingTitle, string $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
@@ -202,7 +202,7 @@ class BreadcrumbsHelper extends Helper
      * @return $this
      * @throws \LogicException In case the matching crumb can not be found.
      */
-    public function insertAfter(string $matchingTitle, string $title, $url = null, array $options = []): self
+    public function insertAfter(string $matchingTitle, string $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
@@ -228,7 +228,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @return $this
      */
-    public function reset(): self
+    public function reset()
     {
         $this->crumbs = [];
 

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -154,7 +154,7 @@ class StringTemplate
      * @param array $templates An associative list of named templates.
      * @return $this
      */
-    public function add(array $templates): self
+    public function add(array $templates)
     {
         $this->setConfig($templates);
         $this->_compileTemplates(array_keys($templates));

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -38,7 +38,7 @@ trait StringTemplateTrait
      * @param array $templates Templates to be added.
      * @return $this
      */
-    public function setTemplates(array $templates): self
+    public function setTemplates(array $templates)
     {
         $this->templater()->add($templates);
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -380,7 +380,7 @@ class View implements EventDispatcherInterface
      * @param \Cake\Http\ServerRequest $request Request instance.
      * @return $this
      */
-    public function setRequest(ServerRequest $request): self
+    public function setRequest(ServerRequest $request)
     {
         $this->request = $request;
         $this->plugin = $request->getParam('plugin');
@@ -404,7 +404,7 @@ class View implements EventDispatcherInterface
      * @param \Cake\Http\Response $response Response instance.
      * @return $this
      */
-    public function setResponse(Response $response): self
+    public function setResponse(Response $response)
     {
         $this->response = $response;
 
@@ -427,7 +427,7 @@ class View implements EventDispatcherInterface
      * @param string $path Path for template files.
      * @return $this
      */
-    public function setTemplatePath(string $path): self
+    public function setTemplatePath(string $path)
     {
         $this->templatePath = $path;
 
@@ -450,7 +450,7 @@ class View implements EventDispatcherInterface
      * @param string $path Path for layout files.
      * @return $this
      */
-    public function setLayoutPath(string $path): self
+    public function setLayoutPath(string $path)
     {
         $this->layoutPath = $path;
 
@@ -476,7 +476,7 @@ class View implements EventDispatcherInterface
      * @param bool $enable Boolean to turn on/off.
      * @return $this
      */
-    public function enableAutoLayout(bool $enable = true): self
+    public function enableAutoLayout(bool $enable = true)
     {
         $this->autoLayout = $enable;
 
@@ -489,7 +489,7 @@ class View implements EventDispatcherInterface
      *
      * @return $this
      */
-    public function disableAutoLayout(): self
+    public function disableAutoLayout()
     {
         $this->autoLayout = false;
 
@@ -512,7 +512,7 @@ class View implements EventDispatcherInterface
      * @param string|null $theme Theme name.
      * @return $this
      */
-    public function setTheme(?string $theme): self
+    public function setTheme(?string $theme)
     {
         $this->theme = $theme;
 
@@ -537,7 +537,7 @@ class View implements EventDispatcherInterface
      * @param string $name Template file name to set.
      * @return $this
      */
-    public function setTemplate(string $name): self
+    public function setTemplate(string $name)
     {
         $this->template = $name;
 
@@ -564,7 +564,7 @@ class View implements EventDispatcherInterface
      * @param string|false $name Layout file name to set.
      * @return $this
      */
-    public function setLayout($name): self
+    public function setLayout($name)
     {
         $this->layout = $name;
 
@@ -789,7 +789,7 @@ class View implements EventDispatcherInterface
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
      */
-    public function set($name, $value = null): self
+    public function set($name, $value = null)
     {
         if (is_array($name)) {
             if (is_array($value)) {
@@ -840,7 +840,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::start()
      */
-    public function start(string $name): self
+    public function start(string $name)
     {
         $this->Blocks->start($name);
 
@@ -858,7 +858,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::concat()
      */
-    public function append(string $name, $value = null): self
+    public function append(string $name, $value = null)
     {
         $this->Blocks->concat($name, $value);
 
@@ -876,7 +876,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::concat()
      */
-    public function prepend(string $name, $value): self
+    public function prepend(string $name, $value)
     {
         $this->Blocks->concat($name, $value, ViewBlock::PREPEND);
 
@@ -893,7 +893,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::set()
      */
-    public function assign(string $name, $value): self
+    public function assign(string $name, $value)
     {
         $this->Blocks->set($name, $value);
 
@@ -908,7 +908,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::set()
      */
-    public function reset(string $name): self
+    public function reset(string $name)
     {
         $this->assign($name, '');
 
@@ -935,7 +935,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @see \Cake\View\ViewBlock::end()
      */
-    public function end(): self
+    public function end()
     {
         $this->Blocks->end();
 
@@ -963,7 +963,7 @@ class View implements EventDispatcherInterface
      * @throws \LogicException when you extend a template with itself or make extend loops.
      * @throws \LogicException when you extend an element which doesn't exist
      */
-    public function extend(string $name): self
+    public function extend(string $name)
     {
         if ($name[0] === '/' || $this->_currentType === static::TYPE_TEMPLATE) {
             $parent = $this->_getViewFileName($name);
@@ -1146,7 +1146,7 @@ class View implements EventDispatcherInterface
      * @see \Cake\View\View::$subDir
      * @since 3.7.0
      */
-    public function setSubDir(string $subDir): self
+    public function setSubDir(string $subDir)
     {
         $this->subDir = $subDir;
 
@@ -1194,7 +1194,7 @@ class View implements EventDispatcherInterface
      * @return $this
      * @since 3.7.0
      */
-    public function setPlugin(string $name): self
+    public function setPlugin(string $name)
     {
         $this->plugin = $name;
 
@@ -1209,7 +1209,7 @@ class View implements EventDispatcherInterface
      * @see \Cake\View\View::$elementCache
      * @since 3.7.0
      */
-    public function setElementCache(string $elementCache): self
+    public function setElementCache(string $elementCache)
     {
         $this->elementCache = $elementCache;
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -131,7 +131,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param mixed $value Value.
      * @return $this
      */
-    public function setVar(string $name, $value = null): self
+    public function setVar(string $name, $value = null)
     {
         $this->_vars[$name] = $value;
 
@@ -145,7 +145,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param bool $merge Whether to merge with existing vars, default true.
      * @return $this
      */
-    public function setVars(array $data, bool $merge = true): self
+    public function setVars(array $data, bool $merge = true)
     {
         if ($merge) {
             $this->_vars = $data + $this->_vars;
@@ -194,7 +194,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $path Path for view files.
      * @return $this
      */
-    public function setTemplatePath(?string $path): self
+    public function setTemplatePath(?string $path)
     {
         $this->_templatePath = $path;
 
@@ -217,7 +217,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $path Path for layout files.
      * @return $this
      */
-    public function setLayoutPath(?string $path): self
+    public function setLayoutPath(?string $path)
     {
         $this->_layoutPath = $path;
 
@@ -242,7 +242,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param bool $enable Boolean to turn on/off.
      * @return $this
      */
-    public function enableAutoLayout(bool $enable = true): self
+    public function enableAutoLayout(bool $enable = true)
     {
         $this->_autoLayout = $enable;
 
@@ -282,7 +282,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *   Use null to remove the current plugin name.
      * @return $this
      */
-    public function setPlugin(?string $name): self
+    public function setPlugin(?string $name)
     {
         $this->_plugin = $name;
 
@@ -306,7 +306,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param bool $merge Whether or not to merge existing data with the new data.
      * @return $this
      */
-    public function setHelpers(array $helpers, bool $merge = true): self
+    public function setHelpers(array $helpers, bool $merge = true)
     {
         if ($merge) {
             $helpers = array_merge($this->_helpers, $helpers);
@@ -333,7 +333,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *   Use null to remove the current theme.
      * @return $this
      */
-    public function setTheme(?string $theme): self
+    public function setTheme(?string $theme)
     {
         $this->_theme = $theme;
 
@@ -357,7 +357,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $name View file name to set, or null to remove the template name.
      * @return $this
      */
-    public function setTemplate(?string $name): self
+    public function setTemplate(?string $name)
     {
         $this->_template = $name;
 
@@ -383,7 +383,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null|false $name Layout file name to set.
      * @return $this
      */
-    public function setLayout($name): self
+    public function setLayout($name)
     {
         $this->_layout = $name;
 
@@ -409,7 +409,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param bool $merge Whether or not to merge existing data with the new data.
      * @return $this
      */
-    public function setOptions(array $options, bool $merge = true): self
+    public function setOptions(array $options, bool $merge = true)
     {
         if ($merge) {
             $options = array_merge($this->_options, $options);
@@ -435,7 +435,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $name The name of the view, or null to remove the current name.
      * @return $this
      */
-    public function setName(?string $name): self
+    public function setName(?string $name)
     {
         $this->_name = $name;
 
@@ -462,7 +462,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $name The class name for the view.
      * @return $this
      */
-    public function setClassName(?string $name): self
+    public function setClassName(?string $name)
     {
         $this->_className = $name;
 

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -82,7 +82,7 @@ trait ViewVarsTrait
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
      */
-    public function set($name, $value = null): self
+    public function set($name, $value = null)
     {
         if (is_array($name)) {
             if (is_array($value)) {


### PR DESCRIPTION
Runs https://github.com/cakephp/cakephp-codesniffer/pull/243 over code base and finds necessary fixes.
Chaining must never use typehinting, doing so compromises its use.
As such we must implement the rule immediately, before the 4.x core including strict typehinting becomes more stable and the wrong typehints do more harm here.

The code sniffer asserts that no accidental "other" return types than $this can leak, together with PHPStan (as shown in https://github.com/FriendsOfCake/bootstrap-ui/pull/273/files#diff-f78b0cf313e75baaee6fc88f3a81a8daR71 and the resulting fail report).
Then we dont need to protect it any further using typehinting. As long as PHP doesnt support chainable properly incl those, we cannot use them here.
The alternative is to go away from chaining and use void, but this is usually less useful.