### PR TITLE
Updated Table::setTable doc to show setting database scheme name

### DIFF
--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -73,6 +73,8 @@ class Collection
     /**
      * Get the column metadata for a table.
      *
+     * The name can include a database schema name in the form 'schema.table'.
+     *
      * Caching will be applied if `cacheMetadata` key is present in the Connection
      * configuration options. Defaults to _cake_model_ when true.
      *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -339,6 +339,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the database table name.
      *
+     * This can include the database schema name in the form 'schema.table'.
+     * If the name must be quoted, enable automatic identifier quoting.
+     *
      * @param string $table Table name.
      * @return $this
      */
@@ -351,6 +354,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
     /**
      * Returns the database table name.
+     *
+     * This can include the database schema name if set using setTable.
      *
      * @return string
      */

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -355,7 +355,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the database table name.
      *
-     * This can include the database schema name if set using setTable.
+     * This can include the database schema name if set using `setTable()`.
      *
      * @return string
      */


### PR DESCRIPTION
The database schema can already be set using the form 'schema.table' for the table name.  This mentions the feature and the format including the need to use automatic identifier quoting if the table name requires quoting.

You cannot manually quote the table name as the code in Collection::describe() doesn't currently handle it.