### PR TITLE
Add Command::executeCommand()

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -258,7 +258,7 @@ class Command
      * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
      * @return int|null The exit code or null for success of the command.
      */
-    public function executeCommand($command, array $args = [], ?ConsoleIo $io = null)
+    public function executeCommand($command, array $args = [], ConsoleIo $io = null)
     {
         if (is_string($command)) {
             if (!class_exists($command)) {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -249,4 +249,34 @@ class Command
     {
         throw new StopException('Command aborted', $code);
     }
+
+    /**
+     * Execute another command with the provided set of arguments.
+     *
+     * @param string|\Cake\Console\Command $command The command class name or command instance.
+     * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
+     * @param array $args The arguments to invoke the command with.
+     * @return int|null The exit code or null for success of the command.
+     */
+    public function executeCommand($command, ConsoleIo $io, array $args = [])
+    {
+        if (is_string($command)) {
+            if (!class_exists($command)) {
+                throw new InvalidArgumentException("Command class '{$command}' does not exist.");
+            }
+            $command = new $command();
+        }
+        if (!$command instanceof Command) {
+            $commandType = getTypeName($command);
+            throw new InvalidArgumentException(
+                "Command '{$commandType}' is not a subclass of Cake\Console\Command."
+            );
+        }
+
+        try {
+            return $command->run($args, $io);
+        } catch (StopException $e) {
+            return $e->getCode();
+        }
+    }
 }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -254,11 +254,11 @@ class Command
      * Execute another command with the provided set of arguments.
      *
      * @param string|\Cake\Console\Command $command The command class name or command instance.
-     * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
      * @param array $args The arguments to invoke the command with.
+     * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
      * @return int|null The exit code or null for success of the command.
      */
-    public function executeCommand($command, ConsoleIo $io, array $args = [])
+    public function executeCommand($command, array $args = [], ?ConsoleIo $io = null)
     {
         if (is_string($command)) {
             if (!class_exists($command)) {
@@ -272,6 +272,7 @@ class Command
                 "Command '{$commandType}' is not a subclass of Cake\Console\Command."
             );
         }
+        $io = $io ?: new ConsoleIo();
 
         try {
             return $command->run($args, $io);

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -283,7 +283,7 @@ class CommandTest extends TestCase
     {
         $output = new ConsoleOutput();
         $command = new Command();
-        $result = $command->executeCommand(DemoCommand::class, $this->getMockIo($output));
+        $result = $command->executeCommand(DemoCommand::class, [], $this->getMockIo($output));
         $this->assertNull($result);
         $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
     }
@@ -299,7 +299,7 @@ class CommandTest extends TestCase
         $this->expectExceptionMessage("Command class 'Nope' does not exist");
 
         $command = new Command();
-        $command->executeCommand('Nope', $this->getMockIo(new ConsoleOutput()));
+        $command->executeCommand('Nope', [], $this->getMockIo(new ConsoleOutput()));
     }
 
     /**
@@ -311,7 +311,7 @@ class CommandTest extends TestCase
     {
         $output = new ConsoleOutput();
         $command = new Command();
-        $command->executeCommand(DemoCommand::class, $this->getMockIo($output), ['Jane']);
+        $command->executeCommand(DemoCommand::class, ['Jane'], $this->getMockIo($output));
         $this->assertEquals(['Quiet!', 'Demo Command!', 'Jane'], $output->messages());
     }
 
@@ -324,7 +324,7 @@ class CommandTest extends TestCase
     {
         $output = new ConsoleOutput();
         $command = new Command();
-        $command->executeCommand(DemoCommand::class, $this->getMockIo($output), ['--quiet', 'Jane']);
+        $command->executeCommand(DemoCommand::class, ['--quiet', 'Jane'], $this->getMockIo($output));
         $this->assertEquals(['Quiet!'], $output->messages());
     }
 
@@ -337,7 +337,7 @@ class CommandTest extends TestCase
     {
         $output = new ConsoleOutput();
         $command = new Command();
-        $result = $command->executeCommand(new DemoCommand(), $this->getMockIo($output));
+        $result = $command->executeCommand(new DemoCommand(), [], $this->getMockIo($output));
         $this->assertNull($result);
         $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
     }
@@ -353,7 +353,7 @@ class CommandTest extends TestCase
         $this->expectExceptionMessage("Command 'stdClass' is not a subclass");
 
         $command = new Command();
-        $command->executeCommand(new \stdClass, $this->getMockIo(new ConsoleOutput()));
+        $command->executeCommand(new \stdClass, [], $this->getMockIo(new ConsoleOutput()));
     }
 
     protected function getMockIo($output)

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
 
@@ -271,6 +272,88 @@ class CommandTest extends TestCase
     {
         $command = new Command();
         $command->abort(99);
+    }
+
+    /**
+     * test executeCommand with a string class
+     *
+     * @return void
+     */
+    public function testExecuteCommandString()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $result = $command->executeCommand(DemoCommand::class, $this->getMockIo($output));
+        $this->assertNull($result);
+        $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
+    }
+
+    /**
+     * test executeCommand with an invalid string class
+     *
+     * @return void
+     */
+    public function testExecuteCommandStringInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Command class 'Nope' does not exist");
+
+        $command = new Command();
+        $command->executeCommand('Nope', $this->getMockIo(new ConsoleOutput()));
+    }
+
+    /**
+     * test executeCommand with arguments
+     *
+     * @return void
+     */
+    public function testExecuteCommandArguments()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $command->executeCommand(DemoCommand::class, $this->getMockIo($output), ['Jane']);
+        $this->assertEquals(['Quiet!', 'Demo Command!', 'Jane'], $output->messages());
+    }
+
+    /**
+     * test executeCommand with arguments
+     *
+     * @return void
+     */
+    public function testExecuteCommandArgumentsOptions()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $command->executeCommand(DemoCommand::class, $this->getMockIo($output), ['--quiet', 'Jane']);
+        $this->assertEquals(['Quiet!'], $output->messages());
+    }
+
+    /**
+     * test executeCommand with an instance
+     *
+     * @return void
+     */
+    public function testExecuteCommandInstance()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $result = $command->executeCommand(new DemoCommand(), $this->getMockIo($output));
+        $this->assertNull($result);
+        $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
+    }
+
+    /**
+     * test executeCommand with an invalid instance
+     *
+     * @return void
+     */
+    public function testExecuteCommandInstanceInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Command 'stdClass' is not a subclass");
+
+        $command = new Command();
+        $command->executeCommand(new \stdClass, $this->getMockIo(new ConsoleOutput()));
     }
 
     protected function getMockIo($output)

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use TestApp\Command\AbortCommand;
 use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
 
@@ -340,6 +341,20 @@ class CommandTest extends TestCase
         $result = $command->executeCommand(new DemoCommand(), [], $this->getMockIo($output));
         $this->assertNull($result);
         $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
+    }
+
+    /**
+     * test executeCommand with an abort
+     *
+     * @return void
+     */
+    public function testExecuteCommandAbort()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $result = $command->executeCommand(AbortCommand::class, [], $this->getMockIo($output));
+        $this->assertSame(127, $result);
+        $this->assertEquals(['<error>Command aborted</error>'], $output->messages());
     }
 
     /**

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -12,5 +12,8 @@ class DemoCommand extends Command
         $io->quiet('Quiet!');
         $io->out('Demo Command!');
         $io->verbose('Verbose!');
+        if ($args->hasArgumentAt(0)) {
+            $io->out($args->getArgumentAt(0));
+        }
     }
 }


### PR DESCRIPTION
This method enables commands to dispatch each other without needing to use the CommandRunner. This provides commands with the ability to be composed from other commands.

Refs #12549