### PR TITLE
Ensure non empty locale when generating cache key.

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -184,7 +184,7 @@ trait DateFormatTrait
      *
      * @param \DateTime $date Date.
      * @param string|int|array $format Format.
-     * @param string $locale The locale name in which the date should be displayed.
+     * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
      */
     protected function _formatObject($date, $format, $locale)
@@ -204,6 +204,10 @@ trait DateFormatTrait
             $calendar = IntlDateFormatter::TRADITIONAL;
         } else {
             $calendar = IntlDateFormatter::GREGORIAN;
+        }
+
+        if ($locale === null) {
+            $locale = I18n::getLocale();
         }
 
         $timezone = $date->getTimezone()->getName();

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -482,6 +482,27 @@ class TimeTest extends TestCase
     }
 
     /**
+     * testI18nFormatUsingSystemLocale
+     *
+     * @return void
+     */
+    public function testI18nFormatUsingSystemLocale()
+    {
+        // Unset default locale for the Time class to ensure system's locale is used.
+        Time::setDefaultLocale();
+        $locale = I18n::getLocale();
+
+        $time = new Time(1556864870);
+        I18n::setLocale('ar');
+        $this->assertEquals('٢٠١٩-٠٥-٠٣', $time->i18nFormat('yyyy-MM-dd'));
+
+        I18n::setLocale('en');
+        $this->assertEquals('2019-05-03', $time->i18nFormat('yyyy-MM-dd'));
+
+        I18n::setLocale($locale);
+    }
+
+    /**
      * test formatting dates with offset style timezone
      *
      * @dataProvider classNameProvider


### PR DESCRIPTION
Fixes #13186.