### PR TITLE
Avoid unnecessary inflection to generate file name for error message.

### DIFF
--- a/src/Template/Error/missing_cell_view.ctp
+++ b/src/Template/Error/missing_cell_view.ctp
@@ -20,13 +20,13 @@ $this->assign('templateName', 'missing_cell_view.ctp');
 $this->assign('title', 'Missing Cell View');
 
 $this->start('subheading');
-printf('The view for <em>%sCell</em> was not be found.', h(Inflector::camelize($name)));
+printf('The view for <em>%sCell</em> was not be found.', h($name));
 $this->end();
 
 $this->start('file');
 ?>
 <p>
-    Confirm you have created the file: "<?= h($file . $this->_ext) ?>"
+    Confirm you have created the file: "<?= h($file) ?>"
     in one of the following paths:
 </p>
 <ul>
@@ -36,7 +36,7 @@ $this->start('file');
         if (strpos($path, CORE_PATH) !== false) {
             continue;
         }
-        echo sprintf('<li>%sCell/%s/%s</li>', h($path), h($name), h($file . $this->_ext));
+        echo sprintf('<li>%sCell/%s/%s</li>', h($path), h($name), h($file));
     endforeach;
 ?>
 </ul>

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -181,12 +181,6 @@ abstract class Cell
 
             $builder = $this->viewBuilder()->setLayout(false);
 
-            if ($template !== null &&
-                strpos($template, '/') === false &&
-                strpos($template, '.') === false
-            ) {
-                $template = Inflector::underscore($template);
-            }
             if ($template !== null) {
                 $builder->setTemplate($template);
             }
@@ -204,7 +198,10 @@ abstract class Cell
             try {
                 return $this->View->render($template);
             } catch (MissingTemplateException $e) {
-                throw new MissingCellViewException(['file' => $template, 'name' => $name], null, $e);
+                $attributes = $e->getAttributes();
+                $attributes = ['file' => basename($attributes['file']), 'name' => $name];
+
+                throw new MissingCellViewException($attributes, null, $e);
             }
         };
 

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -218,12 +218,12 @@ class CellTest extends TestCase
 
         $e = null;
         try {
-            $cell->render('derp');
+            $cell->render('fooBar');
         } catch (MissingCellViewException $e) {
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('Cell view file "derp" is missing.', $e->getMessage());
+        $this->assertEquals('Cell view file "foo_bar.ctp" is missing.', $e->getMessage());
         $this->assertInstanceOf(MissingTemplateException::class, $e->getPrevious());
     }
 


### PR DESCRIPTION
The View class already handles inflecting template name and in case of error the filename can be fetched from previous exception.