### PR TITLE
4.x ".ctp" => ".php" in error templates

### DIFF
--- a/templates/Error/duplicate_named_route.php
+++ b/templates/Error/duplicate_named_route.php
@@ -18,7 +18,7 @@ use Cake\Error\Debugger;
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Duplicate Named Route');
-$this->assign('templateName', 'duplicate_named_route.ctp');
+$this->assign('templateName', 'duplicate_named_route.php');
 
 $attributes = $error->getAttributes();
 

--- a/templates/Error/fatal_error.php
+++ b/templates/Error/fatal_error.php
@@ -15,7 +15,7 @@
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Fatal Error');
-$this->assign('templateName', 'fatal_error.ctp');
+$this->assign('templateName', 'fatal_error.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_action.php
+++ b/templates/Error/missing_action.php
@@ -55,7 +55,7 @@ $this->assign(
     'subheading',
     sprintf('The action <em>%s</em> is not defined in <em>%s</em>', h($action), h($class))
 );
-$this->assign('templateName', 'missing_action.ctp');
+$this->assign('templateName', 'missing_action.php');
 
 $this->start('file');
 ?>

--- a/templates/Error/missing_behavior.php
+++ b/templates/Error/missing_behavior.php
@@ -35,7 +35,7 @@ if (!empty($plugin) && !Plugin::isLoaded($plugin)) {
 
 $this->layout = 'dev_error';
 
-$this->assign('templateName', 'missing_behavior.ctp');
+$this->assign('templateName', 'missing_behavior.php');
 
 $this->assign('title', 'Missing Behavior');
 

--- a/templates/Error/missing_cell_template.php
+++ b/templates/Error/missing_cell_template.php
@@ -16,7 +16,7 @@ use Cake\Utility\Inflector;
 
 $this->layout = 'dev_error';
 
-$this->assign('templateName', 'missing_cell_view.ctp');
+$this->assign('templateName', 'missing_cell_view.php');
 $this->assign('title', 'Missing Cell View');
 
 $this->start('subheading');

--- a/templates/Error/missing_component.php
+++ b/templates/Error/missing_component.php
@@ -34,7 +34,7 @@ if (!empty($plugin) && !Plugin::isLoaded($plugin)) {
 
 $this->layout = 'dev_error';
 $this->assign('title', 'Missing Component');
-$this->assign('templateName', 'missing_component.ctp');
+$this->assign('templateName', 'missing_component.php');
 
 $this->start('subheading');
 printf('<em>%s</em> could not be found.', h($pluginDot . $class));

--- a/templates/Error/missing_connection.php
+++ b/templates/Error/missing_connection.php
@@ -14,7 +14,7 @@
  */
 $this->layout = 'dev_error';
 
-$this->assign('templateName', 'missing_connection.ctp');
+$this->assign('templateName', 'missing_connection.php');
 $this->assign('title', 'Missing Database Connection');
 
 

--- a/templates/Error/missing_controller.php
+++ b/templates/Error/missing_controller.php
@@ -43,7 +43,7 @@ if (empty($plugin)) {
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Controller');
-$this->assign('templateName', 'missing_controller.ctp');
+$this->assign('templateName', 'missing_controller.php');
 
 ?>
 <?php $this->start('subheading');?>

--- a/templates/Error/missing_datasource.php
+++ b/templates/Error/missing_datasource.php
@@ -17,7 +17,7 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Datasource');
-$this->assign('templateName', 'missing_datasource.ctp');
+$this->assign('templateName', 'missing_datasource.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_datasource_config.php
+++ b/templates/Error/missing_datasource_config.php
@@ -16,7 +16,7 @@
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Datasource Configuration');
-$this->assign('templateName', 'missing_datasource_config.ctp');
+$this->assign('templateName', 'missing_datasource_config.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_helper.php
+++ b/templates/Error/missing_helper.php
@@ -34,7 +34,7 @@ if (!empty($plugin) && !Plugin::isLoaded($plugin)) {
 
 $this->layout = 'dev_error';
 $this->assign('title', 'Missing Helper');
-$this->assign('templateName', 'missing_helper.ctp');
+$this->assign('templateName', 'missing_helper.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_layout.php
+++ b/templates/Error/missing_layout.php
@@ -16,7 +16,7 @@
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Layout');
-$this->assign('templateName', 'missing_layout.ctp');
+$this->assign('templateName', 'missing_layout.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_plugin.php
+++ b/templates/Error/missing_plugin.php
@@ -19,7 +19,7 @@ $this->layout = 'dev_error';
 $pluginPath = Configure::read('App.paths.plugins.0');
 
 $this->assign('title', 'Missing Plugin');
-$this->assign('templateName', 'missing_plugin.ctp');
+$this->assign('templateName', 'missing_plugin.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -19,7 +19,7 @@ use Cake\Error\Debugger;
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Route');
-$this->assign('templateName', 'missing_route.ctp');
+$this->assign('templateName', 'missing_route.php');
 
 $attributes = $error->getAttributes();
 

--- a/templates/Error/missing_template.php
+++ b/templates/Error/missing_template.php
@@ -17,7 +17,7 @@ use Cake\Utility\Inflector;
 $this->layout = 'dev_error';
 
 $this->assign('title', 'Missing Template');
-$this->assign('templateName', 'missing_template.ctp');
+$this->assign('templateName', 'missing_template.php');
 
 $isEmail = strpos($file, 'Email/') === 0;
 

--- a/templates/Error/missing_view.php
+++ b/templates/Error/missing_view.php
@@ -32,7 +32,7 @@ if (!empty($plugin) && !Plugin::isLoaded($plugin)) {
 
 $this->layout = 'dev_error';
 $this->assign('title', 'Missing View');
-$this->assign('templateName', 'missing_view.ctp');
+$this->assign('templateName', 'missing_view.php');
 
 $this->start('subheading');
 ?>

--- a/templates/Error/pdo_error.php
+++ b/templates/Error/pdo_error.php
@@ -17,7 +17,7 @@ use Cake\Error\Debugger;
 $this->setLayout('dev_error');
 
 $this->assign('title', 'Database Error');
-$this->assign('templateName', 'pdo_error.ctp');
+$this->assign('templateName', 'pdo_error.php');
 
 $this->start('subheading');
 ?>


### PR DESCRIPTION
show `.php` ext instead of `.ctp` in error-suggestion section