### PR TITLE
Fix side-effect in destructor

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -79,6 +79,18 @@ class SmtpTransport extends AbstractTransport
     }
 
     /**
+     * Unserialize handler.
+     *
+     * Ensure that the socket property isn't reinitialized in a broken state.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        $this->_socket = null;
+    }
+
+    /**
      * Connect to the SMTP server.
      *
      * This method tries to connect only in case there is no open


### PR DESCRIPTION
SmtpTransport had the potential to create a harmful side-effect in its destructor should an untrusted value ever be deserialized. This solves that by removing the socket on wakeup.