### PR TITLE
Fix more array doc blocks to be more precise. Stricter typehints.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -274,9 +274,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>Command</code>
     </PropertyNotSetInConstructor>
-    <UninitializedProperty occurrences="1">
-      <code>$this-&gt;modelClass</code>
-    </UninitializedProperty>
   </file>
   <file src="src/Console/CommandRunner.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -386,7 +383,7 @@
       <code>$command</code>
       <code>$message</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="14">
+    <PossiblyNullPropertyAssignmentValue occurrences="13">
       <code>$locator</code>
       <code>$command</code>
       <code>$locator</code>
@@ -402,12 +399,11 @@
       <code>$locator</code>
       <code>$locator</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="5">
+    <PropertyNotSetInConstructor occurrences="4">
       <code>$OptionParser</code>
       <code>$command</code>
       <code>$name</code>
       <code>$plugin</code>
-      <code>Shell</code>
     </PropertyNotSetInConstructor>
     <UndefinedConstant occurrences="1">
       <code>ROOT</code>
@@ -415,9 +411,8 @@
     <UndefinedMethod occurrences="1">
       <code>main</code>
     </UndefinedMethod>
-    <UninitializedProperty occurrences="2">
+    <UninitializedProperty occurrences="1">
       <code>$this-&gt;name</code>
-      <code>$this-&gt;modelClass</code>
     </UninitializedProperty>
   </file>
   <file src="src/Console/ShellDispatcher.php">
@@ -453,12 +448,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$message</code>
     </InvalidScalarArgument>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;_storage</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>\Cake\Auth\Storage\StorageInterface|null</code>
-    </MoreSpecificReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$redirectUrl</code>
       <code>$redirectUrl</code>
@@ -1621,9 +1610,6 @@
       <code>$weak ? 'W/' : null</code>
       <code>$cookie</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Http/ResponseEmitter.php">
     <MissingParamType occurrences="1">
@@ -1855,8 +1841,7 @@
     <PossiblyNullArgument occurrences="1">
       <code>$locale</code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$_cacher</code>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>TranslatorRegistry</code>
     </PropertyNotSetInConstructor>
   </file>
@@ -1911,11 +1896,6 @@
     <MissingClosureReturnType occurrences="1">
       <code>function (&amp;$item, $key) {</code>
     </MissingClosureReturnType>
-  </file>
-  <file src="src/Mailer/Mailer.php">
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>Mailer</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Mailer/Message.php">
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -2508,18 +2488,6 @@
     <PossiblyNullOperand occurrences="1">
       <code>$frag</code>
     </PossiblyNullOperand>
-  </file>
-  <file src="src/Shell/CacheShell.php">
-    <DeprecatedClass occurrences="2">
-      <code>Shell</code>
-      <code>parent::getOptionParser()</code>
-    </DeprecatedClass>
-    <PossiblyNullArgument occurrences="1">
-      <code>$prefix</code>
-    </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>CacheShell</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Shell/CompletionShell.php">
     <DeprecatedClass occurrences="2">

--- a/src/Auth/FallbackPasswordHasher.php
+++ b/src/Auth/FallbackPasswordHasher.php
@@ -34,7 +34,7 @@ class FallbackPasswordHasher extends AbstractPasswordHasher
     /**
      * Holds the list of password hasher objects that will be used
      *
-     * @var array
+     * @var \Cake\Auth\AbstractPasswordHasher[]
      */
     protected $_hashers = [];
 

--- a/src/Auth/Storage/StorageInterface.php
+++ b/src/Auth/Storage/StorageInterface.php
@@ -18,6 +18,8 @@ namespace Cake\Auth\Storage;
 /**
  * Describes the methods that any class representing an Auth data storage should
  * comply with.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 interface StorageInterface
 {

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -60,7 +60,7 @@ trait ExtractTrait
      * @param array $path Path to extract from.
      * @return mixed
      */
-    protected function _extract($data, $path)
+    protected function _extract($data, array $path)
     {
         $value = null;
         $collectionTransform = false;
@@ -101,7 +101,7 @@ trait ExtractTrait
      * @param array $path Path to extract from.
      * @return mixed
      */
-    protected function _simpleExtract($data, $path)
+    protected function _simpleExtract($data, array $path)
     {
         $value = null;
         foreach ($path as $column) {

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -61,7 +61,7 @@ class CommandRunner implements EventDispatcherInterface
     /**
      * Alias mappings.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = [];
 

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -82,19 +82,19 @@ class ConsoleInputOption
      * @param string $short The short alias for this option
      * @param string $help The help text for this option
      * @param bool $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
-     * @param string $default The default value for this option.
+     * @param string|bool $default The default value for this option.
      * @param array $choices Valid choices for this option.
      * @param bool $multiple Whether this option can accept multiple value definition.
      * @throws \Cake\Console\Exception\ConsoleException
      */
     public function __construct(
         $name,
-        $short = '',
-        $help = '',
-        $boolean = false,
+        string $short = '',
+        string $help = '',
+        bool $boolean = false,
         $default = '',
-        $choices = [],
-        $multiple = false
+        array $choices = [],
+        bool $multiple = false
     ) {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -288,7 +288,7 @@ class ConsoleIo
      *    length of the last message output.
      * @return void
      */
-    public function overwrite($message, int $newlines = 1, ?int $size = null)
+    public function overwrite($message, int $newlines = 1, ?int $size = null): void
     {
         $size = $size ?: $this->_lastWritten;
 
@@ -399,7 +399,7 @@ class ConsoleIo
      * @param string|null $default Default input value.
      * @return mixed Either the default value, or the user-provided input.
      */
-    public function askChoice(string $prompt, $options, $default = null)
+    public function askChoice(string $prompt, $options, ?string $default = null)
     {
         if ($options && is_string($options)) {
             if (strpos($options, ',')) {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -588,7 +588,7 @@ class ConsoleOptionParser
      * @param string $name The subcommand name to remove.
      * @return $this
      */
-    public function removeSubcommand($name)
+    public function removeSubcommand(string $name)
     {
         unset($this->_subcommands[$name]);
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -286,12 +286,12 @@ class ConsoleOutput
      * @return mixed If you are getting styles, the style or null will be returned. If you are creating/modifying
      *   styles true will be returned.
      */
-    public function styles($style = null, $definition = null)
+    public function styles(?string $style = null, $definition = null)
     {
         if ($style === null && $definition === null) {
             return static::$_styles;
         }
-        if (is_string($style) && $definition === null) {
+        if ($definition === null) {
             return static::$_styles[$style] ?? null;
         }
         if ($definition === false) {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -196,7 +196,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     /**
      * Controller actions for which user validation is not required.
      *
-     * @var array
+     * @var string[]
      * @see \Cake\Controller\Component\AuthComponent::allow()
      */
     public $allowedActions = [];
@@ -571,7 +571,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * $this->Auth->allow();
      * ```
      *
-     * @param string|array|null $actions Controller action name or array of actions
+     * @param string|string[]|null $actions Controller action name or array of actions
      * @return void
      * @link https://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-public
      */
@@ -601,7 +601,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * ```
      * to remove all items from the allowed list
      *
-     * @param string|array|null $actions Controller action name or array of actions
+     * @param string|string[]|null $actions Controller action name or array of actions
      * @return void
      * @see \Cake\Controller\Component\AuthComponent::allow()
      * @link https://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-require-authorization
@@ -843,7 +843,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      *   object as storage or if null returns configured storage object.
      * @return \Cake\Auth\Storage\StorageInterface|null
      */
-    public function storage(?StorageInterface $storage = null)
+    public function storage(?StorageInterface $storage = null): ?StorageInterface
     {
         if ($storage !== null) {
             $this->_storage = $storage;

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -864,14 +864,15 @@ class AuthComponent extends Component implements EventDispatcherInterface
             unset($config['className']);
         }
         $className = App::className($class, 'Auth/Storage', 'Storage');
-        if ($className === null || !class_exists($className)) {
+        if ($className === null) {
             throw new Exception(sprintf('Auth storage adapter "%s" was not found.', $class));
         }
         $request = $this->getController()->getRequest();
         $response = $this->getController()->getResponse();
-        $this->_storage = new $className($request, $response, $config);
+        /** @var \Cake\Auth\Storage\StorageInterface $storage */
+        $storage = new $className($request, $response, $config);
 
-        return $this->_storage;
+        return $this->_storage = $storage;
     }
 
     /**

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -142,7 +142,7 @@ class SecurityComponent extends Component
     /**
      * Sets the actions that require a request that is SSL-secured, or empty for all actions
      *
-     * @param string|array|null $actions Actions list
+     * @param string|string[]|null $actions Actions list
      * @return void
      */
     public function requireSecure($actions = null): void

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -74,7 +74,7 @@ if (!function_exists('pluginSplit')) {
      * @param string $name The name you want to plugin split.
      * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
      * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
-     * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
+     * @return string[] Array with 2 indexes. 0 => plugin name, 1 => class name.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
      */
     function pluginSplit(string $name, bool $dotAppend = false, ?string $plugin = null): array
@@ -100,7 +100,7 @@ if (!function_exists('namespaceSplit')) {
      * Commonly used like `list($namespace, $className) = namespaceSplit($class);`.
      *
      * @param string $class The full class name, ie `Cake\Core\App`.
-     * @return array Array with 2 indexes. 0 => namespace, 1 => classname.
+     * @return string[] Array with 2 indexes. 0 => namespace, 1 => classname.
      */
     function namespaceSplit(string $class): array
     {

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -74,7 +74,7 @@ if (!function_exists('pluginSplit')) {
      * @param string $name The name you want to plugin split.
      * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
      * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
-     * @return string[] Array with 2 indexes. 0 => plugin name, 1 => class name.
+     * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
      */
     function pluginSplit(string $name, bool $dotAppend = false, ?string $plugin = null): array

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -28,7 +28,7 @@ class FieldTypeConverter
      * An array containing the name of the fields and the Type objects
      * each should use when converting them.
      *
-     * @var array
+     * @var \Cake\Database\TypeInterface[]
      */
     protected $_typeMap;
 
@@ -45,7 +45,7 @@ class FieldTypeConverter
      * at the moment this object is created. Used so that the types list
      * is not fetched on each single row of the results.
      *
-     * @var array
+     * @var \Cake\Database\TypeInterface[]|\Cake\Database\Type\BatchCastingInterface[]
      */
     protected $types;
 

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -129,6 +129,7 @@ class FieldTypeConverter
 
         if (!empty($this->batchingTypeMap)) {
             foreach ($this->batchingTypeMap as $t => $fields) {
+                /** @psalm-suppress PossiblyUndefinedMethod */
                 $row = $this->types[$t]->manyToPHP($row, $fields, $this->_driver);
             }
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -79,7 +79,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * The list of query clauses to traverse for generating a SELECT statement
      *
-     * @var array
+     * @var string[]
      */
     protected $_selectParts = [
         'select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit',
@@ -89,21 +89,21 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * The list of query clauses to traverse for generating an UPDATE statement
      *
-     * @var array
+     * @var string[]
      */
     protected $_updateParts = ['update', 'set', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating a DELETE statement
      *
-     * @var array
+     * @var string[]
      */
     protected $_deleteParts = ['delete', 'modifier', 'from', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
      *
-     * @var array
+     * @var string[]
      */
     protected $_insertParts = ['insert', 'values', 'epilog'];
 
@@ -121,7 +121,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * statement upon retrieval. Each one of the callback function will receive
      * the row array as first argument.
      *
-     * @var array
+     * @var callable[]
      */
     protected $_resultDecorators = [];
 

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -78,7 +78,7 @@ class TypeFactory
     /**
      * Returns an arrays with all the mapped type objects, indexed by name.
      *
-     * @return array
+     * @return \Cake\Database\TypeInterface[]
      */
     public static function buildAll(): array
     {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -29,7 +29,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Sets hidden fields.
      *
-     * @param array $fields An array of fields to hide from array exports.
+     * @param string[] $fields An array of fields to hide from array exports.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -38,14 +38,14 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Gets the hidden fields.
      *
-     * @return array
+     * @return string[]
      */
     public function getHidden(): array;
 
     /**
      * Sets the virtual fields on this entity.
      *
-     * @param array $fields An array of fields to treat as virtual.
+     * @param string[] $fields An array of fields to treat as virtual.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -54,7 +54,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Gets the virtual fields on this entity.
      *
-     * @return array
+     * @return string[]
      */
     public function getVirtual(): array;
 
@@ -79,7 +79,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Gets the dirty fields.
      *
-     * @return array
+     * @return string[]
      */
     public function getDirty(): array;
 
@@ -123,7 +123,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @param bool $overwrite Whether or not to overwrite pre-existing errors for $field
      * @return $this
      */
-    public function setError($field, $errors, bool $overwrite = false);
+    public function setError(string $field, $errors, bool $overwrite = false);
 
     /**
      * Stores whether or not a field value can be changed or set in this entity.
@@ -195,7 +195,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @param string $field the name of the field to retrieve
      * @return mixed
      */
-    public function &get($field);
+    public function &get(string $field);
 
     /**
      * Returns whether this entity contains a field named $field
@@ -217,7 +217,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Get the list of visible fields.
      *
-     * @return array A list of fields that are 'visible' in all representations.
+     * @return string[] A list of fields that are 'visible' in all representations.
      */
     public function getVisible(): array;
 
@@ -235,11 +235,11 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * Returns an array with the requested fields
      * stored in this entity, indexed by field name
      *
-     * @param array $fields list of fields to be returned
+     * @param string[] $fields list of fields to be returned
      * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array
      */
-    public function extract(array $fields, $onlyDirty = false);
+    public function extract(array $fields, bool $onlyDirty = false): array;
 
     /**
      * Sets the entire entity as clean, which means that it will appear as
@@ -248,7 +248,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function clean();
+    public function clean(): void;
 
     /**
      * Returns whether or not this entity has already been persisted.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -265,13 +265,13 @@ trait EntityTrait
     /**
      * Returns the value of a field by name
      *
-     * @param string|null $field the name of the field to retrieve
+     * @param string $field the name of the field to retrieve
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed
      */
-    public function &get(?string $field)
+    public function &get(string $field)
     {
-        if (!strlen((string)$field)) {
+        if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');
         }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -46,7 +46,7 @@ trait EntityTrait
      * List of field names that should **not** be included in JSON or Array
      * representations of this Entity.
      *
-     * @var array
+     * @var string[]
      */
     protected $_hidden = [];
 
@@ -55,7 +55,7 @@ trait EntityTrait
      * representations of this Entity. If a field is present in both _hidden and _virtual
      * the field will **not** be in the array/json versions of the entity.
      *
-     * @var array
+     * @var string[]
      */
     protected $_virtual = [];
 
@@ -63,7 +63,7 @@ trait EntityTrait
      * Holds a list of the fields that were modified or added after this object
      * was originally created.
      *
-     * @var array
+     * @var bool[]
      */
     protected $_dirty = [];
 
@@ -123,7 +123,7 @@ trait EntityTrait
      * @param string $field Name of the field to access
      * @return mixed
      */
-    public function &__get($field)
+    public function &__get(string $field)
     {
         return $this->get($field);
     }
@@ -135,7 +135,7 @@ trait EntityTrait
      * @param mixed $value The value to set to the field
      * @return void
      */
-    public function __set($field, $value)
+    public function __set(string $field, $value)
     {
         $this->set($field, $value);
     }
@@ -148,7 +148,7 @@ trait EntityTrait
      * @return bool
      * @see \Cake\ORM\Entity::has()
      */
-    public function __isset($field)
+    public function __isset(string $field)
     {
         return $this->has($field);
     }
@@ -159,7 +159,7 @@ trait EntityTrait
      * @param string $field The field to unset
      * @return void
      */
-    public function __unset($field)
+    public function __unset(string $field)
     {
         $this->unset($field);
     }
@@ -265,11 +265,11 @@ trait EntityTrait
     /**
      * Returns the value of a field by name
      *
-     * @param string $field the name of the field to retrieve
+     * @param string|null $field the name of the field to retrieve
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed
      */
-    public function &get($field)
+    public function &get(?string $field)
     {
         if (!strlen((string)$field)) {
             throw new InvalidArgumentException('Cannot get an empty field');
@@ -298,7 +298,7 @@ trait EntityTrait
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed.
      */
-    public function getOriginal($field)
+    public function getOriginal(string $field)
     {
         if (!strlen((string)$field)) {
             throw new InvalidArgumentException('Cannot get an empty field');
@@ -381,7 +381,7 @@ trait EntityTrait
      * @param string $field The field to check.
      * @return bool
      */
-    public function isEmpty($field): bool
+    public function isEmpty(string $field): bool
     {
         $value = $this->get($field);
         if ($value === null
@@ -410,7 +410,7 @@ trait EntityTrait
      * @param string $field The field to check.
      * @return bool
      */
-    public function hasValue($field): bool
+    public function hasValue(string $field): bool
     {
         return !$this->isEmpty($field);
     }
@@ -453,7 +453,7 @@ trait EntityTrait
     /**
      * Sets hidden fields.
      *
-     * @param array $fields An array of fields to hide from array exports.
+     * @param string[] $fields An array of fields to hide from array exports.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -474,7 +474,7 @@ trait EntityTrait
     /**
      * Gets the hidden fields.
      *
-     * @return array
+     * @return string[]
      */
     public function getHidden(): array
     {
@@ -484,7 +484,7 @@ trait EntityTrait
     /**
      * Sets the virtual fields on this entity.
      *
-     * @param array $fields An array of fields to treat as virtual.
+     * @param string[] $fields An array of fields to treat as virtual.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -505,7 +505,7 @@ trait EntityTrait
     /**
      * Gets the virtual fields on this entity.
      *
-     * @return array
+     * @return string[]
      */
     public function getVirtual(): array
     {
@@ -518,7 +518,7 @@ trait EntityTrait
      * The list of visible fields is all standard fields
      * plus virtual fields minus hidden fields.
      *
-     * @return array A list of fields that are 'visible' in all
+     * @return string[] A list of fields that are 'visible' in all
      *     representations.
      */
     public function getVisible(): array
@@ -533,7 +533,7 @@ trait EntityTrait
      * Gets the list of visible fields.
      *
      * @deprecated 4.0.0 Use getVisible() instead. Will be removed in 5.0.
-     * @return array
+     * @return string[]
      */
     public function visibleProperties(): array
     {
@@ -612,7 +612,7 @@ trait EntityTrait
      * @param mixed $value The value to set.
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->set($offset, $value);
     }
@@ -623,7 +623,7 @@ trait EntityTrait
      * @param string $offset The offset to remove.
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->unset($offset);
     }
@@ -636,7 +636,7 @@ trait EntityTrait
      * @param string $type the accessor type ('get' or 'set')
      * @return string method name or empty string (no method available)
      */
-    protected static function _accessor($property, $type)
+    protected static function _accessor(string $property, string $type): string
     {
         $class = static::class;
 
@@ -676,11 +676,11 @@ trait EntityTrait
      * Returns an array with the requested fields
      * stored in this entity, indexed by field name
      *
-     * @param array $fields list of fields to be returned
+     * @param string[] $fields list of fields to be returned
      * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array
      */
-    public function extract(array $fields, $onlyDirty = false): array
+    public function extract(array $fields, bool $onlyDirty = false): array
     {
         $result = [];
         foreach ($fields as $field) {
@@ -944,7 +944,7 @@ trait EntityTrait
      * @param bool $overwrite Whether or not to overwrite pre-existing errors for $field
      * @return $this
      */
-    public function setError($field, $errors, bool $overwrite = false)
+    public function setError(string $field, $errors, bool $overwrite = false)
     {
         if (is_string($errors)) {
             $errors = [$errors];
@@ -959,7 +959,7 @@ trait EntityTrait
      * @param string $field the field in this entity to check for errors
      * @return array errors in nested entity if any
      */
-    protected function _nestedErrors($field): array
+    protected function _nestedErrors(string $field): array
     {
         $path = explode('.', $field);
 
@@ -1000,10 +1000,10 @@ trait EntityTrait
     /**
      * Reads if there are errors for one or many objects.
      *
-     * @param mixed $object The object to read errors from.
+     * @param array|\Cake\Datasource\EntityInterface $object The object to read errors from.
      * @return bool
      */
-    protected function _readHasErrors($object)
+    protected function _readHasErrors($object): bool
     {
         if ($object instanceof EntityInterface && $object->hasErrors()) {
             return true;

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -88,7 +88,7 @@ trait ModelAwareTrait
      * @throws \UnexpectedValueException If $modelClass argument is not provided
      *   and ModelAwareTrait::$modelClass property value is empty.
      */
-    public function loadModel($modelClass = null, $modelType = null)
+    public function loadModel(?string $modelClass = null, ?string $modelType = null)
     {
         if ($modelClass === null) {
             $modelClass = $this->modelClass;

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -164,7 +164,7 @@ class Debugger
      * Returns a reference to the Debugger singleton object instance.
      *
      * @param string|null $class Class name.
-     * @return \Cake\Error\Debugger
+     * @return static
      */
     public static function getInstance(?string $class = null)
     {
@@ -190,7 +190,7 @@ class Debugger
      * @return mixed Config value being read, or the object itself on write operations.
      * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
      */
-    public static function configInstance($key = null, $value = null, $merge = true)
+    public static function configInstance($key = null, $value = null, bool $merge = true)
     {
         if (is_array($key) || func_num_args() >= 2) {
             return static::getInstance()->setConfig($key, $value, $merge);
@@ -933,7 +933,7 @@ TEXT;
      *
      * @return void
      */
-    public static function checkSecurityKeys()
+    public static function checkSecurityKeys(): void
     {
         if (Security::getSalt() === '__SALT__') {
             trigger_error(sprintf(

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -92,7 +92,7 @@ class ErrorHandler extends BaseErrorHandler
      *
      * @param array $options The options for error handling.
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $defaults = [
             'log' => true,

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -87,7 +87,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
      *
      * @var \Cake\Http\ServerRequest|null
      */
-    protected $request = null;
+    protected $request;
 
     /**
      * Creates the controller to perform rendering on the error response.

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -36,7 +36,7 @@ class BodyParserMiddleware implements MiddlewareInterface
     /**
      * Registered Parsers
      *
-     * @var array
+     * @var callable[]
      */
     protected $parsers = [];
 

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -43,7 +43,8 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
 
     /**
      * The list of cookies to encrypt/decrypt
-     * @var array
+     *
+     * @var string[]
      */
     protected $cookieNames;
 
@@ -64,7 +65,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param array $cookieNames The list of cookie names that should have their values encrypted.
+     * @param string[] $cookieNames The list of cookie names that should have their values encrypted.
      * @param string $key The encryption key to use.
      * @param string $cipherType The cipher type to use. Defaults to 'aes'.
      */
@@ -137,6 +138,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      */
     protected function encodeCookies(Response $response): Response
     {
+        /** @var \Cake\Http\Cookie\CookieInterface[] $cookies */
         $cookies = $response->getCookieCollection();
         foreach ($cookies as $cookie) {
             if (in_array($cookie->getName(), $this->cookieNames, true)) {
@@ -156,6 +158,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      */
     protected function encodeSetCookieHeader(ResponseInterface $response): ResponseInterface
     {
+        /** @var \Cake\Http\Cookie\CookieInterface[] $cookies */
         $cookies = CookieCollection::createFromHeader($response->getHeader('Set-Cookie'));
         $header = [];
         foreach ($cookies as $cookie) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -402,7 +402,7 @@ class Response implements ResponseInterface
      *
      * @var \Cake\Http\Cookie\CookieCollection
      */
-    protected $_cookies = null;
+    protected $_cookies;
 
     /**
      * Reason Phrase

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -64,7 +64,7 @@ class TranslatorRegistry extends TranslatorLocator
      * A CacheEngine object that is used to remember translator across
      * requests.
      *
-     * @var \Cake\Cache\CacheEngine
+     * @var \Cake\Cache\CacheEngine|null
      */
     protected $_cacher;
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -189,7 +189,7 @@ abstract class Association
     /**
      * Valid strategies for this association. Subclasses can narrow this down.
      *
-     * @var array
+     * @var string[]
      */
     protected $_validStrategies = [
         self::STRATEGY_JOIN,

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -35,7 +35,7 @@ class BelongsTo extends Association
     /**
      * Valid strategies for this type of association
      *
-     * @var array
+     * @var string[]
      */
     protected $_validStrategies = [
         self::STRATEGY_JOIN,

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -119,7 +119,7 @@ class BelongsToMany extends Association
     /**
      * Valid strategies for this type of association
      *
-     * @var array
+     * @var string[]
      */
     protected $_validStrategies = [
         self::STRATEGY_SELECT,

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -59,7 +59,7 @@ class HasMany extends Association
     /**
      * Valid strategies for this type of association
      *
-     * @var array
+     * @var string[]
      */
     protected $_validStrategies = [
         self::STRATEGY_SELECT,

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -33,7 +33,7 @@ class HasOne extends Association
     /**
      * Valid strategies for this type of association
      *
-     * @var array
+     * @var string[]
      */
     protected $_validStrategies = [
         self::STRATEGY_JOIN,

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -115,7 +115,7 @@ class ProgressHelper extends Helper
      * @param int $num The amount of progress to advance by.
      * @return $this
      */
-    public function increment($num = 1)
+    public function increment(int $num = 1)
     {
         $this->_progress = min(max(0, $this->_progress + $num), $this->_total);
 

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -112,10 +112,10 @@ class ProgressHelper extends Helper
     /**
      * Increment the progress bar.
      *
-     * @param int $num The amount of progress to advance by.
+     * @param int|float $num The amount of progress to advance by.
      * @return $this
      */
-    public function increment(int $num = 1)
+    public function increment($num = 1)
     {
         $this->_progress = min(max(0, $this->_progress + $num), $this->_total);
 

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -37,7 +37,7 @@ class ProgressHelper extends Helper
     /**
      * The current progress.
      *
-     * @var int
+     * @var int|float
      */
     protected $_progress = 0;
 

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -37,7 +37,7 @@ class TableHelper extends Helper
      * Calculate the column widths
      *
      * @param array $rows The rows on which the columns width will be calculated on.
-     * @return array
+     * @return int[]
      */
     protected function _calculateWidths(array $rows): array
     {
@@ -79,7 +79,7 @@ class TableHelper extends Helper
     /**
      * Output a row separator.
      *
-     * @param array $widths The widths of each column to output.
+     * @param int[] $widths The widths of each column to output.
      * @return void
      */
     protected function _rowSeparator(array $widths): void
@@ -96,7 +96,7 @@ class TableHelper extends Helper
      * Output a row.
      *
      * @param array $row The row to output.
-     * @param array $widths The widths of each column to output.
+     * @param int[] $widths The widths of each column to output.
      * @param array $options Options to be passed.
      * @return void
      */

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -82,9 +82,9 @@ class CommandTask extends Shell
      * Scan the provided paths for shells, and append them into $shellList
      *
      * @param string $type The type of object.
-     * @param array $shells The shell name.
+     * @param string[] $shells The shell names.
      * @param array $shellList List of shells.
-     * @param array $skip List of command names to skip.
+     * @param string[] $skip List of command names to skip.
      * @return array The updated $shellList
      */
     protected function _appendShells(string $type, array $shells, array $shellList, array $skip): array

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -723,7 +723,7 @@ class Validation
      * Checks that value has a valid file extension.
      *
      * @param string|array|\Psr\Http\Message\UploadedFileInterface $check Value to check
-     * @param array $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
+     * @param string[] $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
      * @return bool Success
      */
     public static function extension($check, array $extensions = ['gif', 'jpeg', 'png', 'jpg']): bool

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -218,21 +218,21 @@ class View implements EventDispatcherInterface
     /**
      * Holds an array of paths.
      *
-     * @var array
+     * @var string[]
      */
     protected $_paths = [];
 
     /**
      * Holds an array of plugin paths.
      *
-     * @var array
+     * @var string[][]
      */
     protected $_pathsForPlugin = [];
 
     /**
      * The names of views and their parents used with View::extend();
      *
-     * @var array
+     * @var string[]
      */
     protected $_parents = [];
 
@@ -1221,6 +1221,7 @@ class View implements EventDispatcherInterface
      * @param string|null $name Controller action to find template filename for
      * @return string Template filename
      * @throws \Cake\View\Exception\MissingTemplateException when a template file could not be found.
+     * @throws \RuntimeException When template name not provided.
      */
     protected function _getTemplateFileName(?string $name = null): string
     {
@@ -1260,7 +1261,7 @@ class View implements EventDispatcherInterface
             }
         }
 
-        $name = $name . $this->_ext;
+        $name .= $this->_ext;
         $paths = $this->_paths($plugin);
         foreach ($paths as $path) {
             if (file_exists($path . $name)) {
@@ -1316,7 +1317,7 @@ class View implements EventDispatcherInterface
      *
      * @param string $name The name you want to plugin split.
      * @param bool $fallback If true uses the plugin set in the current Request when parsed plugin is not loaded
-     * @return array Array with 2 indexes. 0 => plugin name, 1 => filename
+     * @return string[] Array with 2 indexes. 0 => plugin name, 1 => filename
      */
     public function pluginSplit(string $name, bool $fallback = true): array
     {
@@ -1360,7 +1361,7 @@ class View implements EventDispatcherInterface
         [$plugin, $name] = $this->pluginSplit($name);
 
         $layoutPaths = $this->_getSubPaths(static::TYPE_LAYOUT . DIRECTORY_SEPARATOR . $subDir);
-        $name = $name . $this->_ext;
+        $name .= $this->_ext;
 
         foreach ($this->_paths($plugin) as $path) {
             foreach ($layoutPaths as $layoutPath) {
@@ -1441,7 +1442,7 @@ class View implements EventDispatcherInterface
      *
      * @param string|null $plugin Optional plugin name to scan for view files.
      * @param bool $cached Set to false to force a refresh of view paths. Default true.
-     * @return array paths
+     * @return string[] paths
      */
     protected function _paths(?string $plugin = null, bool $cached = true): array
     {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1317,7 +1317,7 @@ class View implements EventDispatcherInterface
      *
      * @param string $name The name you want to plugin split.
      * @param bool $fallback If true uses the plugin set in the current Request when parsed plugin is not loaded
-     * @return string[] Array with 2 indexes. 0 => plugin name, 1 => filename
+     * @return array Array with 2 indexes. 0 => plugin name, 1 => filename
      */
     public function pluginSplit(string $name, bool $fallback = true): array
     {

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -28,9 +28,9 @@ class ApcuEngineTest extends TestCase
     /**
      * useRequestTime original value
      *
-     * @var bool
+     * @var string
      */
-    protected static $useRequestTime = null;
+    protected static $useRequestTime;
 
     /**
      * Ensure use_request_time is turned off
@@ -51,7 +51,7 @@ class ApcuEngineTest extends TestCase
      */
     public static function teardownAfterClass(): void
     {
-        ini_set('apc.use_request_time', (string)static::$useRequestTime);
+        ini_set('apc.use_request_time', static::$useRequestTime);
     }
 
     /**
@@ -64,7 +64,7 @@ class ApcuEngineTest extends TestCase
         parent::setUp();
         $this->skipIf(!function_exists('apcu_store'), 'APCu is not installed or configured properly.');
 
-        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
+        if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
             $this->skipIf(!ini_get('apc.enable_cli'), 'APCu is not enabled for the CLI.');
         }
 
@@ -91,7 +91,7 @@ class ApcuEngineTest extends TestCase
      * @param array $config
      * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache(array $config = [])
     {
         $defaults = [
             'className' => 'Apcu',

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -28,9 +28,9 @@ class FileTest extends TestCase
     /**
      * File property
      *
-     * @var mixed
+     * @var File
      */
-    public $File = null;
+    public $File;
 
     /**
      * setup the test case

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -28,27 +28,27 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * @var array|null
      */
-    protected $server = null;
+    protected $server;
 
     /**
      * @var array|null
      */
-    protected $post = null;
+    protected $post;
 
     /**
      * @var array|null
      */
-    protected $files = null;
+    protected $files;
 
     /**
      * @var array|null
      */
-    protected $cookies = null;
+    protected $cookies;
 
     /**
      * @var array|null
      */
-    protected $get = null;
+    protected $get;
 
     /**
      * setup

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1593,7 +1593,7 @@ class EntityTest extends TestCase
      */
     public function emptyNamesProvider()
     {
-        return [[''], [null], [false]];
+        return [[''], [null]];
     }
     /**
      * Tests that trying to get an empty property name throws exception

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1595,17 +1595,17 @@ class EntityTest extends TestCase
     {
         return [[''], [null]];
     }
+
     /**
      * Tests that trying to get an empty property name throws exception
      *
-     * @dataProvider emptyNamesProvider
      * @return void
      */
-    public function testEmptyProperties($property)
+    public function testEmptyProperties()
     {
         $this->expectException(\InvalidArgumentException::class);
         $entity = new Entity();
-        $entity->get($property);
+        $entity->get('');
     }
 
     /**

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -148,7 +148,7 @@ class ProgressHelperTest extends TestCase
         $this->helper->increment(20);
         $this->helper->draw();
 
-        $this->helper->increment(40);
+        $this->helper->increment(40.0);
         $this->helper->draw();
 
         $this->helper->increment(40);

--- a/tests/test_app/TestApp/Controller/AuthTestController.php
+++ b/tests/test_app/TestApp/Controller/AuthTestController.php
@@ -24,11 +24,9 @@ use Cake\Routing\Router;
 class AuthTestController extends Controller
 {
     /**
-     * testUrl property
-     *
-     * @var string|array
+     * @var string|null
      */
-    public $testUrl = null;
+    public $testUrl;
 
     /**
      * construct method
@@ -43,6 +41,9 @@ class AuthTestController extends Controller
         parent::__construct($request, $response);
     }
 
+    /**
+     * @return void
+     */
     public function initialize(): void
     {
         $this->loadComponent('Auth');

--- a/tests/test_app/TestApp/Controller/Component/TestAuthComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/TestAuthComponent.php
@@ -26,7 +26,7 @@ class TestAuthComponent extends AuthComponent
     /**
      * @var string|null
      */
-    public $authCheckCalledFrom = null;
+    public $authCheckCalledFrom;
 
     /**
      * @param \Cake\Event\EventInterface $event

--- a/tests/test_app/TestApp/Log/Engine/TestAppLog.php
+++ b/tests/test_app/TestApp/Log/Engine/TestAppLog.php
@@ -24,8 +24,17 @@ use Cake\Log\Engine\BaseLog;
  */
 class TestAppLog extends BaseLog
 {
-    public $passedScope = null;
+    /**
+     * @var array|null
+     */
+    public $passedScope;
 
+    /**
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return void
+     */
     public function log($level, $message, array $context = [])
     {
         $this->passedScope = $context;

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -11,7 +11,11 @@ class Stub
 {
     use ModelAwareTrait;
 
-    public function setProps($name)
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setProps(string $name): void
     {
         $this->_setModelClass($name);
     }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -12,10 +12,10 @@ class TestView extends AppView
     /**
      * getTemplateFileName method
      *
-     * @param string $name Controller action to find template filename for
+     * @param string|null $name Controller action to find template filename for
      * @return string Template filename
      */
-    public function getTemplateFileName($name = null)
+    public function getTemplateFileName(?string $name = null): string
     {
         return $this->_getTemplateFileName($name);
     }
@@ -23,10 +23,10 @@ class TestView extends AppView
     /**
      * getLayoutFileName method
      *
-     * @param string $name The name of the layout to find.
+     * @param string|null $name The name of the layout to find.
      * @return string Filename for layout file (.php).
      */
-    public function getLayoutFileName($name = null)
+    public function getLayoutFileName(?string $name = null): string
     {
         return $this->_getLayoutFileName($name);
     }
@@ -34,11 +34,11 @@ class TestView extends AppView
     /**
      * paths method
      *
-     * @param string $plugin Optional plugin name to scan for view files.
+     * @param string|null $plugin Optional plugin name to scan for view files.
      * @param bool $cached Set to true to force a refresh of view paths.
-     * @return array paths
+     * @return string[] paths
      */
-    public function paths($plugin = null, $cached = true)
+    public function paths(?string $plugin = null, bool $cached = true): array
     {
         return $this->_paths($plugin, $cached);
     }

--- a/tests/test_app/templates/Admin/Error/error400.php
+++ b/tests/test_app/templates/Admin/Error/error400.php
@@ -23,7 +23,7 @@ use Cake\Core\Configure;
     ) ?>
 </p>
 <?php
-if (Configure::read('debug')):
+if (Configure::read('debug')) :
     echo $this->element('exception_stack_trace');
 endif;
 ?>


### PR DESCRIPTION
Part 2/2 of https://github.com/cakephp/cakephp/pull/13183

I wasnt sure if we need Entity:get() to allow null as input - but I didnt remove that yet.
IMO only real string makes sense, and we can then simplify the API here.

`@mixin \Cake\Core\InstanceConfigTrait` is needed on interface contracts where the trait methods are being used in code.

Hopefully, this allows PHPStan and CO to better introspect the code and find issues even more precise and early on now.