### PR TITLE
[2.x]Skip tests that fail on PHP 7.3 built-in functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,6 @@ matrix:
 
     - php: 7.3
       env: DB=mysql PHPUNIT=5.7.19
-  allow_failures:
-    - php: 7.3
-      env: DB=mysql PHPUNIT=5.7.19
   exclude:
     - php: 7.2
       env: DB=mysql

--- a/lib/Cake/Test/Case/I18n/MultibyteTest.php
+++ b/lib/Cake/Test/Case/I18n/MultibyteTest.php
@@ -7640,6 +7640,10 @@ class MultibyteTest extends CakeTestCase {
  * @return void
  */
 	public function testUsingMbStrtoupperArmenian() {
+		if (extension_loaded('mbstring') && version_compare(PHP_VERSION, '7.3', '>=')) {
+			$this->markTestSkipped('PHP7.3+ built-in function mb_strtoupper() behaves slightly different from Multibyte::strtoupper()');
+		}
+
 		$string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
 		$result = mb_strtoupper($string);
 		$expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
@@ -7652,6 +7656,10 @@ class MultibyteTest extends CakeTestCase {
  * @return void
  */
 	public function testUsingMbStrtoupperDiacritic() {
+		if (extension_loaded('mbstring') && version_compare(PHP_VERSION, '7.3', '>=')) {
+			$this->markTestSkipped('PHP7.3+ built-in function mb_strtoupper() behaves slightly different from Multibyte::strtoupper()');
+		}
+
 		$string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
 		$result = mb_strtoupper($string);
 		$expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
@@ -7664,6 +7672,10 @@ class MultibyteTest extends CakeTestCase {
  * @return void
  */
 	public function testUsingMbStrtoupperLigatures() {
+		if (extension_loaded('mbstring') && version_compare(PHP_VERSION, '7.3', '>=')) {
+			$this->markTestSkipped('PHP7.3+ built-in function mb_strtoupper() behaves slightly different from Multibyte::strtoupper()');
+		}
+
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = mb_strtoupper($string);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';


### PR DESCRIPTION
Problems with running CakePHP2 tests on PHP 7.3 were fixed with #12718.
However, the test to fail by calling the built-in functions `mb_strtoupper()` but has been isolated, it remains that failed.
Since these tests actually call built-in functions, I suggest that explicitly skip the reason.