### PR TITLE
Remove response type hint to prevent type error when asserting redirects

### DIFF
--- a/src/TestSuite/Constraint/Response/HeaderEquals.php
+++ b/src/TestSuite/Constraint/Response/HeaderEquals.php
@@ -33,7 +33,7 @@ class HeaderEquals extends ResponseBase
      * @param Response $response Response
      * @param string $headerName Header name
      */
-    public function __construct(Response $response, $headerName)
+    public function __construct($response, $headerName)
     {
         parent::__construct($response);
 

--- a/src/TestSuite/Constraint/Response/HeaderSet.php
+++ b/src/TestSuite/Constraint/Response/HeaderSet.php
@@ -33,7 +33,7 @@ class HeaderSet extends ResponseBase
      * @param Response $response Response
      * @param string $headerName Header name
      */
-    public function __construct(Response $response, $headerName)
+    public function __construct($response, $headerName)
     {
         parent::__construct($response);
 


### PR DESCRIPTION
CakePHP 3.7.7

@ravage84  and I encountered an issue with testing a route based redirect.
Unfortunately, I didn't know how to write a regression test.

```` php
// routes.php
$routes->redirect('/api/foobar/', '/api/foobar/v0');
````

```` php
// MyControllerTest.php
use IntegrationTestTrait;

/**
 * Test Api method
 */
public function testOpenApiRedirectFromfoobarApiRoot()
{
	$this->get('/api/foobar');
        // Same result with assertRedirect()
	$this->assertHeader('location', '/api/foobar/v0');
}
````

````
// PHPUnit Output
TypeError : Argument 1 passed to Cake\TestSuite\Constraint\Response\HeaderSet::__construct() must be an instance of Cake\Http\Response, instance of Zend\Diactoros\Response\RedirectResponse given, called in C:\xampp\htdocs\my_app\vendor\cakephp\cakephp\src\TestSuite\IntegrationTestTrait.php on line 901
 C:\xampp\htdocs\my_app\vendor\cakephp\cakephp\src\TestSuite\Constraint\Response\HeaderSet.php:36
 C:\xampp\htdocs\my_app\vendor\cakephp\cakephp\src\TestSuite\IntegrationTestTrait.php:901
 C:\xampp\htdocs\my_app\plugins\foobarApi\tests\TestCase\Controller\V0ControllerSwaggerUiTest.php:81
````
