### PR TITLE
Make PHP 7.2 the minimum required version for 4.x

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ tools:
 build:
   environment:
     php:
-      version: 7.1
+      version: 7.2
 
   nodes:
     phpcs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,6 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.1
-      env: CODECOVERAGE=1 DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
-    - php: 7.1
-      env: CODECOVERAGE=1 DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - php: 7.1
-      env: CODECOVERAGE=1 DB=sqlite db_dsn='sqlite:///:memory:'
     - php: 7.2
       env: DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
     - php: 7.2
@@ -48,12 +42,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
-  - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi
-  - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test3;'; fi
-
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
-  - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi
-  - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
   - |
       if [[ $TRAVIS_PHP_VERSION != "7.3" ]]; then

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-next",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "source": "https://github.com/cakephp/cakephp"
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "aura/intl": "^3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-next",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
After a healthy discussion the consensus seems to be that requiring 7.2 is reasonable given that 7.1 will soon be end of life and that all major distros already have PHP7.2 or will very soon.

Refs #13103
