### PR TITLE
Remove charset on json content-type

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -581,7 +581,7 @@ class Response implements ResponseInterface
             return;
         }
         $whitelist = [
-            'application/javascript', 'application/json', 'application/xml', 'application/rss+xml'
+            'application/javascript', 'application/xml', 'application/rss+xml'
         ];
 
         $charset = false;

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -167,7 +167,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->assertNotSame($result, $response);
         $this->assertEquals(404, $result->getStatusCode());
         $this->assertContains('"message": "whoops"', '' . $result->getBody());
-        $this->assertEquals('application/json; charset=UTF-8', $result->getHeaderLine('Content-type'));
+        $this->assertEquals('application/json', $result->getHeaderLine('Content-type'));
     }
 
     /**

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -315,7 +315,7 @@ class ResponseTest extends TestCase
         );
         $this->assertSame('application/pdf', $new->getHeaderLine('Content-Type'));
         $this->assertSame(
-            'application/json; charset=UTF-8',
+            'application/json',
             $new->withType('json')->getHeaderLine('Content-Type')
         );
     }
@@ -463,7 +463,6 @@ class ResponseTest extends TestCase
         return [
             ['mp3', 'audio/mpeg'],
             ['js', 'application/javascript; charset=UTF-8'],
-            ['json', 'application/json; charset=UTF-8'],
             ['xml', 'application/xml; charset=UTF-8'],
             ['txt', 'text/plain; charset=UTF-8'],
         ];

--- a/tests/TestCase/Http/ResponseTransformerTest.php
+++ b/tests/TestCase/Http/ResponseTransformerTest.php
@@ -301,10 +301,6 @@ class ResponseTransformerTest extends TestCase
         $cake->type('application/octet-stream');
         $result = ResponseTransformer::toPsr($cake);
         $this->assertSame('application/octet-stream', $result->getHeaderLine('Content-Type'));
-
-        $cake->type('application/json');
-        $result = ResponseTransformer::toPsr($cake);
-        $this->assertSame('application/json; charset=utf-8', $result->getHeaderLine('Content-Type'));
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -331,7 +331,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
         $this->_request['headers'] = [ "Accept" => "application/json" ];
         $this->get('/json_response/api_get_data');
         $this->assertResponseCode(403);
-        $this->assertHeader('Content-Type', 'application/json; charset=UTF-8');
+        $this->assertHeader('Content-Type', 'application/json');
         $this->assertResponseContains('"message": "Sample Message"');
         $this->assertResponseContains('"code": 403');
     }
@@ -1137,7 +1137,7 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     public function testContentTypeInAction()
     {
         $this->get('/tests_apps/set_type');
-        $this->assertHeader('Content-Type', 'application/json; charset=UTF-8');
+        $this->assertHeader('Content-Type', 'application/json');
         $this->assertContentType('json');
         $this->assertContentType('application/json');
     }


### PR DESCRIPTION
Don't emit a charset parameter on the json content type. Chrome has started emitting warnings when this parameter is present as it isn't compliant with the spec.

Fixes #13156