### PR TITLE
Fix doc blocks, add object typehint and remove static typehints.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,7 +29,6 @@ parameters:
         - '#Return type \(null\) of method Cake\\Collection\\Iterator\\NoChildrenIterator::getChildren\(\) should be compatible with return type \(RecursiveIterator\) of method RecursiveIterator::getChildren\(\)#'
         - '#Call to an undefined method DateTimeInterface::setTimezone\(\)#'
         - '#Call to an undefined method Cake\\Datasource\\QueryInterface::eagerLoaded\(\)#'
-        - '#Property Cake\\Mailer\\Transport\\SmtpTransport::\$_socket \(Cake\\Network\\Socket\) does not accept null#'
         -
             message: '#Right side of && is always false#'
             path: 'src/Cache/Engine/MemcachedEngine.php'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1278,9 +1278,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Database/Type/DateTimeType.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$this-&gt;_localeFormat</code>
-    </InvalidScalarArgument>
     <LessSpecificReturnStatement occurrences="2">
       <code>$date</code>
       <code>new $class($format, $tz)</code>
@@ -1304,9 +1301,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Database/Type/DateType.php">
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$this-&gt;_localeFormat</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>DateType</code>
     </PropertyNotSetInConstructor>
@@ -1710,9 +1704,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/I18n/DateFormatTrait.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$format</code>
-    </InvalidScalarArgument>
     <PossiblyInvalidArgument occurrences="2">
       <code>static::$niceFormat</code>
       <code>static::$_jsonEncodeFormat</code>
@@ -1898,9 +1889,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Mailer/Email.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>self</code>
-    </ImplementedReturnTypeMismatch>
     <MissingClosureParamType occurrences="2">
       <code>$item</code>
       <code>$key</code>
@@ -1952,9 +1940,6 @@
     <PossiblyInvalidIterator occurrences="1">
       <code>$lines</code>
     </PossiblyInvalidIterator>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$_socket</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Mailer/TransportRegistry.php">
     <MoreSpecificImplementedParamType occurrences="2">
@@ -3307,9 +3292,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/View/JsonView.php">
-    <MoreSpecificImplementedParamType occurrences="1">
-      <code>$view</code>
-    </MoreSpecificImplementedParamType>
     <PropertyNotSetInConstructor occurrences="1">
       <code>JsonView</code>
     </PropertyNotSetInConstructor>
@@ -3346,9 +3328,6 @@
     </UnresolvableInclude>
   </file>
   <file src="src/View/ViewBuilder.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>$this</code>
-    </ImplementedReturnTypeMismatch>
     <LessSpecificReturnStatement occurrences="1">
       <code>new $className($request, $response, $events, $data)</code>
     </LessSpecificReturnStatement>

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -59,7 +59,7 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
      * @param string $collection The serialized collection
      * @return void
      */
-    public function unserialize($collection)
+    public function unserialize($collection): void
     {
         $this->__construct(unserialize($collection));
     }

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -202,7 +202,7 @@ class BufferedIterator extends Collection implements Countable, Serializable
      * @param string $buffer The serialized buffer iterator
      * @return void
      */
-    public function unserialize($buffer)
+    public function unserialize($buffer): void
     {
         $this->__construct([]);
         $this->_buffer = unserialize($buffer);

--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -104,7 +104,7 @@ class ZipIterator extends MultipleIterator implements CollectionInterface, Seria
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->_iterators);
     }
@@ -115,7 +115,7 @@ class ZipIterator extends MultipleIterator implements CollectionInterface, Seria
      * @param string $iterators The serialized iterators
      * @return void
      */
-    public function unserialize($iterators)
+    public function unserialize($iterators): void
     {
         parent::__construct(MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC);
         $this->_iterators = unserialize($iterators);

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -17,6 +17,7 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Http\Exception\InternalErrorException;
+use Cake\Http\Session;
 use Cake\Utility\Inflector;
 use Exception;
 
@@ -158,7 +159,7 @@ class FlashComponent extends Component
      *
      * @return \Cake\Http\Session
      */
-    protected function getSession()
+    protected function getSession(): Session
     {
         return $this->getController()->getRequest()->getSession();
     }

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -191,7 +191,7 @@ class PaginatorComponent extends Component
      * @return \Cake\Datasource\ResultSetInterface Query results
      * @throws \Cake\Http\Exception\NotFoundException
      */
-    public function paginate($object, array $settings = []): ResultSetInterface
+    public function paginate(object $object, array $settings = []): ResultSetInterface
     {
         $request = $this->_registry->getController()->getRequest();
 
@@ -242,9 +242,9 @@ class PaginatorComponent extends Component
      * Set paginator instance.
      *
      * @param \Cake\Datasource\Paginator $paginator Paginator instance.
-     * @return self
+     * @return $this
      */
-    public function setPaginator(Paginator $paginator): self
+    public function setPaginator(Paginator $paginator)
     {
         $this->_paginator = $paginator;
 

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -41,7 +41,7 @@ use Cake\Core\Exception\Exception;
  * ];
  * ```
  *
- * @see Cake\Core\Configure::load() for how to load custom configuration files.
+ * @see \Cake\Core\Configure::load() for how to load custom configuration files.
  */
 class PhpConfig implements ConfigEngineInterface
 {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -316,7 +316,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @param object $object instance to store in the registry
      * @return $this
      */
-    public function set(string $objectName, $object)
+    public function set(string $objectName, object $object)
     {
         [, $name] = pluginSplit($objectName);
 

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -160,7 +160,7 @@ class Paginator implements PaginatorInterface
      * @return \Cake\Datasource\ResultSetInterface Query results
      * @throws \Cake\Datasource\Exception\PageOutOfBoundsException
      */
-    public function paginate($object, array $params = [], array $settings = [])
+    public function paginate(object $object, array $params = [], array $settings = [])
     {
         $query = null;
         if ($object instanceof QueryInterface) {

--- a/src/Datasource/PaginatorInterface.php
+++ b/src/Datasource/PaginatorInterface.php
@@ -29,7 +29,7 @@ interface PaginatorInterface
      * @param array $settings The settings/configuration used for pagination.
      * @return \Cake\Datasource\ResultSetInterface Query results
      */
-    public function paginate($object, array $params = [], array $settings = []);
+    public function paginate(object $object, array $params = [], array $settings = []);
 
     /**
      * Get paging params after pagination operation.

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -43,8 +43,8 @@ use InvalidArgumentException;
  *
  * @link https://tools.ietf.org/html/rfc6265
  * @link https://en.wikipedia.org/wiki/HTTP_cookie
- * @see Cake\Http\Cookie\CookieCollection for working with collections of cookies.
- * @see Cake\Http\Response::getCookieCollection() for working with response cookies.
+ * @see \Cake\Http\Cookie\CookieCollection for working with collections of cookies.
+ * @see \Cake\Http\Response::getCookieCollection() for working with response cookies.
  */
 class Cookie implements CookieInterface
 {
@@ -181,7 +181,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withName(string $name): CookieInterface
+    public function withName(string $name)
     {
         $this->validateName($name);
         $new = clone $this;
@@ -251,7 +251,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withValue($value): CookieInterface
+    public function withValue($value)
     {
         $new = clone $this;
         $new->_setValue($value);
@@ -274,7 +274,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withPath(string $path): CookieInterface
+    public function withPath(string $path)
     {
         $new = clone $this;
         $new->path = $path;
@@ -293,7 +293,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withDomain(string $domain): CookieInterface
+    public function withDomain(string $domain)
     {
         $new = clone $this;
         $new->domain = $domain;
@@ -320,7 +320,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withSecure(bool $secure): CookieInterface
+    public function withSecure(bool $secure)
     {
         $new = clone $this;
         $new->secure = $secure;
@@ -331,7 +331,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withHttpOnly(bool $httpOnly): CookieInterface
+    public function withHttpOnly(bool $httpOnly)
     {
         $new = clone $this;
         $new->httpOnly = $httpOnly;
@@ -350,7 +350,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withExpiry($dateTime): CookieInterface
+    public function withExpiry($dateTime)
     {
         $new = clone $this;
         $new->expiresAt = $dateTime->setTimezone(new DateTimeZone('GMT'));
@@ -406,7 +406,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withNeverExpire(): CookieInterface
+    public function withNeverExpire()
     {
         $new = clone $this;
         $new->expiresAt = Chronos::createFromDate(2038, 1, 1);
@@ -417,7 +417,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withExpired(): CookieInterface
+    public function withExpired()
     {
         $new = clone $this;
         $new->expiresAt = Chronos::createFromTimestamp(1);
@@ -450,7 +450,7 @@ class Cookie implements CookieInterface
      * @param mixed $value Value to write
      * @return static
      */
-    public function withAddedValue(string $path, $value): CookieInterface
+    public function withAddedValue(string $path, $value)
     {
         $new = clone $this;
         if ($new->isExpanded === false) {
@@ -467,7 +467,7 @@ class Cookie implements CookieInterface
      * @param string $path Path to remove
      * @return static
      */
-    public function withoutAddedValue(string $path): CookieInterface
+    public function withoutAddedValue(string $path)
     {
         $new = clone $this;
         if ($new->isExpanded === false) {

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -155,7 +155,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param string $name The name of the cookie to remove.
      * @return static
      */
-    public function remove(string $name): self
+    public function remove(string $name)
     {
         $new = clone $this;
         $key = mb_strtolower($name);
@@ -289,7 +289,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param \Psr\Http\Message\RequestInterface $request Request to get cookie context from.
      * @return static
      */
-    public function addFromResponse(ResponseInterface $response, RequestInterface $request): self
+    public function addFromResponse(ResponseInterface $response, RequestInterface $request)
     {
         $uri = $request->getUri();
         $host = $uri->getHost();

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -32,7 +32,7 @@ interface CookieInterface
      * @param string $name Name of the cookie
      * @return static
      */
-    public function withName(string $name): CookieInterface;
+    public function withName(string $name);
 
     /**
      * Gets the cookie name
@@ -63,7 +63,7 @@ interface CookieInterface
      * @param string|array $value Value of the cookie to set
      * @return static
      */
-    public function withValue($value): CookieInterface;
+    public function withValue($value);
 
     /**
      * Get the id for a cookie
@@ -87,7 +87,7 @@ interface CookieInterface
      * @param string $path Sets the path
      * @return static
      */
-    public function withPath(string $path): CookieInterface;
+    public function withPath(string $path);
 
     /**
      * Get the domain attribute.
@@ -102,7 +102,7 @@ interface CookieInterface
      * @param string $domain Domain to set
      * @return static
      */
-    public function withDomain(string $domain): CookieInterface;
+    public function withDomain(string $domain);
 
     /**
      * Get the current expiry time
@@ -131,14 +131,14 @@ interface CookieInterface
      * @param \DateTime|\DateTimeImmutable $dateTime Date time object
      * @return static
      */
-    public function withExpiry($dateTime): CookieInterface;
+    public function withExpiry($dateTime);
 
     /**
      * Create a new cookie that will virtually never expire.
      *
      * @return static
      */
-    public function withNeverExpire(): CookieInterface;
+    public function withNeverExpire();
 
     /**
      * Create a new cookie that will expire/delete the cookie from the browser.
@@ -147,7 +147,7 @@ interface CookieInterface
      *
      * @return static
      */
-    public function withExpired(): CookieInterface;
+    public function withExpired();
 
     /**
      * Check if a cookie is expired when compared to $time
@@ -172,7 +172,7 @@ interface CookieInterface
      * @param bool $httpOnly HTTP Only
      * @return static
      */
-    public function withHttpOnly(bool $httpOnly): CookieInterface;
+    public function withHttpOnly(bool $httpOnly);
 
     /**
      * Check if the cookie is secure
@@ -187,7 +187,7 @@ interface CookieInterface
      * @param bool $secure Secure attribute value
      * @return static
      */
-    public function withSecure(bool $secure): CookieInterface;
+    public function withSecure(bool $secure);
 
     /**
      * Returns the cookie as header value

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -283,7 +283,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|array|null $format Any format accepted by IntlDateFormatter.
+     * @param string|int|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDateTime(string $time, $format = null)
@@ -343,7 +343,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $date The date string to parse.
-     * @param string|int|null $format Any format accepted by IntlDateFormatter.
+     * @param string|int|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDate(string $date, $format = null)

--- a/src/I18n/I18nDateTimeInterface.php
+++ b/src/I18n/I18nDateTimeInterface.php
@@ -153,7 +153,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|array|null $format Any format accepted by IntlDateFormatter.
+     * @param string|int|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDateTime(string $time, $format = null);
@@ -177,7 +177,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
      * ```
      *
      * @param string $date The date string to parse.
-     * @param string|int|null $format Any format accepted by IntlDateFormatter.
+     * @param string|int|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDate(string $date, $format = null);

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -510,7 +510,7 @@ class Email implements JsonSerializable, Serializable
         $message = null,
         $config = 'default',
         bool $send = true
-    ): Email {
+    ) {
         $class = self::class;
 
         if (is_array($config) && !isset($config['transport'])) {
@@ -584,7 +584,7 @@ class Email implements JsonSerializable, Serializable
      * @param array $config Email configuration array.
      * @return $this Configured email instance.
      */
-    public function createFromArray(array $config): self
+    public function createFromArray(array $config)
     {
         if (isset($config['viewConfig'])) {
             $this->getRenderer()->viewBuilder()->createFromArray($config['viewConfig']);
@@ -620,9 +620,9 @@ class Email implements JsonSerializable, Serializable
      * Unserializes the Email object.
      *
      * @param string $data Serialized string.
-     * @return static Configured email instance.
+     * @return $this Configured email instance.
      */
-    public function unserialize($data): self
+    public function unserialize($data)
     {
         return $this->createFromArray(unserialize($data));
     }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -620,10 +620,10 @@ class Email implements JsonSerializable, Serializable
      * Unserializes the Email object.
      *
      * @param string $data Serialized string.
-     * @return $this Configured email instance.
+     * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
-        return $this->createFromArray(unserialize($data));
+        $this->createFromArray(unserialize($data));
     }
 }

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -45,7 +45,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Socket to SMTP server
      *
-     * @var \Cake\Network\Socket
+     * @var \Cake\Network\Socket|null
      */
     protected $_socket;
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -832,7 +832,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @return static
      */
-    public function cleanCopy(): self
+    public function cleanCopy()
     {
         $clone = clone $this;
         $clone->setEagerLoader(clone $this->getEagerLoader());

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -53,7 +53,7 @@ class ContextFactory
      *   be of form `['type' => 'a-string', 'callable' => ..]`
      * @return static
      */
-    public static function createWithDefaults(array $providers = []): self
+    public static function createWithDefaults(array $providers = [])
     {
         $providers = [
             [

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -569,7 +569,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @return void
      * @throws \RuntimeException
      */
-    protected function _checkViewVars(&$item, $key)
+    protected function _checkViewVars(&$item, string $key): void
     {
         if ($item instanceof Exception) {
             $item = (string)$item;
@@ -619,10 +619,10 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Unserializes the view builder object.
      *
      * @param string $data Serialized string.
-     * @return $this Configured view builder instance.
+     * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
-        return $this->createFromArray(unserialize($data));
+        $this->createFromArray(unserialize($data));
     }
 }


### PR DESCRIPTION
- With php7.2 we should be able to use object typehint
- return static has the same issues as return $this (chainable), making added methods in the extended classes not usable/seeable with those typehints added. Better we add a sniffer for this too. Note that already a lot of static returns are properly declared, so this is consolidating the differences to a single standard.
- I only didnt touch Response class yet, we should fix that too then afterwards
- Small fixes around doc blocks
- `public function unserialize($data): void` should always be void as per PHP specs.

Part 1/2