### PR TITLE
Fix type error in help generation

### DIFF
--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -79,7 +79,7 @@ class ConsoleInputOption
     /**
      * Make a new Input Option
      *
-     * @param string|array $name The long name of the option, or an array with all the properties.
+     * @param string $name The long name of the option, or an array with all the properties.
      * @param string $short The short alias for this option
      * @param string $help The help text for this option
      * @param bool $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
@@ -89,7 +89,7 @@ class ConsoleInputOption
      * @throws \Cake\Console\Exception\ConsoleException
      */
     public function __construct(
-        $name,
+        string $name,
         string $short = '',
         string $help = '',
         bool $boolean = false,
@@ -97,20 +97,14 @@ class ConsoleInputOption
         array $choices = [],
         bool $multiple = false
     ) {
-        if (is_array($name) && isset($name['name'])) {
-            foreach ($name as $key => $value) {
-                $this->{'_' . $key} = $value;
-            }
-        } else {
-            /** @psalm-suppress PossiblyInvalidPropertyAssignmentValue */
-            $this->_name = $name;
-            $this->_short = $short;
-            $this->_help = $help;
-            $this->_boolean = $boolean;
-            $this->_default = $default;
-            $this->_choices = $choices;
-            $this->_multiple = $multiple;
-        }
+        $this->_name = $name;
+        $this->_short = $short;
+        $this->_help = $help;
+        $this->_boolean = $boolean;
+        $this->_default = is_bool($default) ? $default : (string)$default;
+        $this->_choices = $choices;
+        $this->_multiple = $multiple;
+
         if (strlen($this->_short) > 1) {
             throw new ConsoleException(
                 sprintf('Short option "%s" is invalid, short options must be one letter.', $this->_short)
@@ -173,7 +167,7 @@ class ConsoleInputOption
     {
         $name = strlen($this->_short) > 0 ? ('-' . $this->_short) : ('--' . $this->_name);
         $default = '';
-        if (strlen((string)$this->_default) > 0 && $this->_default !== true) {
+        if (strlen($this->_default) > 0 && $this->_default !== true) {
             $default = ' ' . $this->_default;
         }
         if ($this->_choices) {

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -173,7 +173,7 @@ class ConsoleInputOption
     {
         $name = strlen($this->_short) > 0 ? ('-' . $this->_short) : ('--' . $this->_name);
         $default = '';
-        if (strlen($this->_default) > 0 && $this->_default !== true) {
+        if (strlen((string)$this->_default) > 0 && $this->_default !== true) {
             $default = ' ' . $this->_default;
         }
         if ($this->_choices) {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -418,15 +418,23 @@ class ConsoleOptionParser
             $name = $option->name();
         } else {
             $defaults = [
-                'name' => $name,
                 'short' => '',
                 'help' => '',
                 'default' => '',
                 'boolean' => false,
+                'multiple' => false,
                 'choices' => [],
             ];
             $options += $defaults;
-            $option = new ConsoleInputOption($options);
+            $option = new ConsoleInputOption(
+                $name,
+                $options['short'],
+                $options['help'],
+                $options['boolean'],
+                $options['default'],
+                $options['choices'],
+                $options['multiple']
+            );
         }
         $this->_options[$name] = $option;
         asort($this->_options);

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -191,21 +191,28 @@ txt;
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
-            ->addOption('connection', [
-                'short' => 'c', 'help' => 'The connection to use.', 'default' => 'default',
-            ]);
+               ->addOption('number', [
+                   'help' => 'The number',
+                   'default' => 2,
+               ])
+                ->addOption('connection', [
+                    'short' => 'c',
+                    'help' => 'The connection to use.',
+                    'default' => 'default',
+                ]);
 
         $formatter = new HelpFormatter($parser);
         $result = $formatter->text();
         $expected = <<<txt
 <info>Usage:</info>
-cake mycommand [-c default] [-h] [--test]
+cake mycommand [-c default] [-h] [--number 2] [--test]
 
 <info>Options:</info>
 
 --connection, -c  The connection to use. <comment>(default:
                   default)</comment>
 --help, -h        Display this help.
+--number          The number <comment>(default: 2)</comment>
 --test            A test option.
 
 txt;


### PR DESCRIPTION
Fix type error cause by putting numbers into `strlen()`. When an optino has a default value that is an integer/float generating help should continue to work.

Fixes #13128