### PR TITLE
Fix up cookie get() vs has(). Fixed docblocks.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -32,9 +32,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>DigestAuthenticate</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
-      <code>empty($req)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/Auth/FormAuthenticate.php">
     <PossiblyInvalidArgument occurrences="2">
@@ -1456,9 +1453,8 @@
       <code>$end</code>
       <code>$start</code>
     </PossiblyInvalidOperand>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="1">
       <code>$weak ? 'W/' : null</code>
-      <code>$cookie</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Http/ResponseEmitter.php">
@@ -2466,16 +2462,6 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>$dataValue</code>
     </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/CookieEncryptedEquals.php">
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$cookie['value']</code>
-    </PossiblyNullArrayAccess>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/CookieEquals.php">
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$cookie['value']</code>
-    </PossiblyNullArrayAccess>
   </file>
   <file src="src/TestSuite/Constraint/Response/FileSentAs.php">
     <PossiblyNullReference occurrences="1">

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -331,10 +331,11 @@ class Response extends Message implements ResponseInterface
     {
         $this->buildCookieCollection();
 
-        $cookie = $this->cookies->get($name);
-        if ($cookie === null) {
+        if (!$this->cookies->has($name)) {
             return null;
         }
+
+        $cookie = $this->cookies->get($name);
 
         return $cookie->getValue();
     }
@@ -349,7 +350,7 @@ class Response extends Message implements ResponseInterface
     {
         $this->buildCookieCollection();
 
-        $cookie = $this->cookies->get($name);
+        $cookie = $this->getCookie($name);
         if ($cookie === null) {
             return null;
         }
@@ -401,12 +402,14 @@ class Response extends Message implements ResponseInterface
     {
         $this->buildCookieCollection();
 
-        $cookies = [];
-        foreach ($this->cookies as $cookie) {
-            $cookies[$cookie->getName()] = $this->convertCookieToArray($cookie);
+        $out = [];
+        /** @var \Cake\Http\Cookie\Cookie[] $cookies */
+        $cookies = $this->cookies;
+        foreach ($cookies as $cookie) {
+            $out[$cookie->getName()] = $this->convertCookieToArray($cookie);
         }
 
-        return $cookies;
+        return $out;
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -335,9 +335,7 @@ class Response extends Message implements ResponseInterface
             return null;
         }
 
-        $cookie = $this->cookies->get($name);
-
-        return $cookie->getValue();
+        return $this->cookies->get($name)->getValue();
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -350,10 +350,11 @@ class Response extends Message implements ResponseInterface
     {
         $this->buildCookieCollection();
 
-        $cookie = $this->getCookie($name);
-        if ($cookie === null) {
+        if (!$this->cookies->has($name)) {
             return null;
         }
+
+        $cookie = $this->cookies->get($name);
 
         return $this->convertCookieToArray($cookie);
     }

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -132,7 +132,8 @@ class CookieCollection implements IteratorAggregate, Countable
             sprintf(
                 'Cookie %s not found. Use has() to check first.',
                 $name
-        ));
+            )
+        );
     }
 
     /**

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -116,9 +116,10 @@ class CookieCollection implements IteratorAggregate, Countable
      * Get the first cookie by name.
      *
      * @param string $name The name of the cookie.
-     * @return \Cake\Http\Cookie\CookieInterface|null
+     * @return \Cake\Http\Cookie\CookieInterface
+     * @throws \InvalidArgumentException If cookie not found.
      */
-    public function get(string $name): ?CookieInterface
+    public function get(string $name): CookieInterface
     {
         $key = mb_strtolower($name);
         foreach ($this->cookies as $cookie) {
@@ -127,7 +128,11 @@ class CookieCollection implements IteratorAggregate, Countable
             }
         }
 
-        return null;
+        throw new InvalidArgumentException(
+            sprintf(
+                'Cookie %s not found. Use has() to check first.',
+                $name
+        ));
     }
 
     /**

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -130,7 +130,7 @@ class CookieCollection implements IteratorAggregate, Countable
 
         throw new InvalidArgumentException(
             sprintf(
-                'Cookie %s not found. Use has() to check first.',
+                'Cookie %s not found. Use has() to check first for existence.',
                 $name
             )
         );

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1289,7 +1289,9 @@ class Response implements ResponseInterface
     public function getCookies(): array
     {
         $out = [];
-        foreach ($this->_cookies as $cookie) {
+        /** @var \Cake\Http\Cookie\Cookie[] $cookies */
+        $cookies = $this->_cookies;
+        foreach ($cookies as $cookie) {
             $out[$cookie->getName()] = $this->convertCookieToArray($cookie);
         }
 

--- a/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
@@ -68,7 +68,7 @@ class CookieEncryptedEquals extends CookieEquals
     {
         $cookie = $this->response->getCookie($this->cookieName);
 
-        return $this->_decrypt($cookie['value'], $this->mode) === $other;
+        return $cookie !== null && $this->_decrypt($cookie['value'], $this->mode) === $other;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/CookieEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEquals.php
@@ -57,7 +57,7 @@ class CookieEquals extends ResponseBase
     {
         $cookie = $this->response->getCookie($this->cookieName);
 
-        return $cookie['value'] === $other;
+        return $cookie !== null && $cookie['value'] === $other;
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -22,6 +22,7 @@ use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use DateTime;
+use InvalidArgumentException;
 use PHPUnit\Framework\Error\Warning;
 
 /**
@@ -156,7 +157,9 @@ class CookieCollectionTest extends TestCase
 
         $this->assertNotSame($new, $collection);
         $this->assertFalse($new->has('remember_me'), 'should be removed');
-        $this->assertNull($new->get('remember_me'), 'should be removed');
+
+        $this->expectException(InvalidArgumentException::class);
+        $new->get('remember_me');
     }
 
     /**
@@ -172,7 +175,7 @@ class CookieCollectionTest extends TestCase
         ];
 
         $collection = new CookieCollection($cookies);
-        $this->assertNull($collection->get('nope'));
+        $this->assertFalse($collection->has('nope'));
         $this->assertInstanceOf(Cookie::class, $collection->get('REMEMBER_me'), 'case insensitive cookie names');
         $this->assertInstanceOf(Cookie::class, $collection->get('remember_me'));
         $this->assertSame($cookies[0], $collection->get('remember_me'));


### PR DESCRIPTION
Follows https://github.com/cakephp/cakephp/pull/13223 
and addresses the API issues around has() vs get().
Cleaner expectation for both devs and static analyzers.

This is an important follow up, as other high level code like
CookieEquals etc, that rely on the clean nullable API here, whereas
other more internal parts should use the existing has vs get pattern as designed.

I was not sure if it is worth providing orFail() wrappers for the high levels, like Response:

```
    /**
     * Read a single cookie from the response.
     *
     * This method provides read access to pending cookies. It will
     * not read the `Set-Cookie` header if set.
     *
     * @param string $name The cookie name you want to read.
     * @return array Cookie data.
     * @throws \InvalidArgumentException If cookie not found.
     */
    public function getCookieOrFail(string $name): array
    {
        $cookie = $this->getCookie($name);
        if ($cookie === null) {
            throw new InvalidArgumentException('Cookie not found: ' . $name);
        }

        return $cookie;
    }
```

As such, I left this out for now.