### PR TITLE
Improve parameter description wording

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1215,7 +1215,7 @@ trait IntegrationTestTrait
     /**
      * Asserts that a file with the given name was sent in the response
      *
-     * @param string $expected The file name that should be sent in the response
+     * @param string $expected The absolute file path that should be sent in the response.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */


### PR DESCRIPTION
Only a file name isn't enough.