### PR TITLE
Fix Driver PDO creation with getenv() return values.

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -90,8 +90,8 @@ abstract class Driver implements DriverInterface
     {
         $connection = new PDO(
             $dsn,
-            $config['username'],
-            $config['password'],
+            $config['username'] ?: null,
+            $config['password'] ?: null,
             $config['flags']
         );
         $this->setConnection($connection);


### PR DESCRIPTION
Took me a while to figure that one out..

I have (and many will have) this in my plugin test bootstrap:
```php
Cake\Datasource\ConnectionManager::setConfig('test', [
	'url' => getenv('db_dsn'),
	'driver' => getenv('db_class'),
	'database' => getenv('db_database'),
	'username' => getenv('db_username'),
	'password' => getenv('db_password'),
	'timezone' => 'UTC',
	'quoteIdentifiers' => true,
	'cacheMetadata' => true,
]);
```

You get some cryptic

> Fatal error: Uncaught TypeError: PDO::__construct() expects parameter 2 to be string, bool given in /.../cakebox/Apps/sandbox.local/vendor/dereuromark/cakephp-ide-helper/vendor/cakephp/cakephp/src/Database/Driver.php on line 95

getenv() unfortunately, instead of returning null, returns false hereif not found.
As such, we should be less strict in passing this falsey value on to the PDO, by ?: it.

Otherwise this needs to be on all such getenv() calls as default value, which is less than ideal.