### PR TITLE
Use stricter handling of model class check.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -64,7 +64,7 @@ class Command
             return $this->getTableLocator()->get($alias);
         });
 
-        if (isset($this->modelClass)) {
+        if ($this->modelClass !== '') {
             $this->loadModel();
         }
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -198,7 +198,7 @@ class Shell
             ['associative' => ['tasks']]
         );
 
-        if (isset($this->modelClass)) {
+        if ($this->modelClass !== '') {
             $this->loadModel();
         }
     }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -290,9 +290,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function __get(string $name)
     {
-        [$plugin, $class] = pluginSplit($this->modelClass, true);
-        if ($class === $name) {
-            return $this->loadModel($plugin . $class);
+        if ($this->modelClass !== '') {
+            [$plugin, $class] = pluginSplit($this->modelClass, true);
+            if ($class === $name) {
+                return $this->loadModel($plugin . $class);
+            }
         }
 
         $trace = debug_backtrace();

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
+use InvalidArgumentException;
 
 /**
  * Provides functionality for loading table classes
@@ -37,7 +38,7 @@ trait ModelAwareTrait
      * Use empty string to not use auto-loading on this object. Null auto-detects based on
      * controller name.
      *
-     * @var string
+     * @var string|null
      */
     public $modelClass;
 
@@ -91,6 +92,9 @@ trait ModelAwareTrait
     {
         if ($modelClass === null) {
             $modelClass = $this->modelClass;
+        }
+        if ($modelClass === '') {
+            throw new InvalidArgumentException('You cannot use an empty string as model class name.');
         }
         if ($modelType === null) {
             $modelType = $this->getModelType();


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/13173

loadModel() without argument loads the $modelClass which, if set to empty string
would run into a cloaked error later on.
As such it is best to catch early.

Also doc block nullable part was removed from master merge, I restored it.