### PR TITLE
Remove checks for params/keys no longer used in routing.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -636,9 +636,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $builder->setTemplatePath($this->_templatePath());
         }
 
-        if ($this->request->getParam('bare')) {
-            $builder->disableAutoLayout();
-        }
         $this->autoRender = false;
 
         if ($template !== null) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -623,11 +623,8 @@ class Router
      * Reverses a parsed parameter array into an array.
      *
      * Works similarly to Router::url(), but since parsed URL's contain additional
-     * 'pass' as well as 'url.url' keys. Those keys need to be specially
+     * keys like 'pass', '_matchedRoute' etc. those keys need to be specially
      * handled in order to reverse a params array into a string URL.
-     *
-     * This will strip out 'autoRender', 'bare', 'requested', and 'return' param names as those
-     * are used for CakePHP internals and should not normally be part of an output URL.
      *
      * @param \Cake\Http\ServerRequest|array $params The params array or
      *     Cake\Http\ServerRequest object that needs to be reversed.
@@ -635,33 +632,21 @@ class Router
      */
     public static function reverseToArray($params): array
     {
-        $url = [];
         if ($params instanceof ServerRequest) {
-            $url = $params->getQueryParams();
+            $queryString = $params->getQueryParams();
             $params = $params->getAttribute('params');
-        } elseif (isset($params['url'])) {
-            $url = $params['url'];
+            $params['?'] = $queryString;
         }
         $pass = $params['pass'] ?? [];
 
         unset(
             $params['pass'],
             $params['paging'],
-            $params['models'],
-            $params['url'],
-            $url['url'],
-            $params['autoRender'],
-            $params['bare'],
-            $params['requested'],
-            $params['return'],
             $params['_Token'],
             $params['_matchedRoute'],
             $params['_name']
         );
         $params = array_merge($params, $pass);
-        if (!empty($url)) {
-            $params['?'] = $url;
-        }
 
         return $params;
     }
@@ -670,11 +655,8 @@ class Router
      * Reverses a parsed parameter array into a string.
      *
      * Works similarly to Router::url(), but since parsed URL's contain additional
-     * 'pass' as well as 'url.url' keys. Those keys need to be specially
+     * keys like 'pass', '_matchedRoute' etc. those keys need to be specially
      * handled in order to reverse a params array into a string URL.
-     *
-     * This will strip out 'autoRender', 'bare', 'requested', and 'return' param names as those
-     * are used for CakePHP internals and should not normally be part of an output URL.
      *
      * @param \Cake\Http\ServerRequest|array $params The params array or
      *     Cake\Http\ServerRequest object that needs to be reversed.

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2569,7 +2569,7 @@ class RouterTest extends TestCase
                 'action' => 'view',
                 'pass' => [1],
             ],
-            'query' => ['url' => 'eng/posts/view/1', 'test' => 'value'],
+            'query' => ['test' => 'value'],
         ]);
         $result = Router::reverse($request);
         $expected = '/eng/posts/view/1?test=value';
@@ -2624,9 +2624,8 @@ class RouterTest extends TestCase
             'controller' => 'posts',
             'action' => 'view',
             'pass' => [123],
-            'url' => ['url' => 'eng/posts/view/123', 'foo' => 'bar', 'baz' => 'quu'],
+            '?' => ['foo' => 'bar', 'baz' => 'quu'],
             'paging' => [],
-            'models' => [],
         ];
         $actual = Router::reverseToArray($params);
         $expected = [
@@ -2650,7 +2649,7 @@ class RouterTest extends TestCase
                 'action' => 'view',
                 'pass' => [123],
             ],
-            'query' => ['url' => 'eng/posts/view/1', 'test' => 'value'],
+            'query' => ['test' => 'value'],
         ]);
         $actual = Router::reverseToArray($request);
         $expected = [


### PR DESCRIPTION
They are a relic of Cake 2's URL format and the defunct "request action" feature.