### PR TITLE
Remove misleading deprecation message.

### DIFF
--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -20,8 +20,6 @@ use Cake\Datasource\SchemaInterface;
 
 /**
  * An interface used by database TableSchema objects.
- *
- * Deprecated 3.5.0: Use Cake\Database\TableSchemaAwareInterface instead.
  */
 interface TableSchemaInterface extends SchemaInterface
 {


### PR DESCRIPTION
`TableSchemaAwareInterface` is not an alternative for `TableSchemaInterface`.
The former actually provides getter/setter methods for the latter's instances.