### PR TITLE
Use more precise bool param/return docs.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -99,7 +99,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
      * @param string $username The username/identifier.
      * @param string|null $password The password, if not provided password checking is skipped
      *   and result of find is returned.
-     * @return bool|array Either false on failure, or an array of user data.
+     * @return array|false Either false on failure, or an array of user data.
      */
     protected function _findUser(string $username, ?string $password = null)
     {

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -251,7 +251,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to add
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     abstract public function increment(string $key, int $offset = 1);
 
@@ -260,7 +260,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     abstract public function decrement(string $key, int $offset = 1);
 

--- a/src/Cache/CacheEngineInterface.php
+++ b/src/Cache/CacheEngineInterface.php
@@ -42,7 +42,7 @@ interface CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to add
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment(string $key, int $offset = 1);
 
@@ -51,7 +51,7 @@ interface CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function decrement(string $key, int $offset = 1);
 

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -92,7 +92,7 @@ class ApcuEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      * @link https://secure.php.net/manual/en/function.apcu-inc.php
      */
     public function increment(string $key, int $offset = 1)
@@ -107,7 +107,7 @@ class ApcuEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
+     * @return int|false New decremented value, false otherwise
      * @link https://secure.php.net/manual/en/function.apcu-dec.php
      */
     public function decrement(string $key, int $offset = 1)

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -90,7 +90,7 @@ class ArrayEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -108,7 +108,7 @@ class ArrayEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
+     * @return int|false New decremented value, false otherwise
      */
     public function decrement(string $key, int $offset = 1)
     {

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -369,7 +369,7 @@ class MemcachedEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -381,7 +381,7 @@ class MemcachedEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
+     * @return int|false New decremented value, false otherwise
      */
     public function decrement(string $key, int $offset = 1)
     {

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -70,7 +70,7 @@ class NullEngine extends CacheEngine
      */
     public function increment(string $key, int $offset = 1)
     {
-        return true;
+        return false;
     }
 
     /**
@@ -78,7 +78,7 @@ class NullEngine extends CacheEngine
      */
     public function decrement(string $key, int $offset = 1)
     {
-        return true;
+        return false;
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -179,7 +179,7 @@ class RedisEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -199,7 +199,7 @@ class RedisEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
+     * @return int|false New decremented value, false otherwise
      */
     public function decrement(string $key, int $offset = 1)
     {

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -94,7 +94,7 @@ class WincacheEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -108,7 +108,7 @@ class WincacheEngine extends CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
+     * @return int|false New decremented value, false otherwise
      */
     public function decrement(string $key, int $offset = 1)
     {

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -33,14 +33,14 @@ use ReflectionMethod;
 class CompletionCommand extends Command implements CommandCollectionAwareInterface
 {
     /**
-     * @var \Cake\Command\Cake\Console\CommandCollection
+     * @var \Cake\Console\CommandCollection
      */
     protected $commands;
 
     /**
      * Set the command collection used to get completion data on.
      *
-     * @param \Cake\Command\Cake\Console\CommandCollection $commands The command collection
+     * @param \Cake\Console\CommandCollection $commands The command collection
      * @return void
      */
     public function setCommandCollection(CommandCollection $commands): void
@@ -121,7 +121,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     /**
      * Get the list of defined commands.
      *
-     * @param \Cake\Command\Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
@@ -141,7 +141,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     /**
      * Get the list of defined sub-commands.
      *
-     * @param \Cake\Command\Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
@@ -217,7 +217,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     /**
      * Get the options for a command or subcommand
      *
-     * @param \Cake\Command\Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -143,7 +143,7 @@ class ConsoleIo
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     public function verbose($message, int $newlines = 1)
     {
@@ -155,7 +155,7 @@ class ConsoleIo
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     public function quiet($message, int $newlines = 1)
     {
@@ -176,7 +176,7 @@ class ConsoleIo
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     public function out($message = '', int $newlines = 1, int $level = self::NORMAL)
     {
@@ -195,7 +195,7 @@ class ConsoleIo
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::out
      */
     public function info($message = null, int $newlines = 1, int $level = self::NORMAL)
@@ -211,7 +211,7 @@ class ConsoleIo
      *
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stderr.
+     * @return int|false The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::err
      */
     public function warning($message = null, int $newlines = 1)
@@ -227,7 +227,7 @@ class ConsoleIo
      *
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stderr.
+     * @return int|false The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::err
      */
     public function error($message = null, int $newlines = 1)
@@ -244,7 +244,7 @@ class ConsoleIo
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::out
      */
     public function success($message = null, int $newlines = 1, int $level = self::NORMAL)
@@ -321,7 +321,7 @@ class ConsoleIo
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stderr.
+     * @return int|false The number of bytes returned from writing to stderr.
      */
     public function err($message = '', int $newlines = 1)
     {

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -178,7 +178,7 @@ class ConsoleOutput
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to output.
+     * @return int|false The number of bytes returned from writing to output.
      */
     public function write($message, int $newlines = 1)
     {
@@ -247,7 +247,7 @@ class ConsoleOutput
      * Writes a message to the output stream.
      *
      * @param string $message Message to write.
-     * @return int|bool The number of bytes returned from writing to output.
+     * @return int|false The number of bytes returned from writing to output.
      */
     protected function _write(string $message)
     {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -543,7 +543,7 @@ class Shell
      * Display the help in the correct format
      *
      * @param string $command The command to get help for.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     protected function _displayHelp(string $command)
     {
@@ -660,7 +660,7 @@ class Shell
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     public function verbose($message, int $newlines = 1)
     {
@@ -672,7 +672,7 @@ class Shell
      *
      * @param string|array $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      */
     public function quiet($message, int $newlines = 1)
     {
@@ -693,7 +693,7 @@ class Shell
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      * @link https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
     public function out($message = null, int $newlines = 1, int $level = Shell::NORMAL)
@@ -707,7 +707,7 @@ class Shell
      *
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stderr.
+     * @return int|true The number of bytes returned from writing to stderr.
      */
     public function err($message = null, int $newlines = 1)
     {
@@ -720,7 +720,7 @@ class Shell
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
     public function info($message = null, int $newlines = 1, int $level = Shell::NORMAL)
@@ -733,7 +733,7 @@ class Shell
      *
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return int|bool The number of bytes returned from writing to stderr.
+     * @return int|true The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
      */
     public function warn($message = null, int $newlines = 1)
@@ -747,7 +747,7 @@ class Shell
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-     * @return int|bool The number of bytes returned from writing to stdout.
+     * @return int|true The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
      */
     public function success($message = null, int $newlines = 1, int $level = Shell::NORMAL)

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -807,7 +807,7 @@ trait EntityTrait
      * true means that the instance is not yet persisted in the database, false
      * that it already is.
      *
-     * @param bool|null $new true if it is known this instance was not yet persisted
+     * @param bool|null $new True if it is known this instance was not yet persisted
      * @return bool Whether or not the entity has been persisted.
      */
     public function isNew(?bool $new = null): bool

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -383,8 +383,9 @@ trait QueryTrait
      * ```
      *
      * @param callable|null $formatter The formatting callable.
-     * @param bool|int $mode Whether or not to overwrite, append or prepend the formatter.
+     * @param int|true $mode Whether or not to overwrite, append or prepend the formatter.
      * @return $this
+     * @throws \InvalidArgumentException
      */
     public function formatResults(?callable $formatter = null, $mode = 0)
     {

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -181,7 +181,7 @@ class File
     /**
      * Sets or gets the offset for the currently opened file.
      *
-     * @param int|bool $offset The $offset in bytes to seek. If set to false then the current offset is returned.
+     * @param int|false $offset The $offset in bytes to seek. If set to false then the current offset is returned.
      * @param int $seek PHP Constant SEEK_SET | SEEK_CUR | SEEK_END determining what the $offset is relative to
      * @return int|bool True on success, false on failure (set mode), false on failure
      *   or integer offset on success (get mode).
@@ -405,7 +405,7 @@ class File
     /**
      * Get md5 Checksum of file with previous check of Filesize
      *
-     * @param int|bool $maxsize in MB or true to force
+     * @param int|true $maxsize in MB or true to force
      * @return string|false md5 Checksum {@link https://secure.php.net/md5_file See md5_file()},
      *  or false in case of an error.
      */

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -139,7 +139,7 @@ class Session
      * Get one of the prebaked default session configurations.
      *
      * @param string $name Config name.
-     * @return bool|array
+     * @return array|false
      */
     protected static function _defaultConfig(string $name)
     {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1249,7 +1249,7 @@ abstract class Association
      *
      * @param \Cake\Datasource\EntityInterface $entity the data to be saved
      * @param array $options The options for saving associated data.
-     * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
+     * @return \Cake\Datasource\EntityInterface|false false if $entity could not be saved, otherwise it returns
      * the saved entity
      * @see \Cake\ORM\Table::save()
      */

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -114,7 +114,7 @@ class BelongsTo extends Association
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
      * @param array $options options to be passed to the save method in the target table
-     * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
+     * @return \Cake\Datasource\EntityInterface|false false if $entity could not be saved, otherwise it returns
      * the saved entity
      * @see \Cake\ORM\Table::save()
      */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -676,7 +676,7 @@ class BelongsToMany extends Association
      * @param array $options list of options accepted by `Table::save()`
      * @throws \InvalidArgumentException if the property representing the association
      * in the parent entity cannot be traversed
-     * @return \Cake\Datasource\EntityInterface|bool The parent entity after all links have been
+     * @return \Cake\Datasource\EntityInterface|false The parent entity after all links have been
      * created if no errors happened, false otherwise
      */
     protected function _saveTarget(EntityInterface $parentEntity, array $entities, $options)

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -636,7 +636,7 @@ class BelongsToMany extends Association
      * @param array $options options to be passed to the save method in the target table
      * @throws \InvalidArgumentException if the property representing the association
      * in the parent entity cannot be traversed
-     * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
+     * @return \Cake\Datasource\EntityInterface|false false if $entity could not be saved, otherwise it returns
      * the saved entity
      * @see \Cake\ORM\Table::save()
      * @see \Cake\ORM\Association\BelongsToMany::replaceLinks()

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -138,7 +138,7 @@ class HasMany extends Association
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
      * @param array $options options to be passed to the save method in the target table
-     * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
+     * @return \Cake\Datasource\EntityInterface|false false if $entity could not be saved, otherwise it returns
      * the saved entity
      * @see \Cake\ORM\Table::save()
      * @throws \InvalidArgumentException when the association data cannot be traversed.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -98,7 +98,7 @@ class HasOne extends Association
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
      * @param array $options options to be passed to the save method in the target table
-     * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
+     * @return \Cake\Datasource\EntityInterface|false false if $entity could not be saved, otherwise it returns
      * the saved entity
      * @see \Cake\ORM\Table::save()
      */

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -603,7 +603,7 @@ class TreeBehavior extends Behavior
      * this method will return false
      *
      * @param \Cake\Datasource\EntityInterface $node The node to move
-     * @param int|bool $number How many places to move the node, or true to move to first position
+     * @param int|true $number How many places to move the node, or true to move to first position
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      * @return \Cake\Datasource\EntityInterface|bool $node The node after being moved or false on failure
      */
@@ -624,7 +624,7 @@ class TreeBehavior extends Behavior
      * Helper function used with the actual code for moveUp
      *
      * @param \Cake\Datasource\EntityInterface $node The node to move
-     * @param int|bool $number How many places to move the node, or true to move to first position
+     * @param int|true $number How many places to move the node, or true to move to first position
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      * @return \Cake\Datasource\EntityInterface|bool $node The node after being moved or false on failure
      */
@@ -693,7 +693,7 @@ class TreeBehavior extends Behavior
      * this method will return false
      *
      * @param \Cake\Datasource\EntityInterface $node The node to move
-     * @param int|bool $number How many places to move the node or true to move to last position
+     * @param int|true $number How many places to move the node or true to move to last position
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      * @return \Cake\Datasource\EntityInterface|bool the entity after being moved or false on failure
      */
@@ -714,7 +714,7 @@ class TreeBehavior extends Behavior
      * Helper function used with the actual code for moveDown
      *
      * @param \Cake\Datasource\EntityInterface $node The node to move
-     * @param int|bool $number How many places to move the node, or true to move to last position
+     * @param int|true $number How many places to move the node, or true to move to last position
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      * @return \Cake\Datasource\EntityInterface|bool $node The node after being moved or false on failure
      */
@@ -990,7 +990,7 @@ class TreeBehavior extends Behavior
      * Returns the depth level of a node in the tree.
      *
      * @param int|string|\Cake\Datasource\EntityInterface $entity The entity or primary key get the level of.
-     * @return int|bool Integer of the level or false if the node does not exist.
+     * @return int|false Integer of the level or false if the node does not exist.
      */
     public function getLevel($entity)
     {

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -26,7 +26,7 @@ trait LocatorAwareTrait
     /**
      * Table locator instance
      *
-     * @var \Cake\ORM\Locator\LocatorInterface
+     * @var \Cake\ORM\Locator\LocatorInterface|null
      */
     protected $_tableLocator;
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -625,7 +625,7 @@ class Validation
      * - 1..N => Exactly that many number of decimal places. The '.' is required.
      *
      * @param mixed $check The value the test for decimal.
-     * @param int|bool|null $places Decimal places.
+     * @param int|true|null $places Decimal places.
      * @param string|null $regex If a custom regular expression is used, this is the only validation that will occur.
      * @return bool Success
      */

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1164,7 +1164,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     {
         if ($when === 'create' || $when === 'update') {
             return $when === 'create' ? 'update' : 'create';
-        } elseif (is_callable($when)) {
+        }
+        if (is_callable($when)) {
             return function ($context) use ($when) {
                 return !$when($context);
             };

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1409,7 +1409,7 @@ class FormHelper extends Helper
      *
      * @param string $fieldName The name of the field to generate label for.
      * @param array $options Options list.
-     * @return bool|string false or Generated label element
+     * @return string|false Generated label element or false.
      */
     protected function _getLabel(string $fieldName, array $options)
     {

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -212,7 +212,7 @@ class JsonViewTest extends TestCase
      *
      * @param array $data
      * @param string|null $serialize
-     * @param int|bool|null $jsonOptions
+     * @param int|false|null $jsonOptions
      * @param string $expected
      * @dataProvider renderWithoutViewProvider
      * @return void


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/13212

The (stan) tooling will sure be more accurate on the accepted/returned values if we annotate the actual values to be allowed/used inside the methods.

I also hope then that we can fix the API in 5.0 here for `|false` to typehint + nullable return.