### PR TITLE
Updated code examples for deprecated TableRegistry::get/config

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -38,12 +38,16 @@ use Cake\ORM\Locator\LocatorInterface;
  *
  * ### Getting instances
  *
- * You can fetch instances out of the registry using get(). One instance is stored
- * per alias. Once an alias is populated the same instance will always be returned.
- * This is used to make the ORM use less memory and help make cyclic references easier
- * to solve.
+ * You can fetch instances out of the registry through the `TableLocator`.
+ * {@link TableLocator::get()}
+ * One instance is stored per alias. Once an alias is populated the same
+ * instance will always be returned. This reduces the ORM memory cost and
+ * helps make cyclic references easier to solve.
  *
  * ```
+ * $table = TableRegistry::getTableLocator()->get('Users', $config);
+ *
+ * // Prior to 3.6.0
  * $table = TableRegistry::get('Users', $config);
  * ```
  */

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -24,12 +24,15 @@ use Cake\ORM\Locator\LocatorInterface;
  *
  * ### Configuring instances
  *
- * You may need to configure your table objects, using TableRegistry you can
+ * You may need to configure your table objects. Using the `TableLocator` you can
  * centralize configuration. Any configuration set before instances are created
  * will be used when creating instances. If you modify configuration after
  * an instance is made, the instances *will not* be updated.
  *
  * ```
+ * TableRegistry::getTableLocator()->setConfig('Users', ['table' => 'my_users']);
+ *
+ * // Prior to 3.6.0
  * TableRegistry::config('Users', ['table' => 'my_users']);
  * ```
  *


### PR DESCRIPTION
This seems to be only only 2 remaining references in code.  I tweaked a couple sentences to read easier.