### PR TITLE
Fix plural form calculation for Turkish

### DIFF
--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -116,7 +116,7 @@ class PluralRules
         'th' => 0,
         'ti' => 2,
         'tk' => 1,
-        'tr' => 0,
+        'tr' => 1,
         'uk' => 3,
         'ur' => 1,
         'vi' => 0,

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -116,6 +116,9 @@ class PluralRulesTest extends TestCase
             ['cy', 10, 2],
             ['cy', 11, 3],
             ['cy', 8, 3],
+            ['tr', 0, 1],
+            ['tr', 1, 0],
+            ['tr', 2, 1],
         ];
     }
 


### PR DESCRIPTION
CakePHP assumes that Turkish has only one plural form (in other words, it assumes that "{n} tomato" and "{n} tomatoes" translates the same in Turkish). However, Turkish has two plural forms, n=1 and n!=1, as show on these pages:

• https://unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
• https://translations.launchpad.net/+languages/tr

This PR sets the plural form calculation as it is described on these two pages. For reference, here is the [original issue](/Tatoeba/tatoeba2/issues/1866) in our project that prompted me to submit this PR.