### PR TITLE
Document correct types for $modelClass

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -35,7 +35,10 @@ trait ModelAwareTrait
      * Plugin classes should use `Plugin.Comments` style names to correctly load
      * models from the correct plugin.
      *
-     * @var string
+     * Use false to not use auto-loading on this object. Null auto-detects based on
+     * controller name.
+     *
+     * @var string|false|null
      */
     public $modelClass;
 


### PR DESCRIPTION
I was working on a controller that doesnt need a model.
This clarifies the types here - also needed for [IdeHelper](https://github.com/dereuromark/cakephp-ide-helper) to detect annotations that need adding.