### PR TITLE
Generate column SQL for char(36) in postgres schema

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -399,7 +399,7 @@ class PostgresSchema extends BaseSchema
                 $type = ' CHAR';
             }
             $out .= $type;
-            if (isset($data['length']) && $data['length'] != 36) {
+            if (isset($data['length'])) {
                 $out .= '(' . (int)$data['length'] . ')';
             }
         }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -177,6 +177,10 @@ SQL;
                 ['type' => 'string', 'fixed' => true, 'length' => 10]
             ],
             [
+                ['type' => 'CHAR(36)'],
+                ['type' => 'string', 'fixed' => true, 'length' => 36]
+            ],
+            [
                 ['type' => 'CHARACTER(10)'],
                 ['type' => 'string', 'fixed' => true, 'length' => 10]
             ],
@@ -696,6 +700,11 @@ SQL;
                 '"id" CHAR(32) NOT NULL'
             ],
             [
+                'title',
+                ['type' => 'string', 'length' => 36, 'fixed' => true, 'null' => false],
+                '"title" CHAR(36) NOT NULL'
+            ],
+            [
                 'id',
                 ['type' => 'uuid', 'length' => 36, 'null' => false],
                 '"id" UUID NOT NULL'
@@ -714,6 +723,11 @@ SQL;
                 'title',
                 ['type' => 'string'],
                 '"title" VARCHAR'
+            ],
+            [
+                'title',
+                ['type' => 'string', 'length' => 36],
+                '"title" VARCHAR(36)'
             ],
             [
                 'title',


### PR DESCRIPTION
Don't omit length for 36 byte length CHAR columns. This is likely an artifact of how UUID columns were handled in the past.

Fixes #13167