### PR TITLE
Don't allow View::$layout to be set to false.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,6 +62,9 @@ parameters:
         -
             message: '#Method Cake\\Utility\\Security::engine\(\) should return Cake\\Utility\\Crypto\\OpenSsl but returns object#'
             path: 'src/Utility/Security.php'
+        -
+            message: '#Strict comparison using === between string and false will always evaluate to false#'
+            path: 'src/View/View.php'
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -177,7 +177,7 @@ abstract class Cell implements EventDispatcherInterface
                 ));
             }
 
-            $builder = $this->viewBuilder()->setLayout(false);
+            $builder = $this->viewBuilder();
 
             if ($template !== null &&
                 strpos($template, '/') === false &&
@@ -202,7 +202,7 @@ abstract class Cell implements EventDispatcherInterface
 
             $view = $this->createView();
             try {
-                return $view->render($template);
+                return $view->render($template, false);
             } catch (MissingTemplateException $e) {
                 throw new MissingCellTemplateException($name, $template, $e->getAttributes()['paths'], null, $e);
             }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1351,8 +1351,8 @@ class View implements EventDispatcherInterface
         if ($name === null) {
             if ($this->layout === false) {
                 throw new RuntimeException(
-                    'Setting View::$layout to false is no longer supported.'
-                    . ' Set View::$autoLayout to false instead.'
+                    'Setting View::$layout to false is no longer supported.' .
+                    ' Set View::$autoLayout to false instead.'
                 );
             }
             $name = $this->layout;

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -66,7 +66,7 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * The layout name to render.
      *
-     * @var string|null|false
+     * @var string|null
      */
     protected $_layout;
 
@@ -380,10 +380,10 @@ class ViewBuilder implements JsonSerializable, Serializable
      * The name specified is the filename of the layout in /templates/Layout
      * without the .php extension.
      *
-     * @param string|null|false $name Layout file name to set.
+     * @param string|null $name Layout file name to set.
      * @return $this
      */
-    public function setLayout($name)
+    public function setLayout(?string $name)
     {
         $this->_layout = $name;
 
@@ -393,9 +393,9 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Gets the name of the layout file to render the view inside of.
      *
-     * @return string|null|false
+     * @return string|null
      */
-    public function getLayout()
+    public function getLayout(): ?string
     {
         return $this->_layout;
     }

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1492,7 +1492,7 @@ class EmailTest extends TestCase
         $this->Email->setConfig(['empty']);
         $this->Email->viewBuilder()
             ->setTemplate('default')
-            ->setLayout(false);
+            ->disableAutoLayout();
         $result = $this->Email->send('message body.');
 
         $this->assertContains('message body.', $result['message']);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1596,8 +1596,7 @@ class ViewTest extends TestCase
      */
     public function testExtendNested()
     {
-        $this->View->setLayout(false);
-        $content = $this->View->render('nested_extends');
+        $content = $this->View->render('nested_extends', false);
         $expected = <<<TEXT
 This is the second parent.
 This is the first parent.
@@ -1615,8 +1614,7 @@ TEXT;
     public function testExtendSelf()
     {
         try {
-            $this->View->setLayout(false);
-            $this->View->render('extend_self');
+            $this->View->render('extend_self', false);
             $this->fail('No exception');
         } catch (\LogicException $e) {
             ob_end_clean();
@@ -1632,8 +1630,7 @@ TEXT;
     public function testExtendLoop()
     {
         try {
-            $this->View->setLayout(false);
-            $this->View->render('extend_loop');
+            $this->View->render('extend_loop', false);
             $this->fail('No exception');
         } catch (\LogicException $e) {
             ob_end_clean();
@@ -1648,8 +1645,7 @@ TEXT;
      */
     public function testExtendElement()
     {
-        $this->View->setLayout(false);
-        $content = $this->View->render('extend_element');
+        $content = $this->View->render('extend_element', false);
         $expected = <<<TEXT
 Parent View.
 View content.
@@ -1668,8 +1664,7 @@ TEXT;
     public function testExtendPrefixElement()
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
-        $this->View->setLayout(false);
-        $content = $this->View->render('extend_element');
+        $content = $this->View->render('extend_element', false);
         $expected = <<<TEXT
 Parent View.
 View content.
@@ -1688,8 +1683,7 @@ TEXT;
     public function testExtendMissingElement()
     {
         try {
-            $this->View->setLayout(false);
-            $this->View->render('extend_missing_element');
+            $this->View->render('extend_missing_element', false);
             $this->fail('No exception');
         } catch (\LogicException $e) {
             ob_end_clean();
@@ -1705,8 +1699,7 @@ TEXT;
      */
     public function testExtendWithElementBeforeExtend()
     {
-        $this->View->setLayout(false);
-        $result = $this->View->render('extend_with_element');
+        $result = $this->View->render('extend_with_element', false);
         $expected = <<<TEXT
 Parent View.
 this is the test elementThe view
@@ -1723,7 +1716,7 @@ TEXT;
     public function testExtendWithPrefixElementBeforeExtend()
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
-        $this->View->setLayout(false);
+        $this->View->disableAutoLayout();
         $result = $this->View->render('extend_with_element');
         $expected = <<<TEXT
 Parent View.


### PR DESCRIPTION
View::$autoLayout can be used to control layout rendering.
This allows for cleaner code.