### PR TITLE
Fix FQCN for exceptions via sniffer run.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -19,6 +19,7 @@ use Cake\Cache\CacheEngine;
 use Cake\Cache\InvalidArgumentException;
 use CallbackFilterIterator;
 use Exception;
+use FilesystemIterator;
 use LogicException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -254,7 +255,7 @@ class FileEngine extends CacheEngine
 
         $directory = new RecursiveDirectoryIterator(
             $this->_config['path'],
-            \FilesystemIterator::SKIP_DOTS
+            FilesystemIterator::SKIP_DOTS
         );
         $contents = new RecursiveIteratorIterator(
             $directory,

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -30,6 +30,7 @@ use Cake\Collection\Iterator\TreeIterator;
 use Cake\Collection\Iterator\UnfoldIterator;
 use Cake\Collection\Iterator\ZipIterator;
 use Countable;
+use InvalidArgumentException;
 use LimitIterator;
 use LogicException;
 use OuterIterator;
@@ -424,7 +425,7 @@ trait CollectionTrait
     public function takeLast(int $howMany): CollectionInterface
     {
         if ($howMany < 1) {
-            throw new \InvalidArgumentException("The takeLast method requires a number greater than 0.");
+            throw new InvalidArgumentException("The takeLast method requires a number greater than 0.");
         }
 
         $iterator = $this->optimizeUnwrap();

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -17,6 +17,7 @@ namespace Cake\Database;
 
 use Cake\Database\Expression\QueryExpression;
 use Closure;
+use Countable;
 
 /**
  * Responsible for compiling a Query object into its SQL representation
@@ -127,7 +128,7 @@ class QueryCompiler
     {
         return function ($parts, $name) use (&$sql, $query, $generator) {
             if (!isset($parts) ||
-                ((is_array($parts) || $parts instanceof \Countable) && !count($parts))
+                ((is_array($parts) || $parts instanceof Countable) && !count($parts))
             ) {
                 return;
             }

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Database\Expression\Comparison;
+use RuntimeException;
 
 /**
  * Sql dialect trait
@@ -214,7 +215,7 @@ trait SqlDialectTrait
     protected function _removeAliasesFromConditions(Query $query): Query
     {
         if ($query->clause('join')) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
                 'this can break references to joined tables.'
             );

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -433,6 +433,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $allowEmpty = $this->_config['allowEmptyTranslations'];
 
         return $results->map(function ($row) use ($allowEmpty) {
+            /** @var \Cake\Datasource\EntityInterface|array|null $row */
             if ($row === null) {
                 return $row;
             }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -22,6 +22,7 @@ use Cake\Database\TypeFactory;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
 use Cake\ORM\Association\BelongsToMany;
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -92,7 +93,7 @@ class Marshaller
             // it is a missing association that we should error on.
             if (!$this->_table->hasAssociation($key)) {
                 if (substr($key, 0, 1) !== '_') {
-                    throw new \InvalidArgumentException(sprintf(
+                    throw new InvalidArgumentException(sprintf(
                         'Cannot marshal data for "%s" association. It is not associated with "%s".',
                         $key,
                         $this->_table->getAlias()

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\ORM;
 
 use ArrayObject;
+use BadMethodCallException;
 use Cake\Database\Connection;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query as DatabaseQuery;
@@ -25,6 +26,7 @@ use Cake\Database\ValueBinder;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
 use Cake\Datasource\ResultSetInterface;
+use InvalidArgumentException;
 use JsonSerializable;
 use RuntimeException;
 use Traversable;
@@ -247,7 +249,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         if (!($table instanceof Table)) {
-            throw new \InvalidArgumentException('You must provide either an Association or a Table object');
+            throw new InvalidArgumentException('You must provide either an Association or a Table object');
         }
 
         $fields = array_diff($table->getSchema()->columns(), $excludedFields);
@@ -1267,7 +1269,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             return $this->_call($method, $arguments);
         }
 
-        throw new \BadMethodCallException(
+        throw new BadMethodCallException(
             sprintf('Cannot call method "%s" on a "%s" query', $method, $this->type())
         );
     }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -42,6 +42,7 @@ use Cake\ORM\Rule\IsUnique;
 use Cake\Utility\Inflector;
 use Cake\Validation\ValidatorAwareInterface;
 use Cake\Validation\ValidatorAwareTrait;
+use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -2069,7 +2070,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                         }
                     }
                 });
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $cleanup($entities);
 
             throw $e;

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -24,6 +24,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FixtureInterface;
 use Cake\TestSuite\TestCase;
 use PDOException;
+use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -353,7 +354,7 @@ class FixtureManager
                 get_class($test),
                 $e->getMessage()
             );
-            throw new \RuntimeException($msg, 0, $e);
+            throw new RuntimeException($msg, 0, $e);
         }
     }
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -56,6 +56,7 @@ use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Cake\Utility\Text;
 use Cake\View\Helper\SecureFieldTokenTrait;
+use Exception;
 use LogicException;
 use PHPUnit\Exception as PhpUnitException;
 use Throwable;
@@ -1232,14 +1233,14 @@ trait IntegrationTestTrait
      */
     protected function extractVerboseMessage(string $message): string
     {
-        if ($this->_exception instanceof \Exception) {
+        if ($this->_exception instanceof Exception) {
             $message .= $this->extractExceptionMessage($this->_exception);
         }
         if ($this->_controller === null) {
             return $message;
         }
         $error = $this->_controller->viewBuilder()->getVar('error');
-        if ($error instanceof \Exception) {
+        if ($error instanceof Exception) {
             $message .= $this->extractExceptionMessage($this->viewVariable('error'));
         }
 
@@ -1252,7 +1253,7 @@ trait IntegrationTestTrait
      * @param \Exception $exception Exception to extract
      * @return string
      */
-    protected function extractExceptionMessage(\Exception $exception)
+    protected function extractExceptionMessage(Exception $exception)
     {
         return PHP_EOL .
             sprintf('Possibly related to %s: "%s" ', get_class($exception), $exception->getMessage()) .

--- a/src/TestSuite/TestListenerTrait.php
+++ b/src/TestSuite/TestListenerTrait.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
+use Throwable;
 
 trait TestListenerTrait
 {
@@ -53,14 +54,14 @@ trait TestListenerTrait
     /**
      * @inheritDoc
      */
-    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function addError(Test $test, \Throwable $t, float $time): void
+    public function addError(Test $test, Throwable $t, float $time): void
     {
     }
 
@@ -81,14 +82,14 @@ trait TestListenerTrait
     /**
      * @inheritDoc
      */
-    public function addRiskyTest(Test $test, \Throwable $e, float $time): void
+    public function addRiskyTest(Test $test, Throwable $e, float $time): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function addIncompleteTest(Test $test, \Throwable $e, float $time): void
+    public function addIncompleteTest(Test $test, Throwable $e, float $time): void
     {
     }
 }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -17,6 +17,7 @@ namespace Cake\Validation;
 
 use Cake\I18n\Time;
 use Cake\Utility\Text;
+use Countable;
 use DateTimeInterface;
 use InvalidArgumentException;
 use LogicException;
@@ -236,7 +237,7 @@ class Validation
      */
     public static function numElements($check, string $operator, int $expectedCount): bool
     {
-        if (!is_array($check) && !$check instanceof \Countable) {
+        if (!is_array($check) && !$check instanceof Countable) {
             return false;
         }
 

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -65,7 +65,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
 
         try {
             $this->load($helper);
-        } catch (Exception\MissingHelperException $exception) {
+        } catch (MissingHelperException $exception) {
             if ($this->_View->getPlugin()) {
                 $this->load($this->_View->getPlugin() . '.' . $helper);
 


### PR DESCRIPTION
Running [Spryker UseStatement sniff](https://github.com/spryker/code-sniffer/blob/master/Spryker/Sniffs/Namespaces/UseStatementSniff.php)
It seems the used (slevomatik) CS rule is a bit weak and doesnt see all inline usages.
The Spryker one seems to have some of those also found and fixed as seen here.