### PR TITLE
Make ModelAwareTrait::$modelClass protected.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -290,9 +290,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function __get(string $name)
     {
-        [$plugin, $class] = pluginSplit($this->modelClass, true);
-        if ($class === $name) {
-            return $this->loadModel($plugin . $class);
+        if (!empty($this->modelClass)) {
+            [$plugin, $class] = pluginSplit($this->modelClass, true);
+            if ($class === $name) {
+                return $this->loadModel($plugin . $class);
+            }
         }
 
         $trace = debug_backtrace();

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
+use UnexpectedValueException;
 
 /**
  * Provides functionality for loading table classes
@@ -37,9 +38,9 @@ trait ModelAwareTrait
      * Use empty string to not use auto-loading on this object. Null auto-detects based on
      * controller name.
      *
-     * @var string
+     * @var string|null
      */
-    public $modelClass;
+    protected $modelClass;
 
     /**
      * A list of overridden model factory functions.
@@ -65,7 +66,7 @@ trait ModelAwareTrait
      */
     protected function _setModelClass(string $name): void
     {
-        if (empty($this->modelClass)) {
+        if ($this->modelClass === null) {
             $this->modelClass = $name;
         }
     }
@@ -84,13 +85,16 @@ trait ModelAwareTrait
      * @param string|null $modelType The type of repository to load. Defaults to the modelType() value.
      * @return \Cake\Datasource\RepositoryInterface The model instance created.
      * @throws \Cake\Datasource\Exception\MissingModelException If the model class cannot be found.
-     * @throws \InvalidArgumentException When using a type that has not been registered.
-     * @throws \UnexpectedValueException If no model type has been defined
+     * @throws \UnexpectedValueException If $modelClass argument is not provided
+     *   and ModelAwareTrait::$modelClass property value is empty.
      */
     public function loadModel($modelClass = null, $modelType = null)
     {
         if ($modelClass === null) {
             $modelClass = $this->modelClass;
+        }
+        if (empty($modelClass)) {
+            throw new UnexpectedValueException('Default modelClass is empty');
         }
         if ($modelType === null) {
             $modelType = $this->getModelType();

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -103,8 +103,8 @@ class ShellTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         $this->Shell->tasks = ['Extract' => ['one', 'two']];
         $this->Shell->plugin = 'TestPlugin';
-        $this->Shell->modelClass = 'TestPlugin.TestPluginComments';
         $this->Shell->initialize();
+        // TestApp\Shell\ShellTestShell has $modelClass property set to 'TestPlugin.TestPluginComments'
         $this->Shell->loadModel();
 
         $this->assertTrue(isset($this->Shell->TestPluginComments));

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -177,16 +177,16 @@ class ControllerTest extends TestCase
         $request = new ServerRequest();
         $response = new Response();
         $controller = new \TestApp\Controller\PostsController($request, $response);
-        $this->assertEquals('Posts', $controller->modelClass);
+        $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
         $controller = new \TestApp\Controller\Admin\PostsController($request, $response);
-        $this->assertEquals('Posts', $controller->modelClass);
+        $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
         $request = $request->withParam('plugin', 'TestPlugin');
         $controller = new \TestPlugin\Controller\Admin\CommentsController($request, $response);
-        $this->assertEquals('TestPlugin.Comments', $controller->modelClass);
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->loadModel());
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
     }
 

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -32,10 +32,10 @@ class ModelAwareTraitTest extends TestCase
     public function testSetModelClass()
     {
         $stub = new Stub();
-        $this->assertNull($stub->modelClass);
+        $this->assertNull($stub->getProp('modelClass'));
 
         $stub->setProps('StubArticles');
-        $this->assertEquals('StubArticles', $stub->modelClass);
+        $this->assertEquals('StubArticles', $stub->getProp('modelClass'));
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -32,10 +32,10 @@ class ModelAwareTraitTest extends TestCase
     public function testSetModelClass()
     {
         $stub = new Stub();
-        $this->assertNull($stub->getProp('modelClass'));
+        $this->assertAttributeEquals(null, 'modelClass', $stub);
 
         $stub->setProps('StubArticles');
-        $this->assertEquals('StubArticles', $stub->getProp('modelClass'));
+        $this->assertAttributeEquals('StubArticles', 'modelClass', $stub);
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -64,6 +64,24 @@ class ModelAwareTraitTest extends TestCase
     }
 
     /**
+     * Test that calling loadModel() without $modelClass argument when default
+     * $modelClass property is empty generates exception.
+     *
+     * @return void
+     */
+    public function testLoadModelException()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Default modelClass is empty');
+
+        $stub = new Stub();
+        $stub->setProps('');
+        $stub->setModelType('Table');
+
+        $stub->loadModel();
+    }
+
+    /**
      * test loadModel() with plugin prefixed models
      *
      * Load model should not be called with Foo.Model Bar.Model Model

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -33,6 +33,13 @@ class ShellTestShell extends Shell
     public $name = 'ShellTestShell';
 
     /**
+     * modelClass
+     *
+     * @var string
+     */
+    protected $modelClass = 'TestPlugin.TestPluginComments';
+
+    /**
      * stopped property
      *
      * @var int

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -15,4 +15,9 @@ class Stub
     {
         $this->_setModelClass($name);
     }
+
+    public function getProp($name)
+    {
+        return $this->{$name};
+    }
 }

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -15,9 +15,4 @@ class Stub
     {
         $this->_setModelClass($name);
     }
-
-    public function getProp($name)
-    {
-        return $this->{$name};
-    }
 }


### PR DESCRIPTION
Allow setting the property to empty string in controller to indicate
that controller does not use a default model.

Alternate to #13178.