### PR TITLE
4.x types

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1031,7 +1031,7 @@ class Text
         if ($i !== false) {
             $size = (float)substr($size, 0, $l);
 
-            return $size * pow(1024, $i + 1);
+            return (int)($size * pow(1024, $i + 1));
         }
 
         if (substr($size, -1) === 'B' && ctype_digit(substr($size, 0, -1))) {

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -68,7 +68,7 @@ class BasicAuthenticateTest extends TestCase
             'userModel' => 'AuthUser',
             'fields' => ['username' => 'user', 'password' => 'password'],
         ]);
-        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertSame('AuthUser', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->getConfig('fields'));
     }
 

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -81,7 +81,7 @@ class DigestAuthenticateTest extends TestCase
             'fields' => ['username' => 'user', 'password' => 'pass'],
             'nonce' => 123456,
         ]);
-        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertSame('AuthUser', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'pass'], $object->getConfig('fields'));
         $this->assertEquals(123456, $object->getConfig('nonce'));
         $this->assertEquals(env('SERVER_NAME'), $object->getConfig('realm'));

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -73,7 +73,7 @@ class FormAuthenticateTest extends TestCase
             'userModel' => 'AuthUsers',
             'fields' => ['username' => 'user', 'password' => 'password'],
         ]);
-        $this->assertEquals('AuthUsers', $object->getConfig('userModel'));
+        $this->assertSame('AuthUsers', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->getConfig('fields'));
     }
 

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -40,19 +40,19 @@ class BasicsTest extends TestCase
         $two = ['one' => 'one', 'two' => 'two'];
         $result = array_diff_key($one, $two);
         $expected = ['three' => 3];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $one = ['one' => ['value', 'value-two'], 'two' => 2, 'three' => 3];
         $two = ['two' => 'two'];
         $result = array_diff_key($one, $two);
         $expected = ['one' => ['value', 'value-two'], 'three' => 3];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $one = ['one' => null, 'two' => 2, 'three' => '', 'four' => 0];
         $two = ['two' => 'two'];
         $result = array_diff_key($one, $two);
         $expected = ['one' => null, 'three' => '', 'four' => 0];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $one = ['minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true];
         $two = ['minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true];
@@ -79,13 +79,13 @@ class BasicsTest extends TestCase
         $_SERVER = $_ENV = [];
 
         $_SERVER['SCRIPT_NAME'] = '/a/test/test.php';
-        $this->assertEquals(env('SCRIPT_NAME'), '/a/test/test.php');
+        $this->assertSame(env('SCRIPT_NAME'), '/a/test/test.php');
 
         $_SERVER = $_ENV = [];
 
         $_ENV['CGI_MODE'] = 'BINARY';
         $_ENV['SCRIPT_URL'] = '/a/test/test.php';
-        $this->assertEquals(env('SCRIPT_NAME'), '/a/test/test.php');
+        $this->assertSame(env('SCRIPT_NAME'), '/a/test/test.php');
 
         $_SERVER = $_ENV = [];
 
@@ -125,13 +125,13 @@ class BasicsTest extends TestCase
         $this->assertNull(env('TEST_ME'));
 
         $_ENV['TEST_ME'] = 'a';
-        $this->assertEquals(env('TEST_ME'), 'a');
+        $this->assertSame(env('TEST_ME'), 'a');
 
         $_SERVER['TEST_ME'] = 'b';
-        $this->assertEquals(env('TEST_ME'), 'b');
+        $this->assertSame(env('TEST_ME'), 'b');
 
         unset($_ENV['TEST_ME']);
-        $this->assertEquals(env('TEST_ME'), 'b');
+        $this->assertSame(env('TEST_ME'), 'b');
 
         $_SERVER = $server;
         $_ENV = $env;
@@ -146,20 +146,20 @@ class BasicsTest extends TestCase
     {
         $string = '<foo>';
         $result = h($string);
-        $this->assertEquals('&lt;foo&gt;', $result);
+        $this->assertSame('&lt;foo&gt;', $result);
 
         $in = ['this & that', '<p>Which one</p>'];
         $result = h($in);
         $expected = ['this &amp; that', '&lt;p&gt;Which one&lt;/p&gt;'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '<foo> & &nbsp;';
         $result = h($string);
-        $this->assertEquals('&lt;foo&gt; &amp; &amp;nbsp;', $result);
+        $this->assertSame('&lt;foo&gt; &amp; &amp;nbsp;', $result);
 
         $string = '<foo> & &nbsp;';
         $result = h($string, false);
-        $this->assertEquals('&lt;foo&gt; &amp; &nbsp;', $result);
+        $this->assertSame('&lt;foo&gt; &amp; &nbsp;', $result);
 
         $string = "An invalid\x80string";
         $result = h($string);
@@ -171,7 +171,7 @@ class BasicsTest extends TestCase
             '&lt;foo&gt;',
             '&amp;nbsp;',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $arr = ['<foo>', '&nbsp;'];
         $result = h($arr, false);
@@ -179,7 +179,7 @@ class BasicsTest extends TestCase
             '&lt;foo&gt;',
             '&nbsp;',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $arr = ['f' => '<foo>', 'n' => '&nbsp;'];
         $result = h($arr, false);
@@ -187,12 +187,12 @@ class BasicsTest extends TestCase
             'f' => '&lt;foo&gt;',
             'n' => '&nbsp;',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $arr = ['invalid' => "\x99An invalid\x80string", 'good' => 'Good string'];
         $result = h($arr);
         $this->assertStringContainsString('An invalid', $result['invalid']);
-        $this->assertEquals('Good string', $result['good']);
+        $this->assertSame('Good string', $result['good']);
 
         // Test that boolean values are not converted to strings
         $result = h(false);
@@ -205,11 +205,11 @@ class BasicsTest extends TestCase
 
         $obj = new \stdClass();
         $result = h($obj);
-        $this->assertEquals('(object)stdClass', $result);
+        $this->assertSame('(object)stdClass', $result);
 
         $obj = new Response(['body' => 'Body content']);
         $result = h($obj);
-        $this->assertEquals('Body content', $result);
+        $this->assertSame('Body content', $result);
     }
 
     /**
@@ -220,7 +220,7 @@ class BasicsTest extends TestCase
     public function testDebug()
     {
         ob_start();
-        $this->assertEquals('this-is-a-test', debug('this-is-a-test', false));
+        $this->assertSame('this-is-a-test', debug('this-is-a-test', false));
         $result = ob_get_clean();
         $expectedText = <<<EXPECTED
 %s (line %d)
@@ -231,7 +231,7 @@ class BasicsTest extends TestCase
 EXPECTED;
         $expected = sprintf($expectedText, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $value = '<div>this-is-a-test</div>';
@@ -246,7 +246,7 @@ EXPECTED;
 </div>
 EXPECTED;
         $expected = sprintf($expectedHtml, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 10);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', true, true);
@@ -260,7 +260,7 @@ EXPECTED;
 </div>
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 10);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', true, false);
@@ -274,7 +274,7 @@ EXPECTED;
 </div>
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 10);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', null);
@@ -299,7 +299,7 @@ EXPECTED;
         } else {
             $expected = sprintf($expectedHtml, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 19);
         }
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', null, false);
@@ -324,7 +324,7 @@ EXPECTED;
         } else {
             $expected = sprintf($expectedHtml, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 19);
         }
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', false);
@@ -337,7 +337,7 @@ EXPECTED;
 
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', false, true);
@@ -350,7 +350,7 @@ EXPECTED;
 
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         debug('<div>this-is-a-test</div>', false, false);
@@ -363,7 +363,7 @@ EXPECTED;
 
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertFalse(debug(false, false, false));
@@ -376,7 +376,7 @@ false
 
 EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -390,43 +390,43 @@ EXPECTED;
         $this->assertTrue(pr(true));
         $result = ob_get_clean();
         $expected = "\n1\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertFalse(pr(false));
         $result = ob_get_clean();
         $expected = "\n\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertNull(pr(null));
         $result = ob_get_clean();
         $expected = "\n\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertSame(123, pr(123));
         $result = ob_get_clean();
         $expected = "\n123\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         pr('123');
         $result = ob_get_clean();
         $expected = "\n123\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         pr('this is a test');
         $result = ob_get_clean();
         $expected = "\nthis is a test\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         pr(['this' => 'is', 'a' => 'test', 123 => 456]);
         $result = ob_get_clean();
         $expected = "\nArray\n(\n    [this] => is\n    [a] => test\n    [123] => 456\n)\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -440,44 +440,44 @@ EXPECTED;
         $this->assertTrue(pj(true));
         $result = ob_get_clean();
         $expected = "\ntrue\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertFalse(pj(false));
         $result = ob_get_clean();
         $expected = "\nfalse\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertNull(pj(null));
         $result = ob_get_clean();
         $expected = "\nnull\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $this->assertSame(123, pj(123));
         $result = ob_get_clean();
         $expected = "\n123\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         pj('123');
         $result = ob_get_clean();
         $expected = "\n\"123\"\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         pj('this is a test');
         $result = ob_get_clean();
         $expected = "\n\"this is a test\"\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $value = ['this' => 'is', 'a' => 'test', 123 => 456];
         $this->assertSame($value, pj($value));
         $result = ob_get_clean();
         $expected = "\n{\n    \"this\": \"is\",\n    \"a\": \"test\",\n    \"123\": 456\n}\n\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -488,25 +488,25 @@ EXPECTED;
     public function testPluginSplit()
     {
         $result = pluginSplit('Something.else');
-        $this->assertEquals(['Something', 'else'], $result);
+        $this->assertSame(['Something', 'else'], $result);
 
         $result = pluginSplit('Something.else.more.dots');
-        $this->assertEquals(['Something', 'else.more.dots'], $result);
+        $this->assertSame(['Something', 'else.more.dots'], $result);
 
         $result = pluginSplit('Somethingelse');
-        $this->assertEquals([null, 'Somethingelse'], $result);
+        $this->assertSame([null, 'Somethingelse'], $result);
 
         $result = pluginSplit('Something.else', true);
-        $this->assertEquals(['Something.', 'else'], $result);
+        $this->assertSame(['Something.', 'else'], $result);
 
         $result = pluginSplit('Something.else.more.dots', true);
-        $this->assertEquals(['Something.', 'else.more.dots'], $result);
+        $this->assertSame(['Something.', 'else.more.dots'], $result);
 
         $result = pluginSplit('Post', false, 'Blog');
-        $this->assertEquals(['Blog', 'Post'], $result);
+        $this->assertSame(['Blog', 'Post'], $result);
 
         $result = pluginSplit('Blog.Post', false, 'Ultimate');
-        $this->assertEquals(['Blog', 'Post'], $result);
+        $this->assertSame(['Blog', 'Post'], $result);
     }
 
     /**
@@ -517,16 +517,16 @@ EXPECTED;
     public function testNamespaceSplit()
     {
         $result = namespaceSplit('Something');
-        $this->assertEquals(['', 'Something'], $result);
+        $this->assertSame(['', 'Something'], $result);
 
         $result = namespaceSplit('\Something');
-        $this->assertEquals(['', 'Something'], $result);
+        $this->assertSame(['', 'Something'], $result);
 
         $result = namespaceSplit('Cake\Something');
-        $this->assertEquals(['Cake', 'Something'], $result);
+        $this->assertSame(['Cake', 'Something'], $result);
 
         $result = namespaceSplit('Cake\Test\Something');
-        $this->assertEquals(['Cake\Test', 'Something'], $result);
+        $this->assertSame(['Cake\Test', 'Something'], $result);
     }
 
     /**
@@ -539,13 +539,13 @@ EXPECTED;
         ob_start();
         [$r, $expected] = [stackTrace(), \Cake\Error\Debugger::trace()];
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $opts = ['args' => true];
         ob_start();
         [$r, $expected] = [stackTrace($opts), \Cake\Error\Debugger::trace($opts)];
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -140,7 +140,7 @@ class ApcuEngineTest extends TestCase
         sleep(1);
 
         $result = Cache::read('zero', 'apcu');
-        $this->assertEquals('Should save', $result);
+        $this->assertSame('Should save', $result);
     }
 
     /**
@@ -278,7 +278,7 @@ class ApcuEngineTest extends TestCase
         $result = Cache::clear('apcu');
         $this->assertTrue($result);
         $this->assertNull(Cache::read('some_value', 'apcu'));
-        $this->assertEquals('survive', apcu_fetch('not_cake'));
+        $this->assertSame('survive', apcu_fetch('not_cake'));
         apcu_delete('not_cake');
     }
 
@@ -299,17 +299,17 @@ class ApcuEngineTest extends TestCase
             'warnOnWriteFailures' => true,
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'apcu_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'apcu_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'apcu_groups'));
 
         apcu_inc('test_group_a');
         $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'apcu_groups'));
-        $this->assertEquals('value2', Cache::read('test_groups', 'apcu_groups'));
+        $this->assertSame('value2', Cache::read('test_groups', 'apcu_groups'));
 
         apcu_inc('test_group_b');
         $this->assertNull(Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'apcu_groups'));
-        $this->assertEquals('value3', Cache::read('test_groups', 'apcu_groups'));
+        $this->assertSame('value3', Cache::read('test_groups', 'apcu_groups'));
     }
 
     /**
@@ -327,7 +327,7 @@ class ApcuEngineTest extends TestCase
             'warnOnWriteFailures' => true,
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'apcu_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'apcu_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'apcu_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'apcu_groups'));
 
         $this->assertNull(Cache::read('test_groups', 'apcu_groups'));

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -205,17 +205,17 @@ class ArrayEngineTest extends TestCase
             'warnOnWriteFailures' => true,
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'array_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'array_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'array_groups'));
 
         Cache::clearGroup('group_a', 'array_groups');
         $this->assertNull(Cache::read('test_groups', 'array_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'array_groups'));
-        $this->assertEquals('value2', Cache::read('test_groups', 'array_groups'));
+        $this->assertSame('value2', Cache::read('test_groups', 'array_groups'));
 
         Cache::clearGroup('group_b', 'array_groups');
         $this->assertNull(Cache::read('test_groups', 'array_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'array_groups'));
-        $this->assertEquals('value3', Cache::read('test_groups', 'array_groups'));
+        $this->assertSame('value3', Cache::read('test_groups', 'array_groups'));
     }
 
     /**
@@ -233,7 +233,7 @@ class ArrayEngineTest extends TestCase
             'warnOnWriteFailures' => true,
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'array_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'array_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'array_groups'));
 
         $this->assertTrue(Cache::delete('test_groups', 'array_groups'));
         $this->assertNull(Cache::read('test_groups', 'array_groups'));

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -138,8 +138,8 @@ class FileEngineTest extends TestCase
         $resultB = Cache::read('rw', 'file_test');
 
         Cache::delete('rw', 'file_test');
-        $this->assertEquals('first write', $result);
-        $this->assertEquals('second write', $resultB);
+        $this->assertSame('first write', $result);
+        $this->assertSame('second write', $resultB);
     }
 
     /**
@@ -338,7 +338,7 @@ class FileEngineTest extends TestCase
         $this->assertFileExists(TMP . 'tests/cake_views.countries.something');
 
         $result = Cache::read('views.countries.something', 'file_test');
-        $this->assertEquals('here', $result);
+        $this->assertSame('here', $result);
 
         $result = Cache::clear('file_test');
         $this->assertTrue($result);
@@ -548,7 +548,7 @@ class FileEngineTest extends TestCase
             'groups' => ['group_a', 'group_b'],
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'file_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'file_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'file_groups'));
 
         $this->assertTrue(Cache::write('test_groups2', 'value2', 'file_groups'));
         $this->assertTrue(Cache::write('test_groups3', 'value3', 'file_groups'));
@@ -567,19 +567,19 @@ class FileEngineTest extends TestCase
         ]);
 
         $this->assertTrue(Cache::write('user', 'rchavik', 'repeat'));
-        $this->assertEquals('rchavik', Cache::read('user', 'repeat'));
+        $this->assertSame('rchavik', Cache::read('user', 'repeat'));
 
         Cache::delete('user', 'repeat');
         $this->assertNull(Cache::read('user', 'repeat'));
 
         $this->assertTrue(Cache::write('user', 'ADmad', 'repeat'));
-        $this->assertEquals('ADmad', Cache::read('user', 'repeat'));
+        $this->assertSame('ADmad', Cache::read('user', 'repeat'));
 
         Cache::clearGroup('users', 'repeat');
         $this->assertNull(Cache::read('user', 'repeat'));
 
         $this->assertTrue(Cache::write('user', 'markstory', 'repeat'));
-        $this->assertEquals('markstory', Cache::read('user', 'repeat'));
+        $this->assertSame('markstory', Cache::read('user', 'repeat'));
 
         Cache::drop('repeat');
     }
@@ -597,7 +597,7 @@ class FileEngineTest extends TestCase
             'groups' => ['group_a', 'group_b'],
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'file_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'file_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'file_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'file_groups'));
 
         $this->assertNull(Cache::read('test_groups', 'file_groups'));
@@ -634,7 +634,7 @@ class FileEngineTest extends TestCase
         $this->assertTrue(Cache::clearGroup('group_b', 'file_groups'));
         $this->assertNull(Cache::read('test_groups', 'file_groups'));
         $this->assertNull(Cache::read('test_groups2', 'file_groups2'));
-        $this->assertEquals('value 3', Cache::read('test_groups3', 'file_groups3'));
+        $this->assertSame('value 3', Cache::read('test_groups3', 'file_groups3'));
 
         $this->assertTrue(Cache::write('test_groups4', 'value', 'file_groups'));
         $this->assertTrue(Cache::write('test_groups5', 'value 2', 'file_groups2'));
@@ -643,7 +643,7 @@ class FileEngineTest extends TestCase
         $this->assertTrue(Cache::clearGroup('group_b', 'file_groups'));
         $this->assertNull(Cache::read('test_groups4', 'file_groups'));
         $this->assertNull(Cache::read('test_groups5', 'file_groups2'));
-        $this->assertEquals('value 3', Cache::read('test_groups6', 'file_groups3'));
+        $this->assertSame('value 3', Cache::read('test_groups6', 'file_groups3'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -811,11 +811,11 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue(Cache::write('duration_test', 'yay', 'long_memcached'));
         $this->assertTrue(Cache::write('short_duration_test', 'boo', 'short_memcached'));
 
-        $this->assertEquals('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
-        $this->assertEquals('boo', Cache::read('short_duration_test', 'short_memcached'), 'Value was not read %s');
+        $this->assertSame('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
+        $this->assertSame('boo', Cache::read('short_duration_test', 'short_memcached'), 'Value was not read %s');
 
         usleep(500000);
-        $this->assertEquals('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
+        $this->assertSame('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
 
         usleep(3000000);
         $this->assertNull(Cache::read('short_duration_test', 'short_memcached'), 'Cache was not invalidated %s');
@@ -844,7 +844,7 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue(Cache::clear('memcached'));
 
         $this->assertNull(Cache::read('some_value', 'memcached'));
-        $this->assertEquals('cache2', Cache::read('some_value', 'memcached2'));
+        $this->assertSame('cache2', Cache::read('some_value', 'memcached2'));
 
         Cache::clear('memcached2');
     }
@@ -861,7 +861,7 @@ class MemcachedEngineTest extends TestCase
 
         $this->assertTrue($result);
         $result = Cache::read('test_key', 'memcached');
-        $this->assertEquals('written!', $result);
+        $this->assertSame('written!', $result);
     }
 
     /**
@@ -885,17 +885,17 @@ class MemcachedEngineTest extends TestCase
             'prefix' => 'test_',
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'memcached_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'memcached_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'memcached_groups'));
 
         Cache::increment('group_a', 1, 'memcached_helper');
         $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'memcached_groups'));
-        $this->assertEquals('value2', Cache::read('test_groups', 'memcached_groups'));
+        $this->assertSame('value2', Cache::read('test_groups', 'memcached_groups'));
 
         Cache::increment('group_b', 1, 'memcached_helper');
         $this->assertNull(Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'memcached_groups'));
-        $this->assertEquals('value3', Cache::read('test_groups', 'memcached_groups'));
+        $this->assertSame('value3', Cache::read('test_groups', 'memcached_groups'));
     }
 
     /**
@@ -911,7 +911,7 @@ class MemcachedEngineTest extends TestCase
             'groups' => ['group_a', 'group_b'],
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'memcached_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'memcached_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'memcached_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'memcached_groups'));
 
         $this->assertNull(Cache::read('test_groups', 'memcached_groups'));

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -451,7 +451,7 @@ class RedisEngineTest extends TestCase
         $result = Cache::clear('redis');
         $this->assertTrue($result);
         $this->assertNull(Cache::read('some_value', 'redis'));
-        $this->assertEquals('cache2', Cache::read('some_value', 'redis2'));
+        $this->assertSame('cache2', Cache::read('some_value', 'redis2'));
 
         Cache::clear('redis2');
     }
@@ -468,7 +468,7 @@ class RedisEngineTest extends TestCase
 
         $this->assertTrue($result);
         $result = Cache::read('test_key', 'redis');
-        $this->assertEquals('written!', $result);
+        $this->assertSame('written!', $result);
     }
 
     /**
@@ -492,17 +492,17 @@ class RedisEngineTest extends TestCase
             'prefix' => 'test_',
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'redis_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'redis_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'redis_groups'));
 
         Cache::increment('group_a', 1, 'redis_helper');
         $this->assertNull(Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'redis_groups'));
-        $this->assertEquals('value2', Cache::read('test_groups', 'redis_groups'));
+        $this->assertSame('value2', Cache::read('test_groups', 'redis_groups'));
 
         Cache::increment('group_b', 1, 'redis_helper');
         $this->assertNull(Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'redis_groups'));
-        $this->assertEquals('value3', Cache::read('test_groups', 'redis_groups'));
+        $this->assertSame('value3', Cache::read('test_groups', 'redis_groups'));
     }
 
     /**
@@ -518,7 +518,7 @@ class RedisEngineTest extends TestCase
             'groups' => ['group_a', 'group_b'],
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'redis_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'redis_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'redis_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'redis_groups'));
 
         $this->assertNull(Cache::read('test_groups', 'redis_groups'));

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -243,7 +243,7 @@ class WincacheEngineTest extends TestCase
         $result = Cache::clear('wincache');
         $this->assertTrue($result);
         $this->assertNull(Cache::read('some_value', 'wincache'));
-        $this->assertEquals('safe', wincache_ucache_get('not_cake'));
+        $this->assertSame('safe', wincache_ucache_get('not_cake'));
     }
 
     /**
@@ -262,17 +262,17 @@ class WincacheEngineTest extends TestCase
             'prefix' => 'test_',
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'wincache_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'wincache_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'wincache_groups'));
 
         wincache_ucache_inc('test_group_a');
         $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'wincache_groups'));
-        $this->assertEquals('value2', Cache::read('test_groups', 'wincache_groups'));
+        $this->assertSame('value2', Cache::read('test_groups', 'wincache_groups'));
 
         wincache_ucache_inc('test_group_b');
         $this->assertNull(Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'wincache_groups'));
-        $this->assertEquals('value3', Cache::read('test_groups', 'wincache_groups'));
+        $this->assertSame('value3', Cache::read('test_groups', 'wincache_groups'));
     }
 
     /**
@@ -289,7 +289,7 @@ class WincacheEngineTest extends TestCase
             'prefix' => 'test_',
         ]);
         $this->assertTrue(Cache::write('test_groups', 'value', 'wincache_groups'));
-        $this->assertEquals('value', Cache::read('test_groups', 'wincache_groups'));
+        $this->assertSame('value', Cache::read('test_groups', 'wincache_groups'));
         $this->assertTrue(Cache::delete('test_groups', 'wincache_groups'));
 
         $this->assertNull(Cache::read('test_groups', 'wincache_groups'));

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2065,7 +2065,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $date = $collection->first();
         $this->assertInstanceOf('DateTime', $date);
-        $this->assertEquals('2017-01-01', $date->format('Y-m-d'));
+        $this->assertSame('2017-01-01', $date->format('Y-m-d'));
     }
 
     /**
@@ -2139,7 +2139,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $date = $collection->last();
         $this->assertInstanceOf('DateTime', $date);
-        $this->assertEquals('2017-01-06', $date->format('Y-m-d'));
+        $this->assertSame('2017-01-06', $date->format('Y-m-d'));
     }
 
     /**

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -125,7 +125,7 @@ class CacheCommandsTest extends ConsoleIntegrationTestCase
         $this->exec('cache clear _cake_core_');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
-        $this->assertEquals('value', Cache::read('key', 'test'));
+        $this->assertSame('value', Cache::read('key', 'test'));
     }
 
     /**

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -316,9 +316,9 @@ class CommandCollectionTest extends TestCase
             $result,
             'Duplicate shell was given a full alias'
         );
-        $this->assertEquals('TestPlugin\Shell\ExampleShell', $result['example']);
+        $this->assertSame('TestPlugin\Shell\ExampleShell', $result['example']);
         $this->assertEquals($result['example'], $result['test_plugin.example']);
-        $this->assertEquals('TestPlugin\Shell\SampleShell', $result['test_plugin.sample']);
+        $this->assertSame('TestPlugin\Shell\SampleShell', $result['test_plugin.sample']);
 
         $result = $collection->discoverPlugin('Company/TestPluginThree');
         $this->assertArrayHasKey(

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -91,7 +91,7 @@ class ConsoleIoTest extends TestCase
             ->will($this->returnValue('y'));
 
         $result = $this->io->askChoice('Just a test?', $choices);
-        $this->assertEquals('y', $result);
+        $this->assertSame('y', $result);
     }
 
     /**
@@ -107,7 +107,7 @@ class ConsoleIoTest extends TestCase
             ->will($this->returnValue('Y'));
 
         $result = $this->io->askChoice('Just a test?', $choices);
-        $this->assertEquals('Y', $result);
+        $this->assertSame('Y', $result);
     }
 
     /**
@@ -126,7 +126,7 @@ class ConsoleIoTest extends TestCase
             ->will($this->returnValue('y'));
 
         $result = $this->io->ask('Just a test?');
-        $this->assertEquals('y', $result);
+        $this->assertSame('y', $result);
     }
 
     /**
@@ -145,7 +145,7 @@ class ConsoleIoTest extends TestCase
             ->will($this->returnValue(''));
 
         $result = $this->io->ask('Just a test?', 'n');
-        $this->assertEquals('n', $result);
+        $this->assertSame('n', $result);
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -38,7 +38,7 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->setDescription('A test');
 
         $this->assertEquals($parser, $result, 'Setting description is not chainable');
-        $this->assertEquals('A test', $parser->getDescription(), 'getting value is wrong.');
+        $this->assertSame('A test', $parser->getDescription(), 'getting value is wrong.');
 
         $result = $parser->setDescription(['A test', 'something']);
         $this->assertEquals("A test\nsomething", $parser->getDescription(), 'getting value is wrong.');
@@ -55,7 +55,7 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->setEpilog('A test');
 
         $this->assertEquals($parser, $result, 'Setting epilog is not chainable');
-        $this->assertEquals('A test', $parser->getEpilog(), 'getting value is wrong.');
+        $this->assertSame('A test', $parser->getEpilog(), 'getting value is wrong.');
 
         $result = $parser->setEpilog(['A test', 'something']);
         $this->assertEquals("A test\nsomething", $parser->getEpilog(), 'getting value is wrong.');
@@ -451,7 +451,7 @@ class ConsoleOptionParserTest extends TestCase
         $parser->addArgument(new ConsoleInputArgument('test'));
         $result = $parser->arguments();
         $this->assertCount(1, $result);
-        $this->assertEquals('test', $result[0]->name());
+        $this->assertSame('test', $result[0]->name());
     }
 
     /**
@@ -468,9 +468,9 @@ class ConsoleOptionParserTest extends TestCase
 
         $result = $parser->arguments();
         $this->assertCount(3, $result);
-        $this->assertEquals('other', $result[0]->name());
-        $this->assertEquals('name', $result[1]->name());
-        $this->assertEquals('bag', $result[2]->name());
+        $this->assertSame('other', $result[0]->name());
+        $this->assertSame('name', $result[1]->name());
+        $this->assertSame('bag', $result[2]->name());
         $this->assertSame([0, 1, 2], array_keys($result));
         $this->assertEquals(
             ['other', 'name', 'bag'],
@@ -639,7 +639,7 @@ class ConsoleOptionParserTest extends TestCase
         ])->addArgument('name', ['required' => false]);
 
         $result = $parser->parse(['build']);
-        $this->assertEquals('default', $result[0]['connection']);
+        $this->assertSame('default', $result[0]['connection']);
 
         $result = $parser->subcommands();
         $this->assertArrayHasKey('build', $result);
@@ -657,7 +657,7 @@ class ConsoleOptionParserTest extends TestCase
         $parser->addSubcommand(new ConsoleInputSubcommand('test'));
         $result = $parser->subcommands();
         $this->assertCount(1, $result);
-        $this->assertEquals('test', $result['test']->name());
+        $this->assertSame('test', $result['test']->name());
     }
 
     /**
@@ -666,15 +666,15 @@ class ConsoleOptionParserTest extends TestCase
     public function testAddSubcommandSort()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $this->assertEquals(true, $parser->isSubcommandSortEnabled());
+        $this->assertTrue($parser->isSubcommandSortEnabled());
         $parser->enableSubcommandSort(false);
-        $this->assertEquals(false, $parser->isSubcommandSortEnabled());
+        $this->assertFalse($parser->isSubcommandSortEnabled());
         $parser->addSubcommand(new ConsoleInputSubcommand('betaTest'), []);
         $parser->addSubcommand(new ConsoleInputSubcommand('alphaTest'), []);
         $result = $parser->subcommands();
         $this->assertCount(2, $result);
         $firstResult = key($result);
-        $this->assertEquals('betaTest', $firstResult);
+        $this->assertSame('betaTest', $firstResult);
     }
 
     /**
@@ -994,7 +994,7 @@ TEXT;
     {
         $parser = ConsoleOptionParser::create('factory', false);
         $this->assertInstanceOf('Cake\Console\ConsoleOptionParser', $parser);
-        $this->assertEquals('factory', $parser->getCommand());
+        $this->assertSame('factory', $parser->getCommand());
     }
 
     /**
@@ -1005,7 +1005,7 @@ TEXT;
     public function testCommandInflection()
     {
         $parser = new ConsoleOptionParser('CommandLine');
-        $this->assertEquals('command_line', $parser->getCommand());
+        $this->assertSame('command_line', $parser->getCommand());
     }
 
     /**

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -91,7 +91,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadWithConfig()
     {
         $result = $this->helpers->load('Simple', ['key' => 'value']);
-        $this->assertEquals('value', $result->getConfig('key'));
+        $this->assertSame('value', $result->getConfig('key'));
     }
 
     /**

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -87,8 +87,8 @@ class ShellDispatcherTest extends TestCase
 
         $result = $this->dispatcher->findShell('test_plugin.example');
         $this->assertInstanceOf('TestPlugin\Shell\ExampleShell', $result);
-        $this->assertEquals('TestPlugin', $result->plugin);
-        $this->assertEquals('Example', $result->name);
+        $this->assertSame('TestPlugin', $result->plugin);
+        $this->assertSame('Example', $result->name);
 
         $result = $this->dispatcher->findShell('TestPlugin.example');
         $this->assertInstanceOf('TestPlugin\Shell\ExampleShell', $result);
@@ -131,8 +131,8 @@ class ShellDispatcherTest extends TestCase
 
         $result = $this->dispatcher->findShell('short');
         $this->assertInstanceOf('TestPlugin\Shell\ExampleShell', $result);
-        $this->assertEquals('TestPlugin', $result->plugin);
-        $this->assertEquals('Example', $result->name);
+        $this->assertSame('TestPlugin', $result->plugin);
+        $this->assertSame('Example', $result->name);
     }
 
     /**
@@ -149,7 +149,7 @@ class ShellDispatcherTest extends TestCase
         $result = $this->dispatcher->findShell('sample');
         $this->assertInstanceOf('TestApp\Shell\SampleShell', $result);
         $this->assertEmpty($result->plugin);
-        $this->assertEquals('Sample', $result->name);
+        $this->assertSame('Sample', $result->name);
     }
 
     /**
@@ -403,19 +403,19 @@ class ShellDispatcherTest extends TestCase
     public function testShiftArgs()
     {
         $this->dispatcher->args = ['a', 'b', 'c'];
-        $this->assertEquals('a', $this->dispatcher->shiftArgs());
+        $this->assertSame('a', $this->dispatcher->shiftArgs());
         $this->assertSame($this->dispatcher->args, ['b', 'c']);
 
         $this->dispatcher->args = ['a' => 'b', 'c', 'd'];
-        $this->assertEquals('b', $this->dispatcher->shiftArgs());
+        $this->assertSame('b', $this->dispatcher->shiftArgs());
         $this->assertSame($this->dispatcher->args, ['c', 'd']);
 
         $this->dispatcher->args = ['a', 'b' => 'c', 'd'];
-        $this->assertEquals('a', $this->dispatcher->shiftArgs());
+        $this->assertSame('a', $this->dispatcher->shiftArgs());
         $this->assertSame($this->dispatcher->args, ['b' => 'c', 'd']);
 
         $this->dispatcher->args = [0 => 'a', 2 => 'b', 30 => 'c'];
-        $this->assertEquals('a', $this->dispatcher->shiftArgs());
+        $this->assertSame('a', $this->dispatcher->shiftArgs());
         $this->assertSame($this->dispatcher->args, [0 => 'b', 1 => 'c']);
 
         $this->dispatcher->args = [];

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -90,7 +90,7 @@ class ShellTest extends TestCase
      */
     public function testConstruct()
     {
-        $this->assertEquals('ShellTestShell', $this->Shell->name);
+        $this->assertSame('ShellTestShell', $this->Shell->name);
         $this->assertInstanceOf(ConsoleIo::class, $this->Shell->getIo());
     }
 
@@ -132,7 +132,7 @@ class ShellTest extends TestCase
             'TestApp\Model\Table\ArticlesTable',
             $Shell->Articles
         );
-        $this->assertEquals('Articles', $Shell->modelClass);
+        $this->assertSame('Articles', $Shell->modelClass);
 
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Shell->loadModel('TestPlugin.TestPluginComments');
@@ -165,10 +165,10 @@ class ShellTest extends TestCase
             ->will($this->returnValue('n'));
 
         $result = $this->Shell->in('Just a test?', ['y', 'n'], 'n');
-        $this->assertEquals('n', $result);
+        $this->assertSame('n', $result);
 
         $result = $this->Shell->in('Just a test?', null, 'n');
-        $this->assertEquals('n', $result);
+        $this->assertSame('n', $result);
     }
 
     /**
@@ -186,7 +186,7 @@ class ShellTest extends TestCase
         $this->Shell->interactive = false;
 
         $result = $this->Shell->in('Just a test?', 'y/n', 'n');
-        $this->assertEquals('n', $result);
+        $this->assertSame('n', $result);
     }
 
     /**
@@ -722,7 +722,7 @@ class ShellTest extends TestCase
             ->will($this->returnValue(true));
         $result = $shell->runCommand(['cakes', '--verbose']);
         $this->assertTrue($result);
-        $this->assertEquals('main', $shell->command);
+        $this->assertSame('main', $shell->command);
     }
 
     /**
@@ -745,7 +745,7 @@ class ShellTest extends TestCase
             ->will($this->returnValue(true));
         $result = $shell->runCommand(['hit_me', 'cakes', '--verbose'], true);
         $this->assertTrue($result);
-        $this->assertEquals('hit_me', $shell->command);
+        $this->assertSame('hit_me', $shell->command);
     }
 
     /**
@@ -1346,7 +1346,7 @@ TEXT;
         $this->Shell->plugin = 'plugin';
         $parser = $this->Shell->getOptionParser();
 
-        $this->assertEquals('plugin.test', $parser->getCommand());
+        $this->assertSame('plugin.test', $parser->getCommand());
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -375,7 +375,7 @@ class AuthComponentTest extends TestCase
         ]);
         $objects = array_values($this->Controller->Auth->constructAuthorize());
         $result = $objects[0];
-        $this->assertEquals('controllers/', $result->getConfig('actionPath'));
+        $this->assertSame('controllers/', $result->getConfig('actionPath'));
     }
 
     /**
@@ -406,7 +406,7 @@ class AuthComponentTest extends TestCase
         ]);
         $objects = array_values($this->Controller->Auth->constructAuthenticate());
         $result = $objects[0];
-        $this->assertEquals('AuthUsers', $result->getConfig('userModel'));
+        $this->assertSame('AuthUsers', $result->getConfig('userModel'));
     }
 
     /**
@@ -1245,7 +1245,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->startup($event);
 
         $result = $this->Auth->user();
-        $this->assertEquals('mariano', $result['username']);
+        $this->assertSame('mariano', $result['username']);
 
         $this->assertInstanceOf(
             'Cake\Auth\BasicAuthenticate',
@@ -1253,7 +1253,7 @@ class AuthComponentTest extends TestCase
         );
 
         $result = $this->Auth->user('username');
-        $this->assertEquals('mariano', $result);
+        $this->assertSame('mariano', $result);
         $this->assertFalse(isset($_SESSION['Auth']), 'No user data in session');
     }
 
@@ -1294,7 +1294,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->setConfig('logoutRedirect', '/');
         $result = $this->Auth->logout();
 
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
         $this->assertNull($this->Auth->getController()->getRequest()->getSession()->read('Auth.AuthUsers'));
     }
 
@@ -1358,7 +1358,7 @@ class AuthComponentTest extends TestCase
         });
 
         $this->Auth->startup($event);
-        $this->assertEquals('mariano', $this->Auth->user('username'));
+        $this->assertSame('mariano', $this->Auth->user('username'));
         $this->assertTrue($this->Auth->user('from_callback'));
     }
 
@@ -1454,7 +1454,7 @@ class AuthComponentTest extends TestCase
     {
         $value = ['controller' => 'users', 'action' => 'home'];
         $result = $this->Auth->redirectUrl($value);
-        $this->assertEquals('/users/home', $result);
+        $this->assertSame('/users/home', $result);
     }
 
     /**
@@ -1468,7 +1468,7 @@ class AuthComponentTest extends TestCase
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => '/users/custom']));
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/users/custom', $result);
+        $this->assertSame('/users/custom', $result);
     }
 
     /**
@@ -1486,7 +1486,7 @@ class AuthComponentTest extends TestCase
         Router::setRequestInfo($this->Controller->getRequest());
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/waves/add', $result);
+        $this->assertSame('/waves/add', $result);
     }
 
     /**
@@ -1504,7 +1504,7 @@ class AuthComponentTest extends TestCase
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => '/users/login']));
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/users/home', $result);
+        $this->assertSame('/users/home', $result);
     }
 
     /**
@@ -1522,12 +1522,12 @@ class AuthComponentTest extends TestCase
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => 'http://some.domain.example/users/login']));
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/users/home', $result);
+        $this->assertSame('/users/home', $result);
 
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => '//some.domain.example/users/login']));
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/users/home', $result);
+        $this->assertSame('/users/home', $result);
     }
 
     /**
@@ -1557,7 +1557,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->setConfig('loginRedirect', ['controller' => 'users', 'action' => 'home']);
 
         $result = $this->Auth->redirectUrl();
-        $this->assertEquals('/users/home', $result);
+        $this->assertSame('/users/home', $result);
 
         Configure::write('App', $App);
         Router::reload();
@@ -1650,11 +1650,11 @@ class AuthComponentTest extends TestCase
      */
     public function testSessionKeyBC(): void
     {
-        $this->assertEquals('Auth.User', $this->Auth->sessionKey);
+        $this->assertSame('Auth.User', $this->Auth->sessionKey);
 
         $this->Auth->sessionKey = 'Auth.Member';
-        $this->assertEquals('Auth.Member', $this->Auth->sessionKey);
-        $this->assertEquals('Auth.Member', $this->Auth->storage()->getConfig('key'));
+        $this->assertSame('Auth.Member', $this->Auth->sessionKey);
+        $this->assertSame('Auth.Member', $this->Auth->storage()->getConfig('key'));
 
         $this->Auth->sessionKey = false;
         $this->assertInstanceOf('Cake\Auth\Storage\MemoryStorage', $this->Auth->storage());
@@ -1673,11 +1673,11 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->authCheckCalledFrom = null;
         $this->Controller->startupProcess();
-        $this->assertEquals('Controller.startup', $this->Auth->authCheckCalledFrom);
+        $this->assertSame('Controller.startup', $this->Auth->authCheckCalledFrom);
 
         $this->Auth->authCheckCalledFrom = null;
         $this->Auth->setConfig('checkAuthIn', 'Controller.initialize');
         $this->Controller->startupProcess();
-        $this->assertEquals('Controller.initialize', $this->Auth->authCheckCalledFrom);
+        $this->assertSame('Controller.initialize', $this->Auth->authCheckCalledFrom);
     }
 }

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -270,7 +270,7 @@ class PaginatorComponentTest extends TestCase
             ->will($this->returnValue($query));
 
         $this->Paginator->paginate($table, $settings);
-        $this->assertEquals('popular', $this->controller->getRequest()->getParam('paging.PaginatorPosts.finder'));
+        $this->assertSame('popular', $this->controller->getRequest()->getParam('paging.PaginatorPosts.finder'));
     }
 
     /**
@@ -365,8 +365,8 @@ class PaginatorComponentTest extends TestCase
             ]);
 
         $this->Paginator->paginate($table, $settings);
-        $this->assertEquals('PaginatorPosts.id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sortDefault'));
-        $this->assertEquals('DESC', $this->controller->getRequest()->getParam('paging.PaginatorPosts.directionDefault'));
+        $this->assertSame('PaginatorPosts.id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sortDefault'));
+        $this->assertSame('DESC', $this->controller->getRequest()->getParam('paging.PaginatorPosts.directionDefault'));
     }
 
     /**
@@ -680,8 +680,8 @@ class PaginatorComponentTest extends TestCase
             'direction' => 'herp',
         ]));
         $this->Paginator->paginate($table);
-        $this->assertEquals('id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sort'));
-        $this->assertEquals('asc', $this->controller->getRequest()->getParam('paging.PaginatorPosts.direction'));
+        $this->assertSame('id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sort'));
+        $this->assertSame('asc', $this->controller->getRequest()->getParam('paging.PaginatorPosts.direction'));
     }
 
     /**
@@ -702,7 +702,7 @@ class PaginatorComponentTest extends TestCase
         $options = ['sort' => 'something', 'direction' => 'boogers'];
         $result = $this->Paginator->validateSort($model, $options);
 
-        $this->assertEquals('asc', $result['order']['model.something']);
+        $this->assertSame('asc', $result['order']['model.something']);
     }
 
     /**
@@ -1315,8 +1315,8 @@ class PaginatorComponentTest extends TestCase
 
         $result = $results->toArray();
         $this->assertCount(2, $result);
-        $this->assertEquals('First Post', $result[0]->title);
-        $this->assertEquals('Third Post', $result[1]->title);
+        $this->assertSame('First Post', $result[0]->title);
+        $this->assertSame('Third Post', $result[1]->title);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -138,7 +138,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->assertNull($this->RequestHandler->ext);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'rss'));
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('rss', $this->RequestHandler->ext);
+        $this->assertSame('rss', $this->RequestHandler->ext);
     }
 
     /**
@@ -153,7 +153,7 @@ class RequestHandlerComponentTest extends TestCase
 
         $this->RequestHandler->setExt(null);
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('json', $this->RequestHandler->getExt());
+        $this->assertSame('json', $this->RequestHandler->getExt());
     }
 
     /**
@@ -171,7 +171,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::extensions('json', false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('json', $this->RequestHandler->ext);
+        $this->assertSame('json', $this->RequestHandler->ext);
     }
 
     /**
@@ -202,7 +202,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::extensions(['rss', 'json'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('json', $this->RequestHandler->ext);
+        $this->assertSame('json', $this->RequestHandler->ext);
     }
 
     /**
@@ -238,13 +238,13 @@ class RequestHandlerComponentTest extends TestCase
         Router::extensions(['xml', 'json'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('xml', $this->RequestHandler->ext);
+        $this->assertSame('xml', $this->RequestHandler->ext);
 
         $this->RequestHandler->setExt(null);
         Router::extensions(['json', 'xml'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('json', $this->RequestHandler->ext);
+        $this->assertSame('json', $this->RequestHandler->ext);
     }
 
     /**
@@ -262,7 +262,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->setExt(null);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        $this->assertEquals('json', $this->RequestHandler->ext);
+        $this->assertSame('json', $this->RequestHandler->ext);
     }
 
     /**
@@ -350,7 +350,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $this->RequestHandler->renderAs($this->Controller, 'json');
-        $this->assertEquals('TestApp\View\CustomJsonView', $this->Controller->viewBuilder()->getClassName());
+        $this->assertSame('TestApp\View\CustomJsonView', $this->Controller->viewBuilder()->getClassName());
     }
 
     /**
@@ -384,7 +384,7 @@ class RequestHandlerComponentTest extends TestCase
 
         $view = $this->Controller->createView();
         $this->assertInstanceOf(AjaxView::class, $view);
-        $this->assertEquals('ajax', $view->getLayout());
+        $this->assertSame('ajax', $view->getLayout());
 
         $this->_init();
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'js'));
@@ -416,7 +416,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender(new Event('Controller.beforeRender', $this->Controller));
 
         $this->assertEquals($extension, $this->RequestHandler->ext);
-        $this->assertEquals('text/html', $this->Controller->getResponse()->getType());
+        $this->assertSame('text/html', $this->Controller->getResponse()->getType());
 
         $view = $this->Controller->createView();
         $this->assertInstanceOf(AppView::class, $view);
@@ -443,13 +443,13 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->RequestHandler->beforeRender(new Event('Controller.beforeRender', $this->Controller));
 
-        $this->assertEquals('xml', $this->RequestHandler->ext);
-        $this->assertEquals('application/xml', $this->Controller->getResponse()->getType());
+        $this->assertSame('xml', $this->RequestHandler->ext);
+        $this->assertSame('application/xml', $this->Controller->getResponse()->getType());
 
         $view = $this->Controller->createView();
         $this->assertInstanceOf(XmlView::class, $view);
-        $this->assertEquals('xml', $view->getLayoutPath());
-        $this->assertEquals('xml', $view->getSubDir());
+        $this->assertSame('xml', $view->getLayoutPath());
+        $this->assertSame('xml', $view->getSubDir());
     }
 
     /**
@@ -468,8 +468,8 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $view = $this->Controller->createView();
         $this->assertInstanceOf(JsonView::class, $view);
-        $this->assertEquals('json', $view->getLayoutPath());
-        $this->assertEquals('json', $view->getSubDir());
+        $this->assertSame('json', $view->getLayoutPath());
+        $this->assertSame('json', $view->getSubDir());
     }
 
     /**
@@ -488,8 +488,8 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $view = $this->Controller->createView();
         $this->assertInstanceOf(XmlView::class, $view);
-        $this->assertEquals('xml', $view->getLayoutPath());
-        $this->assertEquals('xml', $view->getSubDir());
+        $this->assertSame('xml', $view->getLayoutPath());
+        $this->assertSame('xml', $view->getSubDir());
     }
 
     /**
@@ -508,7 +508,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->beforeRender($event);
         $view = $this->Controller->createView();
         $this->assertInstanceOf(AjaxView::class, $view);
-        $this->assertEquals('ajax', $view->getLayout());
+        $this->assertSame('ajax', $view->getLayout());
     }
 
     /**
@@ -527,8 +527,8 @@ class RequestHandlerComponentTest extends TestCase
             return $this->Controller->getResponse();
         });
         $this->Controller->render();
-        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->getTemplatePath());
-        $this->assertEquals('csv', $this->Controller->viewBuilder()->getLayoutPath());
+        $this->assertSame('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('csv', $this->Controller->viewBuilder()->getLayoutPath());
     }
 
     /**
@@ -549,7 +549,7 @@ class RequestHandlerComponentTest extends TestCase
             return $this->Controller->getResponse();
         });
         $this->Controller->render();
-        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -786,7 +786,7 @@ XML;
 
         $this->Controller->viewBuilder()->setTemplatePath('request_handler_test\\rss');
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('request_handler_test' . DS . 'js', $this->Controller->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -800,8 +800,8 @@ XML;
 
         $this->RequestHandler->renderAs($this->Controller, 'xml', ['attachment' => 'myfile.xml']);
         $this->assertEquals(XmlView::class, $this->Controller->viewBuilder()->getClassName());
-        $this->assertEquals('application/xml', $this->Controller->getResponse()->getType());
-        $this->assertEquals('UTF-8', $this->Controller->getResponse()->getCharset());
+        $this->assertSame('application/xml', $this->Controller->getResponse()->getType());
+        $this->assertSame('UTF-8', $this->Controller->getResponse()->getCharset());
         $this->assertStringContainsString('myfile.xml', $this->Controller->getResponse()->getHeaderLine('Content-Disposition'));
     }
 
@@ -814,11 +814,11 @@ XML;
     {
         $result = $this->RequestHandler->respondAs('json');
         $this->assertTrue($result);
-        $this->assertEquals('application/json', $this->Controller->getResponse()->getType());
+        $this->assertSame('application/json', $this->Controller->getResponse()->getType());
 
         $result = $this->RequestHandler->respondAs('text/xml');
         $this->assertTrue($result);
-        $this->assertEquals('text/xml', $this->Controller->getResponse()->getType());
+        $this->assertSame('text/xml', $this->Controller->getResponse()->getType());
     }
 
     /**
@@ -849,12 +849,12 @@ XML;
         $this->Controller->render();
 
         $this->RequestHandler->renderAs($this->Controller, 'print');
-        $this->assertEquals('RequestHandlerTest' . DS . 'print', $this->Controller->viewBuilder()->getTemplatePath());
-        $this->assertEquals('print', $this->Controller->viewBuilder()->getLayoutPath());
+        $this->assertSame('RequestHandlerTest' . DS . 'print', $this->Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('print', $this->Controller->viewBuilder()->getLayoutPath());
 
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('RequestHandlerTest' . DS . 'js', $this->Controller->viewBuilder()->getTemplatePath());
-        $this->assertEquals('js', $this->Controller->viewBuilder()->getLayoutPath());
+        $this->assertSame('RequestHandlerTest' . DS . 'js', $this->Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('js', $this->Controller->viewBuilder()->getLayoutPath());
     }
 
     /**
@@ -869,10 +869,10 @@ XML;
 
         $this->Controller->setRequest($this->request->withEnv('REQUEST_METHOD', 'POST')
             ->withEnv('CONTENT_TYPE', 'application/json'));
-        $this->assertEquals('json', $this->RequestHandler->requestedWith());
+        $this->assertSame('json', $this->RequestHandler->requestedWith());
 
         $result = $this->RequestHandler->requestedWith(['json', 'xml']);
-        $this->assertEquals('json', $result);
+        $this->assertSame('json', $result);
 
         $result = $this->RequestHandler->requestedWith(['rss', 'atom']);
         $this->assertFalse($result);
@@ -880,18 +880,18 @@ XML;
         $this->Controller->setRequest($this->request
             ->withEnv('REQUEST_METHOD', 'PATCH')
             ->withEnv('CONTENT_TYPE', 'application/json'));
-        $this->assertEquals('json', $this->RequestHandler->requestedWith());
+        $this->assertSame('json', $this->RequestHandler->requestedWith());
 
         $this->Controller->setRequest($this->request
             ->withEnv('REQUEST_METHOD', 'DELETE')
             ->withEnv('CONTENT_TYPE', 'application/json'));
-        $this->assertEquals('json', $this->RequestHandler->requestedWith());
+        $this->assertSame('json', $this->RequestHandler->requestedWith());
 
         $this->Controller->setRequest($this->request
             ->withEnv('REQUEST_METHOD', 'POST')
             ->withEnv('CONTENT_TYPE', 'application/json'));
         $result = $this->RequestHandler->requestedWith(['json', 'xml']);
-        $this->assertEquals('json', $result);
+        $this->assertSame('json', $result);
 
         $result = $this->RequestHandler->requestedWith(['rss', 'atom']);
         $this->assertFalse($result);
@@ -927,13 +927,13 @@ XML;
     public function testMapAlias(): void
     {
         $result = $this->RequestHandler->mapAlias('xml');
-        $this->assertEquals('application/xml', $result);
+        $this->assertSame('application/xml', $result);
 
         $result = $this->RequestHandler->mapAlias('text/html');
         $this->assertNull($result);
 
         $result = $this->RequestHandler->mapAlias('wap');
-        $this->assertEquals('text/vnd.wap.wml', $result);
+        $this->assertSame('text/vnd.wap.wml', $result);
 
         $result = $this->RequestHandler->mapAlias(['xml', 'js', 'json']);
         $expected = ['application/xml', 'application/javascript', 'application/json'];
@@ -972,11 +972,11 @@ XML;
         $this->assertNotEquals('rss', $this->RequestHandler->prefers());
 
         $this->RequestHandler->setExt('rss');
-        $this->assertEquals('rss', $this->RequestHandler->prefers());
+        $this->assertSame('rss', $this->RequestHandler->prefers());
         $this->assertFalse($this->RequestHandler->prefers('xml'));
-        $this->assertEquals('xml', $this->RequestHandler->prefers(['js', 'xml', 'xhtml']));
+        $this->assertSame('xml', $this->RequestHandler->prefers(['js', 'xml', 'xhtml']));
         $this->assertFalse($this->RequestHandler->prefers(['red', 'blue']));
-        $this->assertEquals('xhtml', $this->RequestHandler->prefers(['js', 'json', 'xhtml']));
+        $this->assertSame('xhtml', $this->RequestHandler->prefers(['js', 'json', 'xhtml']));
         $this->assertTrue($this->RequestHandler->prefers(['rss']), 'Should return true if input matches ext.');
         $this->assertFalse($this->RequestHandler->prefers(['html']), 'No match with ext, return false.');
 
@@ -985,10 +985,10 @@ XML;
             'Accept',
             'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5'
         ));
-        $this->assertEquals('xml', $this->RequestHandler->prefers());
+        $this->assertSame('xml', $this->RequestHandler->prefers());
 
         $this->Controller->setRequest($this->request->withHeader('Accept', '*/*;q=0.5'));
-        $this->assertEquals('html', $this->RequestHandler->prefers());
+        $this->assertSame('html', $this->RequestHandler->prefers());
         $this->assertFalse($this->RequestHandler->prefers('rss'));
 
         $this->Controller->setRequest($this->request->withEnv('HTTP_ACCEPT', ''));
@@ -1016,7 +1016,7 @@ XML;
         $this->assertNull($requestHandler->beforeRender($event));
         $this->assertTrue($event->isStopped());
         $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
-        $this->assertEquals('', (string)$this->Controller->getResponse()->getBody());
+        $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-Type'), 'header should not be removed.');
     }
 
@@ -1041,7 +1041,7 @@ XML;
         $this->assertNull($requestHandler->beforeRender($event));
         $this->assertTrue($event->isStopped());
         $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
-        $this->assertEquals('', (string)$this->Controller->getResponse()->getBody());
+        $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-Type'));
     }
 
@@ -1070,7 +1070,7 @@ XML;
         $this->assertTrue($event->isStopped());
 
         $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
-        $this->assertEquals('', (string)$this->Controller->getResponse()->getBody());
+        $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-type'));
     }
 
@@ -1149,7 +1149,7 @@ XML;
         $this->Controller->set_response_type();
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
-        $this->assertEquals('text/plain', $this->Controller->getResponse()->getType());
+        $this->assertSame('text/plain', $this->Controller->getResponse()->getType());
     }
 
     /**
@@ -1164,6 +1164,6 @@ XML;
 
         $event = new Event('Controller.beforeRender', $this->Controller);
         $this->RequestHandler->beforeRender($event);
-        $this->assertEquals('text/csv', $this->Controller->getResponse()->getType());
+        $this->assertSame('text/csv', $this->Controller->getResponse()->getType());
     }
 }

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -1424,8 +1424,8 @@ class SecurityComponentTest extends TestCase
             $message = $ex->getMessage();
             $reason = $ex->getReason();
         }
-        $this->assertEquals('The request has been black-holed', $message);
-        $this->assertEquals('error description', $reason);
+        $this->assertSame('The request has been black-holed', $message);
+        $this->assertSame('error description', $reason);
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -992,7 +992,7 @@ class ControllerTest extends TestCase
     public function testPlugin(): void
     {
         $controller = new PostsController();
-        $this->assertSame('', $controller->getPlugin());
+        $this->assertNull($controller->getPlugin());
 
         $this->assertSame($controller, $controller->setPlugin('Articles'));
         $this->assertSame('Articles', $controller->getPlugin());

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -280,7 +280,7 @@ class ControllerTest extends TestCase
         $debug = Configure::read('debug');
         Configure::write('debug', false);
         $result = $Controller->render('index');
-        $this->assertEquals('{"test":"value"}', (string)$result->getBody());
+        $this->assertSame('{"test":"value"}', (string)$result->getBody());
         Configure::write('debug', $debug);
     }
 
@@ -333,7 +333,7 @@ class ControllerTest extends TestCase
         $response = $Controller->redirect('http://cakephp.org', (int)$code);
         $this->assertSame($response, $Controller->getResponse());
         $this->assertEquals($code, $response->getStatusCode());
-        $this->assertEquals('http://cakephp.org', $response->getHeaderLine('Location'));
+        $this->assertSame('http://cakephp.org', $response->getHeaderLine('Location'));
         $this->assertFalse($Controller->isAutoRenderEnabled());
     }
 
@@ -352,7 +352,7 @@ class ControllerTest extends TestCase
         });
 
         $response = $Controller->redirect('http://cakephp.org', 301);
-        $this->assertEquals('https://book.cakephp.org', $response->getHeaderLine('Location'));
+        $this->assertSame('https://book.cakephp.org', $response->getHeaderLine('Location'));
         $this->assertEquals(301, $response->getStatusCode());
     }
 
@@ -373,7 +373,7 @@ class ControllerTest extends TestCase
 
         $response = $Controller->redirect('http://cakephp.org', 301);
 
-        $this->assertEquals('http://cakephp.org', $response->getHeaderLine('Location'));
+        $this->assertSame('http://cakephp.org', $response->getHeaderLine('Location'));
         $this->assertEquals(302, $response->getStatusCode());
     }
 
@@ -410,7 +410,7 @@ class ControllerTest extends TestCase
 
         $Controller = new Controller($request);
         $result = $Controller->referer();
-        $this->assertEquals('/posts/index', $result);
+        $this->assertSame('/posts/index', $result);
 
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')
             ->setMethods(['referer'])
@@ -420,7 +420,7 @@ class ControllerTest extends TestCase
             ->will($this->returnValue('/posts/index'));
         $Controller = new Controller($request);
         $result = $Controller->referer(['controller' => 'posts', 'action' => 'index'], true);
-        $this->assertEquals('/posts/index', $result);
+        $this->assertSame('/posts/index', $result);
 
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')
             ->setMethods(['referer'])
@@ -432,11 +432,11 @@ class ControllerTest extends TestCase
 
         $Controller = new Controller($request);
         $result = $Controller->referer(null, false);
-        $this->assertEquals('http://localhost/posts/index', $result);
+        $this->assertSame('http://localhost/posts/index', $result);
 
         $Controller = new Controller(null);
         $result = $Controller->referer('/', false);
-        $this->assertEquals('http://localhost/', $result);
+        $this->assertSame('http://localhost/', $result);
     }
 
     /**
@@ -460,11 +460,11 @@ class ControllerTest extends TestCase
 
         $controller = new Controller($request);
         $result = $controller->referer('/', true);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $controller = new Controller($request);
         $result = $controller->referer('/some/path', true);
-        $this->assertEquals('/some/path', $result);
+        $this->assertSame('/some/path', $result);
     }
 
     /**
@@ -727,8 +727,8 @@ class ControllerTest extends TestCase
         $Controller = new TestController($url, $response);
         $result = $Controller->invokeAction();
 
-        $this->assertEquals('I am from the controller.', (string)$result);
-        $this->assertEquals('I am from the controller.', (string)$Controller->getResponse());
+        $this->assertSame('I am from the controller.', (string)$result);
+        $this->assertSame('I am from the controller.', (string)$Controller->getResponse());
     }
 
     /**
@@ -773,7 +773,7 @@ class ControllerTest extends TestCase
             return $e->getSubject()->getResponse();
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('Admin' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
 
         $request = $request->withParam('prefix', 'admin/super');
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
@@ -782,7 +782,7 @@ class ControllerTest extends TestCase
             return $e->getSubject()->getResponse();
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
 
         $request = new ServerRequest([
             'url' => 'pages/home',
@@ -795,7 +795,7 @@ class ControllerTest extends TestCase
             return $e->getSubject()->getResponse();
         });
         $Controller->render();
-        $this->assertEquals('Pages', $Controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('Pages', $Controller->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -978,10 +978,10 @@ class ControllerTest extends TestCase
     public function testName(): void
     {
         $controller = new PostsController();
-        $this->assertEquals('Posts', $controller->getName());
+        $this->assertSame('Posts', $controller->getName());
 
         $this->assertSame($controller, $controller->setName('Articles'));
-        $this->assertEquals('Articles', $controller->getName());
+        $this->assertSame('Articles', $controller->getName());
     }
 
     /**
@@ -992,10 +992,10 @@ class ControllerTest extends TestCase
     public function testPlugin(): void
     {
         $controller = new PostsController();
-        $this->assertEquals('', $controller->getPlugin());
+        $this->assertSame('', $controller->getPlugin());
 
         $this->assertSame($controller, $controller->setPlugin('Articles'));
-        $this->assertEquals('Articles', $controller->getPlugin());
+        $this->assertSame('Articles', $controller->getPlugin());
     }
 
     /**
@@ -1020,7 +1020,7 @@ class ControllerTest extends TestCase
         $this->assertSame($controller, $controller->setRequest($request));
         $this->assertSame($request, $controller->getRequest());
 
-        $this->assertEquals('Posts', $controller->getRequest()->getParam('plugin'));
+        $this->assertSame('Posts', $controller->getRequest()->getParam('plugin'));
         $this->assertEquals(['foo', 'bar'], $controller->getRequest()->getParam('pass'));
     }
 

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -67,7 +67,7 @@ class IniConfigTest extends TestCase
 
         $this->assertArrayHasKey('admin', $config);
         $this->assertTrue(isset($config['paul']['groups']));
-        $this->assertEquals('ads', $config['admin']['deny']);
+        $this->assertSame('ads', $config['admin']['deny']);
     }
 
     /**
@@ -96,7 +96,7 @@ class IniConfigTest extends TestCase
         $config = $engine->read('acl');
 
         $this->assertArrayHasKey('groups', $config);
-        $this->assertEquals('administrators', $config['groups']);
+        $this->assertSame('administrators', $config['groups']);
     }
 
     /**
@@ -127,7 +127,7 @@ class IniConfigTest extends TestCase
         $config = $engine->read('nested');
 
         $this->assertTrue(isset($config['database']['db']['username']));
-        $this->assertEquals('mark', $config['database']['db']['username']);
+        $this->assertSame('mark', $config['database']['db']['username']);
         $this->assertEquals(3, $config['nesting']['one']['two']['three']);
         $this->assertFalse(isset($config['database.db.username']));
         $this->assertFalse(isset($config['database']['db.username']));
@@ -215,12 +215,12 @@ class IniConfigTest extends TestCase
         $result = $engine->read('TestPlugin.nested');
 
         $this->assertTrue(isset($result['database']['db']['username']));
-        $this->assertEquals('bar', $result['database']['db']['username']);
+        $this->assertSame('bar', $result['database']['db']['username']);
         $this->assertFalse(isset($result['database.db.username']));
         $this->assertFalse(isset($result['database']['db.username']));
 
         $result = $engine->read('TestPlugin.nested');
-        $this->assertEquals('foo', $result['database']['db']['password']);
+        $this->assertSame('foo', $result['database']['db']['password']);
         $this->clearPlugins();
     }
 

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -64,8 +64,8 @@ class JsonConfigTest extends TestCase
     {
         $engine = new JsonConfig($this->path);
         $values = $engine->read('json_test');
-        $this->assertEquals('value', $values['Json']);
-        $this->assertEquals('buried', $values['Deep']['Deeper']['Deepest']);
+        $this->assertSame('value', $values['Json']);
+        $this->assertSame('buried', $values['Deep']['Deeper']['Deepest']);
     }
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -64,8 +64,8 @@ class PhpConfigTest extends TestCase
     {
         $engine = new PhpConfig($this->path);
         $values = $engine->read('var_test');
-        $this->assertEquals('value', $values['Read']);
-        $this->assertEquals('buried', $values['Deep']['Deeper']['Deepest']);
+        $this->assertSame('value', $values['Read']);
+        $this->assertSame('buried', $values['Deep']['Deeper']['Deepest']);
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -106,7 +106,7 @@ class ConfigureTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Configure::read('level1.level2.level3_2');
-        $this->assertEquals('something_else', $result);
+        $this->assertSame('something_else', $result);
 
         $result = Configure::read('debug');
         $this->assertGreaterThanOrEqual(0, $result);
@@ -137,7 +137,7 @@ class ConfigureTest extends TestCase
     {
         $this->assertTrue(Configure::write('SomeName.someKey', 'myvalue'));
         $result = Configure::read('SomeName.someKey');
-        $this->assertEquals('myvalue', $result);
+        $this->assertSame('myvalue', $result);
 
         $this->assertTrue(Configure::write('SomeName.someKey', null));
         $result = Configure::read('SomeName.someKey');
@@ -156,11 +156,11 @@ class ConfigureTest extends TestCase
         $this->assertEquals($expected['One']['Two'], $result);
 
         $result = Configure::read('Key.One.Two.Three.Four.Five');
-        $this->assertEquals('cool', $result);
+        $this->assertSame('cool', $result);
 
         Configure::write('one.two.three.four', '4');
         $result = Configure::read('one.two.three.four');
-        $this->assertEquals('4', $result);
+        $this->assertSame('4', $result);
     }
 
     /**
@@ -176,7 +176,7 @@ class ConfigureTest extends TestCase
         );
         Configure::write('debug', false);
         $result = ini_get('display_errors');
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
 
         Configure::write('debug', true);
         $result = ini_get('display_errors');
@@ -192,7 +192,7 @@ class ConfigureTest extends TestCase
     {
         Configure::write('SomeName.someKey', 'myvalue');
         $result = Configure::read('SomeName.someKey');
-        $this->assertEquals('myvalue', $result);
+        $this->assertSame('myvalue', $result);
 
         Configure::delete('SomeName.someKey');
         $result = Configure::read('SomeName.someKey');
@@ -201,10 +201,10 @@ class ConfigureTest extends TestCase
         Configure::write('SomeName', ['someKey' => 'myvalue', 'otherKey' => 'otherValue']);
 
         $result = Configure::read('SomeName.someKey');
-        $this->assertEquals('myvalue', $result);
+        $this->assertSame('myvalue', $result);
 
         $result = Configure::read('SomeName.otherKey');
-        $this->assertEquals('otherValue', $result);
+        $this->assertSame('otherValue', $result);
 
         Configure::delete('SomeName');
 
@@ -312,16 +312,16 @@ class ConfigureTest extends TestCase
         $result = Configure::load('var_test', 'test');
         $this->assertTrue($result);
 
-        $this->assertEquals('value', Configure::read('Read'));
+        $this->assertSame('value', Configure::read('Read'));
 
         $result = Configure::load('var_test2', 'test', true);
         $this->assertTrue($result);
 
-        $this->assertEquals('value2', Configure::read('Read'));
-        $this->assertEquals('buried2', Configure::read('Deep.Second.SecondDeepest'));
-        $this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'));
-        $this->assertEquals('Overwrite', Configure::read('TestAcl.classname'));
-        $this->assertEquals('one', Configure::read('TestAcl.custom'));
+        $this->assertSame('value2', Configure::read('Read'));
+        $this->assertSame('buried2', Configure::read('Deep.Second.SecondDeepest'));
+        $this->assertSame('buried', Configure::read('Deep.Deeper.Deepest'));
+        $this->assertSame('Overwrite', Configure::read('TestAcl.classname'));
+        $this->assertSame('one', Configure::read('TestAcl.custom'));
     }
 
     /**
@@ -336,13 +336,13 @@ class ConfigureTest extends TestCase
         $result = Configure::load('var_test', 'test');
         $this->assertTrue($result);
 
-        $this->assertEquals('value', Configure::read('Read'));
+        $this->assertSame('value', Configure::read('Read'));
 
         $result = Configure::load('var_test2', 'test', false);
         $this->assertTrue($result);
 
-        $this->assertEquals('value2', Configure::read('Read'));
-        $this->assertEquals('buried2', Configure::read('Deep.Second.SecondDeepest'));
+        $this->assertSame('value2', Configure::read('Read'));
+        $this->assertSame('buried2', Configure::read('Deep.Second.SecondDeepest'));
         $this->assertNull(Configure::read('Deep.Deeper.Deepest'));
     }
 
@@ -357,8 +357,8 @@ class ConfigureTest extends TestCase
         Configure::write('my_key', 'value');
 
         Configure::load('var_test', 'test');
-        $this->assertEquals('value', Configure::read('my_key'), 'Should not overwrite existing data.');
-        $this->assertEquals('value', Configure::read('Read'), 'Should load new data.');
+        $this->assertSame('value', Configure::read('my_key'), 'Should not overwrite existing data.');
+        $this->assertSame('value', Configure::read('Read'), 'Should load new data.');
     }
 
     /**
@@ -375,11 +375,11 @@ class ConfigureTest extends TestCase
         Configure::write('TestAcl.classname', 'old');
 
         Configure::load('var_test', 'test', true);
-        $this->assertEquals('value', Configure::read('Read'), 'Should load new data.');
-        $this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'), 'Should load new data');
-        $this->assertEquals('old', Configure::read('Deep.old'), 'Should not destroy old data.');
-        $this->assertEquals('value', Configure::read('my_key'), 'Should not destroy data.');
-        $this->assertEquals('Original', Configure::read('TestAcl.classname'), 'No arrays');
+        $this->assertSame('value', Configure::read('Read'), 'Should load new data.');
+        $this->assertSame('buried', Configure::read('Deep.Deeper.Deepest'), 'Should load new data');
+        $this->assertSame('old', Configure::read('Deep.old'), 'Should not destroy old data.');
+        $this->assertSame('value', Configure::read('my_key'), 'Should not destroy data.');
+        $this->assertSame('Original', Configure::read('TestAcl.classname'), 'No arrays');
     }
 
     /**
@@ -425,7 +425,7 @@ class ConfigureTest extends TestCase
         $this->assertNull(Configure::read('Testing'));
 
         Configure::restore('store_test', 'configure');
-        $this->assertEquals('yummy', Configure::read('Testing'));
+        $this->assertSame('yummy', Configure::read('Testing'));
 
         Cache::delete('store_test', 'configure');
         Cache::drop('configure');
@@ -450,7 +450,7 @@ class ConfigureTest extends TestCase
         $this->assertNull(Configure::read('store_test'), 'Calling store with data shouldn\'t modify runtime.');
 
         Configure::restore('store_test', 'configure');
-        $this->assertEquals('one', Configure::read('store_test'));
+        $this->assertSame('one', Configure::read('store_test'));
         $this->assertNull(Configure::read('testing'), 'Values that were not stored are not restored.');
 
         Cache::delete('store_test', 'configure');
@@ -563,10 +563,10 @@ class ConfigureTest extends TestCase
         Configure::write('Test', ['key' => 'value', 'key2' => 'value2']);
 
         $result = Configure::consume('Test.key');
-        $this->assertEquals('value', $result);
+        $this->assertSame('value', $result);
 
         $result = Configure::read('Test.key2');
-        $this->assertEquals('value2', $result, 'Other values should remain.');
+        $this->assertSame('value2', $result, 'Other values should remain.');
 
         $result = Configure::consume('Test');
         $expected = ['key2' => 'value2'];

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -176,11 +176,11 @@ class ConfigureTest extends TestCase
         );
         Configure::write('debug', false);
         $result = ini_get('display_errors');
-        $this->assertSame(0, $result);
+        $this->assertSame('0', $result);
 
         Configure::write('debug', true);
         $result = ini_get('display_errors');
-        $this->assertEquals(1, $result);
+        $this->assertEquals('1', $result);
     }
 
     /**

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -33,19 +33,19 @@ class FunctionsTest extends TestCase
     {
         $_ENV['DOES_NOT_EXIST'] = null;
         $this->assertNull(env('DOES_NOT_EXIST'));
-        $this->assertEquals('default', env('DOES_NOT_EXIST', 'default'));
+        $this->assertSame('default', env('DOES_NOT_EXIST', 'default'));
 
         $_ENV['DOES_EXIST'] = 'some value';
-        $this->assertEquals('some value', env('DOES_EXIST'));
-        $this->assertEquals('some value', env('DOES_EXIST', 'default'));
+        $this->assertSame('some value', env('DOES_EXIST'));
+        $this->assertSame('some value', env('DOES_EXIST', 'default'));
 
         $_ENV['EMPTY_VALUE'] = '';
-        $this->assertEquals('', env('EMPTY_VALUE'));
-        $this->assertEquals('', env('EMPTY_VALUE', 'default'));
+        $this->assertSame('', env('EMPTY_VALUE'));
+        $this->assertSame('', env('EMPTY_VALUE', 'default'));
 
         $_ENV['ZERO'] = '0';
-        $this->assertEquals('0', env('ZERO'));
-        $this->assertEquals('0', env('ZERO', '1'));
+        $this->assertSame('0', env('ZERO'));
+        $this->assertSame('0', env('ZERO', '1'));
     }
 
     /**
@@ -146,8 +146,8 @@ class FunctionsTest extends TestCase
      */
     public function testgetTypeName()
     {
-        $this->assertEquals('stdClass', getTypeName(new \stdClass()));
-        $this->assertEquals('array', getTypeName([]));
-        $this->assertEquals('string', getTypeName(''));
+        $this->assertSame('stdClass', getTypeName(new \stdClass()));
+        $this->assertSame('array', getTypeName([]));
+        $this->assertSame('string', getTypeName(''));
     }
 }

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -170,7 +170,7 @@ PHP;
         $path = $plugins->findPath('TestPlugin');
         unlink($configPath);
 
-        $this->assertEquals('/config/path', $path);
+        $this->assertSame('/config/path', $path);
     }
 
     public function testFindPathConfigureData()
@@ -179,7 +179,7 @@ PHP;
         $plugins = new PluginCollection();
         $path = $plugins->findPath('TestPlugin');
 
-        $this->assertEquals('/some/path', $path);
+        $this->assertSame('/some/path', $path);
     }
 
     public function testFindPathMissingPlugin()

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -365,18 +365,18 @@ class ConnectionTest extends TestCase
 
         $result = $this->connection->execute('SELECT title, body  FROM things');
         $row = $result->fetch('assoc');
-        $this->assertEquals('a title', $row['title']);
-        $this->assertEquals('a body', $row['body']);
+        $this->assertSame('a title', $row['title']);
+        $this->assertSame('a body', $row['body']);
 
         $row = $result->fetch('assoc');
         $result->closeCursor();
-        $this->assertEquals('another title', $row['title']);
-        $this->assertEquals('another body', $row['body']);
+        $this->assertSame('another title', $row['title']);
+        $this->assertSame('another body', $row['body']);
 
         $result->execute();
         $row = $result->fetch('assoc');
         $result->closeCursor();
-        $this->assertEquals('a title', $row['title']);
+        $this->assertSame('a title', $row['title']);
     }
 
     /**
@@ -389,8 +389,8 @@ class ConnectionTest extends TestCase
     {
         $result = $this->connection->execute('SELECT title, body  FROM things');
         $row = $result->fetch(\PDO::FETCH_OBJ);
-        $this->assertEquals('a title', $row->title);
-        $this->assertEquals('a body', $row->body);
+        $this->assertSame('a title', $row->title);
+        $this->assertSame('a body', $row->body);
     }
 
     /**
@@ -452,9 +452,9 @@ class ConnectionTest extends TestCase
         $result = $this->connection->execute('SELECT * FROM things WHERE title = :title AND body = :body', $values, ['body' => 'date']);
         $this->assertCount(2, $result);
         $row = $result->fetch('assoc');
-        $this->assertEquals('2012-01-01', $row['body']);
+        $this->assertSame('2012-01-01', $row['body']);
         $row = $result->fetch('assoc');
-        $this->assertEquals('2012-01-01', $row['body']);
+        $this->assertSame('2012-01-01', $row['body']);
         $result->closeCursor();
     }
 
@@ -472,7 +472,7 @@ class ConnectionTest extends TestCase
         $result = $this->connection->execute('SELECT * FROM things WHERE title = :title AND body = :body', $values, ['body' => 'date']);
         $this->assertCount(1, $result);
         $row = $result->fetch('assoc');
-        $this->assertEquals('2012-01-01', $row['body']);
+        $this->assertSame('2012-01-01', $row['body']);
         $result->closeCursor();
     }
 
@@ -1035,7 +1035,7 @@ class ConnectionTest extends TestCase
 
             return 'thing';
         });
-        $this->assertEquals('thing', $result);
+        $this->assertSame('thing', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -163,7 +163,7 @@ class PostgresTest extends TestCase
             ->values([1, 'foo']);
         $translator = $driver->queryTranslator('insert');
         $query = $translator($query);
-        $this->assertEquals('RETURNING *', $query->clause('epilog'));
+        $this->assertSame('RETURNING *', $query->clause('epilog'));
 
         $query = new Query($connection);
         $query->insert(['id', 'title'])
@@ -171,6 +171,6 @@ class PostgresTest extends TestCase
             ->values([1, 'foo'])
             ->epilog('FOO');
         $query = $translator($query);
-        $this->assertEquals('FOO', $query->clause('epilog'));
+        $this->assertSame('FOO', $query->clause('epilog'));
     }
 }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -273,7 +273,7 @@ class SqlserverTest extends TestCase
             ->from('articles')
             ->order(['id'])
             ->offset(10);
-        $this->assertEquals('SELECT id, title FROM articles ORDER BY id OFFSET 10 ROWS', $query->sql());
+        $this->assertSame('SELECT id, title FROM articles ORDER BY id OFFSET 10 ROWS', $query->sql());
 
         $query = new Query($connection);
         $query->select(['id', 'title'])
@@ -281,19 +281,19 @@ class SqlserverTest extends TestCase
             ->order(['id'])
             ->limit(10)
             ->offset(50);
-        $this->assertEquals('SELECT id, title FROM articles ORDER BY id OFFSET 50 ROWS FETCH FIRST 10 ROWS ONLY', $query->sql());
+        $this->assertSame('SELECT id, title FROM articles ORDER BY id OFFSET 50 ROWS FETCH FIRST 10 ROWS ONLY', $query->sql());
 
         $query = new Query($connection);
         $query->select(['id', 'title'])
             ->from('articles')
             ->offset(10);
-        $this->assertEquals('SELECT id, title FROM articles ORDER BY (SELECT NULL) OFFSET 10 ROWS', $query->sql());
+        $this->assertSame('SELECT id, title FROM articles ORDER BY (SELECT NULL) OFFSET 10 ROWS', $query->sql());
 
         $query = new Query($connection);
         $query->select(['id', 'title'])
             ->from('articles')
             ->limit(10);
-        $this->assertEquals('SELECT TOP 10 id, title FROM articles', $query->sql());
+        $this->assertSame('SELECT TOP 10 id, title FROM articles', $query->sql());
     }
 
     /**

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -33,7 +33,7 @@ class FunctionExpressionTest extends TestCase
     public function testArityZero()
     {
         $f = new FunctionExpression('MyFunction');
-        $this->assertEquals('MyFunction()', $f->sql(new ValueBinder()));
+        $this->assertSame('MyFunction()', $f->sql(new ValueBinder()));
     }
 
     /**
@@ -46,15 +46,15 @@ class FunctionExpressionTest extends TestCase
     {
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $binder = new ValueBinder();
-        $this->assertEquals('MyFunction(:param0, :param1)', $f->sql($binder));
+        $this->assertSame('MyFunction(:param0, :param1)', $f->sql($binder));
 
-        $this->assertEquals('foo', $binder->bindings()[':param0']['value']);
-        $this->assertEquals('bar', $binder->bindings()[':param1']['value']);
+        $this->assertSame('foo', $binder->bindings()[':param0']['value']);
+        $this->assertSame('bar', $binder->bindings()[':param1']['value']);
 
         $binder = new ValueBinder();
         $f = new FunctionExpression('MyFunction', ['bar']);
-        $this->assertEquals('MyFunction(:param0)', $f->sql($binder));
-        $this->assertEquals('bar', $binder->bindings()[':param0']['value']);
+        $this->assertSame('MyFunction(:param0)', $f->sql($binder));
+        $this->assertSame('bar', $binder->bindings()[':param0']['value']);
     }
 
     /**
@@ -66,7 +66,7 @@ class FunctionExpressionTest extends TestCase
     {
         $binder = new ValueBinder();
         $f = new FunctionExpression('MyFunction', ['foo' => 'literal', 'bar']);
-        $this->assertEquals('MyFunction(foo, :param0)', $f->sql($binder));
+        $this->assertSame('MyFunction(foo, :param0)', $f->sql($binder));
     }
 
     /**
@@ -80,7 +80,7 @@ class FunctionExpressionTest extends TestCase
         $binder = new ValueBinder();
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
-        $this->assertEquals('Wrapper(bar, MyFunction(:param0, :param1))', $g->sql($binder));
+        $this->assertSame('Wrapper(bar, MyFunction(:param0, :param1))', $g->sql($binder));
     }
 
     /**
@@ -94,7 +94,7 @@ class FunctionExpressionTest extends TestCase
         $binder = new ValueBinder();
         $q = new QueryExpression('a');
         $f = new FunctionExpression('MyFunction', [$q]);
-        $this->assertEquals('MyFunction(a)', $f->sql($binder));
+        $this->assertSame('MyFunction(a)', $f->sql($binder));
     }
 
     /**
@@ -106,10 +106,10 @@ class FunctionExpressionTest extends TestCase
     {
         $binder = new ValueBinder();
         $f = new FunctionExpression('MyFunction', ['a_field' => 'literal', '32' => 'literal']);
-        $this->assertEquals('MyFunction(a_field, 32)', $f->sql($binder));
+        $this->assertSame('MyFunction(a_field, 32)', $f->sql($binder));
 
         $f = new FunctionExpression('MyFunction', ['a_field' => 'literal', 32 => 'literal']);
-        $this->assertEquals('MyFunction(a_field, 32)', $f->sql($binder));
+        $this->assertSame('MyFunction(a_field, 32)', $f->sql($binder));
     }
 
     /**

--- a/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
+++ b/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
@@ -34,9 +34,9 @@ class IdentifierExpressionTest extends TestCase
     public function testGetAndSet()
     {
         $expression = new IdentifierExpression('foo');
-        $this->assertEquals('foo', $expression->getIdentifier());
+        $this->assertSame('foo', $expression->getIdentifier());
         $expression->setIdentifier('bar');
-        $this->assertEquals('bar', $expression->getIdentifier());
+        $this->assertSame('bar', $expression->getIdentifier());
     }
 
     /**
@@ -47,6 +47,6 @@ class IdentifierExpressionTest extends TestCase
     public function testSQL()
     {
         $expression = new IdentifierExpression('foo');
-        $this->assertEquals('foo', $expression->sql(new ValueBinder()));
+        $this->assertSame('foo', $expression->sql(new ValueBinder()));
     }
 }

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -39,7 +39,7 @@ class QueryExpressionTest extends TestCase
         $this->assertSame('+', $expr->getConjunction());
 
         $result = $expr->sql($binder);
-        $this->assertEquals('(1 + 2)', $result);
+        $this->assertSame('(1 + 2)', $result);
     }
 
     /**
@@ -67,7 +67,7 @@ class QueryExpressionTest extends TestCase
         $expr->add(['Users.username' => 'sally'], ['Users.username' => 'string']);
 
         $result = $expr->sql($binder);
-        $this->assertEquals('Users.username = :c0', $result);
+        $this->assertSame('Users.username = :c0', $result);
     }
 
     /**
@@ -91,7 +91,7 @@ class QueryExpressionTest extends TestCase
         );
 
         $result = $expr->sql($binder);
-        $this->assertEquals('(Users.username = :c0 AND Users.active = :c1)', $result);
+        $this->assertSame('(Users.username = :c0 AND Users.active = :c1)', $result);
     }
 
     /**
@@ -104,7 +104,7 @@ class QueryExpressionTest extends TestCase
         $expr = new QueryExpression();
         $binder = new ValueBinder();
         $result = $expr->sql($binder);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
     }
 
     /**
@@ -182,7 +182,7 @@ class QueryExpressionTest extends TestCase
         $bindings = $binder->bindings();
         $type = current($bindings)['type'];
 
-        $this->assertEquals('date', $type);
+        $this->assertSame('date', $type);
     }
 
     /**

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -35,7 +35,7 @@ class TupleComparisonTest extends TestCase
     {
         $f = new TupleComparison(['field1', 'field2'], [1, 2], ['integer', 'integer'], '=');
         $binder = new ValueBinder();
-        $this->assertEquals('(field1, field2) = (:tuple0, :tuple1)', $f->sql($binder));
+        $this->assertSame('(field1, field2) = (:tuple0, :tuple1)', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':tuple0']['value']);
         $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
         $this->assertSame('integer', $binder->bindings()[':tuple0']['type']);
@@ -52,7 +52,7 @@ class TupleComparisonTest extends TestCase
         $field1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison([$field1, 'field2'], [4, 5], ['integer', 'integer'], '>');
         $binder = new ValueBinder();
-        $this->assertEquals('(a = :c0, field2) > (:tuple1, :tuple2)', $f->sql($binder));
+        $this->assertSame('(a = :c0, field2) > (:tuple1, :tuple2)', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':c0']['value']);
         $this->assertSame(4, $binder->bindings()[':tuple1']['value']);
         $this->assertSame(5, $binder->bindings()[':tuple2']['value']);
@@ -68,7 +68,7 @@ class TupleComparisonTest extends TestCase
         $value1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison(['field1', 'field2'], [$value1, 2], ['integer', 'integer'], '=');
         $binder = new ValueBinder();
-        $this->assertEquals('(field1, field2) = (a = :c0, :tuple1)', $f->sql($binder));
+        $this->assertSame('(field1, field2) = (a = :c0, :tuple1)', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':c0']['value']);
         $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
     }
@@ -87,7 +87,7 @@ class TupleComparisonTest extends TestCase
             'IN'
         );
         $binder = new ValueBinder();
-        $this->assertEquals('(field1, field2) IN ((:tuple0,:tuple1), (:tuple2,:tuple3))', $f->sql($binder));
+        $this->assertSame('(field1, field2) IN ((:tuple0,:tuple1), (:tuple2,:tuple3))', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':tuple0']['value']);
         $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
         $this->assertSame(3, $binder->bindings()[':tuple2']['value']);
@@ -140,7 +140,7 @@ class TupleComparisonTest extends TestCase
         $value = new QueryExpression('SELECT 1, 1');
         $f = new TupleComparison(['field1', 'field2'], $value);
         $binder = new ValueBinder();
-        $this->assertEquals('(field1, field2) = (SELECT 1, 1)', $f->sql($binder));
+        $this->assertSame('(field1, field2) = (SELECT 1, 1)', $f->sql($binder));
     }
 
     /**
@@ -154,6 +154,6 @@ class TupleComparisonTest extends TestCase
         $value = [1, 1];
         $f = new TupleComparison(new QueryExpression('a, b'), $value);
         $binder = new ValueBinder();
-        $this->assertEquals('(a, b) = (:tuple0, :tuple1)', $f->sql($binder));
+        $this->assertSame('(a, b) = (:tuple0, :tuple1)', $f->sql($binder));
     }
 }

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -98,7 +98,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->fetchAll('assoc');
 
         $this->assertCount(1, $result);
-        $this->assertEquals('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
+        $this->assertSame('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
     }
 
     /**
@@ -117,7 +117,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->fetchAll('assoc');
 
         $this->assertCount(1, $result);
-        $this->assertEquals('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
+        $this->assertSame('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
     }
 
     /**
@@ -140,8 +140,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->fetchAll('assoc');
 
         $this->assertCount(2, $result);
-        $this->assertEquals('419a8da0482b7756b21f27da40cf8569', $result[0]['id']);
-        $this->assertEquals('419a8da0482b7756b21f27da40cf8569', $result[0]['id']);
+        $this->assertSame('419a8da0482b7756b21f27da40cf8569', $result[0]['id']);
+        $this->assertSame('419a8da0482b7756b21f27da40cf8569', $result[0]['id']);
     }
 
     /**
@@ -191,6 +191,6 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->fetchAll('assoc');
 
         $this->assertCount(1, $result);
-        $this->assertEquals('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
+        $this->assertSame('4c2681c048298a29a7fb413140cf8569', $result[0]['id']);
     }
 }

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -55,8 +55,8 @@ class ExpressionTypeCastingTest extends TestCase
         $comparison = new Comparison('field', 'the thing', 'test', '=');
         $binder = new ValueBinder();
         $sql = $comparison->sql($binder);
-        $this->assertEquals('field = (CONCAT(:param0, :param1))', $sql);
-        $this->assertEquals('the thing', $binder->bindings()[':param0']['value']);
+        $this->assertSame('field = (CONCAT(:param0, :param1))', $sql);
+        $this->assertSame('the thing', $binder->bindings()[':param0']['value']);
 
         $found = false;
         $comparison->traverse(function ($exp) use (&$found) {
@@ -76,9 +76,9 @@ class ExpressionTypeCastingTest extends TestCase
         $comparison = new Comparison('field', ['2', '3'], 'test[]', 'IN');
         $binder = new ValueBinder();
         $sql = $comparison->sql($binder);
-        $this->assertEquals('field IN (CONCAT(:param0, :param1),CONCAT(:param2, :param3))', $sql);
-        $this->assertEquals('2', $binder->bindings()[':param0']['value']);
-        $this->assertEquals('3', $binder->bindings()[':param2']['value']);
+        $this->assertSame('field IN (CONCAT(:param0, :param1),CONCAT(:param2, :param3))', $sql);
+        $this->assertSame('2', $binder->bindings()[':param0']['value']);
+        $this->assertSame('3', $binder->bindings()[':param2']['value']);
 
         $found = false;
         $comparison->traverse(function ($exp) use (&$found) {
@@ -97,9 +97,9 @@ class ExpressionTypeCastingTest extends TestCase
         $between = new BetweenExpression('field', 'from', 'to', 'test');
         $binder = new ValueBinder();
         $sql = $between->sql($binder);
-        $this->assertEquals('field BETWEEN CONCAT(:param0, :param1) AND CONCAT(:param2, :param3)', $sql);
-        $this->assertEquals('from', $binder->bindings()[':param0']['value']);
-        $this->assertEquals('to', $binder->bindings()[':param2']['value']);
+        $this->assertSame('field BETWEEN CONCAT(:param0, :param1) AND CONCAT(:param2, :param3)', $sql);
+        $this->assertSame('from', $binder->bindings()[':param0']['value']);
+        $this->assertSame('to', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
         $between->traverse(function ($exp) use (&$expressions) {
@@ -125,11 +125,11 @@ class ExpressionTypeCastingTest extends TestCase
 
         $binder = new ValueBinder();
         $sql = $case->sql($binder);
-        $this->assertEquals('CASE WHEN foo = :c0 THEN CONCAT(:param1, :param2) ELSE CONCAT(:param3, :param4) END', $sql);
+        $this->assertSame('CASE WHEN foo = :c0 THEN CONCAT(:param1, :param2) ELSE CONCAT(:param3, :param4) END', $sql);
 
-        $this->assertEquals('1', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('value1', $binder->bindings()[':param1']['value']);
-        $this->assertEquals('value2', $binder->bindings()[':param3']['value']);
+        $this->assertSame('1', $binder->bindings()[':c0']['value']);
+        $this->assertSame('value1', $binder->bindings()[':param1']['value']);
+        $this->assertSame('value2', $binder->bindings()[':param3']['value']);
 
         $expressions = [];
         $case->traverse(function ($exp) use (&$expressions) {
@@ -150,8 +150,8 @@ class ExpressionTypeCastingTest extends TestCase
         $function = new FunctionExpression('DATE', ['2016-01'], ['test']);
         $binder = new ValueBinder();
         $sql = $function->sql($binder);
-        $this->assertEquals('DATE(CONCAT(:param0, :param1))', $sql);
-        $this->assertEquals('2016-01', $binder->bindings()[':param0']['value']);
+        $this->assertSame('DATE(CONCAT(:param0, :param1))', $sql);
+        $this->assertSame('2016-01', $binder->bindings()[':param0']['value']);
 
         $expressions = [];
         $function->traverse(function ($exp) use (&$expressions) {
@@ -179,8 +179,8 @@ class ExpressionTypeCastingTest extends TestCase
             ' VALUES ((CONCAT(:param0, :param1))), ((CONCAT(:param2, :param3)))',
             $sql
         );
-        $this->assertEquals('foo', $binder->bindings()[':param0']['value']);
-        $this->assertEquals('bar', $binder->bindings()[':param2']['value']);
+        $this->assertSame('foo', $binder->bindings()[':param0']['value']);
+        $this->assertSame('bar', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
         $values->traverse(function ($exp) use (&$expressions) {

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -44,11 +44,11 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->MyFunc(['b' => 'literal']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('MyFunc', $function->getName());
-        $this->assertEquals('MyFunc(b)', $function->sql(new ValueBinder()));
+        $this->assertSame('MyFunc', $function->getName());
+        $this->assertSame('MyFunc(b)', $function->sql(new ValueBinder()));
 
         $function = $this->functions->MyFunc(['b'], ['string'], 'integer');
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('integer', $function->getReturnType());
     }
 
     /**
@@ -60,13 +60,13 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->sum('total');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('SUM(total)', $function->sql(new ValueBinder()));
-        $this->assertEquals('float', $function->getReturnType());
+        $this->assertSame('SUM(total)', $function->sql(new ValueBinder()));
+        $this->assertSame('float', $function->getReturnType());
 
         $function = $this->functions->sum('total', ['integer']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('SUM(total)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('SUM(total)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
     }
 
     /**
@@ -78,8 +78,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->avg('salary');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('AVG(salary)', $function->sql(new ValueBinder()));
-        $this->assertEquals('float', $function->getReturnType());
+        $this->assertSame('AVG(salary)', $function->sql(new ValueBinder()));
+        $this->assertSame('float', $function->getReturnType());
     }
 
     /**
@@ -91,8 +91,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->max('created', ['datetime']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('MAX(created)', $function->sql(new ValueBinder()));
-        $this->assertEquals('datetime', $function->getReturnType());
+        $this->assertSame('MAX(created)', $function->sql(new ValueBinder()));
+        $this->assertSame('datetime', $function->getReturnType());
     }
 
     /**
@@ -104,8 +104,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->min('created', ['date']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('MIN(created)', $function->sql(new ValueBinder()));
-        $this->assertEquals('date', $function->getReturnType());
+        $this->assertSame('MIN(created)', $function->sql(new ValueBinder()));
+        $this->assertSame('date', $function->getReturnType());
     }
 
     /**
@@ -117,8 +117,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->count('*');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('COUNT(*)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('COUNT(*)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
     }
 
     /**
@@ -130,8 +130,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->concat(['title' => 'literal', ' is a string']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('CONCAT(title, :param0)', $function->sql(new ValueBinder()));
-        $this->assertEquals('string', $function->getReturnType());
+        $this->assertSame('CONCAT(title, :param0)', $function->sql(new ValueBinder()));
+        $this->assertSame('string', $function->getReturnType());
     }
 
     /**
@@ -143,8 +143,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->coalesce(['NULL' => 'literal', '1', 'a'], ['a' => 'date']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('COALESCE(NULL, :param0, :param1)', $function->sql(new ValueBinder()));
-        $this->assertEquals('date', $function->getReturnType());
+        $this->assertSame('COALESCE(NULL, :param0, :param1)', $function->sql(new ValueBinder()));
+        $this->assertSame('date', $function->getReturnType());
     }
 
     /**
@@ -156,18 +156,18 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->now();
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('NOW()', $function->sql(new ValueBinder()));
-        $this->assertEquals('datetime', $function->getReturnType());
+        $this->assertSame('NOW()', $function->sql(new ValueBinder()));
+        $this->assertSame('datetime', $function->getReturnType());
 
         $function = $this->functions->now('date');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('CURRENT_DATE()', $function->sql(new ValueBinder()));
-        $this->assertEquals('date', $function->getReturnType());
+        $this->assertSame('CURRENT_DATE()', $function->sql(new ValueBinder()));
+        $this->assertSame('date', $function->getReturnType());
 
         $function = $this->functions->now('time');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('CURRENT_TIME()', $function->sql(new ValueBinder()));
-        $this->assertEquals('time', $function->getReturnType());
+        $this->assertSame('CURRENT_TIME()', $function->sql(new ValueBinder()));
+        $this->assertSame('time', $function->getReturnType());
     }
 
     /**
@@ -179,13 +179,13 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->extract('day', 'created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('EXTRACT(day FROM created)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('EXTRACT(day FROM created)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
 
         $function = $this->functions->datePart('year', 'modified');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('EXTRACT(year FROM modified)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('EXTRACT(year FROM modified)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
     }
 
     /**
@@ -197,8 +197,8 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->dateAdd('created', -3, 'day');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('DATE_ADD(created, INTERVAL -3 day)', $function->sql(new ValueBinder()));
-        $this->assertEquals('datetime', $function->getReturnType());
+        $this->assertSame('DATE_ADD(created, INTERVAL -3 day)', $function->sql(new ValueBinder()));
+        $this->assertSame('datetime', $function->getReturnType());
     }
 
     /**
@@ -210,13 +210,13 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->dayOfWeek('created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
 
         $function = $this->functions->weekday('created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
-        $this->assertEquals('integer', $function->getReturnType());
+        $this->assertSame('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
     }
 
     /**
@@ -228,7 +228,7 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->rand();
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('RAND()', $function->sql(new ValueBinder()));
-        $this->assertEquals('float', $function->getReturnType());
+        $this->assertSame('RAND()', $function->sql(new ValueBinder()));
+        $this->assertSame('float', $function->getReturnType());
     }
 }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -33,6 +33,6 @@ class LoggedQueryTest extends TestCase
     {
         $logged = new LoggedQuery();
         $logged->query = 'SELECT foo FROM bar';
-        $this->assertEquals('duration=0 rows=0 SELECT foo FROM bar', (string)$logged);
+        $this->assertSame('duration=0 rows=0 SELECT foo FROM bar', (string)$logged);
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -95,18 +95,18 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $result = $query->select('1 + 1')->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertSame(['2'], $result->fetch());
+        $this->assertEquals([2], $result->fetch());
         $result->closeCursor();
 
         //This new field should be appended
         $result = $query->select(['1 + 3'])->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertSame(['2', '4'], $result->fetch());
+        $this->assertEquals([2, 4], $result->fetch());
         $result->closeCursor();
 
         //This should now overwrite all previous fields
         $result = $query->select(['1 + 2', '1 + 5'], true)->execute();
-        $this->assertSame(['3', '6'], $result->fetch());
+        $this->assertEquals([3, 6], $result->fetch());
         $result->closeCursor();
     }
 
@@ -124,7 +124,7 @@ class QueryTest extends TestCase
 
             return ['1 + 2', '1 + 5'];
         })->execute();
-        $this->assertSame(['3', '6'], $result->fetch());
+        $this->assertEquals([3, 6], $result->fetch());
         $result->closeCursor();
     }
 
@@ -2375,7 +2375,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select('id')->from('comments')->page(1);
         $this->assertEquals(25, $query->clause('limit'));
-        $this->assertSame(0, $query->clause('offset'));
+        $this->assertEquals(0, $query->clause('offset'));
 
         $query->select('id')->from('comments')->page(2);
         $this->assertEquals(25, $query->clause('limit'));

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -80,8 +80,8 @@ class QueryTest extends TestCase
     public function testDefaultType()
     {
         $query = new Query($this->connection);
-        $this->assertEquals('', $query->sql());
-        $this->assertEquals('select', $query->type());
+        $this->assertSame('', $query->sql());
+        $this->assertSame('select', $query->type());
     }
 
     /**
@@ -95,18 +95,18 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $result = $query->select('1 + 1')->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertEquals([2], $result->fetch());
+        $this->assertSame(['2'], $result->fetch());
         $result->closeCursor();
 
         //This new field should be appended
         $result = $query->select(['1 + 3'])->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertEquals([2, 4], $result->fetch());
+        $this->assertSame(['2', '4'], $result->fetch());
         $result->closeCursor();
 
         //This should now overwrite all previous fields
         $result = $query->select(['1 + 2', '1 + 5'], true)->execute();
-        $this->assertEquals([3, 6], $result->fetch());
+        $this->assertSame(['3', '6'], $result->fetch());
         $result->closeCursor();
     }
 
@@ -124,7 +124,7 @@ class QueryTest extends TestCase
 
             return ['1 + 2', '1 + 5'];
         })->execute();
-        $this->assertEquals([3, 6], $result->fetch());
+        $this->assertSame(['3', '6'], $result->fetch());
         $result->closeCursor();
     }
 
@@ -151,8 +151,8 @@ class QueryTest extends TestCase
 
         // Overwrite tables and only fetch from authors
         $result = $query->select('name', true)->from('authors', true)->order(['name' => 'desc'], true)->execute();
-        $this->assertEquals(['nate'], $result->fetch());
-        $this->assertEquals(['mariano'], $result->fetch());
+        $this->assertSame(['nate'], $result->fetch());
+        $this->assertSame(['mariano'], $result->fetch());
         $this->assertCount(4, $result);
         $result->closeCursor();
     }
@@ -1359,9 +1359,9 @@ class QueryTest extends TestCase
             ->sql();
         $bindings = $query->getValueBinder()->bindings();
         $this->assertArrayHasKey(':c0', $bindings);
-        $this->assertEquals('c0', $bindings[':c0']['placeholder']);
+        $this->assertSame('c0', $bindings[':c0']['placeholder']);
         $this->assertArrayHasKey(':c1', $bindings);
-        $this->assertEquals('c1', $bindings[':c1']['placeholder']);
+        $this->assertSame('c1', $bindings[':c1']['placeholder']);
     }
 
     /**
@@ -2375,7 +2375,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select('id')->from('comments')->page(1);
         $this->assertEquals(25, $query->clause('limit'));
-        $this->assertEquals(0, $query->clause('offset'));
+        $this->assertSame(0, $query->clause('offset'));
 
         $query->select('id')->from('comments')->page(2);
         $this->assertEquals(25, $query->clause('limit'));
@@ -2755,7 +2755,7 @@ class QueryTest extends TestCase
             ->execute();
 
         while ($row = $result->fetch('assoc')) {
-            $this->assertEquals('bar', $row['foo']);
+            $this->assertSame('bar', $row['foo']);
             $this->assertArrayNotHasKey('modified_id', $row);
         }
 
@@ -3487,7 +3487,7 @@ class QueryTest extends TestCase
         $identifier = $query->identifier('foo');
 
         $this->assertInstanceOf(IdentifierExpression::class, $identifier);
-        $this->assertEquals('foo', $identifier->getIdentifier());
+        $this->assertSame('foo', $identifier->getIdentifier());
     }
 
     /**
@@ -3501,10 +3501,10 @@ class QueryTest extends TestCase
         $identifier = $query->identifier('description');
 
         $this->assertInstanceOf(ExpressionInterface::class, $identifier);
-        $this->assertEquals('description', $identifier->getIdentifier());
+        $this->assertSame('description', $identifier->getIdentifier());
 
         $identifier->setIdentifier('title');
-        $this->assertEquals('title', $identifier->getIdentifier());
+        $this->assertSame('title', $identifier->getIdentifier());
     }
 
     /**
@@ -3686,7 +3686,7 @@ class QueryTest extends TestCase
         $this->assertStringContainsString('SELECT', $sql);
         $this->assertStringContainsString('FROM', $sql);
         $this->assertStringContainsString('WHERE', $sql);
-        $this->assertEquals(' FOR UPDATE', substr($sql, -11));
+        $this->assertSame(' FOR UPDATE', substr($sql, -11));
     }
 
     /**
@@ -3706,7 +3706,7 @@ class QueryTest extends TestCase
         $this->assertStringContainsString('INSERT', $sql);
         $this->assertStringContainsString('INTO', $sql);
         $this->assertStringContainsString('VALUES', $sql);
-        $this->assertEquals(' RETURNING id', substr($sql, -13));
+        $this->assertSame(' RETURNING id', substr($sql, -13));
     }
 
     /**
@@ -3726,7 +3726,7 @@ class QueryTest extends TestCase
         $this->assertStringContainsString('UPDATE', $sql);
         $this->assertStringContainsString('SET', $sql);
         $this->assertStringContainsString('WHERE', $sql);
-        $this->assertEquals(' RETURNING id', substr($sql, -13));
+        $this->assertSame(' RETURNING id', substr($sql, -13));
     }
 
     /**
@@ -3744,7 +3744,7 @@ class QueryTest extends TestCase
             ->sql();
         $this->assertStringContainsString('DELETE FROM', $sql);
         $this->assertStringContainsString('WHERE', $sql);
-        $this->assertEquals(' RETURNING id', substr($sql, -13));
+        $this->assertSame(' RETURNING id', substr($sql, -13));
     }
 
     /**
@@ -4203,9 +4203,9 @@ class QueryTest extends TestCase
             ->execute()
             ->fetchAll('assoc');
 
-        $this->assertEquals('Published', $results[2]['status']);
-        $this->assertEquals('Not published', $results[3]['status']);
-        $this->assertEquals('None', $results[6]['status']);
+        $this->assertSame('Published', $results[2]['status']);
+        $this->assertSame('Not published', $results[3]['status']);
+        $this->assertSame('None', $results[6]['status']);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1262,7 +1262,7 @@ SQL;
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('DROP TABLE `articles`', $result[0]);
+        $this->assertSame('DROP TABLE `articles`', $result[0]);
     }
 
     /**
@@ -1282,7 +1282,7 @@ SQL;
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('TRUNCATE TABLE `articles`', $result[0]);
+        $this->assertSame('TRUNCATE TABLE `articles`', $result[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -295,7 +295,7 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('public.schema_articles');
         $this->assertEquals(['id'], $result->primaryKey());
-        $this->assertEquals('schema_articles', $result->name());
+        $this->assertSame('schema_articles', $result->name());
     }
 
     /**
@@ -1271,7 +1271,7 @@ SQL;
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('DROP TABLE "schema_articles" CASCADE', $result[0]);
+        $this->assertSame('DROP TABLE "schema_articles" CASCADE', $result[0]);
     }
 
     /**
@@ -1296,7 +1296,7 @@ SQL;
             ]);
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('TRUNCATE "schema_articles" RESTART IDENTITY CASCADE', $result[0]);
+        $this->assertSame('TRUNCATE "schema_articles" RESTART IDENTITY CASCADE', $result[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -716,7 +716,7 @@ SQL;
         $this->assertEquals($result, '"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT');
 
         $result = $schema->constraintSql($table, 'primary');
-        $this->assertEquals('', $result, 'Integer primary keys are special in sqlite.');
+        $this->assertSame('', $result, 'Integer primary keys are special in sqlite.');
     }
 
     /**
@@ -742,7 +742,7 @@ SQL;
         $this->assertEquals($result, '"id" BIGINT NOT NULL');
 
         $result = $schema->constraintSql($table, 'primary');
-        $this->assertEquals('CONSTRAINT "primary" PRIMARY KEY ("id")', $result, 'Bigint primary keys are not special.');
+        $this->assertSame('CONSTRAINT "primary" PRIMARY KEY ("id")', $result, 'Bigint primary keys are not special.');
     }
 
     /**
@@ -1011,7 +1011,7 @@ SQL;
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('DROP TABLE "articles"', $result[0]);
+        $this->assertSame('DROP TABLE "articles"', $result[0]);
     }
 
     /**
@@ -1043,8 +1043,8 @@ SQL;
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(2, $result);
-        $this->assertEquals('DELETE FROM sqlite_sequence WHERE name="articles"', $result[0]);
-        $this->assertEquals('DELETE FROM "articles"', $result[1]);
+        $this->assertSame('DELETE FROM sqlite_sequence WHERE name="articles"', $result[0]);
+        $this->assertSame('DELETE FROM "articles"', $result[1]);
     }
 
     /**
@@ -1077,7 +1077,7 @@ SQL;
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('DELETE FROM "articles"', $result[0]);
+        $this->assertSame('DELETE FROM "articles"', $result[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -480,7 +480,7 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('dbo.schema_articles');
         $this->assertEquals(['id'], $result->primaryKey());
-        $this->assertEquals('schema_articles', $result->name());
+        $this->assertSame('schema_articles', $result->name());
     }
 
     /**
@@ -1008,7 +1008,7 @@ SQL;
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
-        $this->assertEquals('DROP TABLE [schema_articles]', $result[0]);
+        $this->assertSame('DROP TABLE [schema_articles]', $result[0]);
     }
 
     /**
@@ -1033,7 +1033,7 @@ SQL;
             ]);
         $result = $table->truncateSql($connection);
         $this->assertCount(2, $result);
-        $this->assertEquals('DELETE FROM [schema_articles]', $result[0]);
+        $this->assertSame('DELETE FROM [schema_articles]', $result[0]);
         $this->assertEquals("DBCC CHECKIDENT('schema_articles', RESEED, 0)", $result[1]);
     }
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -164,7 +164,7 @@ class TableSchemaTest extends TestCase
             'length' => 25,
             'null' => false,
         ]);
-        $this->assertEquals('string', $table->getColumnType('title'));
+        $this->assertSame('string', $table->getColumnType('title'));
         $this->assertNull($table->getColumnType('not there'));
     }
 
@@ -181,9 +181,9 @@ class TableSchemaTest extends TestCase
             'length' => 25,
             'null' => false,
         ]);
-        $this->assertEquals('string', $table->getColumnType('title'));
+        $this->assertSame('string', $table->getColumnType('title'));
         $table->setColumnType('title', 'json');
-        $this->assertEquals('json', $table->getColumnType('title'));
+        $this->assertSame('json', $table->getColumnType('title'));
     }
 
     /**
@@ -200,8 +200,8 @@ class TableSchemaTest extends TestCase
             'length' => 25,
             'null' => false,
         ]);
-        $this->assertEquals('json', $table->getColumnType('title'));
-        $this->assertEquals('text', $table->baseColumnType('title'));
+        $this->assertSame('json', $table->getColumnType('title'));
+        $this->assertSame('text', $table->baseColumnType('title'));
     }
 
     /**
@@ -217,8 +217,8 @@ class TableSchemaTest extends TestCase
             'type' => 'int',
             'null' => false,
         ]);
-        $this->assertEquals('int', $table->getColumnType('thing'));
-        $this->assertEquals('integer', $table->baseColumnType('thing'));
+        $this->assertSame('int', $table->getColumnType('thing'));
+        $this->assertSame('integer', $table->baseColumnType('thing'));
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -89,22 +89,22 @@ class DateTimeTypeTest extends TestCase
     {
         $result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
         $this->assertInstanceOf(FrozenTime::class, $result);
-        $this->assertEquals('2001', $result->format('Y'));
-        $this->assertEquals('01', $result->format('m'));
-        $this->assertEquals('04', $result->format('d'));
-        $this->assertEquals('12', $result->format('H'));
-        $this->assertEquals('13', $result->format('i'));
-        $this->assertEquals('14', $result->format('s'));
+        $this->assertSame('2001', $result->format('Y'));
+        $this->assertSame('01', $result->format('m'));
+        $this->assertSame('04', $result->format('d'));
+        $this->assertSame('12', $result->format('H'));
+        $this->assertSame('13', $result->format('i'));
+        $this->assertSame('14', $result->format('s'));
 
         $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
         $result = $this->type->toPHP('2001-01-04 12:00:00', $this->driver);
         $this->assertInstanceOf(FrozenTime::class, $result);
-        $this->assertEquals('2001', $result->format('Y'));
-        $this->assertEquals('01', $result->format('m'));
-        $this->assertEquals('04', $result->format('d'));
-        $this->assertEquals('06', $result->format('H'));
-        $this->assertEquals('30', $result->format('i'));
-        $this->assertEquals('00', $result->format('s'));
+        $this->assertSame('2001', $result->format('Y'));
+        $this->assertSame('01', $result->format('m'));
+        $this->assertSame('04', $result->format('d'));
+        $this->assertSame('06', $result->format('H'));
+        $this->assertSame('30', $result->format('i'));
+        $this->assertSame('00', $result->format('s'));
     }
 
     /**
@@ -170,31 +170,31 @@ class DateTimeTypeTest extends TestCase
 
         $date = new Time('2013-08-12 15:16:17');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12 15:16:17', $result);
+        $this->assertSame('2013-08-12 15:16:17', $result);
 
         $tz = $date->getTimezone();
         $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->assertSame('2013-08-12 20:46:17', $result);
         $this->assertEquals($tz, $date->getTimezone());
 
         $this->type->setTimezone(new DateTimeZone('Asia/Kolkata'));
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->assertSame('2013-08-12 20:46:17', $result);
         $this->type->setTimezone(null);
 
         $date = new FrozenTime('2013-08-12 15:16:17');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12 15:16:17', $result);
+        $this->assertSame('2013-08-12 15:16:17', $result);
 
         $this->type->setTimezone('Asia/Kolkata'); // UTC+5:30
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12 20:46:17', $result);
+        $this->assertSame('2013-08-12 20:46:17', $result);
         $this->type->setTimezone(null);
 
         $date = 1401906995;
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2014-06-04 18:36:35', $result);
+        $this->assertSame('2014-06-04 18:36:35', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -61,9 +61,9 @@ class DateTypeTest extends TestCase
 
         $result = $this->type->toPHP('2001-01-04', $this->driver);
         $this->assertInstanceOf(DateTimeImmutable::class, $result);
-        $this->assertEquals('2001', $result->format('Y'));
-        $this->assertEquals('01', $result->format('m'));
-        $this->assertEquals('04', $result->format('d'));
+        $this->assertSame('2001', $result->format('Y'));
+        $this->assertSame('01', $result->format('m'));
+        $this->assertSame('04', $result->format('d'));
     }
 
     /**
@@ -102,11 +102,11 @@ class DateTypeTest extends TestCase
 
         $date = new Time('2013-08-12');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12', $result);
+        $this->assertSame('2013-08-12', $result);
 
         $date = new Time('2013-08-12 15:16:18');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('2013-08-12', $result);
+        $this->assertSame('2013-08-12', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -76,16 +76,16 @@ class TimeTypeTest extends TestCase
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
         $result = $this->type->toPHP('00:00:00', $this->driver);
-        $this->assertEquals('00', $result->format('s'));
+        $this->assertSame('00', $result->format('s'));
 
         $result = $this->type->toPHP('00:00:15', $this->driver);
-        $this->assertEquals('15', $result->format('s'));
+        $this->assertSame('15', $result->format('s'));
 
         $result = $this->type->toPHP('16:30:15', $this->driver);
         $this->assertInstanceOf(DateTimeImmutable::class, $result);
-        $this->assertEquals('16', $result->format('H'));
-        $this->assertEquals('30', $result->format('i'));
-        $this->assertEquals('15', $result->format('s'));
+        $this->assertSame('16', $result->format('H'));
+        $this->assertSame('30', $result->format('i'));
+        $this->assertSame('15', $result->format('s'));
     }
 
     /**
@@ -122,11 +122,11 @@ class TimeTypeTest extends TestCase
 
         $date = new Time('16:30:15');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('16:30:15', $result);
+        $this->assertSame('16:30:15', $result);
 
         $date = new Time('2013-08-12 15:16:18');
         $result = $this->type->toDatabase($date, $this->driver);
-        $this->assertEquals('15:16:18', $result);
+        $this->assertSame('15:16:18', $result);
     }
 
     /**

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -65,19 +65,19 @@ class ValueBinderTest extends TestCase
     {
         $valueBinder = new ValueBinder();
         $result = $valueBinder->placeholder('?');
-        $this->assertEquals('?', $result);
+        $this->assertSame('?', $result);
 
         $valueBinder = new ValueBinder();
         $result = $valueBinder->placeholder(':param');
-        $this->assertEquals(':param', $result);
+        $this->assertSame(':param', $result);
 
         $valueBinder = new ValueBinder();
         $result = $valueBinder->placeholder('p');
-        $this->assertEquals(':p0', $result);
+        $this->assertSame(':p0', $result);
         $result = $valueBinder->placeholder('p');
-        $this->assertEquals(':p1', $result);
+        $this->assertSame(':p1', $result);
         $result = $valueBinder->placeholder('c');
-        $this->assertEquals(':c2', $result);
+        $this->assertSame(':c2', $result);
     }
 
     public function testGenerateManyNamed()
@@ -110,7 +110,7 @@ class ValueBinderTest extends TestCase
         $this->assertCount(0, $valueBinder->bindings());
 
         $placeholder = $valueBinder->placeholder('c');
-        $this->assertEquals(':c0', $placeholder);
+        $this->assertSame(':c0', $placeholder);
     }
 
     /**
@@ -129,12 +129,12 @@ class ValueBinderTest extends TestCase
         $valueBinder->placeholder('param');
         $valueBinder->placeholder('param');
         $result = $valueBinder->placeholder('param');
-        $this->assertEquals(':param2', $result);
+        $this->assertSame(':param2', $result);
 
         $valueBinder->resetCount();
 
         $placeholder = $valueBinder->placeholder('param');
-        $this->assertEquals(':param0', $placeholder);
+        $this->assertSame(':param0', $placeholder);
         $this->assertCount(2, $valueBinder->bindings());
     }
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -123,7 +123,7 @@ class ConnectionManagerTest extends TestCase
         $ds = ConnectionManager::get('test');
         $this->assertSame($ds, ConnectionManager::get('test'));
         $this->assertInstanceOf('Cake\Database\Connection', $ds);
-        $this->assertEquals('test', $ds->configName());
+        $this->assertSame('test', $ds->configName());
     }
 
     /**
@@ -441,7 +441,7 @@ class ConnectionManagerTest extends TestCase
     {
         $connection = new FakeConnection();
         $callable = function ($alias) use ($connection) {
-            $this->assertEquals('test_variant', $alias);
+            $this->assertSame('test_variant', $alias);
 
             return $connection;
         };

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -120,7 +120,7 @@ class FactoryLocatorTest extends TestCase
         $result = $stub->loadModel('Magic', 'Table');
         $this->assertInstanceOf('stdClass', $result);
         $this->assertInstanceOf('stdClass', $stub->Magic);
-        $this->assertEquals('Magic', $stub->Magic->name);
+        $this->assertSame('Magic', $stub->Magic->name);
     }
 
     /**
@@ -144,7 +144,7 @@ class FactoryLocatorTest extends TestCase
         $result = $stub->loadModel('Magic');
         $this->assertInstanceOf('stdClass', $result);
         $this->assertInstanceOf('stdClass', $stub->Magic);
-        $this->assertEquals('Magic', $stub->Magic->name);
+        $this->assertSame('Magic', $stub->Magic->name);
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -125,7 +125,7 @@ class ModelAwareTraitTest extends TestCase
         $result = $stub->loadModel('Magic', 'Table');
         $this->assertInstanceOf('stdClass', $result);
         $this->assertInstanceOf('stdClass', $stub->Magic);
-        $this->assertEquals('Magic', $stub->Magic->name);
+        $this->assertSame('Magic', $stub->Magic->name);
     }
 
     /**

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -323,8 +323,8 @@ class PaginatorTest extends TestCase
 
         $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals('PaginatorPosts.id', $pagingParams['PaginatorPosts']['sortDefault']);
-        $this->assertEquals('DESC', $pagingParams['PaginatorPosts']['directionDefault']);
+        $this->assertSame('PaginatorPosts.id', $pagingParams['PaginatorPosts']['sortDefault']);
+        $this->assertSame('DESC', $pagingParams['PaginatorPosts']['directionDefault']);
     }
 
     /**
@@ -652,8 +652,8 @@ class PaginatorTest extends TestCase
         ];
         $this->Paginator->paginate($table, $params);
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals('id', $pagingParams['PaginatorPosts']['sort']);
-        $this->assertEquals('asc', $pagingParams['PaginatorPosts']['direction']);
+        $this->assertSame('id', $pagingParams['PaginatorPosts']['sort']);
+        $this->assertSame('asc', $pagingParams['PaginatorPosts']['direction']);
     }
 
     /**
@@ -674,7 +674,7 @@ class PaginatorTest extends TestCase
         $options = ['sort' => 'something', 'direction' => 'boogers'];
         $result = $this->Paginator->validateSort($model, $options);
 
-        $this->assertEquals('asc', $result['order']['model.something']);
+        $this->assertSame('asc', $result['order']['model.something']);
     }
 
     /**
@@ -712,8 +712,8 @@ class PaginatorTest extends TestCase
         $this->Paginator->paginate($table, [], $options);
         $pagingParams = $this->Paginator->getPagingParams();
 
-        $this->assertEquals('id', $pagingParams['PaginatorPosts']['sort']);
-        $this->assertEquals('asc', $pagingParams['PaginatorPosts']['direction']);
+        $this->assertSame('id', $pagingParams['PaginatorPosts']['sort']);
+        $this->assertSame('asc', $pagingParams['PaginatorPosts']['direction']);
     }
 
     /**
@@ -755,11 +755,11 @@ class PaginatorTest extends TestCase
         $this->Paginator->paginate($table, $queryParams, $options);
         $pagingParams = $this->Paginator->getPagingParams();
 
-        $this->assertEquals('title', $pagingParams['PaginatorPosts']['sort']);
-        $this->assertEquals('asc', $pagingParams['PaginatorPosts']['direction']);
+        $this->assertSame('title', $pagingParams['PaginatorPosts']['sort']);
+        $this->assertSame('asc', $pagingParams['PaginatorPosts']['direction']);
 
-        $this->assertEquals('Articles.title', $pagingParams['PaginatorPosts']['sortDefault']);
-        $this->assertEquals('desc', $pagingParams['PaginatorPosts']['directionDefault']);
+        $this->assertSame('Articles.title', $pagingParams['PaginatorPosts']['sortDefault']);
+        $this->assertSame('desc', $pagingParams['PaginatorPosts']['directionDefault']);
     }
 
     /**
@@ -798,7 +798,7 @@ class PaginatorTest extends TestCase
         ];
         $this->Paginator->paginate($table, $params, $options);
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals('id', $pagingParams['PaginatorPosts']['sort']);
+        $this->assertSame('id', $pagingParams['PaginatorPosts']['sort']);
     }
 
     /**
@@ -1415,8 +1415,8 @@ class PaginatorTest extends TestCase
 
         $result = $results->toArray();
         $this->assertCount(2, $result);
-        $this->assertEquals('First Post', $result[0]->title);
-        $this->assertEquals('Third Post', $result[1]->title);
+        $this->assertSame('First Post', $result[0]->title);
+        $this->assertSame('Third Post', $result[1]->title);
     }
 
     /**

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -70,7 +70,7 @@ class QueryCacherTest extends TestCase
         }, 'queryCache');
 
         $result = $cacher->fetch($query);
-        $this->assertEquals('A winner', $result);
+        $this->assertSame('A winner', $result);
     }
 
     /**
@@ -103,7 +103,7 @@ class QueryCacherTest extends TestCase
         $cacher = new QueryCacher('my_key', 'queryCache');
         $query = $this->getMockBuilder('stdClass')->getMock();
         $result = $cacher->fetch($query);
-        $this->assertEquals('A winner', $result);
+        $this->assertSame('A winner', $result);
     }
 
     /**
@@ -117,7 +117,7 @@ class QueryCacherTest extends TestCase
         $cacher = new QueryCacher('my_key', $this->engine);
         $query = $this->getMockBuilder('stdClass')->getMock();
         $result = $cacher->fetch($query);
-        $this->assertEquals('A winner', $result);
+        $this->assertSame('A winner', $result);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -129,7 +129,7 @@ class DebuggerTest extends TestCase
     public function testSetOutputFormat()
     {
         Debugger::setOutputFormat('html');
-        $this->assertEquals('html', Debugger::getOutputFormat());
+        $this->assertSame('html', Debugger::getOutputFormat());
     }
 
     /**
@@ -140,7 +140,7 @@ class DebuggerTest extends TestCase
     public function testGetSetOutputFormat()
     {
         Debugger::setOutputFormat('html');
-        $this->assertEquals('html', Debugger::getOutputFormat());
+        $this->assertSame('html', Debugger::getOutputFormat());
     }
 
     /**
@@ -289,9 +289,9 @@ class DebuggerTest extends TestCase
      */
     public function testTrimPath()
     {
-        $this->assertEquals('APP/', Debugger::trimPath(APP));
-        $this->assertEquals('CORE' . DS . 'src' . DS, Debugger::trimPath(CAKE));
-        $this->assertEquals('Some/Other/Path', Debugger::trimPath('Some/Other/Path'));
+        $this->assertSame('APP/', Debugger::trimPath(APP));
+        $this->assertSame('CORE' . DS . 'src' . DS, Debugger::trimPath(CAKE));
+        $this->assertSame('Some/Other/Path', Debugger::trimPath('Some/Other/Path'));
     }
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -388,7 +388,7 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->handleException($error);
 
         $result = $errorHandler->response;
-        $this->assertEquals('Rendered by test plugin', $result);
+        $this->assertSame('Rendered by test plugin', $result);
     }
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -388,7 +388,7 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->handleException($error);
 
         $result = $errorHandler->response;
-        $this->assertSame('Rendered by test plugin', $result);
+        $this->assertSame('Rendered by test plugin', (string)$result);
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -120,8 +120,8 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->render();
         $controller = $ExceptionRenderer->__debugInfo()['controller'];
-        $this->assertEquals('error400', $controller->viewBuilder()->getTemplate());
-        $this->assertEquals('Error', $controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
+        $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
 
         $request = $request->withParam('prefix', 'admin');
         $exception = new MissingActionException(['controller' => 'Foo', 'action' => 'bar']);
@@ -130,15 +130,15 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->render();
         $controller = $ExceptionRenderer->__debugInfo()['controller'];
-        $this->assertEquals('missingAction', $controller->viewBuilder()->getTemplate());
-        $this->assertEquals('Error', $controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('missingAction', $controller->viewBuilder()->getTemplate());
+        $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
 
         Configure::write('debug', false);
         $ExceptionRenderer = new ExceptionRenderer($exception, $request);
 
         $ExceptionRenderer->render();
         $controller = $ExceptionRenderer->__debugInfo()['controller'];
-        $this->assertEquals('error400', $controller->viewBuilder()->getTemplate());
+        $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
         $this->assertEquals(
             'Admin' . DIRECTORY_SEPARATOR . 'Error',
             $controller->viewBuilder()->getTemplatePath()
@@ -158,7 +158,7 @@ class ExceptionRendererTest extends TestCase
 
         $result = $ExceptionRenderer->render();
 
-        $this->assertEquals('widget thing is missing', (string)$result->getBody());
+        $this->assertSame('widget thing is missing', (string)$result->getBody());
     }
 
     /**
@@ -242,7 +242,7 @@ class ExceptionRendererTest extends TestCase
 
         $result = (string)$ExceptionRenderer->render()->getBody();
 
-        $this->assertEquals('error400', $ExceptionRenderer->__debugInfo()['template']);
+        $this->assertSame('error400', $ExceptionRenderer->__debugInfo()['template']);
         $this->assertStringContainsString('Not Found', $result);
         $this->assertStringNotContainsString('Secret info not to be leaked', $result);
     }
@@ -456,7 +456,7 @@ class ExceptionRendererTest extends TestCase
 
         $result = $ExceptionRenderer->render();
         $this->assertTrue($result->hasHeader('Allow'));
-        $this->assertEquals('POST, DELETE', $result->getHeaderLine('Allow'));
+        $this->assertSame('POST, DELETE', $result->getHeaderLine('Allow'));
     }
 
     /**
@@ -757,11 +757,11 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->setController($controller);
 
         $response = $ExceptionRenderer->render();
-        $this->assertEquals('text/html', $response->getType());
+        $this->assertSame('text/html', $response->getType());
         $this->assertStringContainsString('Not Found', (string)$response->getBody());
         $this->assertTrue($this->called, 'Listener added was not triggered.');
-        $this->assertEquals('', $controller->viewBuilder()->getLayoutPath());
-        $this->assertEquals('Error', $controller->viewBuilder()->getTemplatePath());
+        $this->assertSame('', $controller->viewBuilder()->getLayoutPath());
+        $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -788,7 +788,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->setController($controller);
 
         $response = $ExceptionRenderer->render();
-        $this->assertEquals('text/html', $response->getType());
+        $this->assertSame('text/html', $response->getType());
         $this->assertStringContainsString('Not Found', (string)$response->getBody());
         $this->assertTrue($this->called, 'Listener added was not triggered.');
         $this->assertSame('', $controller->viewBuilder()->getLayoutPath());

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -316,6 +316,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
         });
         $response = $middleware->process($request, $handler);
         $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals('An Internal Server Error Occurred', '' . $response->getBody());
+        $this->assertSame('An Internal Server Error Occurred', '' . $response->getBody());
     }
 }

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -54,7 +54,7 @@ class ConditionDecoratorTest extends TestCase
         $this->assertTrue($decorator->canTrigger($event));
 
         $result = $decorator($event);
-        $this->assertEquals('success', $result);
+        $this->assertSame('success', $result);
     }
 
     /**

--- a/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
@@ -43,7 +43,7 @@ class SubjectFilterDecoratorTest extends TestCase
         ]);
 
         $this->assertTrue($decorator->canTrigger($event));
-        $this->assertEquals('success', $decorator($event));
+        $this->assertSame('success', $decorator($event));
 
         $decorator = new SubjectFilterDecorator($callable, [
             'allowedSubject' => '\Some\Other\Class',

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -73,7 +73,7 @@ class EventDispatcherTraitTest extends TestCase
 
         $this->assertInstanceOf(Event::class, $event);
         $this->assertSame($this->subject, $event->getSubject());
-        $this->assertEquals('some.event', $event->getName());
+        $this->assertSame('some.event', $event->getName());
         $this->assertEquals(['foo' => 'bar'], $event->getData());
     }
 }

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -274,7 +274,7 @@ class EventManagerTest extends TestCase
             ->method('listenerFunction')
             ->with($event);
         $manager->dispatch($event);
-        $this->assertEquals('something special', $event->getResult());
+        $this->assertSame('something special', $event->getResult());
     }
 
     /**
@@ -548,7 +548,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $event = new Event('my_event', $manager);
         $manager->dispatch($event);
-        $this->assertEquals('ok', $event->getData('callback'));
+        $this->assertSame('ok', $event->getData('callback'));
     }
 
     /**

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -38,7 +38,7 @@ class EventTest extends TestCase
     public function testName()
     {
         $event = new Event('fake.event');
-        $this->assertEquals('fake.event', $event->getName());
+        $this->assertSame('fake.event', $event->getName());
     }
 
     /**
@@ -82,7 +82,7 @@ class EventTest extends TestCase
         $event = new Event('fake.event', $this, ['some' => 'data']);
         $this->assertEquals(['some' => 'data'], $event->getData());
 
-        $this->assertEquals('data', $event->getData('some'));
+        $this->assertSame('data', $event->getData('some'));
         $this->assertNull($event->getData('undef'));
     }
 
@@ -98,7 +98,7 @@ class EventTest extends TestCase
         $event = new Event('fake.event', $this, $data);
         $this->assertEquals(['some' => 'data'], $event->getData());
 
-        $this->assertEquals('data', $event->getData('some'));
+        $this->assertSame('data', $event->getData('some'));
         $this->assertNull($event->getData('undef'));
     }
 
@@ -112,6 +112,6 @@ class EventTest extends TestCase
     {
         $event = new Event('fake.event', $this);
         $this->assertEquals($this, $event->getSubject());
-        $this->assertEquals('fake.event', $event->getName());
+        $this->assertSame('fake.event', $event->getName());
     }
 }

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -93,7 +93,7 @@ class FileTest extends TestCase
         $this->assertEquals($expecting, $result);
 
         $result = $this->File->ext();
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = $this->File->name();
         $expecting = 'LICENSE';
@@ -132,7 +132,7 @@ class FileTest extends TestCase
     public function testUtf8Filenames()
     {
         $File = new File(TMP . 'tests/permissions/نام فارسی.php', true);
-        $this->assertEquals('نام فارسی', $File->name());
+        $this->assertSame('نام فارسی', $File->name());
         $this->assertTrue($File->exists());
         $this->assertTrue($File->readable());
     }
@@ -399,7 +399,7 @@ class FileTest extends TestCase
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertTrue($someFile->open());
-        $this->assertEquals('', $someFile->read());
+        $this->assertSame('', $someFile->read());
         $someFile->close();
         $someFile->delete();
     }

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -93,7 +93,7 @@ class FileTest extends TestCase
         $this->assertEquals($expecting, $result);
 
         $result = $this->File->ext();
-        $this->assertSame('', $result);
+        $this->assertFalse($result);
 
         $result = $this->File->name();
         $expecting = 'LICENSE';

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -361,15 +361,15 @@ class FolderTest extends TestCase
 
         $this->assertTrue($Folder->chmod($new, 0755, true));
         $perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
-        $this->assertEquals('0755', $perms);
+        $this->assertSame('0755', $perms);
 
         $this->assertTrue($Folder->chmod($new, 0744, true, ['skip_me.php', 'test2']));
 
         $perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
-        $this->assertEquals('0755', $perms);
+        $this->assertSame('0755', $perms);
 
         $perms = substr(sprintf('%o', fileperms($new . DS . 'test1')), -4);
-        $this->assertEquals('0744', $perms);
+        $this->assertSame('0744', $perms);
     }
 
     /**
@@ -679,7 +679,7 @@ class FolderTest extends TestCase
     public function testSlashTerm()
     {
         $result = Folder::slashTerm('/path/to/file');
-        $this->assertEquals('/path/to/file/', $result);
+        $this->assertSame('/path/to/file/', $result);
     }
 
     /**
@@ -714,15 +714,15 @@ class FolderTest extends TestCase
     {
         $path = '/path/to/file';
         $result = Folder::correctSlashFor($path);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $path = '\\path\\to\\file';
         $result = Folder::correctSlashFor($path);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $path = 'C:\\path\to\\file';
         $result = Folder::correctSlashFor($path);
-        $this->assertEquals('\\', $result);
+        $this->assertSame('\\', $result);
     }
 
     /**
@@ -852,7 +852,7 @@ class FolderTest extends TestCase
     {
         $path = TMP . 'tests' . DS;
         $Folder = new Folder($path . 'config_non_existent', true);
-        $this->assertEquals(0, $Folder->dirSize());
+        $this->assertSame(0, $Folder->dirSize());
 
         $File = new File($Folder->pwd() . DS . 'my.php', true, 0777);
         $File->create();

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -131,8 +131,8 @@ class FormTest extends TestCase
         $form->validate($data);
         $errors = $form->getErrors();
         $this->assertCount(2, $errors);
-        $this->assertEquals('Must be a valid email', $errors['email']['format']);
-        $this->assertEquals('Must be so long', $errors['body']['length']);
+        $this->assertSame('Must be a valid email', $errors['email']['format']);
+        $this->assertSame('Must be so long', $errors['body']['length']);
     }
 
     /**
@@ -207,7 +207,7 @@ class FormTest extends TestCase
         $form->setData(['title' => 'title', 'is_published' => true]);
 
         $this->assertSame($expected, $form->getData());
-        $this->assertEquals('title', $form->getData('title'));
+        $this->assertSame('title', $form->getData('title'));
         $this->assertNull($form->getData('non-existent'));
     }
 

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -37,8 +37,8 @@ class SchemaTest extends TestCase
             'body' => ['type' => 'string', 'length' => 1000],
         ]);
         $this->assertEquals(['email', 'body'], $schema->fields());
-        $this->assertEquals('string', $schema->field('email')['type']);
-        $this->assertEquals('string', $schema->field('body')['type']);
+        $this->assertSame('string', $schema->field('email')['type']);
+        $this->assertSame('string', $schema->field('body')['type']);
     }
 
     /**
@@ -113,8 +113,8 @@ class SchemaTest extends TestCase
                 'type' => 'decimal',
                 'required' => true,
             ]);
-        $this->assertEquals('string', $schema->fieldType('name'));
-        $this->assertEquals('decimal', $schema->fieldType('numbery'));
+        $this->assertSame('string', $schema->fieldType('name'));
+        $this->assertSame('decimal', $schema->fieldType('numbery'));
         $this->assertNull($schema->fieldType('nope'));
     }
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -69,7 +69,7 @@ class BaseApplicationTest extends TestCase
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $result = $app->handle($request);
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals('Hello Jane', '' . $result->getBody());
+        $this->assertSame('Hello Jane', '' . $result->getBody());
     }
 
     /**

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -341,26 +341,26 @@ class StreamTest extends TestCase
         /** @var \Cake\Http\Client\Response[] $responses */
         $responses = $this->stream->createResponses($headers, $content);
         $this->assertCount(3, $responses);
-        $this->assertEquals('close', $responses[0]->getHeaderLine('Connection'));
-        $this->assertEquals('', (string)$responses[0]->getBody());
-        $this->assertEquals('', (string)$responses[1]->getBody());
+        $this->assertSame('close', $responses[0]->getHeaderLine('Connection'));
+        $this->assertSame('', (string)$responses[0]->getBody());
+        $this->assertSame('', (string)$responses[1]->getBody());
         $this->assertEquals($content, (string)$responses[2]->getBody());
 
         $this->assertEquals(302, $responses[0]->getStatusCode());
         $this->assertEquals(302, $responses[1]->getStatusCode());
         $this->assertEquals(200, $responses[2]->getStatusCode());
 
-        $this->assertEquals('value', $responses[0]->getCookie('first'));
+        $this->assertSame('value', $responses[0]->getCookie('first'));
         $this->assertNull($responses[0]->getCookie('second'));
         $this->assertNull($responses[0]->getCookie('third'));
 
         $this->assertNull($responses[1]->getCookie('first'));
-        $this->assertEquals('val', $responses[1]->getCookie('second'));
+        $this->assertSame('val', $responses[1]->getCookie('second'));
         $this->assertNull($responses[1]->getCookie('third'));
 
         $this->assertNull($responses[2]->getCookie('first'));
         $this->assertNull($responses[2]->getCookie('second'));
-        $this->assertEquals('works', $responses[2]->getCookie('third'));
+        $this->assertSame('works', $responses[2]->getCookie('third'));
     }
 
     /**

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -38,9 +38,9 @@ class ResponseTest extends TestCase
         ];
         $response = new Response($headers, 'winner!');
 
-        $this->assertEquals('1.0', $response->getProtocolVersion());
+        $this->assertSame('1.0', $response->getProtocolVersion());
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertSame('OK', $response->getReasonPhrase());
         $this->assertEquals(
             'text/html;charset="UTF-8"',
             $response->getHeaderLine('content-type')
@@ -49,7 +49,7 @@ class ResponseTest extends TestCase
             'Tue, 25 Dec 2012 04:43:47 GMT',
             $response->getHeaderLine('Date')
         );
-        $this->assertEquals('winner!', '' . $response->getBody());
+        $this->assertSame('winner!', '' . $response->getBody());
     }
 
     /**
@@ -67,7 +67,7 @@ class ResponseTest extends TestCase
         $response = new Response($headers, 'ok');
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertEquals('1.0', $response->getProtocolVersion());
+        $this->assertSame('1.0', $response->getProtocolVersion());
         $this->assertEquals(
             'text/html;charset="UTF-8"',
             $response->getHeaderLine('content-type')
@@ -87,7 +87,7 @@ class ResponseTest extends TestCase
         ];
         $response = new Response($headers, 'ok');
 
-        $this->assertEquals('1.0', $response->getProtocolVersion());
+        $this->assertSame('1.0', $response->getProtocolVersion());
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -100,7 +100,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response([], 'string');
 
-        $this->assertEquals('string', $response->getStringBody());
+        $this->assertSame('string', $response->getStringBody());
     }
 
     /**
@@ -168,7 +168,7 @@ class ResponseTest extends TestCase
 </root>
 XML;
         $response = new Response([], $data);
-        $this->assertEquals('Test', (string)$response->getXml()->test);
+        $this->assertSame('Test', (string)$response->getXml()->test);
 
         $data = '';
         $response = new Response([], $data);
@@ -349,18 +349,18 @@ XML;
         $response = new Response($headers, '');
 
         $this->assertNull($response->getCookie('undef'));
-        $this->assertEquals('value', $response->getCookie('test'));
-        $this->assertEquals('soon', $response->getCookie('expiring'));
+        $this->assertSame('value', $response->getCookie('test'));
+        $this->assertSame('soon', $response->getCookie('expiring'));
 
         $result = $response->getCookieData('expiring');
-        $this->assertEquals('soon', $result['value']);
+        $this->assertSame('soon', $result['value']);
         $this->assertTrue($result['httponly']);
         $this->assertTrue($result['secure']);
         $this->assertEquals(
             'Wed, 09-Jun-2021 10:18:14 GMT',
             $result['expires']
         );
-        $this->assertEquals('/', $result['path']);
+        $this->assertSame('/', $result['path']);
 
         $result = $response->getCookies();
         $this->assertCount(3, $result);
@@ -432,14 +432,14 @@ XML;
             'Content-Type: text/html; charset="UTF-8"',
         ];
         $response = new Response($headers, '');
-        $this->assertEquals('UTF-8', $response->getEncoding());
+        $this->assertSame('UTF-8', $response->getEncoding());
 
         $headers = [
             'HTTP/1.0 200 Ok',
             "Content-Type: text/html; charset='ISO-8859-1'",
         ];
         $response = new Response($headers, '');
-        $this->assertEquals('ISO-8859-1', $response->getEncoding());
+        $this->assertSame('ISO-8859-1', $response->getEncoding());
     }
 
     /**
@@ -457,6 +457,6 @@ XML;
         ];
         $body = base64_decode('H4sIAAAAAAAAA/NIzcnJVyjPL8pJUQQAlRmFGwwAAAA=');
         $response = new Response($headers, $body);
-        $this->assertEquals('Hello world!', $response->getBody()->getContents());
+        $this->assertSame('Hello world!', $response->getBody()->getContents());
     }
 }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -214,8 +214,8 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) use ($cookies, $headers) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/test.html', $request->getUri() . '');
-                $this->assertEquals('split=value', $request->getHeaderLine('Cookie'));
+                $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
+                $this->assertSame('split=value', $request->getHeaderLine('Cookie'));
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
                 $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
 
@@ -354,8 +354,8 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) {
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/search', '' . $request->getUri());
-                $this->assertEquals('some data', '' . $request->getBody());
+                $this->assertSame('http://cakephp.org/search', '' . $request->getUri());
+                $this->assertSame('some data', '' . $request->getBody());
 
                 return true;
             }))
@@ -414,7 +414,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/', '' . $request->getUri());
+                $this->assertSame('http://cakephp.org/', '' . $request->getUri());
                 $this->assertEquals($headers['Authorization'], $request->getHeaderLine('Authorization'));
                 $this->assertEquals($headers['Proxy-Authorization'], $request->getHeaderLine('Proxy-Authorization'));
 
@@ -468,7 +468,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) use ($method) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals($method, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/projects/add', '' . $request->getUri());
+                $this->assertSame('http://cakephp.org/projects/add', '' . $request->getUri());
 
                 return true;
             }))
@@ -550,7 +550,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($data) {
                 $this->assertEquals($data, '' . $request->getBody());
-                $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
+                $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
 
                 return true;
             }))
@@ -703,7 +703,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals(Request::METHOD_HEAD, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
+                $this->assertSame('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
 
                 return true;
             }))
@@ -828,7 +828,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) use ($headers) {
                 $this->assertInstanceOf('Zend\Diactoros\Request', $request);
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-                $this->assertEquals('http://cakephp.org/test.html', $request->getUri() . '');
+                $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
                 $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
 

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -73,7 +73,7 @@ class CookieTest extends TestCase
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $result = $cookie->toHeaderValue();
-        $this->assertEquals('cakephp=cakephp-rocks; path=/', $result);
+        $this->assertSame('cakephp=cakephp-rocks; path=/', $result);
 
         $date = Chronos::createFromFormat('m/d/Y h:i:s', '12/1/2027 12:00:00');
 
@@ -97,11 +97,11 @@ class CookieTest extends TestCase
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $result = $cookie->getValue();
-        $this->assertEquals('cakephp-rocks', $result);
+        $this->assertSame('cakephp-rocks', $result);
 
         $cookie = new Cookie('cakephp', '');
         $result = $cookie->getValue();
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
     }
 
     /**
@@ -380,7 +380,7 @@ class CookieTest extends TestCase
         ];
         $cookie = new Cookie('cakephp', json_encode($data));
         $this->assertFalse($cookie->isExpanded());
-        $this->assertEquals('developer', $cookie->read('profile.profession'));
+        $this->assertSame('developer', $cookie->read('profile.profession'));
         $this->assertTrue($cookie->isExpanded(), 'Cookies expand when read.');
 
         $cookie = $cookie->withValue(json_encode($data));
@@ -418,7 +418,7 @@ class CookieTest extends TestCase
         $this->assertEquals($data, $result);
 
         $result = $cookie->read('profile.profession');
-        $this->assertEquals('developer', $result);
+        $this->assertSame('developer', $result);
     }
 
     /**
@@ -430,7 +430,7 @@ class CookieTest extends TestCase
     {
         $data = 'key|value,key2|value2';
         $cookie = new Cookie('cakephp', $data);
-        $this->assertEquals('value', $cookie->read('key'));
+        $this->assertSame('value', $cookie->read('key'));
         $this->assertNull($cookie->read('nope'));
     }
 
@@ -448,7 +448,7 @@ class CookieTest extends TestCase
             ],
         ];
         $cookie = new Cookie('cakephp', $data);
-        $this->assertEquals('developer', $cookie->read('profile.profession'));
+        $this->assertSame('developer', $cookie->read('profile.profession'));
 
         $expected = '{"username":"florian","profile":{"profession":"developer"}}';
         $this->assertStringContainsString(urlencode($expected), $cookie->toHeaderValue());
@@ -462,12 +462,12 @@ class CookieTest extends TestCase
     public function testGetId()
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $this->assertEquals('cakephp;;/', $cookie->getId());
+        $this->assertSame('cakephp;;/', $cookie->getId());
 
         $cookie = new Cookie('CAKEPHP', 'cakephp-rocks');
-        $this->assertEquals('CAKEPHP;;/', $cookie->getId());
+        $this->assertSame('CAKEPHP;;/', $cookie->getId());
 
         $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
-        $this->assertEquals('test;example.com;/path', $cookie->getId());
+        $this->assertSame('test;example.com;/path', $cookie->getId());
     }
 }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -93,8 +93,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $cookie = $response->getCookie('csrfToken');
         $this->assertNotEmpty($cookie, 'Should set a token.');
         $this->assertRegExp('/^[a-f0-9]+$/', $cookie['value'], 'Should look like a hash.');
-        $this->assertEquals(0, $cookie['expire'], 'session duration.');
-        $this->assertEquals('/dir/', $cookie['path'], 'session path.');
+        $this->assertSame(0, $cookie['expire'], 'session duration.');
+        $this->assertSame('/dir/', $cookie['path'], 'session path.');
         $this->assertEquals($cookie['value'], $updatedRequest->getParam('_csrfToken'));
     }
 
@@ -285,7 +285,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertNotEmpty($cookie, 'Should set a token.');
         $this->assertRegExp('/^[a-f0-9]+$/', $cookie['value'], 'Should look like a hash.');
         $this->assertWithinRange((new Time('+1 hour'))->format('U'), $cookie['expire'], 1, 'session duration.');
-        $this->assertEquals('/dir/', $cookie['path'], 'session path.');
+        $this->assertSame('/dir/', $cookie['path'], 'session path.');
         $this->assertTrue($cookie['secure'], 'cookie security flag missing');
         $this->assertTrue($cookie['httpOnly'], 'cookie httpOnly flag missing');
     }

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -72,7 +72,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('It worked', $out);
+        $this->assertSame('It worked', $out);
         $expected = [
             'HTTP/1.1 201 Created',
             'Content-Type: text/html',
@@ -97,7 +97,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('', $out);
+        $this->assertSame('', $out);
         $expected = [
             'HTTP/1.1 204 No Content',
             'X-testing: value',
@@ -122,7 +122,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('ok', $out);
+        $this->assertSame('ok', $out);
         $expected = [
             'HTTP/1.1 200 OK',
             'Content-Type: text/plain',
@@ -171,7 +171,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('ok', $out);
+        $this->assertSame('ok', $out);
         $expected = [
             'HTTP/1.1 200 OK',
             'Content-Type: text/plain',
@@ -248,7 +248,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('It worked', $out);
+        $this->assertSame('It worked', $out);
         $expected = [
             'HTTP/1.1 201 Created',
             'Content-Type: text/plain',
@@ -272,7 +272,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('t wo', $out);
+        $this->assertSame('t wo', $out);
         $expected = [
             'HTTP/1.1 200 OK',
             'Content-Type: text/plain',
@@ -297,7 +297,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response, 2);
         $out = ob_get_clean();
 
-        $this->assertEquals('It worked', $out);
+        $this->assertSame('It worked', $out);
     }
 
     /**
@@ -316,7 +316,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('rked', $out);
+        $this->assertSame('rked', $out);
     }
 
     /**
@@ -335,7 +335,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('It worked', $out);
+        $this->assertSame('It worked', $out);
     }
 
     /**
@@ -358,7 +358,7 @@ class ResponseEmitterTest extends TestCase
         $this->emitter->emit($response);
         $out = ob_get_clean();
 
-        $this->assertEquals('t wo', $out);
+        $this->assertSame('t wo', $out);
         $expected = [
             'HTTP/1.1 201 Created',
             'Content-Range: bytes 1-4/9',

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -73,9 +73,9 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $this->assertSame('', (string)$response->getBody());
-        $this->assertEquals('UTF-8', $response->getCharset());
-        $this->assertEquals('text/html', $response->getType());
-        $this->assertEquals('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('UTF-8', $response->getCharset());
+        $this->assertSame('text/html', $response->getType());
+        $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(200, $response->getStatusCode());
 
         $options = [
@@ -85,10 +85,10 @@ class ResponseTest extends TestCase
             'status' => 203,
         ];
         $response = new Response($options);
-        $this->assertEquals('This is the body', (string)$response->getBody());
-        $this->assertEquals('my-custom-charset', $response->getCharset());
-        $this->assertEquals('audio/mpeg', $response->getType());
-        $this->assertEquals('audio/mpeg', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('This is the body', (string)$response->getBody());
+        $this->assertSame('my-custom-charset', $response->getCharset());
+        $this->assertSame('audio/mpeg', $response->getType());
+        $this->assertSame('audio/mpeg', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(203, $response->getStatusCode());
     }
 
@@ -100,13 +100,13 @@ class ResponseTest extends TestCase
     public function testWithCharset()
     {
         $response = new Response();
-        $this->assertEquals('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
 
         $new = $response->withCharset('iso-8859-1');
         $this->assertStringNotContainsString('iso', $response->getHeaderLine('Content-Type'), 'Old instance not changed');
         $this->assertSame('iso-8859-1', $new->getCharset());
 
-        $this->assertEquals('text/html; charset=iso-8859-1', $new->getHeaderLine('Content-Type'));
+        $this->assertSame('text/html; charset=iso-8859-1', $new->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -117,7 +117,7 @@ class ResponseTest extends TestCase
     public function testGetType()
     {
         $response = new Response();
-        $this->assertEquals('text/html', $response->getType());
+        $this->assertSame('text/html', $response->getType());
 
         $this->assertEquals(
             'application/pdf',
@@ -142,7 +142,7 @@ class ResponseTest extends TestCase
         $response->setTypeMap('ical', 'text/calendar');
 
         $response = $response->withType('ical')->getType();
-        $this->assertEquals('text/calendar', $response);
+        $this->assertSame('text/calendar', $response);
     }
 
     /**
@@ -154,7 +154,7 @@ class ResponseTest extends TestCase
         $response->setTypeMap('ical', ['text/calendar']);
 
         $response = $response->withType('ical')->getType();
-        $this->assertEquals('text/calendar', $response);
+        $this->assertSame('text/calendar', $response);
     }
 
     /**
@@ -290,7 +290,7 @@ class ResponseTest extends TestCase
         $this->assertEquals(gmdate('D, j M Y G:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
         $this->assertEquals(gmdate('D, j M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Last-Modified'));
         $this->assertEquals(gmdate('D, j M Y H:i:s', $time) . ' GMT', $new->getHeaderLine('Expires'));
-        $this->assertEquals('public, max-age=0', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('public, max-age=0', $new->getHeaderLine('Cache-Control'));
     }
 
     /**
@@ -343,11 +343,11 @@ class ResponseTest extends TestCase
     public function testMapType()
     {
         $response = new Response();
-        $this->assertEquals('wav', $response->mapType('audio/x-wav'));
-        $this->assertEquals('pdf', $response->mapType('application/pdf'));
-        $this->assertEquals('xml', $response->mapType('text/xml'));
-        $this->assertEquals('html', $response->mapType('*/*'));
-        $this->assertEquals('csv', $response->mapType('application/vnd.ms-excel'));
+        $this->assertSame('wav', $response->mapType('audio/x-wav'));
+        $this->assertSame('pdf', $response->mapType('application/pdf'));
+        $this->assertSame('xml', $response->mapType('text/xml'));
+        $this->assertSame('html', $response->mapType('*/*'));
+        $this->assertSame('csv', $response->mapType('application/vnd.ms-excel'));
         $expected = ['json', 'xhtml', 'css'];
         $result = $response->mapType(['application/json', 'application/xhtml+xml', 'text/css']);
         $this->assertEquals($expected, $result);
@@ -419,14 +419,14 @@ class ResponseTest extends TestCase
 
         $new = $response->withAddedLink('http://example.com', ['rel' => 'prev']);
         $this->assertFalse($response->hasHeader('Link'), 'Old instance not modified');
-        $this->assertEquals('<http://example.com>; rel="prev"', $new->getHeaderLine('Link'));
+        $this->assertSame('<http://example.com>; rel="prev"', $new->getHeaderLine('Link'));
 
         $new = $response->withAddedLink('http://example.com');
-        $this->assertEquals('<http://example.com>', $new->getHeaderLine('Link'));
+        $this->assertSame('<http://example.com>', $new->getHeaderLine('Link'));
 
         $new = $response->withAddedLink('http://example.com?p=1', ['rel' => 'prev'])
             ->withAddedLink('http://example.com?p=2', ['rel' => 'next', 'foo' => 'bar']);
-        $this->assertEquals('<http://example.com?p=1>; rel="prev",<http://example.com?p=2>; rel="next"; foo="bar"', $new->getHeaderLine('Link'));
+        $this->assertSame('<http://example.com?p=1>; rel="prev",<http://example.com?p=2>; rel="next"; foo="bar"', $new->getHeaderLine('Link'));
     }
 
     /**
@@ -494,16 +494,16 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withSharable(true);
         $this->assertFalse($response->hasHeader('Cache-Control'), 'old instance unchanged');
-        $this->assertEquals('public', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('public', $new->getHeaderLine('Cache-Control'));
 
         $new = $response->withSharable(false);
-        $this->assertEquals('private', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('private', $new->getHeaderLine('Cache-Control'));
 
         $new = $response->withSharable(true, 3600);
-        $this->assertEquals('public, max-age=3600', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('public, max-age=3600', $new->getHeaderLine('Cache-Control'));
 
         $new = $response->withSharable(false, 3600);
-        $this->assertEquals('private, max-age=3600', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('private, max-age=3600', $new->getHeaderLine('Cache-Control'));
     }
 
     /**
@@ -517,11 +517,11 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Cache-Control'));
 
         $new = $response->withMaxAge(3600);
-        $this->assertEquals('max-age=3600', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('max-age=3600', $new->getHeaderLine('Cache-Control'));
 
         $new = $response->withMaxAge(3600)
             ->withSharable(false);
-        $this->assertEquals('max-age=3600, private', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('max-age=3600, private', $new->getHeaderLine('Cache-Control'));
     }
 
     /**
@@ -535,10 +535,10 @@ class ResponseTest extends TestCase
         $new = $response->withSharedMaxAge(3600);
 
         $this->assertFalse($response->hasHeader('Cache-Control'));
-        $this->assertEquals('s-maxage=3600', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('s-maxage=3600', $new->getHeaderLine('Cache-Control'));
 
         $new = $response->withSharedMaxAge(3600)->withSharable(true);
-        $this->assertEquals('s-maxage=3600, public', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('s-maxage=3600, public', $new->getHeaderLine('Cache-Control'));
     }
 
     /**
@@ -553,7 +553,7 @@ class ResponseTest extends TestCase
 
         $new = $response->withMustRevalidate(true);
         $this->assertFalse($response->hasHeader('Cache-Control'));
-        $this->assertEquals('must-revalidate', $new->getHeaderLine('Cache-Control'));
+        $this->assertSame('must-revalidate', $new->getHeaderLine('Cache-Control'));
 
         $new = $new->withMustRevalidate(false);
         $this->assertEmpty($new->getHeaderLine('Cache-Control'));
@@ -570,11 +570,11 @@ class ResponseTest extends TestCase
         $new = $response->withVary('Accept-encoding');
 
         $this->assertFalse($response->hasHeader('Vary'));
-        $this->assertEquals('Accept-encoding', $new->getHeaderLine('Vary'));
+        $this->assertSame('Accept-encoding', $new->getHeaderLine('Vary'));
 
         $new = $response->withVary(['Accept-encoding', 'Accept-language']);
         $this->assertFalse($response->hasHeader('Vary'));
-        $this->assertEquals('Accept-encoding,Accept-language', $new->getHeaderLine('Vary'));
+        $this->assertSame('Accept-encoding,Accept-language', $new->getHeaderLine('Vary'));
     }
 
     /**
@@ -588,10 +588,10 @@ class ResponseTest extends TestCase
         $new = $response->withEtag('something');
 
         $this->assertFalse($response->hasHeader('Etag'));
-        $this->assertEquals('"something"', $new->getHeaderLine('Etag'));
+        $this->assertSame('"something"', $new->getHeaderLine('Etag'));
 
         $new = $response->withEtag('something', true);
-        $this->assertEquals('W/"something"', $new->getHeaderLine('Etag'));
+        $this->assertSame('W/"something"', $new->getHeaderLine('Etag'));
     }
 
     /**
@@ -802,7 +802,7 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withCookie(new Cookie('testing', 'abc123'));
         $this->assertNull($response->getCookie('testing'), 'withCookie does not mutate');
-        $this->assertEquals('abc123', $new->getCookie('testing')['value']);
+        $this->assertSame('abc123', $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', 99));
         $this->assertEquals(99, $new->getCookie('testing')['value']);
@@ -873,7 +873,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $response = $response->withCookie(new Cookie('testing', 'abc123'));
-        $this->assertEquals('abc123', $response->getCookie('testing')['value']);
+        $this->assertSame('abc123', $response->getCookie('testing')['value']);
 
         $new = $response->withExpiredCookie(new Cookie('testing'));
 
@@ -924,12 +924,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $cookie = new Cookie('yay', 'a value');
         $response = $response->withCookie($cookie);
-        $this->assertEquals('a value', $response->getCookie('yay')['value']);
+        $this->assertSame('a value', $response->getCookie('yay')['value']);
 
         $new = $response->withExpiredCookie($cookie);
 
         $this->assertNull($response->getCookie('yay')['expire']);
-        $this->assertEquals('1', $new->getCookie('yay')['expire']);
+        $this->assertSame('1', $new->getCookie('yay')['expire']);
     }
 
     /**
@@ -1133,8 +1133,8 @@ class ResponseTest extends TestCase
             'attachment; filename="something_special.css"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
-        $this->assertEquals('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $body = $new->getBody();
         $this->assertInstanceOf('Zend\Diactoros\Stream', $body);
 
@@ -1153,12 +1153,12 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $new = $response->withFile(CONFIG . 'no_section.ini');
-        $this->assertEquals('text/html; charset=UTF-8', $new->getHeaderLine('Content-Type'));
+        $this->assertSame('text/html; charset=UTF-8', $new->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="no_section.ini"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $body = $new->getBody();
         $expected = "some_key = some_value\nbool_key = 1\n";
         $this->assertEquals($expected, $body->getContents());
@@ -1175,7 +1175,7 @@ class ResponseTest extends TestCase
         $response = new Response();
 
         $new = $response->withFile(CONFIG . 'no_section.ini');
-        $this->assertEquals('application/octet-stream', $new->getHeaderLine('Content-Type'));
+        $this->assertSame('application/octet-stream', $new->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="no_section.ini"',
             $new->getHeaderLine('Content-Disposition')
@@ -1193,7 +1193,7 @@ class ResponseTest extends TestCase
         $response = new Response();
 
         $new = $response->withFile(CONFIG . 'no_section.ini');
-        $this->assertEquals('application/force-download', $new->getHeaderLine('Content-Type'));
+        $this->assertSame('application/force-download', $new->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -1224,7 +1224,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $new = $response->withFile(TEST_APP . 'vendor/img/test_2.JPG');
-        $this->assertEquals('image/jpeg', $new->getHeaderLine('Content-Type'));
+        $this->assertSame('image/jpeg', $new->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -1277,8 +1277,8 @@ class ResponseTest extends TestCase
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertEquals($length, $new->getHeaderLine('Content-Length'));
         $this->assertEquals($offsetResponse, $new->getHeaderLine('Content-Range'));
     }
@@ -1301,10 +1301,10 @@ class ResponseTest extends TestCase
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
-        $this->assertEquals('18', $new->getHeaderLine('Content-Length'));
-        $this->assertEquals('bytes 8-25/38', $new->getHeaderLine('Content-Range'));
+        $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('18', $new->getHeaderLine('Content-Length'));
+        $this->assertSame('bytes 8-25/38', $new->getHeaderLine('Content-Range'));
         $this->assertEquals(206, $new->getStatusCode());
     }
 
@@ -1347,10 +1347,10 @@ class ResponseTest extends TestCase
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
-        $this->assertEquals('38', $new->getHeaderLine('Content-Length'));
-        $this->assertEquals('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
+        $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('38', $new->getHeaderLine('Content-Length'));
+        $this->assertSame('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
         $this->assertEquals(206, $new->getStatusCode());
     }
 
@@ -1372,9 +1372,9 @@ class ResponseTest extends TestCase
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
-        $this->assertEquals('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals('bytes', $new->getHeaderLine('Accept-Ranges'));
-        $this->assertEquals('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
+        $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
         $this->assertEquals(416, $new->getStatusCode());
     }
 
@@ -1404,7 +1404,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $version = $response->getProtocolVersion();
-        $this->assertEquals('1.1', $version);
+        $this->assertSame('1.1', $version);
     }
 
     /**
@@ -1416,12 +1416,12 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $version = $response->getProtocolVersion();
-        $this->assertEquals('1.1', $version);
+        $this->assertSame('1.1', $version);
         $response2 = $response->withProtocolVersion('1.0');
         $version = $response2->getProtocolVersion();
-        $this->assertEquals('1.0', $version);
+        $this->assertSame('1.0', $version);
         $version = $response->getProtocolVersion();
-        $this->assertEquals('1.1', $version);
+        $this->assertSame('1.1', $version);
         $this->assertNotEquals($response, $response2);
     }
 
@@ -1468,7 +1468,7 @@ class ResponseTest extends TestCase
 
         $response = $response->withStatus(404);
         $reasonPhrase = $response->getReasonPhrase();
-        $this->assertEquals('Not Found', $reasonPhrase);
+        $this->assertSame('Not Found', $reasonPhrase);
     }
 
     /**
@@ -1482,7 +1482,7 @@ class ResponseTest extends TestCase
         $body = $response->getBody();
         $body->rewind();
         $result = $body->getContents();
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $stream = new Stream('php://memory', 'wb+');
         $stream->write('test1');
@@ -1491,12 +1491,12 @@ class ResponseTest extends TestCase
         $body = $response2->getBody();
         $body->rewind();
         $result = $body->getContents();
-        $this->assertEquals('test1', $result);
+        $this->assertSame('test1', $result);
 
         $body = $response->getBody();
         $body->rewind();
         $result = $body->getContents();
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
     }
 
     /**
@@ -1636,7 +1636,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $headers = $response->getHeaderLine('Accept');
-        $this->assertEquals('', $headers);
+        $this->assertSame('', $headers);
 
         $response = $response->withAddedHeader('Accept', 'application/json');
         $response = $response->withAddedHeader('Accept', 'application/xml');

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -919,6 +919,9 @@ class ResponseTest extends TestCase
         $this->assertLessThan(FrozenTime::createFromTimestamp(1), (string)$expiredCookie->getCookie('testing')['expire']);
     }
 
+    /**
+     * @return void
+     */
     public function testWithExpiredCookieObject()
     {
         $response = new Response();
@@ -929,7 +932,7 @@ class ResponseTest extends TestCase
         $new = $response->withExpiredCookie($cookie);
 
         $this->assertNull($response->getCookie('yay')['expire']);
-        $this->assertSame('1', $new->getCookie('yay')['expire']);
+        $this->assertSame(1, $new->getCookie('yay')['expire']);
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -140,7 +140,7 @@ class ServerRequestFactoryTest extends TestCase
         $res = ServerRequestFactory::fromGlobals($server);
         $session = $res->getAttribute('session');
         $this->assertInstanceOf(Session::class, $session);
-        $this->assertEquals('/basedir/', ini_get('session.cookie_path'), 'Needs trailing / for cookie to work');
+        $this->assertSame('/basedir/', ini_get('session.cookie_path'), 'Needs trailing / for cookie to work');
     }
 
     /**
@@ -157,9 +157,9 @@ class ServerRequestFactoryTest extends TestCase
             'REQUEST_URI' => '/posts/add',
         ];
         $res = ServerRequestFactory::fromGlobals($server);
-        $this->assertEquals('basedir', $res->getAttribute('base'));
-        $this->assertEquals('basedir/', $res->getAttribute('webroot'));
-        $this->assertEquals('/posts/add', $res->getUri()->getPath());
+        $this->assertSame('basedir', $res->getAttribute('base'));
+        $this->assertSame('basedir/', $res->getAttribute('webroot'));
+        $this->assertSame('/posts/add', $res->getUri()->getPath());
     }
 
     /**
@@ -178,9 +178,9 @@ class ServerRequestFactoryTest extends TestCase
         ];
         $res = ServerRequestFactory::fromGlobals($server);
 
-        $this->assertEquals('/urlencode%20me', $res->getAttribute('base'));
-        $this->assertEquals('/urlencode%20me/', $res->getAttribute('webroot'));
-        $this->assertEquals('/posts/view/1', $res->getUri()->getPath());
+        $this->assertSame('/urlencode%20me', $res->getAttribute('base'));
+        $this->assertSame('/urlencode%20me/', $res->getAttribute('webroot'));
+        $this->assertSame('/posts/view/1', $res->getUri()->getPath());
     }
 
     /**
@@ -197,9 +197,9 @@ class ServerRequestFactoryTest extends TestCase
         ];
         $res = ServerRequestFactory::fromGlobals($server);
 
-        $this->assertEquals('', $res->getAttribute('base'));
-        $this->assertEquals('/', $res->getAttribute('webroot'));
-        $this->assertEquals('/posts/add', $res->getUri()->getPath());
+        $this->assertSame('', $res->getAttribute('base'));
+        $this->assertSame('/', $res->getAttribute('webroot'));
+        $this->assertSame('/posts/add', $res->getUri()->getPath());
     }
 
     /**
@@ -278,8 +278,8 @@ class ServerRequestFactoryTest extends TestCase
         ];
         $res = ServerRequestFactory::fromGlobals($server);
 
-        $this->assertEquals('/webroot/', $res->getAttribute('webroot'));
-        $this->assertEquals('/index.php', $res->getAttribute('base'));
-        $this->assertEquals('/posts/add', $res->getUri()->getPath());
+        $this->assertSame('/webroot/', $res->getAttribute('webroot'));
+        $this->assertSame('/index.php', $res->getAttribute('base'));
+        $this->assertSame('/posts/add', $res->getUri()->getPath());
     }
 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -157,7 +157,7 @@ class ServerRequestTest extends TestCase
         ];
         $request = new ServerRequest($data);
         $this->assertEquals($request->getQueryParams(), $data['query']);
-        $this->assertEquals('/some/path', $request->getRequestTarget());
+        $this->assertSame('/some/path', $request->getRequestTarget());
     }
 
     /**
@@ -170,10 +170,10 @@ class ServerRequestTest extends TestCase
         $_SERVER['REQUEST_URI'] = '/some/other/path';
 
         $request = new ServerRequest(['url' => '/articles/view/1']);
-        $this->assertEquals('/articles/view/1', $request->getUri()->getPath());
+        $this->assertSame('/articles/view/1', $request->getUri()->getPath());
 
         $request = new ServerRequest(['url' => '/']);
-        $this->assertEquals('/', $request->getUri()->getPath());
+        $this->assertSame('/', $request->getUri()->getPath());
     }
     /**
      * Test that querystring args provided in the URL string are parsed.
@@ -186,8 +186,8 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
         $expected = ['one' => 'something', 'two' => 'else'];
         $this->assertEquals($expected, $request->getQueryParams());
-        $this->assertEquals('/some/path', $request->getUri()->getPath());
-        $this->assertEquals('one=something&two=else', $request->getUri()->getQuery());
+        $this->assertSame('/some/path', $request->getUri()->getPath());
+        $this->assertSame('one=something&two=else', $request->getUri()->getQuery());
     }
 
     /**
@@ -199,19 +199,19 @@ class ServerRequestTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/tasks/index?ts=123456';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/tasks/index', $request->getRequestTarget());
+        $this->assertSame('/tasks/index', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/tasks/index/?ts=123456';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/tasks/index/', $request->getRequestTarget());
+        $this->assertSame('/tasks/index/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/some/path?url=http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/some/path', $request->getRequestTarget());
+        $this->assertSame('/some/path', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/other/path?url=http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/other/path', $request->getRequestTarget());
+        $this->assertSame('/other/path', $request->getRequestTarget());
     }
 
     /**
@@ -221,11 +221,11 @@ class ServerRequestTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/jump/http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/jump/http://cakephp.org', $request->getRequestTarget());
+        $this->assertSame('/jump/http://cakephp.org', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/jump/http://cakephp.org';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/jump/http://cakephp.org', $request->getRequestTarget());
+        $this->assertSame('/jump/http://cakephp.org', $request->getRequestTarget());
     }
 
     /**
@@ -239,10 +239,10 @@ class ServerRequestTest extends TestCase
         $this->assertSame('/', $request->getPath());
 
         $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
-        $this->assertEquals('/some/path', $request->getPath());
+        $this->assertSame('/some/path', $request->getPath());
 
         $request = $request->withRequestTarget('/foo/bar?x=y');
-        $this->assertEquals('/foo/bar', $request->getPath());
+        $this->assertSame('/foo/bar', $request->getPath());
     }
 
     /**
@@ -449,14 +449,14 @@ class ServerRequestTest extends TestCase
         $uploads = $request->getUploadedFiles();
         $this->assertCount(3, $uploads);
         $this->assertArrayHasKey(0, $uploads);
-        $this->assertEquals('scratch.text', $uploads[0]['image']->getClientFilename());
+        $this->assertSame('scratch.text', $uploads[0]['image']->getClientFilename());
 
         $this->assertArrayHasKey('pictures', $uploads);
-        $this->assertEquals('a-file.png', $uploads['pictures'][0]['file']->getClientFilename());
-        $this->assertEquals('a-moose.png', $uploads['pictures'][1]['file']->getClientFilename());
+        $this->assertSame('a-file.png', $uploads['pictures'][0]['file']->getClientFilename());
+        $this->assertSame('a-moose.png', $uploads['pictures'][1]['file']->getClientFilename());
 
         $this->assertArrayHasKey('image_main', $uploads);
-        $this->assertEquals('born on.txt', $uploads['image_main']['file']->getClientFilename());
+        $this->assertSame('born on.txt', $uploads['image_main']['file']->getClientFilename());
     }
 
     /**
@@ -491,9 +491,9 @@ class ServerRequestTest extends TestCase
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
         $this->assertArrayHasKey('birth_cert', $uploads);
-        $this->assertEquals('born on.txt', $uploads['birth_cert']->getClientFilename());
-        $this->assertEquals(0, $uploads['birth_cert']->getError());
-        $this->assertEquals('application/octet-stream', $uploads['birth_cert']->getClientMediaType());
+        $this->assertSame('born on.txt', $uploads['birth_cert']->getClientFilename());
+        $this->assertSame(0, $uploads['birth_cert']->getError());
+        $this->assertSame('application/octet-stream', $uploads['birth_cert']->getClientMediaType());
         $this->assertEquals(123, $uploads['birth_cert']->getSize());
     }
 
@@ -632,21 +632,21 @@ class ServerRequestTest extends TestCase
     {
         $post = ['_method' => 'POST'];
         $request = new ServerRequest(compact('post'));
-        $this->assertEquals('POST', $request->getEnv('REQUEST_METHOD'));
+        $this->assertSame('POST', $request->getEnv('REQUEST_METHOD'));
 
         $post = ['_method' => 'DELETE'];
         $request = new ServerRequest(compact('post'));
-        $this->assertEquals('DELETE', $request->getEnv('REQUEST_METHOD'));
+        $this->assertSame('DELETE', $request->getEnv('REQUEST_METHOD'));
 
         $request = new ServerRequest(['environment' => ['HTTP_X_HTTP_METHOD_OVERRIDE' => 'PUT']]);
-        $this->assertEquals('PUT', $request->getEnv('REQUEST_METHOD'));
+        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
 
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'POST'],
             'post' => ['_method' => 'PUT'],
         ]);
-        $this->assertEquals('PUT', $request->getEnv('REQUEST_METHOD'));
-        $this->assertEquals('POST', $request->getEnv('ORIGINAL_REQUEST_METHOD'));
+        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
+        $this->assertSame('POST', $request->getEnv('ORIGINAL_REQUEST_METHOD'));
     }
 
     /**
@@ -664,22 +664,22 @@ class ServerRequestTest extends TestCase
         ]]);
 
         $request->trustProxy = true;
-        $this->assertEquals('real.ip', $request->clientIp());
+        $this->assertSame('real.ip', $request->clientIp());
 
         $request = $request->withEnv('HTTP_X_FORWARDED_FOR', '');
-        $this->assertEquals('192.168.1.1', $request->clientIp());
+        $this->assertSame('192.168.1.1', $request->clientIp());
 
         $request = $request->withEnv('HTTP_X_REAL_IP', '');
-        $this->assertEquals('192.168.1.2', $request->clientIp());
+        $this->assertSame('192.168.1.2', $request->clientIp());
 
         $request->trustProxy = false;
-        $this->assertEquals('192.168.1.3', $request->clientIp());
+        $this->assertSame('192.168.1.3', $request->clientIp());
 
         $request = $request->withEnv('HTTP_X_FORWARDED_FOR', '');
-        $this->assertEquals('192.168.1.3', $request->clientIp());
+        $this->assertSame('192.168.1.3', $request->clientIp());
 
         $request = $request->withEnv('HTTP_CLIENT_IP', '');
-        $this->assertEquals('192.168.1.3', $request->clientIp());
+        $this->assertSame('192.168.1.3', $request->clientIp());
     }
 
     /**
@@ -703,19 +703,19 @@ class ServerRequestTest extends TestCase
             '192.168.1.3',
         ]);
 
-        $this->assertEquals('real.ip', $request->clientIp());
+        $this->assertSame('real.ip', $request->clientIp());
 
         $request = $request->withEnv(
             'HTTP_X_FORWARDED_FOR',
             'spoof.fake.ip, real.ip, 192.168.1.0, 192.168.1.2, 192.168.1.3'
         );
-        $this->assertEquals('192.168.1.3', $request->clientIp());
+        $this->assertSame('192.168.1.3', $request->clientIp());
 
         $request = $request->withEnv('HTTP_X_FORWARDED_FOR', '');
-        $this->assertEquals('192.168.1.1', $request->clientIp());
+        $this->assertSame('192.168.1.1', $request->clientIp());
 
         $request->trustProxy = false;
-        $this->assertEquals('192.168.1.4', $request->clientIp());
+        $this->assertSame('192.168.1.4', $request->clientIp());
     }
 
     /**
@@ -873,7 +873,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'delete'],
         ]);
-        $this->assertEquals('delete', $request->getMethod());
+        $this->assertSame('delete', $request->getMethod());
     }
 
     /**
@@ -888,8 +888,8 @@ class ServerRequestTest extends TestCase
         ]);
         $new = $request->withMethod('put');
         $this->assertNotSame($new, $request);
-        $this->assertEquals('delete', $request->getMethod());
-        $this->assertEquals('put', $new->getMethod());
+        $this->assertSame('delete', $request->getMethod());
+        $this->assertSame('put', $new->getMethod());
     }
 
     /**
@@ -915,13 +915,13 @@ class ServerRequestTest extends TestCase
     public function testGetProtocolVersion()
     {
         $request = new ServerRequest();
-        $this->assertEquals('1.1', $request->getProtocolVersion());
+        $this->assertSame('1.1', $request->getProtocolVersion());
 
         // SERVER var.
         $request = new ServerRequest([
             'environment' => ['SERVER_PROTOCOL' => 'HTTP/1.0'],
         ]);
-        $this->assertEquals('1.0', $request->getProtocolVersion());
+        $this->assertSame('1.0', $request->getProtocolVersion());
     }
 
     /**
@@ -934,8 +934,8 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest();
         $new = $request->withProtocolVersion('1.0');
         $this->assertNotSame($new, $request);
-        $this->assertEquals('1.1', $request->getProtocolVersion());
-        $this->assertEquals('1.0', $new->getProtocolVersion());
+        $this->assertSame('1.1', $request->getProtocolVersion());
+        $this->assertSame('1.0', $new->getProtocolVersion());
     }
 
     /**
@@ -962,10 +962,10 @@ class ServerRequestTest extends TestCase
             'HTTP_HOST' => 'localhost',
             'HTTP_X_FORWARDED_HOST' => 'cakephp.org',
         ]]);
-        $this->assertEquals('localhost', $request->host());
+        $this->assertSame('localhost', $request->host());
 
         $request->trustProxy = true;
-        $this->assertEquals('cakephp.org', $request->host());
+        $this->assertSame('cakephp.org', $request->host());
     }
 
     /**
@@ -977,14 +977,14 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest(['environment' => ['SERVER_PORT' => '80']]);
 
-        $this->assertEquals('80', $request->port());
+        $this->assertSame('80', $request->port());
 
         $request = $request->withEnv('SERVER_PORT', '443');
         $request = $request->withEnv('HTTP_X_FORWARDED_PORT', '80');
-        $this->assertEquals('443', $request->port());
+        $this->assertSame('443', $request->port());
 
         $request->trustProxy = true;
-        $this->assertEquals('80', $request->port());
+        $this->assertSame('80', $request->port());
     }
 
     /**
@@ -996,10 +996,10 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest(['environment' => ['HTTP_HOST' => 'something.example.com']]);
 
-        $this->assertEquals('example.com', $request->domain());
+        $this->assertSame('example.com', $request->domain());
 
         $request = $request->withEnv('HTTP_HOST', 'something.example.co.uk');
-        $this->assertEquals('example.co.uk', $request->domain(2));
+        $this->assertSame('example.co.uk', $request->domain(2));
     }
 
     /**
@@ -1011,14 +1011,14 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest(['environment' => ['HTTPS' => 'on']]);
 
-        $this->assertEquals('https', $request->scheme());
+        $this->assertSame('https', $request->scheme());
 
         $request = $request->withEnv('HTTPS', '');
-        $this->assertEquals('http', $request->scheme());
+        $this->assertSame('http', $request->scheme());
 
         $request = $request->withEnv('HTTP_X_FORWARDED_PROTO', 'https');
         $request->trustProxy = true;
-        $this->assertEquals('https', $request->scheme());
+        $this->assertSame('https', $request->scheme());
     }
 
     /**
@@ -1285,13 +1285,13 @@ class ServerRequestTest extends TestCase
             'HTTP_CONTENT_MD5' => 'abc123',
             'HTTP_DOUBLE' => ['a', 'b'],
         ]]);
-        $this->assertEquals('', $request->getHeaderLine('Authorization'));
+        $this->assertSame('', $request->getHeaderLine('Authorization'));
 
         $expected = $request->getEnv('CONTENT_LENGTH');
         $this->assertEquals($expected, $request->getHeaderLine('Content-Length'));
         $this->assertEquals($expected, $request->getHeaderLine('content-Length'));
         $this->assertEquals($expected, $request->getHeaderLine('ConTent-LenGth'));
-        $this->assertEquals('a, b', $request->getHeaderLine('Double'));
+        $this->assertSame('a, b', $request->getHeaderLine('Double'));
     }
 
     /**
@@ -1335,8 +1335,8 @@ class ServerRequestTest extends TestCase
         $new = $request->withAddedHeader('Double', 'c');
         $this->assertNotSame($new, $request);
 
-        $this->assertEquals('a, b', $request->getHeaderLine('Double'), 'old request is unchanged');
-        $this->assertEquals('a, b, c', $new->getHeaderLine('Double'), 'new request is correct');
+        $this->assertSame('a, b', $request->getHeaderLine('Double'), 'old request is unchanged');
+        $this->assertSame('a, b, c', $new->getHeaderLine('Double'), 'new request is correct');
 
         $new = $request->withAddedHeader('Content-Length', 777);
         $this->assertEquals([1337, 777], $new->getHeader('Content-Length'), 'scalar values are appended');
@@ -1363,7 +1363,7 @@ class ServerRequestTest extends TestCase
         $this->assertNotSame($new, $request);
 
         $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
-        $this->assertEquals('', $new->getHeaderLine('Content-length'), 'new request is correct');
+        $this->assertSame('', $new->getHeaderLine('Content-length'), 'new request is correct');
     }
 
     /**
@@ -1515,41 +1515,41 @@ class ServerRequestTest extends TestCase
         $_SERVER['PATH_INFO'] = '/posts/view/1';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/urlencode%20me', $request->getAttribute('base'));
-        $this->assertEquals('/urlencode%20me/', $request->getAttribute('webroot'));
-        $this->assertEquals('/posts/view/1', $request->getRequestTarget());
+        $this->assertSame('/urlencode%20me', $request->getAttribute('base'));
+        $this->assertSame('/urlencode%20me/', $request->getAttribute('webroot'));
+        $this->assertSame('/posts/view/1', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches';
         $_SERVER['PHP_SELF'] = '/1.2.x.x/webroot/index.php';
         $_SERVER['PATH_INFO'] = '/posts/view/1';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/1.2.x.x', $request->getAttribute('base'));
-        $this->assertEquals('/1.2.x.x/', $request->getAttribute('webroot'));
-        $this->assertEquals('/posts/view/1', $request->getRequestTarget());
+        $this->assertSame('/1.2.x.x', $request->getAttribute('base'));
+        $this->assertSame('/1.2.x.x/', $request->getAttribute('webroot'));
+        $this->assertSame('/posts/view/1', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/webroot';
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SERVER['PATH_INFO'] = '/posts/add';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->getAttribute('base'));
-        $this->assertEquals('/', $request->getAttribute('webroot'));
-        $this->assertEquals('/posts/add', $request->getRequestTarget());
+        $this->assertSame('', $request->getAttribute('base'));
+        $this->assertSame('/', $request->getAttribute('webroot'));
+        $this->assertSame('/posts/add', $request->getRequestTarget());
 
         $_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/test/';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->getAttribute('base'));
-        $this->assertEquals('/', $request->getAttribute('webroot'));
+        $this->assertSame('', $request->getAttribute('base'));
+        $this->assertSame('/', $request->getAttribute('webroot'));
 
         $_SERVER['DOCUMENT_ROOT'] = '/some/apps/where';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->getAttribute('base'));
-        $this->assertEquals('/', $request->getAttribute('webroot'));
+        $this->assertSame('', $request->getAttribute('base'));
+        $this->assertSame('/', $request->getAttribute('webroot'));
 
         Configure::write('App.dir', 'auth');
 
@@ -1558,8 +1558,8 @@ class ServerRequestTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/demos', $request->getAttribute('base'));
-        $this->assertEquals('/demos/', $request->getAttribute('webroot'));
+        $this->assertSame('/demos', $request->getAttribute('base'));
+        $this->assertSame('/demos/', $request->getAttribute('webroot'));
 
         Configure::write('App.dir', 'code');
 
@@ -1567,8 +1567,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/clients/PewterReport/webroot/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/clients/PewterReport', $request->getAttribute('base'));
-        $this->assertEquals('/clients/PewterReport/', $request->getAttribute('webroot'));
+        $this->assertSame('/clients/PewterReport', $request->getAttribute('base'));
+        $this->assertSame('/clients/PewterReport/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1585,8 +1585,8 @@ class ServerRequestTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/control', $request->getAttribute('base'));
-        $this->assertEquals('/control/', $request->getAttribute('webroot'));
+        $this->assertSame('/control', $request->getAttribute('base'));
+        $this->assertSame('/control/', $request->getAttribute('webroot'));
 
         Configure::write('App.base', false);
         Configure::write('App.dir', 'affiliate');
@@ -1596,8 +1596,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/newaffiliate/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('', $request->getAttribute('base'));
-        $this->assertEquals('/', $request->getAttribute('webroot'));
+        $this->assertSame('', $request->getAttribute('base'));
+        $this->assertSame('/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1619,45 +1619,45 @@ class ServerRequestTest extends TestCase
         unset($_SERVER['PATH_INFO']);
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/';
         $_SERVER['PATH_INFO'] = '/';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/apples';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/apples';
         $_SERVER['PATH_INFO'] = '/apples';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/apples', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/apples', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/melons/share/';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/melons/share/';
         $_SERVER['PATH_INFO'] = '/melons/share/';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/melons/share/', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/melons/share/', $request->getRequestTarget());
 
         $_SERVER['REQUEST_URI'] = '/cakephp/webroot/index.php/bananas/eat/tasty_banana';
         $_SERVER['PHP_SELF'] = '/cakephp/webroot/index.php/bananas/eat/tasty_banana';
         $_SERVER['PATH_INFO'] = '/bananas/eat/tasty_banana';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/bananas/eat/tasty_banana', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/bananas/eat/tasty_banana', $request->getRequestTarget());
     }
 
     /**
@@ -1673,9 +1673,9 @@ class ServerRequestTest extends TestCase
         $_SERVER['PATH_INFO'] = '/bananas/eat';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/cakephp', $request->getAttribute('base'));
-        $this->assertEquals('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertEquals('/bananas/eat', $request->getRequestTarget());
+        $this->assertSame('/cakephp', $request->getAttribute('base'));
+        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
+        $this->assertSame('/bananas/eat', $request->getRequestTarget());
     }
 
     /**
@@ -1698,9 +1698,9 @@ class ServerRequestTest extends TestCase
         ]);
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/cake/webroot/', $request->getAttribute('webroot'));
-        $this->assertEquals('/posts/index', $request->getRequestTarget());
+        $this->assertSame('/cake/index.php', $request->getAttribute('base'));
+        $this->assertSame('/cake/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/posts/index', $request->getRequestTarget());
     }
 
     /**
@@ -1714,43 +1714,43 @@ class ServerRequestTest extends TestCase
         Configure::write('App.baseUrl', '/App/webroot/index.php');
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/webroot/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/App/webroot/index.php', $request->getAttribute('base'));
+        $this->assertSame('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/App/webroot/test.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/webroot/test.php', $request->getAttribute('base'));
-        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/App/webroot/test.php', $request->getAttribute('base'));
+        $this->assertSame('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/App/index.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/App/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/App/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/App/index.php', $request->getAttribute('base'));
+        $this->assertSame('/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/App/webroot/index.php');
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/CakeBB/App/webroot/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/CakeBB/App/webroot/index.php', $request->getAttribute('base'));
+        $this->assertSame('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/App/index.php');
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/CakeBB/App/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/CakeBB/App/index.php', $request->getAttribute('base'));
+        $this->assertSame('/CakeBB/App/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/CakeBB/index.php');
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/CakeBB/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/CakeBB/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/CakeBB/index.php', $request->getAttribute('base'));
+        $this->assertSame('/CakeBB/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/dbhauser/index.php');
         $_SERVER['DOCUMENT_ROOT'] = '/kunden/homepages/4/d181710652/htdocs/joomla';
         $_SERVER['SCRIPT_FILENAME'] = '/kunden/homepages/4/d181710652/htdocs/joomla/dbhauser/index.php';
         $request = ServerRequestFactory::fromGlobals();
 
-        $this->assertEquals('/dbhauser/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/dbhauser/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/dbhauser/index.php', $request->getAttribute('base'));
+        $this->assertSame('/dbhauser/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1765,8 +1765,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/index.php', $request->getAttribute('base'));
+        $this->assertSame('/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1781,16 +1781,16 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/approval/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/approval/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/approval/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/approval/index.php', $request->getAttribute('base'));
+        $this->assertSame('/approval/webroot/', $request->getAttribute('webroot'));
 
         Configure::write('App.baseUrl', '/webrootable/index.php');
         $_SERVER['DOCUMENT_ROOT'] = '/Users/markstory/Sites/';
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/webrootable/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/webrootable/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/webrootable/webroot/', $request->getAttribute('webroot'));
+        $this->assertSame('/webrootable/index.php', $request->getAttribute('base'));
+        $this->assertSame('/webrootable/webroot/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1805,8 +1805,8 @@ class ServerRequestTest extends TestCase
         $_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/webroot/index.php';
 
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/index.php', $request->getAttribute('base'));
-        $this->assertEquals('/', $request->getAttribute('webroot'));
+        $this->assertSame('/index.php', $request->getAttribute('base'));
+        $this->assertSame('/', $request->getAttribute('webroot'));
     }
 
     /**
@@ -1822,7 +1822,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertSame('', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
@@ -1830,7 +1830,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake_dev', $request->getAttribute('base'));
+        $this->assertSame('/cake_dev', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
     }
 
@@ -1846,7 +1846,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('', $request->getAttribute('base'));
+        $this->assertSame('', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
@@ -1854,7 +1854,7 @@ class ServerRequestTest extends TestCase
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('/cake_dev', $request->getAttribute('base'));
+        $this->assertSame('/cake_dev', $request->getAttribute('base'));
         $this->assertEquals([], $request->getQueryParams());
     }
 
@@ -2278,7 +2278,7 @@ class ServerRequestTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $uri = $request->getUri();
 
-        $this->assertEquals('/' . $expected['url'], $uri->getPath(), 'Uri->getPath() is incorrect');
+        $this->assertSame('/' . $expected['url'], $uri->getPath(), 'Uri->getPath() is incorrect');
         $this->assertEquals($expected['base'], $request->getAttribute('base'), 'base is incorrect');
         $this->assertEquals($expected['webroot'], $request->getAttribute('webroot'), 'webroot is incorrect');
 
@@ -2641,7 +2641,7 @@ class ServerRequestTest extends TestCase
             'input' => 'I came from stdin',
         ]);
         $result = $request->input();
-        $this->assertEquals('I came from stdin', $result);
+        $this->assertSame('I came from stdin', $result);
     }
 
     /**
@@ -2697,7 +2697,7 @@ XML;
         ]);
         $result = $request->getBody();
         $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $result);
-        $this->assertEquals('key=val&some=data', $result->getContents());
+        $this->assertSame('key=val&some=data', $result->getContents());
     }
 
     /**
@@ -2727,7 +2727,7 @@ XML;
         $request = new ServerRequest(['url' => 'articles/view/3']);
         $result = $request->getUri();
         $this->assertInstanceOf('Psr\Http\Message\UriInterface', $result);
-        $this->assertEquals('/articles/view/3', $result->getPath());
+        $this->assertSame('/articles/view/3', $result->getPath());
     }
 
     /**
@@ -2836,7 +2836,7 @@ XML;
                 ],
             ],
         ]);
-        $this->assertEquals('A value in the cookie', $request->getCookie('testing'));
+        $this->assertSame('A value in the cookie', $request->getCookie('testing'));
         $this->assertNull($request->getCookie('not there'));
         $this->assertSame('default', $request->getCookie('not there', 'default'));
 
@@ -2981,11 +2981,11 @@ XML;
     {
         $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('application/json', $request->contentType());
+        $this->assertSame('application/json', $request->contentType());
 
         $_SERVER['CONTENT_TYPE'] = 'application/xml';
         $request = ServerRequestFactory::fromGlobals();
-        $this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
+        $this->assertSame('application/xml', $request->contentType(), 'prefer non http header.');
     }
 
     /**
@@ -3087,9 +3087,9 @@ XML;
         $result = $request->withData('Model.new_value', 'new value');
         $this->assertNull($request->getData('Model.new_value'), 'Original request should not change.');
         $this->assertNotSame($result, $request);
-        $this->assertEquals('new value', $result->getData('Model.new_value'));
-        $this->assertEquals('new value', $result->getData()['Model']['new_value']);
-        $this->assertEquals('value', $result->getData('Model.field'));
+        $this->assertSame('new value', $result->getData('Model.new_value'));
+        $this->assertSame('new value', $result->getData()['Model']['new_value']);
+        $this->assertSame('value', $result->getData('Model.field'));
     }
 
     /**
@@ -3272,7 +3272,7 @@ XML;
             $request->getRequestTarget(),
             'should be unchanged.'
         );
-        $this->assertEquals('/articles/view/3', $new->getRequestTarget(), 'reflects method call');
+        $this->assertSame('/articles/view/3', $new->getRequestTarget(), 'reflects method call');
     }
 
     /**

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -226,7 +226,7 @@ class ServerTest extends TestCase
         ob_start();
         $server->emit($response);
         $result = ob_get_clean();
-        $this->assertEquals('body content', $result);
+        $this->assertSame('body content', $result);
     }
 
     /**

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -72,7 +72,7 @@ class CacheSessionTest extends TestCase
     public function testWrite()
     {
         $this->storage->write('abc', 'Some value');
-        $this->assertEquals('Some value', Cache::read('abc', 'session_test'), 'Value was not written.');
+        $this->assertSame('Some value', Cache::read('abc', 'session_test'), 'Value was not written.');
     }
 
     /**
@@ -83,7 +83,7 @@ class CacheSessionTest extends TestCase
     public function testRead()
     {
         $this->storage->write('test_one', 'Some other value');
-        $this->assertEquals('Some other value', $this->storage->read('test_one'), 'Incorrect value.');
+        $this->assertSame('Some other value', $this->storage->read('test_one'), 'Incorrect value.');
     }
 
     /**

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -71,9 +71,9 @@ class DatabaseSessionTest extends TestCase
 
         $session = $this->getTableLocator()->get('Sessions');
         $this->assertInstanceOf('Cake\ORM\Table', $session);
-        $this->assertEquals('Sessions', $session->getAlias());
+        $this->assertSame('Sessions', $session->getAlias());
         $this->assertEquals(ConnectionManager::get('test'), $session->getConnection());
-        $this->assertEquals('sessions', $session->getTable());
+        $this->assertSame('sessions', $session->getTable());
     }
 
     /**

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -67,9 +67,9 @@ class SessionTest extends TestCase
         ];
 
         Session::create($config);
-        $this->assertEquals('', ini_get('session.use_trans_sid'), 'Ini value is incorrect');
-        $this->assertEquals('example.com', ini_get('session.referer_check'), 'Ini value is incorrect');
-        $this->assertEquals('test', ini_get('session.name'), 'Ini value is incorrect');
+        $this->assertSame('', ini_get('session.use_trans_sid'), 'Ini value is incorrect');
+        $this->assertSame('example.com', ini_get('session.referer_check'), 'Ini value is incorrect');
+        $this->assertSame('test', ini_get('session.name'), 'Ini value is incorrect');
     }
 
     /**
@@ -84,10 +84,10 @@ class SessionTest extends TestCase
         ini_set('session.cookie_path', '/foo');
 
         new Session();
-        $this->assertEquals('/', ini_get('session.cookie_path'));
+        $this->assertSame('/', ini_get('session.cookie_path'));
 
         new Session(['cookiePath' => '/base']);
-        $this->assertEquals('/base', ini_get('session.cookie_path'));
+        $this->assertSame('/base', ini_get('session.cookie_path'));
     }
 
     /**
@@ -117,11 +117,11 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->write('testing', '1,2,3');
         $result = $session->read('testing');
-        $this->assertEquals('1,2,3', $result);
+        $this->assertSame('1,2,3', $result);
 
         $session->write('testing', ['1' => 'one', '2' => 'two', '3' => 'three']);
         $result = $session->read('testing.1');
-        $this->assertEquals('one', $result);
+        $this->assertSame('one', $result);
 
         $result = $session->read('testing');
         $this->assertEquals(['1' => 'one', '2' => 'two', '3' => 'three'], $result);
@@ -154,7 +154,7 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $session->write('', 'empty');
-        $this->assertEquals('empty', $session->read(''));
+        $this->assertSame('empty', $session->read(''));
 
         $session->write('Simple', ['values']);
         $this->assertEquals(['values'], $session->read('Simple'));
@@ -188,7 +188,7 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $session->write('Some.string', 'value');
-        $this->assertEquals('value', $session->read('Some.string'));
+        $this->assertSame('value', $session->read('Some.string'));
 
         $session->write('Some.string.array', ['values']);
         $this->assertEquals(['values'], $session->read('Some.string.array'));
@@ -205,10 +205,10 @@ class SessionTest extends TestCase
         $session->write('Some.string', 'value');
         $session->write('Some.array', ['key1' => 'value1', 'key2' => 'value2']);
 
-        $this->assertEquals('value', $session->read('Some.string'));
+        $this->assertSame('value', $session->read('Some.string'));
 
         $value = $session->consume('Some.string');
-        $this->assertEquals('value', $value);
+        $this->assertSame('value', $value);
         $this->assertFalse($session->check('Some.string'));
 
         $value = $session->consume('');
@@ -414,13 +414,13 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->write('', 'empty string');
         $this->assertTrue($session->check(''));
-        $this->assertEquals('empty string', $session->read(''));
+        $this->assertSame('empty string', $session->read(''));
 
         $session->write('SessionTestCase', 0);
-        $this->assertEquals(0, $session->read('SessionTestCase'));
+        $this->assertSame(0, $session->read('SessionTestCase'));
 
         $session->write('SessionTestCase', '0');
-        $this->assertEquals('0', $session->read('SessionTestCase'));
+        $this->assertSame('0', $session->read('SessionTestCase'));
         $this->assertNotSame($session->read('SessionTestCase'), 0);
 
         $session->write('SessionTestCase', false);
@@ -451,7 +451,7 @@ class SessionTest extends TestCase
 
         $session = Session::create($config);
         $this->assertInstanceOf('TestApp\Http\Session\TestAppLibSession', $session->engine());
-        $this->assertEquals('user', ini_get('session.save_handler'));
+        $this->assertSame('user', ini_get('session.save_handler'));
         $this->assertEquals(['these' => 'are', 'a few' => 'options'], $session->engine()->options);
     }
 
@@ -476,7 +476,7 @@ class SessionTest extends TestCase
 
         $session = Session::create($config);
         $this->assertInstanceOf('TestPlugin\Http\Session\TestPluginSession', $session->engine());
-        $this->assertEquals('user', ini_get('session.save_handler'));
+        $this->assertSame('user', ini_get('session.save_handler'));
     }
 
     /**
@@ -526,7 +526,7 @@ class SessionTest extends TestCase
         ];
 
         new Session($config);
-        $this->assertEquals(0, ini_get('session.cookie_lifetime'));
+        $this->assertSame(0, ini_get('session.cookie_lifetime'));
         $this->assertEquals(400 * 60, ini_get('session.gc_maxlifetime'));
     }
 
@@ -540,7 +540,7 @@ class SessionTest extends TestCase
     public function testSessionName()
     {
         new Session(['cookie' => 'made_up_name']);
-        $this->assertEquals('made_up_name', session_name());
+        $this->assertSame('made_up_name', session_name());
     }
 
     /**

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -526,7 +526,7 @@ class SessionTest extends TestCase
         ];
 
         new Session($config);
-        $this->assertSame(0, ini_get('session.cookie_lifetime'));
+        $this->assertSame('0', ini_get('session.cookie_lifetime'));
         $this->assertEquals(400 * 60, ini_get('session.gc_maxlifetime'));
     }
 

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -131,7 +131,7 @@ class DateTest extends TestCase
     public function testToString($class)
     {
         $date = new $class('2015-11-06 11:32:45');
-        $this->assertEquals('11/6/15', (string)$date);
+        $this->assertSame('11/6/15', (string)$date);
     }
 
     /**
@@ -144,9 +144,9 @@ class DateTest extends TestCase
     {
         $date = new $class('2015-11-06 11:32:45');
 
-        $this->assertEquals('Nov 6, 2015', $date->nice());
-        $this->assertEquals('Nov 6, 2015', $date->nice(new DateTimeZone('America/New_York')));
-        $this->assertEquals('6 nov. 2015', $date->nice(null, 'fr-FR'));
+        $this->assertSame('Nov 6, 2015', $date->nice());
+        $this->assertSame('Nov 6, 2015', $date->nice(new DateTimeZone('America/New_York')));
+        $this->assertSame('6 nov. 2015', $date->nice(null, 'fr-FR'));
     }
 
     /**
@@ -162,7 +162,7 @@ class DateTest extends TestCase
         }
 
         $date = new $class('2015-11-06 11:32:45');
-        $this->assertEquals('"2015-11-06"', json_encode($date));
+        $this->assertSame('"2015-11-06"', json_encode($date));
     }
 
     /**
@@ -174,11 +174,11 @@ class DateTest extends TestCase
     public function testParseDate($class)
     {
         $date = $class::parseDate('11/6/15');
-        $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
+        $this->assertSame('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
         $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015');
-        $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
+        $this->assertSame('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -190,11 +190,11 @@ class DateTest extends TestCase
     public function testParseDateTime($class)
     {
         $date = $class::parseDate('11/6/15 12:33:12');
-        $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
+        $this->assertSame('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
         $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015 12:54:12');
-        $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
+        $this->assertSame('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -264,7 +264,7 @@ class DateTest extends TestCase
                 'format' => 'dd-MM-YYYY',
             ]
         );
-        $this->assertEquals('on 31-07-1990', $result);
+        $this->assertSame('on 31-07-1990', $result);
     }
 
     /**
@@ -432,11 +432,11 @@ class DateTest extends TestCase
     {
         $date = new $class('2007-9-25');
         $result = $date->timeAgoInWords(['format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on 2007-09-25', $result);
+        $this->assertSame('on 2007-09-25', $result);
 
         $date = new $class('2007-9-25');
         $result = $date->timeAgoInWords(['format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on 2007-09-25', $result);
+        $this->assertSame('on 2007-09-25', $result);
 
         $date = new $class('+2 weeks +2 days');
         $result = $date->timeAgoInWords(['format' => 'yyyy-MM-dd']);
@@ -444,7 +444,7 @@ class DateTest extends TestCase
 
         $date = new $class('+2 months +2 days');
         $result = $date->timeAgoInWords(['end' => '1 month', 'format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
+        $this->assertSame('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
     }
 
     /**
@@ -457,23 +457,23 @@ class DateTest extends TestCase
     {
         $date = new $class('-2 months -2 days');
         $result = $date->timeAgoInWords(['end' => '3 month']);
-        $this->assertEquals('2 months, 2 days ago', $result);
+        $this->assertSame('2 months, 2 days ago', $result);
 
         $date = new $class('-2 months -2 days');
         $result = $date->timeAgoInWords(['end' => '3 month']);
-        $this->assertEquals('2 months, 2 days ago', $result);
+        $this->assertSame('2 months, 2 days ago', $result);
 
         $date = new $class('-2 months -2 days');
         $result = $date->timeAgoInWords(['end' => '1 month', 'format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on ' . date('Y-m-d', strtotime('-2 months -2 days')), $result);
+        $this->assertSame('on ' . date('Y-m-d', strtotime('-2 months -2 days')), $result);
 
         $date = new $class('-2 years -5 months -2 days');
         $result = $date->timeAgoInWords(['end' => '3 years']);
-        $this->assertEquals('2 years, 5 months, 2 days ago', $result);
+        $this->assertSame('2 years, 5 months, 2 days ago', $result);
 
         $date = new $class('-2 weeks -2 days');
         $result = $date->timeAgoInWords(['format' => 'yyyy-MM-dd']);
-        $this->assertEquals('2 weeks, 2 days ago', $result);
+        $this->assertSame('2 weeks, 2 days ago', $result);
 
         $date = new $class('-3 years -12 months');
         $result = $date->timeAgoInWords();
@@ -484,7 +484,7 @@ class DateTest extends TestCase
         $result = $date->timeAgoInWords(
             ['end' => '1 year', 'accuracy' => ['month' => 'month']]
         );
-        $this->assertEquals('1 month ago', $result);
+        $this->assertSame('1 month ago', $result);
 
         $date = new $class('-1 years -2 weeks -3 days');
         $result = $date->timeAgoInWords(
@@ -495,11 +495,11 @@ class DateTest extends TestCase
 
         $date = new $class('-13 months -5 days');
         $result = $date->timeAgoInWords(['end' => '2 years']);
-        $this->assertEquals('1 year, 1 month, 5 days ago', $result);
+        $this->assertSame('1 year, 1 month, 5 days ago', $result);
 
         $date = new $class('-23 hours');
         $result = $date->timeAgoInWords(['accuracy' => 'day']);
-        $this->assertEquals('today', $result);
+        $this->assertSame('today', $result);
     }
 
     /**
@@ -513,7 +513,7 @@ class DateTest extends TestCase
     {
         date_default_timezone_set('Europe/Paris');
         $result = $class::parseDate('25-02-2016', 'd-M-y');
-        $this->assertEquals('25-02-2016', $result->format('d-m-Y'));
+        $this->assertSame('25-02-2016', $result->format('d-m-Y'));
     }
 
     /**
@@ -537,15 +537,15 @@ class DateTest extends TestCase
     public function testDefaultLocaleEffectsFormatting($class)
     {
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('Dec 3, 2015', $result->nice());
+        $this->assertSame('Dec 3, 2015', $result->nice());
 
         $class::setDefaultLocale('fr-FR');
 
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('12 mars 2015', $result->nice());
+        $this->assertSame('12 mars 2015', $result->nice());
 
         $expected = 'Y-m-d';
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('2015-03-12', $result->format($expected));
+        $this->assertSame('2015-03-12', $result->format($expected));
     }
 }

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -32,7 +32,7 @@ class IcuFormatterTest extends TestCase
     public function testFormatEmptyValues()
     {
         $formatter = new IcuFormatter();
-        $this->assertEquals('', $formatter->format('en_US', '', []));
+        $this->assertSame('', $formatter->format('en_US', '', []));
     }
 
     /**
@@ -43,13 +43,13 @@ class IcuFormatterTest extends TestCase
     public function testFormatSimple()
     {
         $formatter = new IcuFormatter();
-        $this->assertEquals('Hello José', $formatter->format('en_US', 'Hello {0}', ['José']));
+        $this->assertSame('Hello José', $formatter->format('en_US', 'Hello {0}', ['José']));
         $result = $formatter->format(
             '1 Orange',
             '{0, number} {1}',
             [1.0, 'Orange']
         );
-        $this->assertEquals('1 Orange', $result);
+        $this->assertSame('1 Orange', $result);
     }
 
     /**

--- a/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
@@ -32,7 +32,7 @@ class SprintfFormatterTest extends TestCase
     public function testFormatSimple()
     {
         $formatter = new SprintfFormatter();
-        $this->assertEquals('Hello José', $formatter->format('en_US', 'Hello %s', ['José']));
-        $this->assertEquals('1 Orange', $formatter->format('en_US', '%d %s', [1, 'Orange']));
+        $this->assertSame('Hello José', $formatter->format('en_US', 'Hello %s', ['José']));
+        $this->assertSame('1 Orange', $formatter->format('en_US', '%d %s', [1, 'Orange']));
     }
 }

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -83,7 +83,7 @@ class I18nTest extends TestCase
     {
         $translator = I18n::getTranslator();
         $this->assertInstanceOf('Aura\Intl\TranslatorInterface', $translator);
-        $this->assertEquals('%d is 1 (po translated)', $translator->translate('%d = 1'));
+        $this->assertSame('%d is 1 (po translated)', $translator->translate('%d = 1'));
         $this->assertSame($translator, I18n::getTranslator(), 'backwards compat works');
     }
 
@@ -95,7 +95,7 @@ class I18nTest extends TestCase
     public function testGetTranslatorLoadMoFile()
     {
         $translator = I18n::getTranslator('default', 'es_ES');
-        $this->assertEquals('Plural Rule 6 (translated)', $translator->translate('Plural Rule 1'));
+        $this->assertSame('Plural Rule 6 (translated)', $translator->translate('Plural Rule 1'));
     }
 
     /**
@@ -109,10 +109,10 @@ class I18nTest extends TestCase
         I18n::setDefaultFormatter('sprintf');
         $translator = I18n::getTranslator(); // en_US
         $result = $translator->translate('%d = 0 or > 1', ['_count' => 1]);
-        $this->assertEquals('1 is 1 (po translated)', $result);
+        $this->assertSame('1 is 1 (po translated)', $result);
 
         $result = $translator->translate('%d = 0 or > 1', ['_count' => 2]);
-        $this->assertEquals('2 is 2-4 (po translated)', $result);
+        $this->assertSame('2 is 2-4 (po translated)', $result);
     }
 
     /**
@@ -125,10 +125,10 @@ class I18nTest extends TestCase
     {
         $translator = I18n::getTranslator('special');
         $result = $translator->translate('There are {0} things', ['_count' => 2, 'plenty']);
-        $this->assertEquals('There are plenty things', $result);
+        $this->assertSame('There are plenty things', $result);
 
         $result = $translator->translate('There are {0} things', ['_count' => 1]);
-        $this->assertEquals('There is only one', $result);
+        $this->assertSame('There is only one', $result);
     }
 
     /**
@@ -140,13 +140,13 @@ class I18nTest extends TestCase
     {
         $translator = I18n::getTranslator('default', 'ru');
         $result = $translator->translate('{0} months', ['_count' => 1, 1]);
-        $this->assertEquals('1 months ends in 1, not 11', $result);
+        $this->assertSame('1 months ends in 1, not 11', $result);
 
         $result = $translator->translate('{0} months', ['_count' => 2, 2]);
-        $this->assertEquals('2 months ends in 2-4, not 12-14', $result);
+        $this->assertSame('2 months ends in 2-4, not 12-14', $result);
 
         $result = $translator->translate('{0} months', ['_count' => 7, 7]);
-        $this->assertEquals('7 months everything else', $result);
+        $this->assertSame('7 months everything else', $result);
     }
 
     /**
@@ -166,7 +166,7 @@ class I18nTest extends TestCase
         }, 'fr_FR');
 
         $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
+        $this->assertSame('Le moo', $translator->translate('Cow'));
     }
 
     /**
@@ -218,11 +218,11 @@ class I18nTest extends TestCase
      */
     public function testGetDefaultLocale()
     {
-        $this->assertEquals('en_US', I18n::getLocale());
-        $this->assertEquals('en_US', ini_get('intl.default_locale'));
+        $this->assertSame('en_US', I18n::getLocale());
+        $this->assertSame('en_US', ini_get('intl.default_locale'));
         I18n::setLocale('fr_FR');
-        $this->assertEquals('fr_FR', I18n::getLocale());
-        $this->assertEquals('fr_FR', ini_get('intl.default_locale'));
+        $this->assertSame('fr_FR', I18n::getLocale());
+        $this->assertSame('fr_FR', ini_get('intl.default_locale'));
     }
 
     /**
@@ -244,7 +244,7 @@ class I18nTest extends TestCase
 
         I18n::setLocale('fr_FR');
         $translator = I18n::getTranslator('custom');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
+        $this->assertSame('Le moo', $translator->translate('Cow'));
     }
 
     /**
@@ -255,11 +255,11 @@ class I18nTest extends TestCase
     public function testBasicTranslateFunction()
     {
         I18n::setDefaultFormatter('sprintf');
-        $this->assertEquals('%d is 1 (po translated)', __('%d = 1'));
-        $this->assertEquals('1 is 1 (po translated)', __('%d = 1', 1));
-        $this->assertEquals('1 is 1 (po translated)', __('%d = 1', [1]));
-        $this->assertEquals('The red dog, and blue cat', __('The %s dog, and %s cat', ['red', 'blue']));
-        $this->assertEquals('The red dog, and blue cat', __('The %s dog, and %s cat', 'red', 'blue'));
+        $this->assertSame('%d is 1 (po translated)', __('%d = 1'));
+        $this->assertSame('1 is 1 (po translated)', __('%d = 1', 1));
+        $this->assertSame('1 is 1 (po translated)', __('%d = 1', [1]));
+        $this->assertSame('The red dog, and blue cat', __('The %s dog, and %s cat', ['red', 'blue']));
+        $this->assertSame('The red dog, and blue cat', __('The %s dog, and %s cat', 'red', 'blue'));
     }
 
     /**
@@ -269,29 +269,29 @@ class I18nTest extends TestCase
      */
     public function testBasicTranslateFunctionsWithNullParam()
     {
-        $this->assertEquals('text {0}', __('text {0}'));
-        $this->assertEquals('text ', __('text {0}', null));
+        $this->assertSame('text {0}', __('text {0}'));
+        $this->assertSame('text ', __('text {0}', null));
 
-        $this->assertEquals('text {0}', __n('text {0}', 'texts {0}', 1));
-        $this->assertEquals('text ', __n('text {0}', 'texts {0}', 1, null));
+        $this->assertSame('text {0}', __n('text {0}', 'texts {0}', 1));
+        $this->assertSame('text ', __n('text {0}', 'texts {0}', 1, null));
 
-        $this->assertEquals('text {0}', __d('default', 'text {0}'));
-        $this->assertEquals('text ', __d('default', 'text {0}', null));
+        $this->assertSame('text {0}', __d('default', 'text {0}'));
+        $this->assertSame('text ', __d('default', 'text {0}', null));
 
-        $this->assertEquals('text {0}', __dn('default', 'text {0}', 'texts {0}', 1));
-        $this->assertEquals('text ', __dn('default', 'text {0}', 'texts {0}', 1, null));
+        $this->assertSame('text {0}', __dn('default', 'text {0}', 'texts {0}', 1));
+        $this->assertSame('text ', __dn('default', 'text {0}', 'texts {0}', 1, null));
 
-        $this->assertEquals('text {0}', __x('default', 'text {0}'));
-        $this->assertEquals('text ', __x('default', 'text {0}', null));
+        $this->assertSame('text {0}', __x('default', 'text {0}'));
+        $this->assertSame('text ', __x('default', 'text {0}', null));
 
-        $this->assertEquals('text {0}', __xn('default', 'text {0}', 'texts {0}', 1));
-        $this->assertEquals('text ', __xn('default', 'text {0}', 'texts {0}', 1, null));
+        $this->assertSame('text {0}', __xn('default', 'text {0}', 'texts {0}', 1));
+        $this->assertSame('text ', __xn('default', 'text {0}', 'texts {0}', 1, null));
 
-        $this->assertEquals('text {0}', __dx('default', 'words', 'text {0}'));
-        $this->assertEquals('text ', __dx('default', 'words', 'text {0}', null));
+        $this->assertSame('text {0}', __dx('default', 'words', 'text {0}'));
+        $this->assertSame('text ', __dx('default', 'words', 'text {0}', null));
 
-        $this->assertEquals('text {0}', __dxn('default', 'words', 'text {0}', 'texts {0}', 1));
-        $this->assertEquals('text ', __dxn('default', 'words', 'text {0}', 'texts {0}', 1, null));
+        $this->assertSame('text {0}', __dxn('default', 'words', 'text {0}', 'texts {0}', 1));
+        $this->assertSame('text ', __dxn('default', 'words', 'text {0}', 'texts {0}', 1, null));
     }
 
     /**
@@ -302,7 +302,7 @@ class I18nTest extends TestCase
     public function testBasicTranslateFunctionPluralData()
     {
         I18n::setDefaultFormatter('sprintf');
-        $this->assertEquals('%d is 1 (po translated)', __('%d = 0 or > 1'));
+        $this->assertSame('%d is 1 (po translated)', __('%d = 0 or > 1'));
     }
 
     /**
@@ -314,16 +314,16 @@ class I18nTest extends TestCase
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __n('singular msg', '%d = 0 or > 1', 1);
-        $this->assertEquals('1 is 1 (po translated)', $result);
+        $this->assertSame('1 is 1 (po translated)', $result);
 
         $result = __n('singular msg', '%d = 0 or > 1', 2);
-        $this->assertEquals('2 is 2-4 (po translated)', $result);
+        $this->assertSame('2 is 2-4 (po translated)', $result);
 
         $result = __n('%s %s and %s are good', '%s and %s are best', 1, ['red', 'blue']);
-        $this->assertEquals('1 red and blue are good', $result);
+        $this->assertSame('1 red and blue are good', $result);
 
         $result = __n('%s %s and %s are good', '%s and %s are best', 1, 'red', 'blue');
-        $this->assertEquals('1 red and blue are good', $result);
+        $this->assertSame('1 red and blue are good', $result);
     }
 
     /**
@@ -335,7 +335,7 @@ class I18nTest extends TestCase
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __n('No translation needed', 'not used', 1);
-        $this->assertEquals('No translation needed', $result);
+        $this->assertSame('No translation needed', $result);
     }
 
     /**
@@ -356,17 +356,17 @@ class I18nTest extends TestCase
 
             return $package;
         }, 'en_US');
-        $this->assertEquals('Le moo', __d('custom', 'Cow'));
-        $this->assertEquals('Unknown', __d('custom', 'Unknown'));
+        $this->assertSame('Le moo', __d('custom', 'Cow'));
+        $this->assertSame('Unknown', __d('custom', 'Unknown'));
 
         $result = __d('custom', 'The {0} is tasty', ['fruit']);
-        $this->assertEquals('The fruit is delicious', $result);
+        $this->assertSame('The fruit is delicious', $result);
 
         $result = __d('custom', 'The {0} is tasty', 'fruit');
-        $this->assertEquals('The fruit is delicious', $result);
+        $this->assertSame('The fruit is delicious', $result);
 
         $result = __d('custom', 'Average price {0}', ['9.99']);
-        $this->assertEquals('Price Average 9.99', $result);
+        $this->assertSame('Price Average 9.99', $result);
     }
 
     /**
@@ -392,10 +392,10 @@ class I18nTest extends TestCase
 
             return $package;
         }, 'en_US');
-        $this->assertEquals('Le Moo', __dn('custom', 'Cow', 'Cows', 1));
-        $this->assertEquals('Les Moos', __dn('custom', 'Cow', 'Cows', 2));
-        $this->assertEquals('{0} years', __dn('custom', '{0} year', '{0} years', 1));
-        $this->assertEquals('{0} years', __dn('custom', '{0} year', '{0} years', 2));
+        $this->assertSame('Le Moo', __dn('custom', 'Cow', 'Cows', 1));
+        $this->assertSame('Les Moos', __dn('custom', 'Cow', 'Cows', 2));
+        $this->assertSame('{0} years', __dn('custom', '{0} year', '{0} years', 1));
+        $this->assertSame('{0} years', __dn('custom', '{0} year', '{0} years', 2));
     }
 
     /**
@@ -431,11 +431,11 @@ class I18nTest extends TestCase
             return $package;
         }, 'en_US');
 
-        $this->assertEquals('The letters A and B', __x('character', 'letters', ['A', 'B']));
-        $this->assertEquals('The letter A', __x('character', 'letter', ['A']));
+        $this->assertSame('The letters A and B', __x('character', 'letters', ['A', 'B']));
+        $this->assertSame('The letter A', __x('character', 'letter', ['A']));
 
-        $this->assertEquals('The letters A and B', __x('character', 'letters', 'A', 'B'));
-        $this->assertEquals('The letter A', __x('character', 'letter', 'A'));
+        $this->assertSame('The letters A and B', __x('character', 'letters', 'A', 'B'));
+        $this->assertSame('The letter A', __x('character', 'letter', 'A'));
 
         $this->assertEquals(
             'She wrote a letter to Thomas and Sara',
@@ -476,8 +476,8 @@ class I18nTest extends TestCase
             return $package;
         }, 'en_US');
 
-        $this->assertEquals('letter', __x('character', 'letter'));
-        $this->assertEquals('letter', __x('unknown', 'letter'));
+        $this->assertSame('letter', __x('character', 'letter'));
+        $this->assertSame('letter', __x('unknown', 'letter'));
     }
 
     /**
@@ -500,8 +500,8 @@ class I18nTest extends TestCase
             return $package;
         }, 'en_US');
 
-        $this->assertEquals('letter', __x('garbage', 'letter'));
-        $this->assertEquals('a paper letter', __('letter'));
+        $this->assertSame('letter', __x('garbage', 'letter'));
+        $this->assertSame('a paper letter', __('letter'));
     }
 
     /**
@@ -536,8 +536,8 @@ class I18nTest extends TestCase
 
             return $package;
         }, 'en_US');
-        $this->assertEquals('The letters A and B', __xn('character', 'letter', 'letters', 2, ['A', 'B']));
-        $this->assertEquals('The letter A', __xn('character', 'letter', 'letters', 1, ['A']));
+        $this->assertSame('The letters A and B', __xn('character', 'letter', 'letters', 2, ['A', 'B']));
+        $this->assertSame('The letter A', __xn('character', 'letter', 'letters', 1, ['A']));
 
         $this->assertEquals(
             'She wrote a letter to Thomas and Sara',
@@ -591,8 +591,8 @@ class I18nTest extends TestCase
             return $package;
         }, 'en_US');
 
-        $this->assertEquals('The letters A and B', __dx('custom', 'character', 'letters', ['A', 'B']));
-        $this->assertEquals('The letter A', __dx('custom', 'character', 'letter', ['A']));
+        $this->assertSame('The letters A and B', __dx('custom', 'character', 'letters', ['A', 'B']));
+        $this->assertSame('The letter A', __dx('custom', 'character', 'letter', ['A']));
 
         $this->assertEquals(
             'She wrote a letter to Thomas and Sara',
@@ -703,7 +703,7 @@ class I18nTest extends TestCase
     public function testLoaderFactory()
     {
         I18n::config('custom', function ($name, $locale) {
-            $this->assertEquals('custom', $name);
+            $this->assertSame('custom', $name);
             $package = new Package('default');
 
             if ($locale === 'fr_FR') {
@@ -730,15 +730,15 @@ class I18nTest extends TestCase
         });
 
         $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertEquals('Le Moo', $translator->translate('Cow'));
-        $this->assertEquals('Les Moos', $translator->translate('Cows', ['_count' => 2]));
+        $this->assertSame('Le Moo', $translator->translate('Cow'));
+        $this->assertSame('Les Moos', $translator->translate('Cows', ['_count' => 2]));
 
         $translator = I18n::getTranslator('custom', 'es_ES');
-        $this->assertEquals('El Moo', $translator->translate('Cow'));
-        $this->assertEquals('Los Moos', $translator->translate('Cows', ['_count' => 2]));
+        $this->assertSame('El Moo', $translator->translate('Cow'));
+        $this->assertSame('Los Moos', $translator->translate('Cows', ['_count' => 2]));
 
         $translator = I18n::getTranslator();
-        $this->assertEquals('%d is 1 (po translated)', $translator->translate('%d = 1'));
+        $this->assertSame('%d is 1 (po translated)', $translator->translate('%d = 1'));
     }
 
     /**
@@ -765,10 +765,10 @@ class I18nTest extends TestCase
         });
 
         $translator = I18n::getTranslator('custom');
-        $this->assertEquals('Le Moo custom', $translator->translate('Cow'));
+        $this->assertSame('Le Moo custom', $translator->translate('Cow'));
 
         $translator = I18n::getTranslator();
-        $this->assertEquals('Le Moo default', $translator->translate('Cow'));
+        $this->assertSame('Le Moo default', $translator->translate('Cow'));
     }
 
     /**
@@ -797,8 +797,8 @@ class I18nTest extends TestCase
         }, 'fr_FR');
 
         $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
-        $this->assertEquals('Le bark', $translator->translate('Dog'));
+        $this->assertSame('Le moo', $translator->translate('Cow'));
+        $this->assertSame('Le bark', $translator->translate('Dog'));
     }
 
     /**
@@ -825,8 +825,8 @@ class I18nTest extends TestCase
         }, 'fr_FR');
 
         $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
-        $this->assertEquals('Dog', $translator->translate('Dog'));
+        $this->assertSame('Le moo', $translator->translate('Cow'));
+        $this->assertSame('Dog', $translator->translate('Dog'));
     }
 
     /**
@@ -846,7 +846,7 @@ class I18nTest extends TestCase
             return $package;
         }, 'fr_FR');
         I18n::config('custom', function ($name, $locale) {
-            $this->assertEquals('custom', $name);
+            $this->assertSame('custom', $name);
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -856,8 +856,8 @@ class I18nTest extends TestCase
         });
 
         $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
-        $this->assertEquals('Le bark', $translator->translate('Dog'));
+        $this->assertSame('Le moo', $translator->translate('Cow'));
+        $this->assertSame('Le bark', $translator->translate('Dog'));
     }
 
     /**
@@ -869,7 +869,7 @@ class I18nTest extends TestCase
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __('No translation needed');
-        $this->assertEquals('No translation needed', $result);
+        $this->assertSame('No translation needed', $result);
     }
 
     /**
@@ -880,8 +880,8 @@ class I18nTest extends TestCase
     public function testPluralTranslationsFromDomain()
     {
         I18n::setLocale('de');
-        $this->assertEquals('Standorte', __dn('wa', 'Location', 'Locations', 0));
-        $this->assertEquals('Standort', __dn('wa', 'Location', 'Locations', 1));
-        $this->assertEquals('Standorte', __dn('wa', 'Location', 'Locations', 2));
+        $this->assertSame('Standorte', __dn('wa', 'Location', 'Locations', 0));
+        $this->assertSame('Standort', __dn('wa', 'Location', 'Locations', 1));
+        $this->assertSame('Standorte', __dn('wa', 'Location', 'Locations', 2));
     }
 }

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -57,13 +57,13 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('default', 'en');
         $package = $loader();
         $messages = $package->getMessages();
-        $this->assertEquals('Po (translated)', $messages['Plural Rule 1']['_context']['']);
+        $this->assertSame('Po (translated)', $messages['Plural Rule 1']['_context']['']);
 
         Configure::write('App.paths.locales', [TEST_APP . 'custom_locale' . DS]);
         $loader = new MessagesFileLoader('default', 'en');
         $package = $loader();
         $messages = $package->getMessages();
-        $this->assertEquals('Po (translated) from custom folder', $messages['Plural Rule 1']['_context']['']);
+        $this->assertSame('Po (translated) from custom folder', $messages['Plural Rule 1']['_context']['']);
     }
 
     /**

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -316,14 +316,14 @@ class NumberTest extends TestCase
     public function testDefaultCurrency()
     {
         $result = $this->Number->defaultCurrency();
-        $this->assertEquals('USD', $result);
+        $this->assertSame('USD', $result);
 
         $this->Number->defaultCurrency(false);
         I18n::setLocale('es_ES');
-        $this->assertEquals('EUR', $this->Number->defaultCurrency());
+        $this->assertSame('EUR', $this->Number->defaultCurrency());
 
         $this->Number->defaultCurrency('JPY');
-        $this->assertEquals('JPY', $this->Number->defaultCurrency());
+        $this->assertSame('JPY', $this->Number->defaultCurrency());
     }
 
     /**
@@ -411,7 +411,7 @@ class NumberTest extends TestCase
     {
         I18n::setLocale('fr_FR');
         $result = $this->Number->precision(1.234);
-        $this->assertEquals('1,234', $result);
+        $this->assertSame('1,234', $result);
     }
 
     /**
@@ -543,10 +543,10 @@ class NumberTest extends TestCase
     {
         I18n::setLocale('fr_FR');
         $result = $this->Number->toReadableSize(1321205);
-        $this->assertEquals('1,26 MB', $result);
+        $this->assertSame('1,26 MB', $result);
 
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024 * 1024);
-        $this->assertEquals('512,05 GB', $result);
+        $this->assertSame('512,05 GB', $result);
     }
 
     /**
@@ -557,14 +557,14 @@ class NumberTest extends TestCase
     public function testConfig()
     {
         $result = $this->Number->currency(15000, 'INR', ['locale' => 'en_IN']);
-        $this->assertEquals('₹ 15,000.00', $result);
+        $this->assertSame('₹ 15,000.00', $result);
 
         Number::config('en_IN', \NumberFormatter::CURRENCY, [
             'pattern' => '¤ #,##,##0',
         ]);
 
         $result = $this->Number->currency(15000, 'INR', ['locale' => 'en_IN']);
-        $this->assertEquals('₹ 15,000', $result);
+        $this->assertSame('₹ 15,000', $result);
     }
 
     /**
@@ -576,27 +576,27 @@ class NumberTest extends TestCase
     {
         I18n::setLocale('en_US');
         $result = $this->Number->ordinal(1);
-        $this->assertEquals('1st', $result);
+        $this->assertSame('1st', $result);
 
         $result = $this->Number->ordinal(2);
-        $this->assertEquals('2nd', $result);
+        $this->assertSame('2nd', $result);
 
         $result = $this->Number->ordinal(2, [
             'locale' => 'fr_FR',
         ]);
-        $this->assertEquals('2e', $result);
+        $this->assertSame('2e', $result);
 
         $result = $this->Number->ordinal(3);
-        $this->assertEquals('3rd', $result);
+        $this->assertSame('3rd', $result);
 
         $result = $this->Number->ordinal(4);
-        $this->assertEquals('4th', $result);
+        $this->assertSame('4th', $result);
 
         I18n::setLocale('fr_FR');
         $result = $this->Number->ordinal(1);
-        $this->assertEquals('1er', $result);
+        $this->assertSame('1er', $result);
 
         $result = $this->Number->ordinal(2);
-        $this->assertEquals('2e', $result);
+        $this->assertSame('2e', $result);
     }
 }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -247,8 +247,8 @@ class PoFileParserTest extends TestCase
 
         // Check translated messages
         I18n::setLocale('de_DE');
-        $this->assertEquals('Standorte', __d('wa', 'Locations'));
+        $this->assertSame('Standorte', __d('wa', 'Locations'));
         I18n::setLocale('en_EN');
-        $this->assertEquals('Locations', __d('wa', 'Locations'));
+        $this->assertSame('Locations', __d('wa', 'Locations'));
     }
 }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -210,7 +210,7 @@ class TimeTest extends TestCase
                 'format' => 'dd-MM-YYYY HH:mm:ss',
             ]
         );
-        $this->assertEquals('on 31-07-1990 13:33:00', $result);
+        $this->assertSame('on 31-07-1990 13:33:00', $result);
     }
 
     /**
@@ -317,7 +317,7 @@ class TimeTest extends TestCase
 
         $time = new $class('+20 days');
         $result = $time->timeAgoInWords(['accuracy' => 'month']);
-        $this->assertEquals('in about a month', $result);
+        $this->assertSame('in about a month', $result);
     }
 
     /**
@@ -330,7 +330,7 @@ class TimeTest extends TestCase
     {
         $time = new $class('2007-9-25');
         $result = $time->timeAgoInWords(['format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on 2007-09-25', $result);
+        $this->assertSame('on 2007-09-25', $result);
 
         $time = new $class('+2 weeks +2 days');
         $result = $time->timeAgoInWords(['format' => 'yyyy-MM-dd']);
@@ -338,7 +338,7 @@ class TimeTest extends TestCase
 
         $time = new $class('+2 months +2 days');
         $result = $time->timeAgoInWords(['end' => '1 month', 'format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
+        $this->assertSame('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
     }
 
     /**
@@ -351,23 +351,23 @@ class TimeTest extends TestCase
     {
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 month']);
-        $this->assertEquals('2 months, 2 days ago', $result);
+        $this->assertSame('2 months, 2 days ago', $result);
 
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 month']);
-        $this->assertEquals('2 months, 2 days ago', $result);
+        $this->assertSame('2 months, 2 days ago', $result);
 
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '1 month', 'format' => 'yyyy-MM-dd']);
-        $this->assertEquals('on ' . date('Y-m-d', strtotime('-2 months -2 days')), $result);
+        $this->assertSame('on ' . date('Y-m-d', strtotime('-2 months -2 days')), $result);
 
         $time = new $class('-2 years -5 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 years']);
-        $this->assertEquals('2 years, 5 months, 2 days ago', $result);
+        $this->assertSame('2 years, 5 months, 2 days ago', $result);
 
         $time = new $class('-2 weeks -2 days');
         $result = $time->timeAgoInWords(['format' => 'yyyy-MM-dd']);
-        $this->assertEquals('2 weeks, 2 days ago', $result);
+        $this->assertSame('2 weeks, 2 days ago', $result);
 
         $time = new $class('-3 years -12 months');
         $result = $time->timeAgoInWords();
@@ -378,7 +378,7 @@ class TimeTest extends TestCase
         $result = $time->timeAgoInWords(
             ['end' => '1 year', 'accuracy' => ['month' => 'month']]
         );
-        $this->assertEquals('1 month ago', $result);
+        $this->assertSame('1 month ago', $result);
 
         $time = new $class('-1 years -2 weeks -3 days');
         $result = $time->timeAgoInWords(
@@ -389,19 +389,19 @@ class TimeTest extends TestCase
 
         $time = new $class('-13 months -5 days');
         $result = $time->timeAgoInWords(['end' => '2 years']);
-        $this->assertEquals('1 year, 1 month, 5 days ago', $result);
+        $this->assertSame('1 year, 1 month, 5 days ago', $result);
 
         $time = new $class('-58 minutes');
         $result = $time->timeAgoInWords(['accuracy' => 'hour']);
-        $this->assertEquals('about an hour ago', $result);
+        $this->assertSame('about an hour ago', $result);
 
         $time = new $class('-23 hours');
         $result = $time->timeAgoInWords(['accuracy' => 'day']);
-        $this->assertEquals('about a day ago', $result);
+        $this->assertSame('about a day ago', $result);
 
         $time = new $class('-20 days');
         $result = $time->timeAgoInWords(['accuracy' => 'month']);
-        $this->assertEquals('about a month ago', $result);
+        $this->assertSame('about a month ago', $result);
     }
 
     /**
@@ -417,7 +417,7 @@ class TimeTest extends TestCase
 
         $result = $time->nice('America/New_York');
         $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
-        $this->assertEquals('UTC', $time->getTimezone()->getName());
+        $this->assertSame('UTC', $time->getTimezone()->getName());
 
         $this->assertTimeFormat('20 avr. 2014 20:00', $time->nice(null, 'fr-FR'));
         $this->assertTimeFormat('20 avr. 2014 16:00', $time->nice('America/New_York', 'fr-FR'));
@@ -496,10 +496,10 @@ class TimeTest extends TestCase
 
         $time = new Time(1556864870);
         I18n::setLocale('ar');
-        $this->assertEquals('٢٠١٩-٠٥-٠٣', $time->i18nFormat('yyyy-MM-dd'));
+        $this->assertSame('٢٠١٩-٠٥-٠٣', $time->i18nFormat('yyyy-MM-dd'));
 
         I18n::setLocale('en');
-        $this->assertEquals('2019-05-03', $time->i18nFormat('yyyy-MM-dd'));
+        $this->assertSame('2019-05-03', $time->i18nFormat('yyyy-MM-dd'));
 
         I18n::setLocale($locale);
     }
@@ -544,9 +544,9 @@ class TimeTest extends TestCase
     {
         $return = $class::listTimezones();
         $this->assertTrue(isset($return['Asia']['Asia/Bangkok']));
-        $this->assertEquals('Bangkok', $return['Asia']['Asia/Bangkok']);
+        $this->assertSame('Bangkok', $return['Asia']['Asia/Bangkok']);
         $this->assertTrue(isset($return['America']['America/Argentina/Buenos_Aires']));
-        $this->assertEquals('Argentina/Buenos_Aires', $return['America']['America/Argentina/Buenos_Aires']);
+        $this->assertSame('Argentina/Buenos_Aires', $return['America']['America/Argentina/Buenos_Aires']);
         $this->assertTrue(isset($return['UTC']['UTC']));
         $this->assertArrayNotHasKey('Cuba', $return);
         $this->assertArrayNotHasKey('US', $return);
@@ -557,16 +557,16 @@ class TimeTest extends TestCase
 
         $return = $class::listTimezones(null, null, ['abbr' => true]);
         $this->assertTrue(isset($return['Asia']['Asia/Jakarta']));
-        $this->assertEquals('Jakarta - WIB', $return['Asia']['Asia/Jakarta']);
-        $this->assertEquals('Regina - CST', $return['America']['America/Regina']);
+        $this->assertSame('Jakarta - WIB', $return['Asia']['Asia/Jakarta']);
+        $this->assertSame('Regina - CST', $return['America']['America/Regina']);
 
         $return = $class::listTimezones(null, null, [
             'abbr' => true,
             'before' => ' (',
             'after' => ')',
         ]);
-        $this->assertEquals('Jayapura (WIT)', $return['Asia']['Asia/Jayapura']);
-        $this->assertEquals('Regina (CST)', $return['America']['America/Regina']);
+        $this->assertSame('Jayapura (WIT)', $return['Asia']['Asia/Jayapura']);
+        $this->assertSame('Regina (CST)', $return['America']['America/Regina']);
 
         $return = $class::listTimezones('#^(America|Pacific)/#', null, false);
         $this->assertArrayHasKey('America/Argentina/Buenos_Aires', $return);
@@ -664,34 +664,34 @@ class TimeTest extends TestCase
         $time = new $class('2014-04-20 10:10:10');
 
         $other = new $class('2014-04-27 10:10:10');
-        $this->assertEquals('1 week before', $time->diffForHumans($other));
+        $this->assertSame('1 week before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-21 09:10:10');
-        $this->assertEquals('23 hours before', $time->diffForHumans($other));
+        $this->assertSame('23 hours before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-13 09:10:10');
-        $this->assertEquals('1 week after', $time->diffForHumans($other));
+        $this->assertSame('1 week after', $time->diffForHumans($other));
 
         $other = new $class('2014-04-06 09:10:10');
-        $this->assertEquals('2 weeks after', $time->diffForHumans($other));
+        $this->assertSame('2 weeks after', $time->diffForHumans($other));
 
         $other = new $class('2014-04-21 10:10:10');
-        $this->assertEquals('1 day before', $time->diffForHumans($other));
+        $this->assertSame('1 day before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-22 10:10:10');
-        $this->assertEquals('2 days before', $time->diffForHumans($other));
+        $this->assertSame('2 days before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-20 10:11:10');
-        $this->assertEquals('1 minute before', $time->diffForHumans($other));
+        $this->assertSame('1 minute before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-20 10:12:10');
-        $this->assertEquals('2 minutes before', $time->diffForHumans($other));
+        $this->assertSame('2 minutes before', $time->diffForHumans($other));
 
         $other = new $class('2014-04-20 10:10:09');
-        $this->assertEquals('1 second after', $time->diffForHumans($other));
+        $this->assertSame('1 second after', $time->diffForHumans($other));
 
         $other = new $class('2014-04-20 10:10:08');
-        $this->assertEquals('2 seconds after', $time->diffForHumans($other));
+        $this->assertSame('2 seconds after', $time->diffForHumans($other));
     }
 
     /**
@@ -704,13 +704,13 @@ class TimeTest extends TestCase
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
-        $this->assertEquals('1 year', $time->diffForHumans(null, true));
+        $this->assertSame('1 year', $time->diffForHumans(null, true));
 
         $other = new $class('2014-04-27 10:10:10');
-        $this->assertEquals('1 week', $time->diffForHumans($other, true));
+        $this->assertSame('1 week', $time->diffForHumans($other, true));
 
         $time = new $class('2016-04-20 10:10:10');
-        $this->assertEquals('4 months', $time->diffForHumans(null, true));
+        $this->assertSame('4 months', $time->diffForHumans(null, true));
     }
 
     /**
@@ -723,10 +723,10 @@ class TimeTest extends TestCase
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
-        $this->assertEquals('1 year ago', $time->diffForHumans());
+        $this->assertSame('1 year ago', $time->diffForHumans());
 
         $time = new $class('2016-04-20 10:10:10');
-        $this->assertEquals('4 months from now', $time->diffForHumans());
+        $this->assertSame('4 months from now', $time->diffForHumans());
     }
 
     /**
@@ -742,13 +742,13 @@ class TimeTest extends TestCase
         }
 
         $time = new $class('2014-04-20 10:10:10');
-        $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
+        $this->assertSame('"2014-04-20T10:10:10+00:00"', json_encode($time));
 
         $class::setJsonEncodeFormat('yyyy-MM-dd HH:mm:ss');
-        $this->assertEquals('"2014-04-20 10:10:10"', json_encode($time));
+        $this->assertSame('"2014-04-20 10:10:10"', json_encode($time));
 
         $class::setJsonEncodeFormat($class::UNIX_TIMESTAMP_FORMAT);
-        $this->assertEquals('1397988610', json_encode($time));
+        $this->assertSame('1397988610', json_encode($time));
     }
 
     /**
@@ -766,7 +766,7 @@ class TimeTest extends TestCase
         $this->assertInstanceOf('DateTimeZone', $date->timezone);
 
         $result = json_encode($date);
-        $this->assertEquals('"2016-11-29T09:00:00+00:00"', $result);
+        $this->assertSame('"2016-11-29T09:00:00+00:00"', $result);
         $this->assertInstanceOf('DateTimeZone', $date->getTimezone());
     }
 
@@ -797,16 +797,16 @@ class TimeTest extends TestCase
     {
         $time = $class::parseDateTime('01/01/1970 00:00am');
         $this->assertNotNull($time);
-        $this->assertEquals('1970-01-01 00:00', $time->format('Y-m-d H:i'));
+        $this->assertSame('1970-01-01 00:00', $time->format('Y-m-d H:i'));
 
         $time = $class::parseDateTime('10/13/2013 12:54am');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:54', $time->format('Y-m-d H:i'));
+        $this->assertSame('2013-10-13 00:54', $time->format('Y-m-d H:i'));
 
         $class::setDefaultLocale('fr-FR');
         $time = $class::parseDateTime('13 10, 2013 12:54');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 12:54', $time->format('Y-m-d H:i'));
+        $this->assertSame('2013-10-13 12:54', $time->format('Y-m-d H:i'));
 
         $time = $class::parseDateTime('13 foo 10 2013 12:54');
         $this->assertNull($time);
@@ -822,23 +822,23 @@ class TimeTest extends TestCase
     {
         $time = $class::parseDate('10/13/2013 12:54am');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+        $this->assertSame('2013-10-13 00:00', $time->format('Y-m-d H:i'));
 
         $time = $class::parseDate('10/13/2013');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+        $this->assertSame('2013-10-13 00:00', $time->format('Y-m-d H:i'));
 
         $class::setDefaultLocale('fr-FR');
         $time = $class::parseDate('13 10, 2013 12:54');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+        $this->assertSame('2013-10-13 00:00', $time->format('Y-m-d H:i'));
 
         $time = $class::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
 
         $time = $class::parseDate('13 10, 2013', 'dd M, y');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13', $time->format('Y-m-d'));
+        $this->assertSame('2013-10-13', $time->format('Y-m-d'));
     }
 
     /**
@@ -851,12 +851,12 @@ class TimeTest extends TestCase
     {
         $time = $class::parseTime('12:54am');
         $this->assertNotNull($time);
-        $this->assertEquals('00:54:00', $time->format('H:i:s'));
+        $this->assertSame('00:54:00', $time->format('H:i:s'));
 
         $class::setDefaultLocale('fr-FR');
         $time = $class::parseTime('23:54');
         $this->assertNotNull($time);
-        $this->assertEquals('23:54:00', $time->format('H:i:s'));
+        $this->assertSame('23:54:00', $time->format('H:i:s'));
 
         $time = $class::parseTime('31c2:54');
         $this->assertNull($time);
@@ -873,7 +873,7 @@ class TimeTest extends TestCase
         I18n::setLocale('ru_RU');
         $time = new $class('5 days ago');
         $result = $time->timeAgoInWords();
-        $this->assertEquals('5 days ago', $result);
+        $this->assertSame('5 days ago', $result);
     }
 
     /**
@@ -887,7 +887,7 @@ class TimeTest extends TestCase
         date_default_timezone_set('Europe/Paris');
         $class::setDefaultLocale('fr-FR');
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('2015-03-12', $result->format('Y-m-d'));
+        $this->assertSame('2015-03-12', $result->format('Y-m-d'));
         $this->assertEquals(new \DateTimeZone('Europe/Paris'), $result->tz);
     }
 
@@ -921,7 +921,7 @@ class TimeTest extends TestCase
 
         $expected = 'Y-m-d';
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('2015-03-12', $result->format($expected));
+        $this->assertSame('2015-03-12', $result->format($expected));
     }
 
     /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -691,7 +691,7 @@ class LogTest extends TestCase
     {
         $instance = new FileLog();
         Log::setConfig('default', function ($alias) use ($instance) {
-            $this->assertEquals('default', $alias);
+            $this->assertSame('default', $alias);
 
             return $instance;
         });

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2065,7 +2065,7 @@ class EmailTest extends TestCase
 
         $template = $this->Email->viewBuilder()->getTemplate();
         $layout = $this->Email->viewBuilder()->getLayout();
-        $this->assertEquals('', $template);
+        $this->assertSame('', $template);
         $this->assertEquals($configs['layout'], $layout);
     }
 
@@ -2112,13 +2112,13 @@ class EmailTest extends TestCase
     public function testViewRender()
     {
         $result = $this->Email->getViewRenderer();
-        $this->assertEquals('Cake\View\View', $result);
+        $this->assertSame('Cake\View\View', $result);
 
         $result = $this->Email->setViewRenderer('Cake\View\ThemeView');
         $this->assertInstanceOf('Cake\Mailer\Email', $result);
 
         $result = $this->Email->getViewRenderer();
-        $this->assertEquals('Cake\View\ThemeView', $result);
+        $this->assertSame('Cake\View\ThemeView', $result);
     }
 
     /**
@@ -2129,13 +2129,13 @@ class EmailTest extends TestCase
     public function testEmailFormat()
     {
         $result = $this->Email->getEmailFormat();
-        $this->assertEquals('text', $result);
+        $this->assertSame('text', $result);
 
         $result = $this->Email->setEmailFormat('html');
         $this->assertInstanceOf('Cake\Mailer\Email', $result);
 
         $result = $this->Email->getEmailFormat();
-        $this->assertEquals('html', $result);
+        $this->assertSame('html', $result);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->Email->setEmailFormat('invalid');
@@ -2153,16 +2153,16 @@ class EmailTest extends TestCase
         $this->assertEquals(Configure::read('App.encoding'), $email->getHeaderCharset());
 
         $email = new Email(['charset' => 'iso-2022-jp', 'headerCharset' => 'iso-2022-jp-ms']);
-        $this->assertEquals('iso-2022-jp', $email->getCharset());
-        $this->assertEquals('iso-2022-jp-ms', $email->getHeaderCharset());
+        $this->assertSame('iso-2022-jp', $email->getCharset());
+        $this->assertSame('iso-2022-jp-ms', $email->getHeaderCharset());
 
         $email = new Email(['charset' => 'iso-2022-jp']);
-        $this->assertEquals('iso-2022-jp', $email->getCharset());
-        $this->assertEquals('iso-2022-jp', $email->getHeaderCharset());
+        $this->assertSame('iso-2022-jp', $email->getCharset());
+        $this->assertSame('iso-2022-jp', $email->getHeaderCharset());
 
         $email = new Email(['headerCharset' => 'iso-2022-jp-ms']);
         $this->assertEquals(Configure::read('App.encoding'), $email->getCharset());
-        $this->assertEquals('iso-2022-jp-ms', $email->getHeaderCharset());
+        $this->assertSame('iso-2022-jp-ms', $email->getHeaderCharset());
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -216,7 +216,7 @@ class MailerTest extends TestCase
             ->with('foo', 'bar');
 
         $mailer->send('test', ['foo', 'bar']);
-        $this->assertEquals('cakephp', $mailer->viewBuilder()->getTemplate());
+        $this->assertSame('cakephp', $mailer->viewBuilder()->getTemplate());
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -111,7 +111,7 @@ class SmtpTransportTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('SMTP server did not accept the connection or trying to connect to non TLS SMTP server using TLS.', $e->getMessage());
+        $this->assertSame('SMTP server did not accept the connection or trying to connect to non TLS SMTP server using TLS.', $e->getMessage());
         $this->assertInstanceOf(SocketException::class, $e->getPrevious());
         $this->assertStringContainsString('500 5.3.3 Unrecognized command', $e->getPrevious()->getMessage());
     }
@@ -173,7 +173,7 @@ class SmtpTransportTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('SMTP server did not accept the connection.', $e->getMessage());
+        $this->assertSame('SMTP server did not accept the connection.', $e->getMessage());
         $this->assertInstanceOf(SocketException::class, $e->getPrevious());
         $this->assertStringContainsString('200 Not Accepted', $e->getPrevious()->getMessage());
     }
@@ -264,7 +264,7 @@ class SmtpTransportTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('SMTP server did not accept the username.', $e->getMessage());
+        $this->assertSame('SMTP server did not accept the username.', $e->getMessage());
         $this->assertInstanceOf(SocketException::class, $e->getPrevious());
         $this->assertStringContainsString('535 5.7.8 Authentication failed', $e->getPrevious()->getMessage());
     }
@@ -291,7 +291,7 @@ class SmtpTransportTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('SMTP server did not accept the password.', $e->getMessage());
+        $this->assertSame('SMTP server did not accept the password.', $e->getMessage());
         $this->assertInstanceOf(SocketException::class, $e->getPrevious());
         $this->assertStringContainsString('535 5.7.8 Authentication failed', $e->getPrevious()->getMessage());
     }

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -141,14 +141,14 @@ class SocketTest extends TestCase
         try {
             $this->Socket = new Socket();
             $this->Socket->connect();
-            $this->assertEquals('127.0.0.1', $this->Socket->address());
+            $this->assertSame('127.0.0.1', $this->Socket->address());
             $this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
             $this->assertNull($this->Socket->lastError());
             $this->assertContains('127.0.0.1', $this->Socket->addresses());
 
             $this->Socket = new Socket(['host' => '127.0.0.1']);
             $this->Socket->connect();
-            $this->assertEquals('127.0.0.1', $this->Socket->address());
+            $this->assertSame('127.0.0.1', $this->Socket->address());
             $this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
             $this->assertNull($this->Socket->lastError());
             $this->assertContains('127.0.0.1', $this->Socket->addresses());
@@ -188,7 +188,7 @@ class SocketTest extends TestCase
             $this->Socket = new Socket($config);
             $this->assertTrue($this->Socket->connect());
             $this->assertNull($this->Socket->read(26));
-            $this->assertEquals('2: ' . 'Connection timed out', $this->Socket->lastError());
+            $this->assertSame('2: ' . 'Connection timed out', $this->Socket->lastError());
         } catch (SocketException $e) {
             $this->markTestSkipped('Cannot test network, skipping.');
         }
@@ -209,7 +209,7 @@ class SocketTest extends TestCase
             $config = ['host' => '127.0.0.1', 'timeout' => 1];
             $this->Socket = new Socket($config);
             $this->assertNull($this->Socket->read(1024 * 1024));
-            $this->assertEquals('2: ' . 'Connection timed out', $this->Socket->lastError());
+            $this->assertSame('2: ' . 'Connection timed out', $this->Socket->lastError());
         } catch (SocketException $e) {
             $this->markTestSkipped('Cannot test network, skipping.');
         }
@@ -224,7 +224,7 @@ class SocketTest extends TestCase
     {
         $this->Socket = new Socket();
         $this->Socket->setLastError(4, 'some error here');
-        $this->assertEquals('4: some error here', $this->Socket->lastError());
+        $this->assertSame('4: some error here', $this->Socket->lastError());
     }
 
     /**
@@ -327,8 +327,8 @@ class SocketTest extends TestCase
         $socket = new Socket($configSslTls);
         try {
             $socket->connect();
-            $this->assertEquals('smtp.gmail.com', $socket->getConfig('host'));
-            $this->assertEquals('ssl', $socket->getConfig('protocol'));
+            $this->assertSame('smtp.gmail.com', $socket->getConfig('host'));
+            $this->assertSame('ssl', $socket->getConfig('protocol'));
         } catch (SocketException $e) {
             $this->markTestSkipped('Cannot test network, skipping.');
         }
@@ -481,7 +481,7 @@ class SocketTest extends TestCase
         $this->assertTrue($result['ssl']['verify_peer']);
         $this->assertFalse($result['ssl']['allow_self_signed']);
         $this->assertEquals(5, $result['ssl']['verify_depth']);
-        $this->assertEquals('smtp.gmail.com', $result['ssl']['CN_match']);
+        $this->assertSame('smtp.gmail.com', $result['ssl']['CN_match']);
         $this->assertArrayNotHasKey('ssl_verify_peer', $socket->getConfig());
         $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->getConfig());
         $this->assertArrayNotHasKey('ssl_verify_host', $socket->getConfig());

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -85,9 +85,9 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
         ]);
-        $this->assertEquals('article_id', $assoc->getForeignKey());
+        $this->assertSame('article_id', $assoc->getForeignKey());
         $this->assertSame($assoc, $assoc->setForeignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->getForeignKey());
+        $this->assertSame('another_key', $assoc->getForeignKey());
     }
 
     /**
@@ -158,8 +158,8 @@ class BelongsToManyTest extends TestCase
         ]);
         $junction = $assoc->junction();
         $this->assertInstanceOf(Table::class, $junction);
-        $this->assertEquals('ArticlesTags', $junction->getAlias());
-        $this->assertEquals('articles_tags', $junction->getTable());
+        $this->assertSame('ArticlesTags', $junction->getAlias());
+        $this->assertSame('articles_tags', $junction->getTable());
         $this->assertSame($this->article, $junction->getAssociation('Articles')->getTarget());
         $this->assertSame($this->tag, $junction->getAssociation('Tags')->getTarget());
 
@@ -226,12 +226,12 @@ class BelongsToManyTest extends TestCase
             'targetForeignKey' => 'article',
         ]);
         $junction = $this->article->getAssociation('Tags')->junction();
-        $this->assertEquals('article', $junction->getAssociation('Articles')->getForeignKey());
-        $this->assertEquals('article', $this->article->getAssociation('ArticlesTags')->getForeignKey());
+        $this->assertSame('article', $junction->getAssociation('Articles')->getForeignKey());
+        $this->assertSame('article', $this->article->getAssociation('ArticlesTags')->getForeignKey());
 
         $junction = $this->tag->getAssociation('Articles')->junction();
-        $this->assertEquals('tag', $junction->getAssociation('Tags')->getForeignKey());
-        $this->assertEquals('tag', $this->tag->getAssociation('ArticlesTags')->getForeignKey());
+        $this->assertSame('tag', $junction->getAssociation('Tags')->getForeignKey());
+        $this->assertSame('tag', $this->tag->getAssociation('ArticlesTags')->getForeignKey());
     }
 
     /**
@@ -247,8 +247,8 @@ class BelongsToManyTest extends TestCase
             'joinTable' => 'tags_articles',
         ]);
         $junction = $assoc->junction();
-        $this->assertEquals('TagsArticles', $junction->getAlias());
-        $this->assertEquals('tags_articles', $junction->getTable());
+        $this->assertSame('TagsArticles', $junction->getAlias());
+        $this->assertSame('tags_articles', $junction->getTable());
     }
 
     /**
@@ -405,7 +405,7 @@ class BelongsToManyTest extends TestCase
         $entity = new Entity(['id' => 1, 'name' => 'PHP']);
         $association->cascadeDelete($entity);
 
-        $this->assertEquals(0, $articleTag->find()->where(['article_id' => 1])->count());
+        $this->assertSame(0, $articleTag->find()->where(['article_id' => 1])->count());
     }
 
     /**
@@ -914,7 +914,7 @@ class BelongsToManyTest extends TestCase
 
         $entity = $articles->get(1, ['contain' => 'Tags']);
         $this->assertCount($originalCount, $entity->tags, 'Should not have changed.');
-        $this->assertEquals('tag1', $entity->tags[0]->name);
+        $this->assertSame('tag1', $entity->tags[0]->name);
     }
 
     /**
@@ -1108,16 +1108,16 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
         ]);
-        $this->assertEquals('tag_id', $assoc->getTargetForeignKey());
+        $this->assertSame('tag_id', $assoc->getTargetForeignKey());
         $assoc->setTargetForeignKey('another_key');
-        $this->assertEquals('another_key', $assoc->getTargetForeignKey());
+        $this->assertSame('another_key', $assoc->getTargetForeignKey());
 
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
             'targetForeignKey' => 'foo',
         ]);
-        $this->assertEquals('foo', $assoc->getTargetForeignKey());
+        $this->assertSame('foo', $assoc->getTargetForeignKey());
     }
 
     /**
@@ -1135,12 +1135,12 @@ class BelongsToManyTest extends TestCase
             'targetForeignKey' => 'Tag',
         ]);
         $junction = $assoc->junction();
-        $this->assertEquals('Art', $junction->getAssociation('Articles')->getForeignKey());
-        $this->assertEquals('Tag', $junction->getAssociation('Tags')->getForeignKey());
+        $this->assertSame('Art', $junction->getAssociation('Articles')->getForeignKey());
+        $this->assertSame('Tag', $junction->getAssociation('Tags')->getForeignKey());
 
         $inverseRelation = $this->tag->getAssociation('Articles');
-        $this->assertEquals('Tag', $inverseRelation->getForeignKey());
-        $this->assertEquals('Art', $inverseRelation->getTargetForeignKey());
+        $this->assertSame('Tag', $inverseRelation->getForeignKey());
+        $this->assertSame('Art', $inverseRelation->getTargetForeignKey());
     }
 
     /**
@@ -1152,7 +1152,7 @@ class BelongsToManyTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsToMany('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->getProperty());
+        $this->assertSame('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -1170,7 +1170,7 @@ class BelongsToManyTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new BelongsToMany('Contacts.Tags', $config);
-        $this->assertEquals('tags', $association->getProperty());
+        $this->assertSame('tags', $association->getProperty());
     }
 
     /**
@@ -1197,25 +1197,25 @@ class BelongsToManyTest extends TestCase
         $tagAssoc = $articles->getAssociation('Tags');
         $this->assertNotEmpty($tagAssoc, 'btm should exist');
         $this->assertEquals($conditions, $tagAssoc->getConditions());
-        $this->assertEquals('target_foreign_key', $tagAssoc->getTargetForeignKey());
-        $this->assertEquals('foreign_key', $tagAssoc->getForeignKey());
+        $this->assertSame('target_foreign_key', $tagAssoc->getTargetForeignKey());
+        $this->assertSame('foreign_key', $tagAssoc->getForeignKey());
 
         $jointAssoc = $articles->getAssociation('SpecialTags');
         $this->assertNotEmpty($jointAssoc, 'has many to junction should exist');
         $this->assertInstanceOf(HasMany::class, $jointAssoc);
-        $this->assertEquals('foreign_key', $jointAssoc->getForeignKey());
+        $this->assertSame('foreign_key', $jointAssoc->getForeignKey());
 
         $articleAssoc = $tags->getAssociation('Articles');
         $this->assertNotEmpty($articleAssoc, 'reverse btm should exist');
         $this->assertInstanceOf(BelongsToMany::class, $articleAssoc);
         $this->assertEquals($conditions, $articleAssoc->getConditions());
-        $this->assertEquals('foreign_key', $articleAssoc->getTargetForeignKey(), 'keys should swap');
-        $this->assertEquals('target_foreign_key', $articleAssoc->getForeignKey(), 'keys should swap');
+        $this->assertSame('foreign_key', $articleAssoc->getTargetForeignKey(), 'keys should swap');
+        $this->assertSame('target_foreign_key', $articleAssoc->getForeignKey(), 'keys should swap');
 
         $jointAssoc = $tags->getAssociation('SpecialTags');
         $this->assertNotEmpty($jointAssoc, 'has many to junction should exist');
         $this->assertInstanceOf(HasMany::class, $jointAssoc);
-        $this->assertEquals('target_foreign_key', $jointAssoc->getForeignKey());
+        $this->assertSame('target_foreign_key', $jointAssoc->getForeignKey());
     }
 
     /**
@@ -1384,6 +1384,6 @@ class BelongsToManyTest extends TestCase
             return $query->where(['Articles.id' => 1]);
         });
         // The inner join on special_tags excludes the results.
-        $this->assertEquals(0, $query->count());
+        $this->assertSame(0, $query->count());
     }
 }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -94,9 +94,9 @@ class BelongsToTest extends TestCase
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ]);
-        $this->assertEquals('company_id', $assoc->getForeignKey());
+        $this->assertSame('company_id', $assoc->getForeignKey());
         $this->assertSame($assoc, $assoc->setForeignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->getForeignKey());
+        $this->assertSame('another_key', $assoc->getForeignKey());
     }
 
     /**
@@ -112,7 +112,7 @@ class BelongsToTest extends TestCase
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ]);
-        $this->assertEquals('company_id', $assoc->getForeignKey());
+        $this->assertSame('company_id', $assoc->getForeignKey());
     }
 
     /**
@@ -336,7 +336,7 @@ class BelongsToTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsTo('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->getProperty());
+        $this->assertSame('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -354,7 +354,7 @@ class BelongsToTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new BelongsTo('Contacts.Companies', $config);
-        $this->assertEquals('company', $association->getProperty());
+        $this->assertSame('company', $association->getProperty());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -115,9 +115,9 @@ class HasManyTest extends TestCase
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author,
         ]);
-        $this->assertEquals('author_id', $assoc->getForeignKey());
+        $this->assertSame('author_id', $assoc->getForeignKey());
         $this->assertSame($assoc, $assoc->setForeignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->getForeignKey());
+        $this->assertSame('another_key', $assoc->getForeignKey());
     }
 
     /**
@@ -131,7 +131,7 @@ class HasManyTest extends TestCase
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author,
         ]);
-        $this->assertEquals('author_id', $assoc->getForeignKey());
+        $this->assertSame('author_id', $assoc->getForeignKey());
     }
 
     /**
@@ -542,7 +542,7 @@ class HasManyTest extends TestCase
         $this->assertTrue($association->cascadeDelete($author));
 
         $query = $articles->query()->where(['author_id' => 1]);
-        $this->assertEquals(0, $query->count(), 'Cleared related rows');
+        $this->assertSame(0, $query->count(), 'Cleared related rows');
 
         $query = $articles->query()->where(['author_id' => 3]);
         $this->assertEquals(1, $query->count(), 'other records left behind');
@@ -589,7 +589,7 @@ class HasManyTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new HasMany('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->getProperty());
+        $this->assertSame('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -607,7 +607,7 @@ class HasManyTest extends TestCase
             'targetTable' => $mock,
         ];
         $association = new HasMany('Contacts.Addresses', $config);
-        $this->assertEquals('addresses', $association->getProperty());
+        $this->assertSame('addresses', $association->getProperty());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -74,9 +74,9 @@ class HasOneTest extends TestCase
         $assoc = new HasOne('Profiles', [
             'sourceTable' => $this->user,
         ]);
-        $this->assertEquals('user_id', $assoc->getForeignKey());
+        $this->assertSame('user_id', $assoc->getForeignKey());
         $this->assertEquals($assoc, $assoc->setForeignKey('another_key'));
-        $this->assertEquals('another_key', $assoc->getForeignKey());
+        $this->assertSame('another_key', $assoc->getForeignKey());
     }
 
     /**
@@ -251,7 +251,7 @@ class HasOneTest extends TestCase
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new HasOne('Thing', $config);
-        $this->assertEquals('thing_placeholder', $association->getProperty());
+        $this->assertSame('thing_placeholder', $association->getProperty());
     }
 
     /**
@@ -266,7 +266,7 @@ class HasOneTest extends TestCase
             'targetTable' => $this->profile,
         ];
         $association = new HasOne('Contacts.Profiles', $config);
-        $this->assertEquals('profile', $association->getProperty());
+        $this->assertSame('profile', $association->getProperty());
     }
 
     /**
@@ -362,7 +362,7 @@ class HasOneTest extends TestCase
         $user = new Entity(['id' => 3]);
         $this->assertTrue($association->cascadeDelete($user));
         $query = $this->profile->query()->where(['user_id' => 3]);
-        $this->assertEquals(0, $query->count(), 'Matching record was deleted.');
+        $this->assertSame(0, $query->count(), 'Matching record was deleted.');
     }
 
     /**
@@ -393,6 +393,6 @@ class HasOneTest extends TestCase
         $user = new Entity(['id' => 3]);
         $this->assertTrue($association->cascadeDelete($user));
         $query = $this->profile->query()->where(['user_id' => 3]);
-        $this->assertEquals(0, $query->count(), 'Matching record was deleted.');
+        $this->assertSame(0, $query->count(), 'Matching record was deleted.');
     }
 }

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -162,7 +162,7 @@ class AssociationCollectionTest extends TestCase
         $belongsTo = new BelongsTo('Users', [
             'sourceTable' => $table,
         ]);
-        $this->assertEquals('user', $belongsTo->getProperty());
+        $this->assertSame('user', $belongsTo->getProperty());
         $this->associations->add('Users', $belongsTo);
         $this->assertNull($this->associations->get('user'));
 

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -201,6 +201,6 @@ class AssociationProxyTest extends TestCase
         $mock->expects($this->once())->method('crazy')
             ->with('a', 'b')
             ->will($this->returnValue('thing'));
-        $this->assertEquals('thing', $articles->authors->crazy('a', 'b'));
+        $this->assertSame('thing', $articles->authors->crazy('a', 'b'));
     }
 }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -89,9 +89,9 @@ class AssociationTest extends TestCase
      */
     public function testSetName()
     {
-        $this->assertEquals('Foo', $this->association->getName());
+        $this->assertSame('Foo', $this->association->getName());
         $this->assertSame($this->association, $this->association->setName('Bar'));
-        $this->assertEquals('Bar', $this->association->getName());
+        $this->assertSame('Bar', $this->association->getName());
     }
 
     /**
@@ -102,7 +102,7 @@ class AssociationTest extends TestCase
     public function testSetNameBeforeTarget()
     {
         $this->association->setName('Bar');
-        $this->assertEquals('Bar', $this->association->getName());
+        $this->assertSame('Bar', $this->association->getName());
     }
 
     /**
@@ -191,9 +191,9 @@ class AssociationTest extends TestCase
 
         $this->association->setClassName(AuthorsTable::class);
         $className = get_class($this->association->getTarget());
-        $this->assertEquals('TestApp\Model\Table\AuthorsTable', $className);
+        $this->assertSame('TestApp\Model\Table\AuthorsTable', $className);
         $this->association->setClassName('Authors');
-        $this->assertEquals('Authors', $this->association->getClassName());
+        $this->assertSame('Authors', $this->association->getClassName());
     }
 
     /**
@@ -214,7 +214,7 @@ class AssociationTest extends TestCase
             ->setConstructorArgs(['Foo', $config])
             ->getMock();
 
-        $this->assertEquals('Test', $this->association->getClassName());
+        $this->assertSame('Test', $this->association->getClassName());
     }
 
     /**
@@ -289,7 +289,7 @@ class AssociationTest extends TestCase
     public function testSetBindingKey()
     {
         $this->assertSame($this->association, $this->association->setBindingKey('foo_id'));
-        $this->assertEquals('foo_id', $this->association->getBindingKey());
+        $this->assertSame('foo_id', $this->association->getBindingKey());
     }
 
     /**
@@ -335,9 +335,9 @@ class AssociationTest extends TestCase
      */
     public function testSetForeignKey()
     {
-        $this->assertEquals('a_key', $this->association->getForeignKey());
+        $this->assertSame('a_key', $this->association->getForeignKey());
         $this->assertSame($this->association, $this->association->setForeignKey('another_key'));
-        $this->assertEquals('another_key', $this->association->getForeignKey());
+        $this->assertSame('another_key', $this->association->getForeignKey());
     }
 
     /**
@@ -444,9 +444,9 @@ class AssociationTest extends TestCase
      */
     public function testSetJoinType()
     {
-        $this->assertEquals('INNER', $this->association->getJoinType());
+        $this->assertSame('INNER', $this->association->getJoinType());
         $this->assertSame($this->association, $this->association->setJoinType('LEFT'));
-        $this->assertEquals('LEFT', $this->association->getJoinType());
+        $this->assertSame('LEFT', $this->association->getJoinType());
     }
 
     /**
@@ -456,9 +456,9 @@ class AssociationTest extends TestCase
      */
     public function testSetProperty()
     {
-        $this->assertEquals('foo', $this->association->getProperty());
+        $this->assertSame('foo', $this->association->getProperty());
         $this->assertSame($this->association, $this->association->setProperty('thing'));
-        $this->assertEquals('thing', $this->association->getProperty());
+        $this->assertSame('thing', $this->association->getProperty());
     }
 
     /**
@@ -471,7 +471,7 @@ class AssociationTest extends TestCase
         $this->expectException(\PHPUnit\Framework\Error\Warning::class);
         $this->expectExceptionMessageRegExp('/^Association property name "foo" clashes with field of same name of table "test"/');
         $this->source->setSchema(['foo' => ['type' => 'string']]);
-        $this->assertEquals('foo', $this->association->getProperty());
+        $this->assertSame('foo', $this->association->getProperty());
     }
 
     /**
@@ -500,7 +500,7 @@ class AssociationTest extends TestCase
             ->setConstructorArgs(['Foo', $config])
             ->getMock();
 
-        $this->assertEquals('foo', $association->getProperty());
+        $this->assertSame('foo', $association->getProperty());
     }
 
     /**
@@ -510,13 +510,13 @@ class AssociationTest extends TestCase
      */
     public function testSetStrategy()
     {
-        $this->assertEquals('join', $this->association->getStrategy());
+        $this->assertSame('join', $this->association->getStrategy());
 
         $this->association->setStrategy('select');
-        $this->assertEquals('select', $this->association->getStrategy());
+        $this->assertSame('select', $this->association->getStrategy());
 
         $this->association->setStrategy('subquery');
-        $this->assertEquals('subquery', $this->association->getStrategy());
+        $this->assertSame('subquery', $this->association->getStrategy());
     }
 
     /**
@@ -537,9 +537,9 @@ class AssociationTest extends TestCase
      */
     public function testSetFinderMethod()
     {
-        $this->assertEquals('all', $this->association->getFinder());
+        $this->assertSame('all', $this->association->getFinder());
         $this->assertSame($this->association, $this->association->setFinder('published'));
-        $this->assertEquals('published', $this->association->getFinder());
+        $this->assertSame('published', $this->association->getFinder());
     }
 
     /**
@@ -565,7 +565,7 @@ class AssociationTest extends TestCase
             ])
             ->setConstructorArgs(['Foo', $config])
             ->getMock();
-        $this->assertEquals('published', $assoc->getFinder());
+        $this->assertSame('published', $assoc->getFinder());
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -263,7 +263,7 @@ class CounterCacheBehaviorTest extends TestCase
         $category2 = $this->_getCategory(2);
         $this->assertEquals(1, $user1->get('post_count'));
         $this->assertEquals(2, $user2->get('post_count'));
-        $this->assertEquals(0, $category1->get('post_count'));
+        $this->assertSame(0, $category1->get('post_count'));
         $this->assertEquals(3, $category2->get('post_count'));
     }
 

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -34,13 +34,13 @@ class TranslateTraitTest extends TestCase
     {
         $entity = new TranslateTestEntity();
         $entity->translation('eng')->set('title', 'My Title');
-        $this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
 
         $this->assertTrue($entity->isDirty('_translations'));
 
         $entity->translation('spa')->set('body', 'Contenido');
-        $this->assertEquals('My Title', $entity->translation('eng')->get('title'));
-        $this->assertEquals('Contenido', $entity->translation('spa')->get('body'));
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
+        $this->assertSame('Contenido', $entity->translation('spa')->get('body'));
     }
 
     /**
@@ -55,8 +55,8 @@ class TranslateTraitTest extends TestCase
             'eng' => new Entity(['title' => 'My Title']),
             'spa' => new Entity(['title' => 'Titulo']),
         ]);
-        $this->assertEquals('My Title', $entity->translation('eng')->get('title'));
-        $this->assertEquals('Titulo', $entity->translation('spa')->get('title'));
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
+        $this->assertSame('Titulo', $entity->translation('spa')->get('title'));
     }
 
     /**
@@ -90,7 +90,7 @@ class TranslateTraitTest extends TestCase
             'spa' => new Entity(['title' => 'Titulo']),
         ]);
         $entity->clean();
-        $this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
         $this->assertTrue($entity->isDirty('_translations'));
     }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -471,7 +471,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $translations = $this->getTableLocator()->get('ArticlesTranslations')->find()
             ->where(['id' => $article->id])
             ->count();
-        $this->assertEquals(0, $translations);
+        $this->assertSame(0, $translations);
     }
 
     /**
@@ -863,10 +863,10 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
             $table->find('translations')->where(['id' => 1])
         )->first();
 
-        $this->assertEquals('Mi nuevo titulo', $results['spa']['title']);
-        $this->assertEquals('Contenido Actualizado', $results['spa']['body']);
+        $this->assertSame('Mi nuevo titulo', $results['spa']['title']);
+        $this->assertSame('Contenido Actualizado', $results['spa']['body']);
 
-        $this->assertEquals('First Article1', $results['eng']['title']);
+        $this->assertSame('First Article1', $results['eng']['title']);
     }
 
     /**
@@ -1058,8 +1058,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $this->assertCount(2, $result);
         $this->assertArrayHasKey('en', $result);
         $this->assertArrayHasKey('es', $result);
-        $this->assertEquals('English Title', $result['en']->title);
-        $this->assertEquals('Titulo Español', $result['es']->title);
+        $this->assertSame('English Title', $result['en']->title);
+        $this->assertSame('Titulo Español', $result['es']->title);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -92,8 +92,8 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertEquals(I18nTable::class, $i18n->getName());
         $this->assertInstanceOf(I18nTable::class, $i18n->getTarget());
-        $this->assertEquals('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
-        $this->assertEquals('custom_i18n_table', $i18n->getTarget()->getTable());
+        $this->assertSame('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
+        $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTable());
     }
 
     /**
@@ -113,7 +113,7 @@ class TranslateBehaviorTest extends TestCase
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals('select', $i18n->getStrategy());
+        $this->assertSame('select', $i18n->getStrategy());
     }
 
     /**
@@ -324,16 +324,16 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
 
-        $this->assertEquals('en_US', $table->getLocale());
+        $this->assertSame('en_US', $table->getLocale());
 
         $table->setLocale('fr_FR');
-        $this->assertEquals('fr_FR', $table->getLocale());
+        $this->assertSame('fr_FR', $table->getLocale());
 
         $table->setLocale(null);
-        $this->assertEquals('en_US', $table->getLocale());
+        $this->assertSame('en_US', $table->getLocale());
 
         I18n::setLocale('fr_FR');
-        $this->assertEquals('fr_FR', $table->getLocale());
+        $this->assertSame('fr_FR', $table->getLocale());
     }
 
     /**
@@ -695,8 +695,8 @@ class TranslateBehaviorTest extends TestCase
         $translations = $this->_extractTranslations($comments);
         $this->assertEquals($expected, $translations->toArray());
 
-        $this->assertEquals('Titulek #1', $results->first()->title);
-        $this->assertEquals('Obsah #1', $results->first()->body);
+        $this->assertSame('Titulek #1', $results->first()->title);
+        $this->assertSame('Obsah #1', $results->first()->body);
     }
 
     /**
@@ -766,7 +766,7 @@ class TranslateBehaviorTest extends TestCase
         $result = $table->get(2, ['contain' => 'Tags']);
         $this->assertNotEmpty($result);
         $this->assertNotEmpty($result->tags);
-        $this->assertEquals('Translated Info', $result->tags[0]->special_tags[0]->extra_info);
+        $this->assertSame('Translated Info', $result->tags[0]->special_tags[0]->extra_info);
     }
 
     /**
@@ -787,13 +787,13 @@ class TranslateBehaviorTest extends TestCase
 
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('New translated article', $article->get('title'));
-        $this->assertEquals('Content #1', $article->get('body'));
+        $this->assertSame('New translated article', $article->get('title'));
+        $this->assertSame('Content #1', $article->get('body'));
 
         $table->setLocale(false);
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('First Article', $article->get('title'));
+        $this->assertSame('First Article', $article->get('title'));
 
         $table->setLocale('eng');
         $article->set('title', 'Wow, such translated article');
@@ -803,8 +803,8 @@ class TranslateBehaviorTest extends TestCase
 
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('Wow, such translated article', $article->get('title'));
-        $this->assertEquals('A translated body', $article->get('body'));
+        $this->assertSame('Wow, such translated article', $article->get('title'));
+        $this->assertSame('A translated body', $article->get('body'));
     }
 
     /**
@@ -822,12 +822,12 @@ class TranslateBehaviorTest extends TestCase
         $this->assertEquals(1, $article->get('id'));
         $article->set('title', 'Le titre');
         $table->save($article);
-        $this->assertEquals('fra', $article->get('_locale'));
+        $this->assertSame('fra', $article->get('_locale'));
 
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('Le titre', $article->get('title'));
-        $this->assertEquals('First Article Body', $article->get('body'));
+        $this->assertSame('Le titre', $article->get('title'));
+        $this->assertSame('First Article Body', $article->get('body'));
 
         $article->set('title', 'Un autre titre');
         $article->set('body', 'Le contenu');
@@ -835,8 +835,8 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNull($article->get('_i18n'));
 
         $article = $table->find()->first();
-        $this->assertEquals('Un autre titre', $article->get('title'));
-        $this->assertEquals('Le contenu', $article->get('body'));
+        $this->assertSame('Un autre titre', $article->get('title'));
+        $this->assertSame('Le contenu', $article->get('body'));
     }
 
     /**
@@ -996,14 +996,14 @@ class TranslateBehaviorTest extends TestCase
 
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('First Article', $article->get('title'));
-        $this->assertEquals('First Article Body', $article->get('body'));
+        $this->assertSame('First Article', $article->get('title'));
+        $this->assertSame('First Article Body', $article->get('body'));
 
         $table->setLocale('fra');
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
-        $this->assertEquals('Le titre', $article->get('title'));
-        $this->assertEquals('First Article Body', $article->get('body'));
+        $this->assertSame('Le titre', $article->get('title'));
+        $this->assertSame('First Article Body', $article->get('body'));
     }
 
     /**
@@ -1026,7 +1026,7 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNull($article->get('_i18n'));
 
         $article = $table->find()->first();
-        $this->assertEquals('Le titre', $article->get('title'));
+        $this->assertSame('Le titre', $article->get('title'));
     }
 
     /**
@@ -1044,7 +1044,7 @@ class TranslateBehaviorTest extends TestCase
         $translations = $this->getTableLocator()->get('I18n')->find()
             ->where(['model' => 'Articles', 'foreign_key' => $article->id])
             ->count();
-        $this->assertEquals(0, $translations);
+        $this->assertSame(0, $translations);
     }
 
     /**
@@ -1068,8 +1068,8 @@ class TranslateBehaviorTest extends TestCase
 
         $article = $results = $table->find('translations')->first();
         $translations = $article->get('_translations');
-        $this->assertEquals('Another title', $translations['deu']->get('title'));
-        $this->assertEquals('Another body', $translations['eng']->get('body'));
+        $this->assertSame('Another title', $translations['deu']->get('title'));
+        $this->assertSame('Another body', $translations['eng']->get('body'));
     }
 
     /**
@@ -1094,10 +1094,10 @@ class TranslateBehaviorTest extends TestCase
 
         $article = $results = $table->find('translations')->first();
         $translations = $article->get('_translations');
-        $this->assertEquals('Another title', $translations['deu']->get('title'));
-        $this->assertEquals('Another body', $translations['eng']->get('body'));
-        $this->assertEquals('Titulo', $translations['spa']->get('title'));
-        $this->assertEquals('Titre', $translations['fre']->get('title'));
+        $this->assertSame('Another title', $translations['deu']->get('title'));
+        $this->assertSame('Another body', $translations['eng']->get('body'));
+        $this->assertSame('Titulo', $translations['spa']->get('title'));
+        $this->assertSame('Titre', $translations['fre']->get('title'));
     }
 
     /**
@@ -1141,8 +1141,8 @@ class TranslateBehaviorTest extends TestCase
 
         $table->save($article);
         $article = $table->find('translations')->where(['Articles.id' => 1])->first();
-        $this->assertEquals('Un article', $article->translation('fra')->title);
-        $this->assertEquals('Un artículo', $article->translation('spa')->title);
+        $this->assertSame('Un article', $article->translation('fra')->title);
+        $this->assertSame('Un artículo', $article->translation('spa')->title);
     }
 
     /**
@@ -1161,8 +1161,8 @@ class TranslateBehaviorTest extends TestCase
         $results = $query->sortBy('id', SORT_ASC)->toList();
         $this->assertCount(2, $results);
 
-        $this->assertEquals('First Comment for Second Article', $results[0]->comment);
-        $this->assertEquals('Second Comment for Second Article', $results[1]->comment);
+        $this->assertSame('First Comment for Second Article', $results[0]->comment);
+        $this->assertSame('Second Comment for Second Article', $results[1]->comment);
     }
 
     /**
@@ -1188,7 +1188,7 @@ class TranslateBehaviorTest extends TestCase
         foreach ($association->getConditions() as $key => $value) {
             if (strpos($key, 'comment_translation.model') !== false) {
                 $found = true;
-                $this->assertEquals('Comments', $value);
+                $this->assertSame('Comments', $value);
                 break;
             }
         }
@@ -1218,7 +1218,7 @@ class TranslateBehaviorTest extends TestCase
         foreach ($association->getConditions() as $key => $value) {
             if (strpos($key, 'body_translation.model') !== false) {
                 $found = true;
-                $this->assertEquals('Posts', $value);
+                $this->assertSame('Posts', $value);
                 break;
             }
         }
@@ -1311,7 +1311,7 @@ class TranslateBehaviorTest extends TestCase
         $article->set('body', 'New Body');
         $table->save($article);
         $result = $table->get(1);
-        $this->assertEquals('New Body', $result->body);
+        $this->assertSame('New Body', $result->body);
         $this->assertSame($article->title, $result->title);
     }
 
@@ -1432,7 +1432,7 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertArrayHasKey('es', $results, 'New translation added');
         $this->assertArrayHasKey('eng', $results, 'Old translations present');
-        $this->assertEquals('Spanish Translation', $results['es']['title']);
+        $this->assertSame('Spanish Translation', $results['es']['title']);
     }
 
     /**
@@ -1470,11 +1470,11 @@ class TranslateBehaviorTest extends TestCase
             $table->find('translations')->where(['id' => 1])
         )->first();
 
-        $this->assertEquals('Mi nuevo titulo', $results['spa']['title']);
-        $this->assertEquals('Contenido Actualizado', $results['spa']['body']);
+        $this->assertSame('Mi nuevo titulo', $results['spa']['title']);
+        $this->assertSame('Contenido Actualizado', $results['spa']['body']);
 
-        $this->assertEquals('First Article1', $results['eng']['title']);
-        $this->assertEquals('Description #1', $results['eng']['description']);
+        $this->assertSame('First Article1', $results['eng']['title']);
+        $this->assertSame('Description #1', $results['eng']['description']);
     }
 
     /**
@@ -1498,8 +1498,8 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNull($article->get('_i18n'));
 
         $article = $table->get(1);
-        $this->assertEquals('New title', $article->get('title'));
-        $this->assertEquals('New body', $article->get('body'));
+        $this->assertSame('New title', $article->get('title'));
+        $this->assertSame('New body', $article->get('body'));
     }
 
     /**
@@ -1530,11 +1530,11 @@ class TranslateBehaviorTest extends TestCase
         $this->assertNull($article->get('_i18n'));
 
         $article = $table->find('translations')->where(['id' => 1])->first();
-        $this->assertEquals('New title', $article->get('title'));
-        $this->assertEquals('New body', $article->get('body'));
+        $this->assertSame('New title', $article->get('title'));
+        $this->assertSame('New body', $article->get('body'));
 
-        $this->assertEquals('ES title', $article->_translations['es']->title);
-        $this->assertEquals('ES body', $article->_translations['es']->body);
+        $this->assertSame('ES title', $article->_translations['es']->title);
+        $this->assertSame('ES body', $article->_translations['es']->body);
     }
 
     /**
@@ -1622,8 +1622,8 @@ class TranslateBehaviorTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertArrayHasKey('en', $result);
         $this->assertArrayHasKey('es', $result);
-        $this->assertEquals('English Title', $result['en']->title);
-        $this->assertEquals('Titulo Español', $result['es']->title);
+        $this->assertSame('English Title', $result['en']->title);
+        $this->assertSame('Titulo Español', $result['es']->title);
     }
 
     /**
@@ -1663,8 +1663,8 @@ class TranslateBehaviorTest extends TestCase
         ];
         $this->assertEquals($expected, $entity->getError('es'));
 
-        $this->assertEquals('English Title', $result['en']->title);
-        $this->assertEquals('', $result['es']->title);
+        $this->assertSame('English Title', $result['en']->title);
+        $this->assertNull($result['es']->title);
     }
 
     /**
@@ -1703,10 +1703,10 @@ class TranslateBehaviorTest extends TestCase
         $this->assertSame($en, $entity->get('_translations')['en']);
         $this->assertSame($es, $entity->get('_translations')['es']);
 
-        $this->assertEquals('English Title', $result['en']->title);
-        $this->assertEquals('Spanish Title', $result['es']->title);
-        $this->assertEquals('Old body', $result['en']->body);
-        $this->assertEquals('Old body', $result['es']->body);
+        $this->assertSame('English Title', $result['en']->title);
+        $this->assertSame('Spanish Title', $result['es']->title);
+        $this->assertSame('Old body', $result['en']->body);
+        $this->assertSame('Old body', $result['es']->body);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -179,7 +179,7 @@ class TreeBehaviorTest extends TestCase
 
         // count leaf children
         $count = $this->table->childCount($table->get(10), false);
-        $this->assertEquals(0, $count);
+        $this->assertSame(0, $count);
 
         // test scoping
         $table = $this->getTableLocator()->get('MenuLinkTrees');
@@ -287,7 +287,7 @@ class TreeBehaviorTest extends TestCase
         $query->clause('order')->iterateParts(function ($dir, $field) use (&$result) {
             $result = $field;
         });
-        $this->assertEquals('MenuLinkTrees.lft', $result);
+        $this->assertSame('MenuLinkTrees.lft', $result);
 
         $result = $query->toArray();
         $expected = [
@@ -1448,7 +1448,7 @@ class TreeBehaviorTest extends TestCase
         $entity = new Entity(['parent_id' => null, 'name' => 'Depth 0']);
         $this->table->save($entity);
         $entity = $this->table->get(12);
-        $this->assertEquals(0, $entity->depth);
+        $this->assertSame(0, $entity->depth);
 
         $entity = new Entity(['parent_id' => 1, 'name' => 'Depth 1']);
         $this->table->save($entity);
@@ -1484,7 +1484,7 @@ class TreeBehaviorTest extends TestCase
         $entity->parent_id = null;
         $this->table->save($entity);
         $entity = $this->table->get(6);
-        $this->assertEquals(0, $entity->depth);
+        $this->assertSame(0, $entity->depth);
 
         $entity = $this->table->get(7);
         $this->assertEquals(1, $entity->depth);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -107,7 +107,7 @@ class BehaviorRegistryTest extends TestCase
         $result = $this->EventManager->listeners('Model.beforeFind');
         $this->assertCount(1, $result);
         $this->assertInstanceOf('TestApp\Model\Behavior\SluggableBehavior', $result[0]['callable'][0]);
-        $this->assertEquals('beforeFind', $result[0]['callable'][1], 'Method name should match.');
+        $this->assertSame('beforeFind', $result[0]['callable'][1], 'Method name should match.');
     }
 
     /**

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -506,18 +506,18 @@ class EagerLoaderTest extends TestCase
         $loader = new EagerLoader();
         $loader->contain($contains);
         $normalized = $loader->normalized($this->table);
-        $this->assertEquals('clients', $normalized['clients']->aliasPath());
-        $this->assertEquals('client', $normalized['clients']->propertyPath());
+        $this->assertSame('clients', $normalized['clients']->aliasPath());
+        $this->assertSame('client', $normalized['clients']->propertyPath());
 
         $assocs = $normalized['clients']->associations();
-        $this->assertEquals('clients.orders', $assocs['orders']->aliasPath());
-        $this->assertEquals('client.order', $assocs['orders']->propertyPath());
+        $this->assertSame('clients.orders', $assocs['orders']->aliasPath());
+        $this->assertSame('client.order', $assocs['orders']->propertyPath());
 
         $assocs = $assocs['orders']->associations();
-        $this->assertEquals('clients.orders.orderTypes', $assocs['orderTypes']->aliasPath());
-        $this->assertEquals('client.order.order_type', $assocs['orderTypes']->propertyPath());
-        $this->assertEquals('clients.orders.stuff', $assocs['stuff']->aliasPath());
-        $this->assertEquals('client.order.stuff', $assocs['stuff']->propertyPath());
+        $this->assertSame('clients.orders.orderTypes', $assocs['orderTypes']->aliasPath());
+        $this->assertSame('client.order.order_type', $assocs['orderTypes']->propertyPath());
+        $this->assertSame('clients.orders.stuff', $assocs['stuff']->aliasPath());
+        $this->assertSame('client.order.stuff', $assocs['stuff']->propertyPath());
 
         $assocs = $assocs['stuff']->associations();
         $this->assertEquals(

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -36,17 +36,17 @@ class EntityTest extends TestCase
         $entity = new Entity();
         $this->assertNull($entity->getOriginal('foo'));
         $entity->set('foo', 'bar');
-        $this->assertEquals('bar', $entity->foo);
-        $this->assertEquals('bar', $entity->getOriginal('foo'));
+        $this->assertSame('bar', $entity->foo);
+        $this->assertSame('bar', $entity->getOriginal('foo'));
 
         $entity->set('foo', 'baz');
-        $this->assertEquals('baz', $entity->foo);
-        $this->assertEquals('bar', $entity->getOriginal('foo'));
+        $this->assertSame('baz', $entity->foo);
+        $this->assertSame('bar', $entity->getOriginal('foo'));
 
         $entity->set('id', 1);
         $this->assertSame(1, $entity->id);
         $this->assertEquals(1, $entity->getOriginal('id'));
-        $this->assertEquals('bar', $entity->getOriginal('foo'));
+        $this->assertSame('bar', $entity->getOriginal('foo'));
     }
 
     /**
@@ -60,14 +60,14 @@ class EntityTest extends TestCase
         $entity->setAccess('*', true);
 
         $entity->set(['foo' => 'bar', 'id' => 1]);
-        $this->assertEquals('bar', $entity->foo);
+        $this->assertSame('bar', $entity->foo);
         $this->assertSame(1, $entity->id);
 
         $entity->set(['foo' => 'baz', 'id' => 2, 'thing' => 3]);
-        $this->assertEquals('baz', $entity->foo);
+        $this->assertSame('baz', $entity->foo);
         $this->assertSame(2, $entity->id);
         $this->assertSame(3, $entity->thing);
-        $this->assertEquals('bar', $entity->getOriginal('foo'));
+        $this->assertSame('bar', $entity->getOriginal('foo'));
         $this->assertEquals(1, $entity->getOriginal('id'));
     }
 
@@ -169,12 +169,12 @@ class EntityTest extends TestCase
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertEquals('Jones', $name);
+                $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->name);
+        $this->assertSame('Dr. Jones', $entity->name);
     }
 
     /**
@@ -191,7 +191,7 @@ class EntityTest extends TestCase
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertEquals('Jones', $name);
+                $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
             }));
@@ -203,7 +203,7 @@ class EntityTest extends TestCase
                 return ['c', 'd'];
             }));
         $entity->set(['name' => 'Jones', 'stuff' => ['a', 'b']]);
-        $this->assertEquals('Dr. Jones', $entity->name);
+        $this->assertSame('Dr. Jones', $entity->name);
         $this->assertEquals(['c', 'd'], $entity->stuff);
     }
 
@@ -223,13 +223,13 @@ class EntityTest extends TestCase
         $entity->expects($this->never())->method('_setStuff');
 
         $entity->set('name', 'Jones', ['setter' => false]);
-        $this->assertEquals('Jones', $entity->name);
+        $this->assertSame('Jones', $entity->name);
 
         $entity->set('stuff', 'Thing', ['setter' => false]);
-        $this->assertEquals('Thing', $entity->stuff);
+        $this->assertSame('Thing', $entity->stuff);
 
         $entity->set(['name' => 'foo', 'stuff' => 'bar'], ['setter' => false]);
-        $this->assertEquals('bar', $entity->stuff);
+        $this->assertSame('bar', $entity->stuff);
     }
 
     /**
@@ -302,8 +302,8 @@ class EntityTest extends TestCase
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->get('name'));
-        $this->assertEquals('Dr. Jones', $entity->get('name'));
+        $this->assertSame('Dr. Jones', $entity->get('name'));
+        $this->assertSame('Dr. Jones', $entity->get('name'));
     }
 
     /**
@@ -322,12 +322,12 @@ class EntityTest extends TestCase
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->get('name'));
-        $this->assertEquals('Dr. Jones', $entity->get('name'));
+        $this->assertSame('Dr. Jones', $entity->get('name'));
+        $this->assertSame('Dr. Jones', $entity->get('name'));
 
         $entity->set('name', 'Mark');
-        $this->assertEquals('Dr. Mark', $entity->get('name'));
-        $this->assertEquals('Dr. Mark', $entity->get('name'));
+        $this->assertSame('Dr. Mark', $entity->get('name'));
+        $this->assertSame('Dr. Mark', $entity->get('name'));
     }
 
     /**
@@ -346,10 +346,10 @@ class EntityTest extends TestCase
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->get('name'));
+        $this->assertSame('Dr. Jones', $entity->get('name'));
 
         $entity->unset('name');
-        $this->assertEquals('Dr. ', $entity->get('name'));
+        $this->assertSame('Dr. ', $entity->get('name'));
     }
 
     /**
@@ -380,9 +380,9 @@ class EntityTest extends TestCase
     {
         $entity = new Entity();
         $entity->name = 'Jones';
-        $this->assertEquals('Jones', $entity->name);
+        $this->assertSame('Jones', $entity->name);
         $entity->name = 'George';
-        $this->assertEquals('George', $entity->name);
+        $this->assertSame('George', $entity->name);
     }
 
     /**
@@ -398,12 +398,12 @@ class EntityTest extends TestCase
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertEquals('Jones', $name);
+                $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
             }));
         $entity->name = 'Jones';
-        $this->assertEquals('Dr. Jones', $entity->name);
+        $this->assertSame('Dr. Jones', $entity->name);
     }
 
     /**
@@ -420,12 +420,12 @@ class EntityTest extends TestCase
             ->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertEquals('Jones', $name);
+                $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
             }));
         $entity->Name = 'Jones';
-        $this->assertEquals('Dr. Jones', $entity->Name);
+        $this->assertSame('Dr. Jones', $entity->Name);
     }
 
     /**
@@ -446,7 +446,7 @@ class EntityTest extends TestCase
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->name);
+        $this->assertSame('Dr. Jones', $entity->name);
     }
 
     /**
@@ -463,12 +463,12 @@ class EntityTest extends TestCase
             ->method('_getName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertEquals('Jones', $name);
+                $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
             }));
         $entity->set('Name', 'Jones');
-        $this->assertEquals('Dr. Jones', $entity->Name);
+        $this->assertSame('Dr. Jones', $entity->Name);
     }
 
     /**
@@ -630,8 +630,8 @@ class EntityTest extends TestCase
             ->with('bar')
             ->will($this->returnValue('worked too'));
 
-        $this->assertEquals('worked', $entity['foo']);
-        $this->assertEquals('worked too', $entity['bar']);
+        $this->assertSame('worked', $entity['foo']);
+        $this->assertSame('worked too', $entity['bar']);
     }
 
     /**
@@ -1521,14 +1521,14 @@ class EntityTest extends TestCase
         $entity->setAccess('title', true);
 
         $entity->set(['title' => 'test', 'body' => 'Nope']);
-        $this->assertEquals('test', $entity->title);
+        $this->assertSame('test', $entity->title);
         $this->assertNull($entity->body);
 
         $entity->body = 'Yep';
-        $this->assertEquals('Yep', $entity->body, 'Single set should bypass guards.');
+        $this->assertSame('Yep', $entity->body, 'Single set should bypass guards.');
 
         $entity->set('body', 'Yes');
-        $this->assertEquals('Yes', $entity->body, 'Single set should bypass guards.');
+        $this->assertSame('Yes', $entity->body, 'Single set should bypass guards.');
     }
 
     /**
@@ -1584,7 +1584,7 @@ class EntityTest extends TestCase
         $entity = new Entity();
         $this->assertSame('', $entity->getSource());
         $entity->setSource('foos');
-        $this->assertEquals('foos', $entity->getSource());
+        $this->assertSame('foos', $entity->getSource());
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -162,11 +162,11 @@ class TableLocatorTest extends TestCase
             'table' => 'my_articles',
         ]);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('my_articles', $result->getTable());
+        $this->assertSame('my_articles', $result->getTable());
 
         $result2 = $this->_locator->get('Articles');
         $this->assertSame($result, $result2);
-        $this->assertEquals('my_articles', $result->getTable());
+        $this->assertSame('my_articles', $result->getTable());
 
         $this->assertSame($this->_locator, $result->associations()->getTableLocator());
     }
@@ -180,33 +180,33 @@ class TableLocatorTest extends TestCase
     {
         $result = $this->_locator->get('Droids');
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('droids', $result->getTable());
-        $this->assertEquals('Droids', $result->getAlias());
+        $this->assertSame('droids', $result->getTable());
+        $this->assertSame('Droids', $result->getAlias());
 
         $result = $this->_locator->get('R2D2', ['className' => 'Droids']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('droids', $result->getTable(), 'The table should be derived from the className');
-        $this->assertEquals('R2D2', $result->getAlias());
+        $this->assertSame('droids', $result->getTable(), 'The table should be derived from the className');
+        $this->assertSame('R2D2', $result->getAlias());
 
         $result = $this->_locator->get('C3P0', ['className' => 'Droids', 'table' => 'rebels']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('rebels', $result->getTable(), 'The table should be taken from options');
-        $this->assertEquals('C3P0', $result->getAlias());
+        $this->assertSame('rebels', $result->getTable(), 'The table should be taken from options');
+        $this->assertSame('C3P0', $result->getAlias());
 
         $result = $this->_locator->get('Funky.Chipmunks');
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('chipmunks', $result->getTable(), 'The table should be derived from the alias');
-        $this->assertEquals('Chipmunks', $result->getAlias());
+        $this->assertSame('chipmunks', $result->getTable(), 'The table should be derived from the alias');
+        $this->assertSame('Chipmunks', $result->getAlias());
 
         $result = $this->_locator->get('Awesome', ['className' => 'Funky.Monkies']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('monkies', $result->getTable(), 'The table should be derived from the classname');
-        $this->assertEquals('Awesome', $result->getAlias());
+        $this->assertSame('monkies', $result->getTable(), 'The table should be derived from the classname');
+        $this->assertSame('Awesome', $result->getAlias());
 
         $result = $this->_locator->get('Stuff', ['className' => 'Cake\ORM\Table']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('stuff', $result->getTable(), 'The table should be derived from the alias');
-        $this->assertEquals('Stuff', $result->getAlias());
+        $this->assertSame('stuff', $result->getTable(), 'The table should be derived from the alias');
+        $this->assertSame('Stuff', $result->getAlias());
     }
 
     /**
@@ -220,7 +220,7 @@ class TableLocatorTest extends TestCase
             'table' => 'my_articles',
         ]);
         $result = $this->_locator->get('Articles');
-        $this->assertEquals('my_articles', $result->getTable(), 'Should use getConfig() data.');
+        $this->assertSame('my_articles', $result->getTable(), 'Should use getConfig() data.');
     }
 
     /**
@@ -234,8 +234,8 @@ class TableLocatorTest extends TestCase
         $result = $this->_locator->get('Articles', [
             'connectionName' => 'testing',
         ]);
-        $this->assertEquals('articles', $result->getTable());
-        $this->assertEquals('test', $result->getConnection()->configName());
+        $this->assertSame('articles', $result->getTable());
+        $this->assertSame('test', $result->getConnection()->configName());
     }
 
     /**
@@ -415,8 +415,8 @@ class TableLocatorTest extends TestCase
 
         $table = $this->_locator->get('users', ['table' => 'users']);
         $this->assertInstanceOf('Cake\ORM\Table', $table);
-        $this->assertEquals('users', $table->getTable());
-        $this->assertEquals('users', $table->getAlias());
+        $this->assertSame('users', $table->getTable());
+        $this->assertSame('users', $table->getAlias());
         $this->assertSame($connection, $table->getConnection());
         $this->assertEquals(array_keys($schema), $table->getSchema()->columns());
         $this->assertEquals($schema['id']['type'], $table->getSchema()->getColumnType('id'));
@@ -427,8 +427,8 @@ class TableLocatorTest extends TestCase
         $this->_locator->setConfig('users', $options);
         $table = $this->_locator->get('users', ['className' => MyUsersTable::class]);
         $this->assertInstanceOf(MyUsersTable::class, $table);
-        $this->assertEquals('users', $table->getTable());
-        $this->assertEquals('users', $table->getAlias());
+        $this->assertSame('users', $table->getTable());
+        $this->assertSame('users', $table->getAlias());
         $this->assertSame($connection, $table->getConnection());
         $this->assertEquals(array_keys($schema), $table->getSchema()->columns());
         $this->assertEquals($schema['id']['type'], $table->getSchema()->getColumnType('id'));

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -130,7 +130,7 @@ class MarshallerTest extends TestCase
         $this->assertEquals($data, $result->toArray());
         $this->assertTrue($result->isDirty(), 'Should be a dirty entity.');
         $this->assertTrue($result->isNew(), 'Should be new');
-        $this->assertEquals('Articles', $result->getSource());
+        $this->assertSame('Articles', $result->getSource());
     }
 
     /**
@@ -603,13 +603,13 @@ class MarshallerTest extends TestCase
             $result->tags[0]->_joinData->user,
             'joinData should contain a user entity.'
         );
-        $this->assertEquals('Bill', $result->tags[0]->_joinData->user->username);
+        $this->assertSame('Bill', $result->tags[0]->_joinData->user->username);
         $this->assertInstanceOf(
             'Cake\ORM\Entity',
             $result->tags[1]->_joinData->user,
             'joinData should contain a user entity.'
         );
-        $this->assertEquals('Mark', $result->tags[1]->_joinData->user->username);
+        $this->assertSame('Mark', $result->tags[1]->_joinData->user->username);
     }
 
     /**
@@ -707,7 +707,7 @@ class MarshallerTest extends TestCase
 
         $this->assertEquals($data['tags'][0]['id'], $result->tags[0]->id);
         $this->assertEquals($data['tags'][1]['name'], $result->tags[1]->name);
-        $this->assertEquals(0, $result->tags[0]->_joinData->active);
+        $this->assertSame(0, $result->tags[0]->_joinData->active);
         $this->assertEquals(1, $result->tags[1]->_joinData->active);
     }
 
@@ -805,7 +805,7 @@ class MarshallerTest extends TestCase
         $this->assertNotEmpty($result->tags[0]->_joinData);
         $this->assertNotEmpty($result->tags[1]->_joinData);
         $this->assertTrue($result->isDirty('tags'), 'Modified prop should be dirty');
-        $this->assertEquals(0, $result->tags[0]->_joinData->active);
+        $this->assertSame(0, $result->tags[0]->_joinData->active);
         $this->assertEquals(1, $result->tags[1]->_joinData->active);
     }
 
@@ -849,7 +849,7 @@ class MarshallerTest extends TestCase
         $this->assertEquals($data['tags'][2]['name'], $result->tags[2]->name);
 
         $this->assertEquals(1, $result->tags[0]->_joinData->active);
-        $this->assertEquals(0, $result->tags[1]->_joinData->active);
+        $this->assertSame(0, $result->tags[1]->_joinData->active);
         $this->assertEquals(1, $result->tags[2]->_joinData->active);
     }
 
@@ -1513,10 +1513,10 @@ class MarshallerTest extends TestCase
 
         $this->assertTrue($entity->isDirty('user'), 'association should be dirty');
         $this->assertTrue($entity->isDirty('body'), 'body should be dirty');
-        $this->assertEquals('My Content', $entity->body);
+        $this->assertSame('My Content', $entity->body);
         $this->assertSame($user, $entity->user);
-        $this->assertEquals('mark', $entity->user->username);
-        $this->assertEquals('not a secret', $entity->user->password);
+        $this->assertSame('mark', $entity->user->username);
+        $this->assertSame('not a secret', $entity->user->password);
     }
 
     /**
@@ -1543,10 +1543,10 @@ class MarshallerTest extends TestCase
         $marshall = new Marshaller($this->articles);
         $marshall->merge($entity, $data, ['associated' => ['Users']]);
 
-        $this->assertEquals('My Content', $entity->body);
+        $this->assertSame('My Content', $entity->body);
         $this->assertInstanceOf('Cake\ORM\Entity', $entity->user);
-        $this->assertEquals('mark', $entity->user->username);
-        $this->assertEquals('not a secret', $entity->user->password);
+        $this->assertSame('mark', $entity->user->username);
+        $this->assertSame('not a secret', $entity->user->password);
         $this->assertTrue($entity->isDirty('user'));
         $this->assertTrue($entity->isDirty('body'));
         $this->assertTrue($entity->user->isNew());
@@ -1627,13 +1627,13 @@ class MarshallerTest extends TestCase
         $this->assertSame($entity, $result);
         $this->assertSame($user, $result->user);
         $this->assertTrue($result->isDirty('user'), 'association should be dirty');
-        $this->assertEquals('not so secret', $entity->user->password);
+        $this->assertSame('not so secret', $entity->user->password);
 
         $this->assertTrue($result->isDirty('comments'));
         $this->assertSame($comment1, $entity->comments[0]);
         $this->assertSame($comment2, $entity->comments[1]);
-        $this->assertEquals('Altered comment 1', $entity->comments[0]->comment);
-        $this->assertEquals('Altered comment 2', $entity->comments[1]->comment);
+        $this->assertSame('Altered comment 1', $entity->comments[0]->comment);
+        $this->assertSame('Altered comment 2', $entity->comments[1]->comment);
 
         $thirdComment = $this->articles->Comments
             ->find()
@@ -1969,7 +1969,7 @@ class MarshallerTest extends TestCase
             'associated' => ['Tags' => ['ids' => true]],
         ]);
         $this->assertCount(1, $result->tags);
-        $this->assertEquals('tag3', $result->tags[0]->name);
+        $this->assertSame('tag3', $result->tags[0]->name);
         $this->assertTrue($result->isDirty('tags'));
     }
 
@@ -2126,7 +2126,7 @@ class MarshallerTest extends TestCase
         $this->assertEquals(2, $result->tags[1]->id);
 
         $this->assertEquals(1, $result->tags[0]->_joinData->active);
-        $this->assertEquals(0, $result->tags[1]->_joinData->active);
+        $this->assertSame(0, $result->tags[1]->_joinData->active);
 
         $this->assertEquals(
             $data['tags'][0]['_joinData']['user']['username'],
@@ -2183,7 +2183,7 @@ class MarshallerTest extends TestCase
         $result = $marshall->merge($entity, $data, $options);
 
         $this->assertEquals($data['title'], $result->title);
-        $this->assertEquals('My content', $result->body);
+        $this->assertSame('My content', $result->body);
         $this->assertTrue($result->isDirty('tags'));
         $this->assertSame($tag1, $entity->tags[0]);
         $this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
@@ -2195,7 +2195,7 @@ class MarshallerTest extends TestCase
             ['active' => 1, 'foo' => 'baz'],
             $entity->tags[1]->_joinData->toArray()
         );
-        $this->assertEquals('new tag', $entity->tags[1]->tag);
+        $this->assertSame('new tag', $entity->tags[1]->tag);
         $this->assertTrue($entity->tags[0]->isDirty('_joinData'));
         $this->assertTrue($entity->tags[1]->isDirty('_joinData'));
     }
@@ -2263,15 +2263,15 @@ class MarshallerTest extends TestCase
         $result = $marshall->merge($entity, $data, $options);
 
         $this->assertEquals($data['title'], $result->title);
-        $this->assertEquals('My content', $result->body);
+        $this->assertSame('My content', $result->body);
         $this->assertTrue($entity->isDirty('tags'));
         $this->assertSame($tag1, $entity->tags[0]);
 
         $this->assertTrue($tag1->isDirty('_joinData'));
         $this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
-        $this->assertEquals('Bill', $entity->tags[0]->_joinData->user->username);
-        $this->assertEquals('secret', $entity->tags[0]->_joinData->user->password);
-        $this->assertEquals('ber', $entity->tags[1]->_joinData->user->username);
+        $this->assertSame('Bill', $entity->tags[0]->_joinData->user->username);
+        $this->assertSame('secret', $entity->tags[0]->_joinData->user->password);
+        $this->assertSame('ber', $entity->tags[1]->_joinData->user->username);
     }
 
     /**
@@ -2328,9 +2328,9 @@ class MarshallerTest extends TestCase
 
         $this->assertSame($entities[0], $result[0]);
         $this->assertSame($entities[1], $result[1]);
-        $this->assertEquals('Changed 1', $result[0]->comment);
+        $this->assertSame('Changed 1', $result[0]->comment);
         $this->assertEquals(1, $result[0]->user_id);
-        $this->assertEquals('Changed 2', $result[1]->comment);
+        $this->assertSame('Changed 2', $result[1]->comment);
         $this->assertTrue($result[0]->isDirty('user_id'));
         $this->assertFalse($result[1]->isDirty('user_id'));
     }
@@ -2386,9 +2386,9 @@ class MarshallerTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertNotSame($entities[0], $result[0]);
         $this->assertSame($entities[1], $result[0]);
-        $this->assertEquals('Changed 2', $result[0]->comment);
+        $this->assertSame('Changed 2', $result[0]->comment);
 
-        $this->assertEquals('Comment 1', $result[1]->comment);
+        $this->assertSame('Comment 1', $result[1]->comment);
     }
 
     /**
@@ -2472,10 +2472,10 @@ class MarshallerTest extends TestCase
         $result = $marshall->mergeMany($entities, $data);
 
         $this->assertCount(3, $result);
-        $this->assertEquals('Changed 1', $result[0]->comment);
+        $this->assertSame('Changed 1', $result[0]->comment);
         $this->assertEquals(1, $result[0]->user_id);
-        $this->assertEquals('Changed 2', $result[1]->comment);
-        $this->assertEquals('New 1', $result[2]->comment);
+        $this->assertSame('Changed 2', $result[1]->comment);
+        $this->assertSame('New 1', $result[2]->comment);
     }
 
     /**
@@ -2499,7 +2499,7 @@ class MarshallerTest extends TestCase
         $marshall = new Marshaller($this->comments);
         $result = $marshall->merge($entity, $data);
         $this->assertInstanceOf(FrozenTime::class, $entity->created);
-        $this->assertEquals('2014-02-14', $entity->created->format('Y-m-d'));
+        $this->assertSame('2014-02-14', $entity->created->format('Y-m-d'));
     }
 
     /**
@@ -2556,7 +2556,7 @@ class MarshallerTest extends TestCase
         $this->assertEmpty($result->getErrors());
         $this->assertEquals(1, $result->author_id);
         $this->assertInstanceOf(OpenArticleEntity::class, $result->user);
-        $this->assertEquals('mark', $result->user->username);
+        $this->assertSame('mark', $result->user->username);
 
         $translations = $result->get('_translations');
         $this->assertCount(2, $translations);
@@ -2716,11 +2716,11 @@ class MarshallerTest extends TestCase
             'associated' => ['Users' => ['fields' => ['extra']]],
         ]);
         $this->assertNull($entity->body);
-        $this->assertEquals('else', $entity->something);
+        $this->assertSame('else', $entity->something);
         $this->assertSame($user, $entity->user);
-        $this->assertEquals('mark', $entity->user->username);
-        $this->assertEquals('secret', $entity->user->password);
-        $this->assertEquals('data', $entity->user->extra);
+        $this->assertSame('mark', $entity->user->username);
+        $this->assertSame('secret', $entity->user->password);
+        $this->assertSame('data', $entity->user->extra);
         $this->assertTrue($entity->isDirty('user'));
     }
 
@@ -2771,13 +2771,13 @@ class MarshallerTest extends TestCase
             $result->tags[0]->_joinData->user,
             'joinData should contain a user entity.'
         );
-        $this->assertEquals('Bill', $result->tags[0]->_joinData->user->username);
+        $this->assertSame('Bill', $result->tags[0]->_joinData->user->username);
         $this->assertInstanceOf(
             'Cake\ORM\Entity',
             $result->tags[1]->_joinData->user,
             'joinData should contain a user entity.'
         );
-        $this->assertEquals('Mark', $result->tags[1]->_joinData->user->username);
+        $this->assertSame('Mark', $result->tags[1]->_joinData->user->username);
 
         $this->assertNull($result->tags[0]->_joinData->crazy);
         $this->assertNull($result->tags[1]->_joinData->crazy);
@@ -2831,7 +2831,7 @@ class MarshallerTest extends TestCase
             'associated' => ['Tags._joinData' => ['fields' => ['foo']]],
         ]);
         $this->assertEquals($data['title'], $result->title);
-        $this->assertEquals('My content', $result->body);
+        $this->assertSame('My content', $result->body);
         $this->assertSame($tag1, $entity->tags[0]);
         $this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
         $this->assertSame(
@@ -2842,7 +2842,7 @@ class MarshallerTest extends TestCase
             ['foo' => 'baz'],
             $entity->tags[1]->_joinData->toArray()
         );
-        $this->assertEquals('new tag', $entity->tags[1]->tag);
+        $this->assertSame('new tag', $entity->tags[1]->tag);
         $this->assertTrue($entity->tags[0]->isDirty('_joinData'));
         $this->assertTrue($entity->tags[1]->isDirty('_joinData'));
     }
@@ -3153,10 +3153,10 @@ class MarshallerTest extends TestCase
 
         $entity = $marshall->one($data);
 
-        $this->assertEquals('Modified title', $entity->title);
-        $this->assertEquals('My content', $entity->body);
-        $this->assertEquals('Robert', $entity->user->name);
-        $this->assertEquals('robert', $entity->user->username);
+        $this->assertSame('Modified title', $entity->title);
+        $this->assertSame('My content', $entity->body);
+        $this->assertSame('Robert', $entity->user->name);
+        $this->assertSame('robert', $entity->user->username);
     }
 
     /**
@@ -3233,11 +3233,11 @@ class MarshallerTest extends TestCase
             'associated' => ['Users', 'Comments', 'Tags'],
         ]);
 
-        $this->assertEquals('h45h3d', $entity->user->secret);
-        $this->assertEquals('First post (modified)', $entity->comments[0]->comment);
-        $this->assertEquals('Second post (modified)', $entity->comments[1]->comment);
-        $this->assertEquals('news (modified)', $entity->tags[0]->tag);
-        $this->assertEquals('cakephp (modified)', $entity->tags[1]->tag);
+        $this->assertSame('h45h3d', $entity->user->secret);
+        $this->assertSame('First post (modified)', $entity->comments[0]->comment);
+        $this->assertSame('Second post (modified)', $entity->comments[1]->comment);
+        $this->assertSame('news (modified)', $entity->tags[0]->tag);
+        $this->assertSame('cakephp (modified)', $entity->tags[1]->tag);
         $this->assertEquals(1, $entity->tags[0]->_joinData->modified_by);
         $this->assertEquals(1, $entity->tags[1]->_joinData->modified_by);
     }
@@ -3268,10 +3268,10 @@ class MarshallerTest extends TestCase
         ];
         $marshall = new Marshaller($this->articles);
         $marshall->merge($entity, $data, ['associated' => ['Users']]);
-        $this->assertEquals('My Content', $entity->body);
+        $this->assertSame('My Content', $entity->body);
         $this->assertInstanceOf('Cake\ORM\Entity', $entity->user);
-        $this->assertEquals('mark', $entity->user->username);
-        $this->assertEquals('not a secret', $entity->user->password);
+        $this->assertSame('mark', $entity->user->username);
+        $this->assertSame('not a secret', $entity->user->password);
         $this->assertFalse($entity->isDirty('user'));
         $this->assertTrue($entity->user->isNew());
     }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -296,7 +296,7 @@ class QueryRegressionTest extends TestCase
         $articles->save($entity);
         $entity = $articles->get(2, ['contain' => ['Highlights']]);
         $this->assertEquals(4, $entity->highlights[0]->_joinData->tag_id);
-        $this->assertEquals('2014-06-01', $entity->highlights[0]->_joinData->highlighted_time->format('Y-m-d'));
+        $this->assertSame('2014-06-01', $entity->highlights[0]->_joinData->highlighted_time->format('Y-m-d'));
     }
 
     /**
@@ -414,12 +414,12 @@ class QueryRegressionTest extends TestCase
                 'Highlights.Authors',
             ],
         ]);
-        $this->assertEquals('mark', end($entity->highlights)->author->name);
+        $this->assertSame('mark', end($entity->highlights)->author->name);
 
         $lastTag = end($entity->special_tags);
         $this->assertTrue($lastTag->highlighted);
-        $this->assertEquals('2014-06-01 10:10:00', $lastTag->highlighted_time->format('Y-m-d H:i:s'));
-        $this->assertEquals('mariano', $lastTag->author->name);
+        $this->assertSame('2014-06-01 10:10:00', $lastTag->highlighted_time->format('Y-m-d H:i:s'));
+        $this->assertSame('mariano', $lastTag->author->name);
     }
 
     /**
@@ -511,8 +511,8 @@ class QueryRegressionTest extends TestCase
             ],
         ]);
         $highlights = $entity->highlights[0];
-        $this->assertEquals('First top article', $highlights->top_articles[0]->title);
-        $this->assertEquals('Second top article', $highlights->top_articles[1]->title);
+        $this->assertSame('First top article', $highlights->top_articles[0]->title);
+        $this->assertSame('Second top article', $highlights->top_articles[1]->title);
         $this->assertEquals(
             new Time('2014-06-01 10:10:00'),
             $highlights->_joinData->highlighted_time
@@ -790,8 +790,8 @@ class QueryRegressionTest extends TestCase
             ->where(['id NOT IN' => $sub]);
         $result = $query->toArray();
         $this->assertCount(2, $result);
-        $this->assertEquals('First Article', $result[0]->title);
-        $this->assertEquals('Third Article', $result[1]->title);
+        $this->assertSame('First Article', $result[0]->title);
+        $this->assertSame('Third Article', $result[1]->title);
     }
 
     /**
@@ -1133,7 +1133,7 @@ class QueryRegressionTest extends TestCase
 
         $results = $query->toArray();
         $this->assertCount(1, $results);
-        $this->assertEquals('redblue', $results[0]->comments[0]->concat);
+        $this->assertSame('redblue', $results[0]->comments[0]->concat);
     }
 
     /**
@@ -1222,7 +1222,7 @@ class QueryRegressionTest extends TestCase
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $table->deleteAll(['1 = 1']);
-        $this->assertEquals(0, $table->find()->count());
+        $this->assertSame(0, $table->find()->count());
         $this->assertNull($table->find()->last());
     }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1220,9 +1220,9 @@ class QueryTest extends TestCase
         $first = $results[0];
         $this->assertEquals(1, $first->id);
         $this->assertEquals(1, $first->author_id);
-        $this->assertEquals('First Article', $first->title);
-        $this->assertEquals('First Article Body', $first->body);
-        $this->assertEquals('Y', $first->published);
+        $this->assertSame('First Article', $first->title);
+        $this->assertSame('First Article Body', $first->body);
+        $this->assertSame('Y', $first->published);
     }
 
     /**
@@ -1459,9 +1459,9 @@ class QueryTest extends TestCase
         $first = $results[0];
         $this->assertEquals(1, $first->id);
         $this->assertEquals(1, $first->author_id);
-        $this->assertEquals('First Article', $first->title);
-        $this->assertEquals('First Article Body', $first->body);
-        $this->assertEquals('Y', $first->published);
+        $this->assertSame('First Article', $first->title);
+        $this->assertSame('First Article Body', $first->body);
+        $this->assertSame('Y', $first->published);
     }
 
     /**
@@ -2528,7 +2528,7 @@ class QueryTest extends TestCase
 
         $results = $query->toArray();
         $this->assertCount(1, $results);
-        $this->assertEquals('tag3', $results[0]->_matchingData['tags']->name);
+        $this->assertSame('tag3', $results[0]->_matchingData['tags']->name);
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -389,14 +389,14 @@ class ResultSetTest extends TestCase
             'foreignKey' => 'user_id',
         ]);
         $result = $comments->find()->contain(['Authors'])->first();
-        $this->assertEquals('TestPlugin.Comments', $result->getSource());
-        $this->assertEquals('TestPlugin.Authors', $result->author->getSource());
+        $this->assertSame('TestPlugin.Comments', $result->getSource());
+        $this->assertSame('TestPlugin.Authors', $result->author->getSource());
 
         $result = $comments->find()->matching('Authors', function ($q) {
             return $q->where(['Authors.id' => 1]);
         })->first();
-        $this->assertEquals('TestPlugin.Comments', $result->getSource());
-        $this->assertEquals('TestPlugin.Authors', $result->_matchingData['Authors']->getSource());
+        $this->assertSame('TestPlugin.Comments', $result->getSource());
+        $this->assertSame('TestPlugin.Authors', $result->_matchingData['Authors']->getSource());
         $this->clearPlugins();
     }
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -765,7 +765,7 @@ class RulesCheckerIntegrationTest extends TestCase
                     ],
                     $options->getArrayCopy()
                 );
-                $this->assertEquals('create', $operation);
+                $this->assertSame('create', $operation);
                 $event->stopPropagation();
 
                 return true;
@@ -805,7 +805,7 @@ class RulesCheckerIntegrationTest extends TestCase
                     ],
                     $options->getArrayCopy()
                 );
-                $this->assertEquals('create', $operation);
+                $this->assertSame('create', $operation);
                 $this->assertFalse($result);
                 $event->stopPropagation();
 
@@ -1252,8 +1252,8 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('Authors');
         $rules = $table->rulesChecker();
         $rules->add(function ($entity, $options) {
-            $this->assertEquals('bar', $options['foo']);
-            $this->assertEquals('option', $options['another']);
+            $this->assertSame('bar', $options['foo']);
+            $this->assertSame('option', $options['another']);
 
             return false;
         }, ['another' => 'option']);
@@ -1272,8 +1272,8 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $rules = $table->rulesChecker();
         $rules->addDelete(function ($entity, $options) {
-            $this->assertEquals('bar', $options['foo']);
-            $this->assertEquals('option', $options['another']);
+            $this->assertSame('bar', $options['foo']);
+            $this->assertSame('option', $options['another']);
 
             return false;
         }, ['another' => 'option']);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -136,26 +136,26 @@ class TableTest extends TestCase
     public function testTableMethod()
     {
         $table = new Table(['table' => 'users']);
-        $this->assertEquals('users', $table->getTable());
+        $this->assertSame('users', $table->getTable());
 
         $table = new UsersTable();
-        $this->assertEquals('users', $table->getTable());
+        $this->assertSame('users', $table->getTable());
 
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingsTable')
             ->getMock();
-        $this->assertEquals('special_things', $table->getTable());
+        $this->assertSame('special_things', $table->getTable());
 
         $table = new Table(['alias' => 'LoveBoats']);
-        $this->assertEquals('love_boats', $table->getTable());
+        $this->assertSame('love_boats', $table->getTable());
 
         $table->setTable('other');
-        $this->assertEquals('other', $table->getTable());
+        $this->assertSame('other', $table->getTable());
 
         $table->setTable('database.other');
-        $this->assertEquals('database.other', $table->getTable());
+        $this->assertSame('database.other', $table->getTable());
     }
 
     /**
@@ -166,23 +166,23 @@ class TableTest extends TestCase
     public function testSetAlias()
     {
         $table = new Table(['alias' => 'users']);
-        $this->assertEquals('users', $table->getAlias());
+        $this->assertSame('users', $table->getAlias());
 
         $table = new Table(['table' => 'stuffs']);
-        $this->assertEquals('stuffs', $table->getAlias());
+        $this->assertSame('stuffs', $table->getAlias());
 
         $table = new UsersTable();
-        $this->assertEquals('Users', $table->getAlias());
+        $this->assertSame('Users', $table->getAlias());
 
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->setMethods(['find'])
             ->setMockClassName('SpecialThingTable')
             ->getMock();
-        $this->assertEquals('SpecialThing', $table->getAlias());
+        $this->assertSame('SpecialThing', $table->getAlias());
 
         $table->setAlias('AnotherOne');
-        $this->assertEquals('AnotherOne', $table->getAlias());
+        $this->assertSame('AnotherOne', $table->getAlias());
     }
 
     /**
@@ -193,9 +193,9 @@ class TableTest extends TestCase
     public function testAliasField()
     {
         $table = new Table(['alias' => 'Users']);
-        $this->assertEquals('Users.id', $table->aliasField('id'));
+        $this->assertSame('Users.id', $table->aliasField('id'));
 
-        $this->assertEquals('Users.id', $table->aliasField('Users.id'));
+        $this->assertSame('Users.id', $table->aliasField('Users.id'));
     }
 
     /**
@@ -225,9 +225,9 @@ class TableTest extends TestCase
                 '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
             ],
         ]);
-        $this->assertEquals('id', $table->getPrimaryKey());
+        $this->assertSame('id', $table->getPrimaryKey());
         $this->assertSame($table, $table->setPrimaryKey('thingID'));
-        $this->assertEquals('thingID', $table->getPrimaryKey());
+        $this->assertSame('thingID', $table->getPrimaryKey());
 
         $table->setPrimaryKey(['thingID', 'user_id']);
         $this->assertEquals(['thingID', 'user_id'], $table->getPrimaryKey());
@@ -247,7 +247,7 @@ class TableTest extends TestCase
                 'name' => ['type' => 'string'],
             ],
         ]);
-        $this->assertEquals('name', $table->getDisplayField());
+        $this->assertSame('name', $table->getDisplayField());
     }
 
     /**
@@ -264,7 +264,7 @@ class TableTest extends TestCase
                 'title' => ['type' => 'string'],
             ],
         ]);
-        $this->assertEquals('title', $table->getDisplayField());
+        $this->assertSame('title', $table->getDisplayField());
     }
 
     /**
@@ -282,7 +282,7 @@ class TableTest extends TestCase
                 '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
             ],
         ]);
-        $this->assertEquals('id', $table->getDisplayField());
+        $this->assertSame('id', $table->getDisplayField());
     }
 
     /**
@@ -300,9 +300,9 @@ class TableTest extends TestCase
                 '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
             ],
         ]);
-        $this->assertEquals('id', $table->getDisplayField());
+        $this->assertSame('id', $table->getDisplayField());
         $table->setDisplayField('foo');
-        $this->assertEquals('foo', $table->getDisplayField());
+        $this->assertSame('foo', $table->getDisplayField());
     }
 
     /**
@@ -567,8 +567,8 @@ class TableTest extends TestCase
         $belongsTo = $table->belongsTo('user', $options);
         $this->assertInstanceOf(BelongsTo::class, $belongsTo);
         $this->assertSame($belongsTo, $table->getAssociation('user'));
-        $this->assertEquals('user', $belongsTo->getName());
-        $this->assertEquals('fake_id', $belongsTo->getForeignKey());
+        $this->assertSame('user', $belongsTo->getName());
+        $this->assertSame('fake_id', $belongsTo->getForeignKey());
         $this->assertEquals(['a' => 'b'], $belongsTo->getConditions());
         $this->assertSame($table, $belongsTo->getSource());
     }
@@ -585,8 +585,8 @@ class TableTest extends TestCase
         $hasOne = $table->hasOne('profile', $options);
         $this->assertInstanceOf(HasOne::class, $hasOne);
         $this->assertSame($hasOne, $table->getAssociation('profile'));
-        $this->assertEquals('profile', $hasOne->getName());
-        $this->assertEquals('user_id', $hasOne->getForeignKey());
+        $this->assertSame('profile', $hasOne->getName());
+        $this->assertSame('user_id', $hasOne->getForeignKey());
         $this->assertEquals(['b' => 'c'], $hasOne->getConditions());
         $this->assertSame($table, $hasOne->getSource());
     }
@@ -716,8 +716,8 @@ class TableTest extends TestCase
         $hasMany = $table->hasMany('article', $options);
         $this->assertInstanceOf(HasMany::class, $hasMany);
         $this->assertSame($hasMany, $table->getAssociation('article'));
-        $this->assertEquals('article', $hasMany->getName());
-        $this->assertEquals('author_id', $hasMany->getForeignKey());
+        $this->assertSame('article', $hasMany->getName());
+        $this->assertSame('author_id', $hasMany->getForeignKey());
         $this->assertEquals(['b' => 'c'], $hasMany->getConditions());
         $this->assertEquals(['foo' => 'asc'], $hasMany->getSort());
         $this->assertSame($table, $hasMany->getSource());
@@ -834,8 +834,8 @@ class TableTest extends TestCase
         $belongsToMany = $table->belongsToMany('tag', $options);
         $this->assertInstanceOf(BelongsToMany::class, $belongsToMany);
         $this->assertSame($belongsToMany, $table->getAssociation('tag'));
-        $this->assertEquals('tag', $belongsToMany->getName());
-        $this->assertEquals('thing_id', $belongsToMany->getForeignKey());
+        $this->assertSame('tag', $belongsToMany->getName());
+        $this->assertSame('thing_id', $belongsToMany->getForeignKey());
         $this->assertEquals(['b' => 'c'], $belongsToMany->getConditions());
         $this->assertEquals(['foo' => 'asc'], $belongsToMany->getSort());
         $this->assertSame($table, $belongsToMany->getSource());
@@ -873,22 +873,22 @@ class TableTest extends TestCase
 
         $belongsTo = $associations->get('users');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $belongsTo);
-        $this->assertEquals('users', $belongsTo->getName());
-        $this->assertEquals('fake_id', $belongsTo->getForeignKey());
+        $this->assertSame('users', $belongsTo->getName());
+        $this->assertSame('fake_id', $belongsTo->getForeignKey());
         $this->assertEquals(['a' => 'b'], $belongsTo->getConditions());
         $this->assertSame($table, $belongsTo->getSource());
 
         $hasOne = $associations->get('profiles');
         $this->assertInstanceOf(HasOne::class, $hasOne);
-        $this->assertEquals('profiles', $hasOne->getName());
+        $this->assertSame('profiles', $hasOne->getName());
 
         $hasMany = $associations->get('authors');
         $this->assertInstanceOf(HasMany::class, $hasMany);
-        $this->assertEquals('authors', $hasMany->getName());
+        $this->assertSame('authors', $hasMany->getName());
 
         $belongsToMany = $associations->get('tags');
         $this->assertInstanceOf(BelongsToMany::class, $belongsToMany);
-        $this->assertEquals('tags', $belongsToMany->getName());
+        $this->assertSame('tags', $belongsToMany->getName());
         $this->assertSame('things_tags', $belongsToMany->junction()->getTable());
         $this->assertSame(['Tags.starred' => true], $belongsToMany->getConditions());
     }
@@ -1382,7 +1382,7 @@ class TableTest extends TestCase
     public function testEntityClassDefault()
     {
         $table = new Table();
-        $this->assertEquals('Cake\ORM\Entity', $table->getEntityClass());
+        $this->assertSame('Cake\ORM\Entity', $table->getEntityClass());
     }
 
     /**
@@ -1401,7 +1401,7 @@ class TableTest extends TestCase
 
         $table = new Table();
         $this->assertSame($table, $table->setEntityClass('TestUser'));
-        $this->assertEquals('TestApp\Model\Entity\TestUser', $table->getEntityClass());
+        $this->assertSame('TestApp\Model\Entity\TestUser', $table->getEntityClass());
     }
 
     /**
@@ -1418,14 +1418,14 @@ class TableTest extends TestCase
         }
 
         $table = $this->getTableLocator()->get('CustomCookies');
-        $this->assertEquals('TestApp\Model\Entity\CustomCookie', $table->getEntityClass());
+        $this->assertSame('TestApp\Model\Entity\CustomCookie', $table->getEntityClass());
 
         if (!class_exists('TestApp\Model\Entity\Address')) {
             class_alias($class, 'TestApp\Model\Entity\Address');
         }
 
         $table = $this->getTableLocator()->get('Addresses');
-        $this->assertEquals('TestApp\Model\Entity\Address', $table->getEntityClass());
+        $this->assertSame('TestApp\Model\Entity\Address', $table->getEntityClass());
     }
 
     /**
@@ -1473,7 +1473,7 @@ class TableTest extends TestCase
     public function testTableClassConventionForAPP()
     {
         $table = new \TestApp\Model\Table\ArticlesTable();
-        $this->assertEquals('TestApp\Model\Entity\Article', $table->getEntityClass());
+        $this->assertSame('TestApp\Model\Entity\Article', $table->getEntityClass());
     }
 
     /**
@@ -1755,7 +1755,7 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('article');
         $table->addBehavior('Sluggable');
-        $this->assertEquals('some-value', $table->slugify('some value'));
+        $this->assertSame('some-value', $table->slugify('some value'));
     }
 
     /**
@@ -1767,7 +1767,7 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('article');
         $table->addBehavior('Sluggable', ['implementedMethods' => ['wednesday' => 'slugify']]);
-        $this->assertEquals('some-value', $table->wednesday('some value'));
+        $this->assertSame('some-value', $table->wednesday('some value'));
     }
 
     /**
@@ -1991,7 +1991,7 @@ class TableTest extends TestCase
         $this->assertSame($data, $table->save($data));
         $this->assertEquals($data->id, self::$nextUserId);
         $row = $table->find('all')->where(['id' => self::$nextUserId])->first();
-        $this->assertEquals('foo', $row->get('password'));
+        $this->assertSame('foo', $row->get('password'));
     }
 
     /**
@@ -2491,7 +2491,7 @@ class TableTest extends TestCase
         $this->assertSame($entity, $table->save($entity));
 
         $row = $table->find('all')->where(['id' => 2])->first();
-        $this->assertEquals('baggins', $row->username);
+        $this->assertSame('baggins', $row->username);
         $this->assertEquals($original->password, $row->password);
         $this->assertEquals($original->created, $row->created);
         $this->assertEquals($original->updated, $row->updated);
@@ -3271,8 +3271,8 @@ class TableTest extends TestCase
         $existingAuthor = $table->find()->first();
         $newAuthor = $table->newEmptyEntity();
 
-        $this->assertEquals('TestPlugin.Authors', $existingAuthor->getSource());
-        $this->assertEquals('TestPlugin.Authors', $newAuthor->getSource());
+        $this->assertSame('TestPlugin.Authors', $existingAuthor->getSource());
+        $this->assertSame('TestPlugin.Authors', $newAuthor->getSource());
     }
 
     /**
@@ -3607,8 +3607,8 @@ class TableTest extends TestCase
         $this->assertSame($entity, $table->save($entity));
 
         $entity = $table->get(3, ['contain' => ['articles']]);
-        $this->assertEquals('big jose', $entity->name, 'Author did not persist');
-        $this->assertEquals('New title', $entity->articles[0]->title, 'Article did not persist');
+        $this->assertSame('big jose', $entity->name, 'Author did not persist');
+        $this->assertSame('New title', $entity->articles[0]->title, 'Article did not persist');
     }
 
     /**
@@ -3868,10 +3868,10 @@ class TableTest extends TestCase
 
         $articles->save($entity, $optionBuilder);
         $this->assertFalse($entity->isNew());
-        $this->assertEquals('test save options', $entity->title);
+        $this->assertSame('test save options', $entity->title);
         $this->assertNotEmpty($entity->id);
         $this->assertNotEmpty($entity->author->id);
-        $this->assertEquals('author name', $entity->author->name);
+        $this->assertSame('author name', $entity->author->name);
 
         $entity = $articles->newEntity([
             'title' => 'test save options 2',
@@ -3886,7 +3886,7 @@ class TableTest extends TestCase
 
         $articles->save($entity, $optionBuilder);
         $this->assertFalse($entity->isNew());
-        $this->assertEquals('test save options 2', $entity->title);
+        $this->assertSame('test save options 2', $entity->title);
         $this->assertNotEmpty($entity->id);
         $this->assertEmpty($entity->author->id);
         $this->assertTrue($entity->author->isNew());
@@ -4763,7 +4763,7 @@ class TableTest extends TestCase
         $this->assertEquals(2, $article->tags[0]->id);
         $this->assertEquals(3, $article->tags[1]->id);
         $this->assertEquals(4, $article->tags[2]->id);
-        $this->assertEquals('foo', $article->tags[2]->name);
+        $this->assertSame('foo', $article->tags[2]->name);
     }
 
     /**
@@ -5613,15 +5613,15 @@ class TableTest extends TestCase
         $this->assertTrue($callbackExecuted);
         $this->assertFalse($firstArticle->isNew());
         $this->assertNotNull($firstArticle->id);
-        $this->assertEquals('Not there', $firstArticle->title);
-        $this->assertEquals('New body', $firstArticle->body);
+        $this->assertSame('Not there', $firstArticle->title);
+        $this->assertSame('New body', $firstArticle->body);
 
         $secondArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
             $this->fail('Should not be called for existing entities.');
         });
         $this->assertFalse($secondArticle->isNew());
         $this->assertNotNull($secondArticle->id);
-        $this->assertEquals('Not there', $secondArticle->title);
+        $this->assertSame('Not there', $secondArticle->title);
         $this->assertEquals($firstArticle->id, $secondArticle->id);
     }
 
@@ -5639,7 +5639,7 @@ class TableTest extends TestCase
         });
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('First Article', $article->title);
+        $this->assertSame('First Article', $article->title);
     }
 
     /**
@@ -5663,14 +5663,14 @@ class TableTest extends TestCase
         $this->assertTrue($callbackExecuted);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('First Article', $article->title);
-        $this->assertEquals('New body', $article->body);
-        $this->assertEquals('N', $article->published);
+        $this->assertSame('First Article', $article->title);
+        $this->assertSame('New body', $article->body);
+        $this->assertSame('N', $article->published);
         $this->assertEquals(2, $article->author_id);
 
         $query = $articles->find()->where(['author_id' => 2, 'title' => 'First Article']);
         $article = $articles->findOrCreate($query);
-        $this->assertEquals('First Article', $article->title);
+        $this->assertSame('First Article', $article->title);
         $this->assertEquals(2, $article->author_id);
         $this->assertFalse($article->isNew());
     }
@@ -5687,7 +5687,7 @@ class TableTest extends TestCase
         $article = $articles->findOrCreate(['title' => 'Just Something New']);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('Just Something New', $article->title);
+        $this->assertSame('Just Something New', $article->title);
     }
 
     /**
@@ -5714,7 +5714,7 @@ class TableTest extends TestCase
         $this->assertTrue($calledTwo);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('Set Defaults Here', $article->title);
+        $this->assertSame('Set Defaults Here', $article->title);
     }
 
     /**
@@ -5732,7 +5732,7 @@ class TableTest extends TestCase
         }, ['defaults' => false]);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('A Different Title', $article->title);
+        $this->assertSame('A Different Title', $article->title);
         $this->assertNull($article->published, 'Expected Null since defaults are disabled.');
     }
 
@@ -5759,7 +5759,7 @@ class TableTest extends TestCase
         });
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('Success', $article->title);
+        $this->assertSame('Success', $article->title);
         $this->assertTrue($article->afterSaveCommit);
     }
 
@@ -5783,7 +5783,7 @@ class TableTest extends TestCase
         }, ['atomic' => false]);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
-        $this->assertEquals('Success', $article->title);
+        $this->assertSame('Success', $article->title);
     }
 
     /**
@@ -6116,11 +6116,11 @@ class TableTest extends TestCase
     public function testSetEntitySource()
     {
         $table = $this->getTableLocator()->get('Articles');
-        $this->assertEquals('Articles', $table->newEmptyEntity()->getSource());
+        $this->assertSame('Articles', $table->newEmptyEntity()->getSource());
 
         $this->loadPlugins(['TestPlugin']);
         $table = $this->getTableLocator()->get('TestPlugin.Comments');
-        $this->assertEquals('TestPlugin.Comments', $table->newEmptyEntity()->getSource());
+        $this->assertSame('TestPlugin.Comments', $table->newEmptyEntity()->getSource());
     }
 
     /**

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -65,7 +65,7 @@ class AssetMiddlewareTest extends TestCase
         $res = $middleware->process($request, $handler);
 
         $body = $res->getBody()->getContents();
-        $this->assertEquals('', $body);
+        $this->assertSame('', $body);
         $this->assertEquals(304, $res->getStatusCode());
         $this->assertNotEmpty($res->getHeaderLine('Last-Modified'));
     }
@@ -84,7 +84,7 @@ class AssetMiddlewareTest extends TestCase
         $res = $middleware->process($request, $handler);
 
         $body = $res->getBody()->getContents();
-        $this->assertEquals('', $body);
+        $this->assertSame('', $body);
     }
 
     /**

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -67,7 +67,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/subdir/pages', $response->getHeaderLine('Location'));
+        $this->assertSame('http://localhost/subdir/pages', $response->getHeaderLine('Location'));
     }
 
     /**
@@ -88,7 +88,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/pages', $response->getHeaderLine('Location'));
+        $this->assertSame('http://localhost/pages', $response->getHeaderLine('Location'));
     }
 
     /**
@@ -161,7 +161,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertNotEmpty(Router::routes());
-            $this->assertEquals('/app/articles', Router::routes()[0]->template);
+            $this->assertSame('/app/articles', Router::routes()[0]->template);
 
             return new Response();
         });
@@ -251,7 +251,7 @@ class RoutingMiddlewareTest extends TestCase
                 '_matchedRoute' => '/articles-patch',
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
-            $this->assertEquals('PATCH', $req->getMethod());
+            $this->assertSame('PATCH', $req->getMethod());
 
             return new Response();
         });

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -50,28 +50,28 @@ class DashedRouteTest extends TestCase
             'action' => 'myView',
             'id' => 1,
         ]);
-        $this->assertEquals('/my-posts/my-view/1', $result);
+        $this->assertSame('/my-posts/my-view/1', $result);
 
         $route = new DashedRoute('/', ['controller' => 'Pages', 'action' => 'myDisplay', 'home']);
         $result = $route->match(['controller' => 'Pages', 'action' => 'myDisplay', 'home']);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
         $route = new DashedRoute('/blog/:action', ['controller' => 'Posts']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView']);
-        $this->assertEquals('/blog/my-view', $result);
+        $this->assertSame('/blog/my-view', $result);
 
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', '?' => ['id' => 2]]);
-        $this->assertEquals('/blog/my-view?id=2', $result);
+        $this->assertSame('/blog/my-view?id=2', $result);
 
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', 1]);
         $this->assertNull($result);
 
         $route = new DashedRoute('/foo/:controller/:action', ['action' => 'index']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView']);
-        $this->assertEquals('/foo/posts/my-view', $result);
+        $this->assertSame('/foo/posts/my-view', $result);
 
         $route = new DashedRoute('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'myView']);
         $result = $route->match([
@@ -80,7 +80,7 @@ class DashedRouteTest extends TestCase
             'action' => 'myView',
             'id' => '1',
         ]);
-        $this->assertEquals('/test-plugin/1/', $result);
+        $this->assertSame('/test-plugin/1/', $result);
 
         $result = $route->match([
             'plugin' => 'TestPlugin',
@@ -89,7 +89,7 @@ class DashedRouteTest extends TestCase
             'id' => '1',
             '0',
         ]);
-        $this->assertEquals('/test-plugin/1/0', $result);
+        $this->assertSame('/test-plugin/1/0', $result);
 
         $result = $route->match([
             'plugin' => 'TestPlugin',
@@ -125,7 +125,7 @@ class DashedRouteTest extends TestCase
             'action' => 'myView',
             'id' => 1,
         ]);
-        $this->assertEquals('/my-posts/my-view-1', $result);
+        $this->assertSame('/my-posts/my-view-1', $result);
 
         $route = new DashedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
         $result = $route->match([
@@ -134,7 +134,7 @@ class DashedRouteTest extends TestCase
             'id' => '1',
             'slug' => 'the-slug',
         ]);
-        $this->assertEquals('/my-posts/my-view/the-slug-1', $result);
+        $this->assertSame('/my-posts/my-view/the-slug-1', $result);
     }
 
     /**
@@ -147,24 +147,24 @@ class DashedRouteTest extends TestCase
         $route = new DashedRoute('/:controller/:action/:id', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my-posts/my-view/1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('myView', $result['action']);
-        $this->assertEquals('1', $result['id']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('myView', $result['action']);
+        $this->assertSame('1', $result['id']);
 
         $route = new DashedRoute('/:controller/:action-:id');
         $route->compile();
         $result = $route->parse('/my-posts/my-view-1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('myView', $result['action']);
-        $this->assertEquals('1', $result['id']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('myView', $result['action']);
+        $this->assertSame('1', $result['id']);
 
         $route = new DashedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my-posts/my-view/the-slug-1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('myView', $result['action']);
-        $this->assertEquals('1', $result['id']);
-        $this->assertEquals('the-slug', $result['slug']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('myView', $result['action']);
+        $this->assertSame('1', $result['id']);
+        $this->assertSame('the-slug', $result['slug']);
 
         $route = new DashedRoute(
             '/admin/:controller',
@@ -175,21 +175,21 @@ class DashedRouteTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->parse('/admin/my-posts', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('index', $result['action']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('index', $result['action']);
 
         $route = new DashedRoute(
             '/media/search/*',
             ['controller' => 'Media', 'action' => 'searchIt']
         );
         $result = $route->parse('/media/search', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('searchIt', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('searchIt', $result['action']);
         $this->assertEquals([], $result['pass']);
 
         $result = $route->parse('/media/search/tv_shows', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('searchIt', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('searchIt', $result['action']);
         $this->assertEquals(['tv_shows'], $result['pass']);
     }
 
@@ -209,8 +209,8 @@ class DashedRouteTest extends TestCase
         $expectedUrl = '/plugin/controller-name/action-name';
         $this->assertEquals($expectedUrl, $url);
         $result = $route->parse($expectedUrl, 'GET');
-        $this->assertEquals('ControllerName', $result['controller']);
-        $this->assertEquals('actionName', $result['action']);
-        $this->assertEquals('Vendor/PluginName', $result['plugin']);
+        $this->assertSame('ControllerName', $result['controller']);
+        $this->assertSame('actionName', $result['action']);
+        $this->assertSame('Vendor/PluginName', $result['plugin']);
     }
 }

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -51,7 +51,7 @@ class EntityRouteTest extends TestCase
             '_name' => 'articlesView',
         ]);
 
-        $this->assertEquals('/articles/2/other-slug', $result);
+        $this->assertSame('/articles/2/other-slug', $result);
     }
 
     /**
@@ -78,7 +78,7 @@ class EntityRouteTest extends TestCase
             '_name' => 'articlesView',
         ]);
 
-        $this->assertEquals('/articles/2/article-slug', $result);
+        $this->assertSame('/articles/2/article-slug', $result);
     }
 
     /**
@@ -105,7 +105,7 @@ class EntityRouteTest extends TestCase
             '_name' => 'articlesView',
         ]);
 
-        $this->assertEquals('/articles/2_article-slug', $result);
+        $this->assertSame('/articles/2_article-slug', $result);
     }
 
     /**
@@ -133,7 +133,7 @@ class EntityRouteTest extends TestCase
             '_name' => 'articlesView',
         ]);
 
-        $this->assertEquals('/articles/2/article-slug', $result);
+        $this->assertSame('/articles/2/article-slug', $result);
     }
 
     /**

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -50,28 +50,28 @@ class InflectedRouteTest extends TestCase
             'action' => 'my_view',
             'id' => 1,
         ]);
-        $this->assertEquals('/my_posts/my_view/1', $result);
+        $this->assertSame('/my_posts/my_view/1', $result);
 
         $route = new InflectedRoute('/', ['controller' => 'Pages', 'action' => 'my_view', 'home']);
         $result = $route->match(['controller' => 'Pages', 'action' => 'my_view', 'home']);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
         $route = new InflectedRoute('/blog/:action', ['controller' => 'Posts']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view']);
-        $this->assertEquals('/blog/my_view', $result);
+        $this->assertSame('/blog/my_view', $result);
 
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view', '?' => ['id' => 2]]);
-        $this->assertEquals('/blog/my_view?id=2', $result);
+        $this->assertSame('/blog/my_view?id=2', $result);
 
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view', 1]);
         $this->assertNull($result);
 
         $route = new InflectedRoute('/foo/:controller/:action', ['action' => 'index']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view']);
-        $this->assertEquals('/foo/posts/my_view', $result);
+        $this->assertSame('/foo/posts/my_view', $result);
 
         $route = new InflectedRoute('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'my_view']);
         $result = $route->match([
@@ -80,7 +80,7 @@ class InflectedRouteTest extends TestCase
             'action' => 'my_view',
             'id' => '1',
         ]);
-        $this->assertEquals('/test_plugin/1/', $result);
+        $this->assertSame('/test_plugin/1/', $result);
 
         $result = $route->match([
             'plugin' => 'TestPlugin',
@@ -89,7 +89,7 @@ class InflectedRouteTest extends TestCase
             'id' => '1',
             '0',
         ]);
-        $this->assertEquals('/test_plugin/1/0', $result);
+        $this->assertSame('/test_plugin/1/0', $result);
 
         $result = $route->match([
             'plugin' => 'TestPlugin',
@@ -125,7 +125,7 @@ class InflectedRouteTest extends TestCase
             'action' => 'my_view',
             'id' => 1,
         ]);
-        $this->assertEquals('/my_posts/my_view-1', $result);
+        $this->assertSame('/my_posts/my_view-1', $result);
 
         $route = new InflectedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
         $result = $route->match([
@@ -134,7 +134,7 @@ class InflectedRouteTest extends TestCase
             'id' => '1',
             'slug' => 'the-slug',
         ]);
-        $this->assertEquals('/my_posts/my_view/the-slug-1', $result);
+        $this->assertSame('/my_posts/my_view/the-slug-1', $result);
     }
 
     /**
@@ -147,24 +147,24 @@ class InflectedRouteTest extends TestCase
         $route = new InflectedRoute('/:controller/:action/:id', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my_posts/my_view/1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('my_view', $result['action']);
-        $this->assertEquals('1', $result['id']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('my_view', $result['action']);
+        $this->assertSame('1', $result['id']);
 
         $route = new InflectedRoute('/:controller/:action-:id');
         $route->compile();
         $result = $route->parse('/my_posts/my_view-1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('my_view', $result['action']);
-        $this->assertEquals('1', $result['id']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('my_view', $result['action']);
+        $this->assertSame('1', $result['id']);
 
         $route = new InflectedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my_posts/my_view/the-slug-1', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('my_view', $result['action']);
-        $this->assertEquals('1', $result['id']);
-        $this->assertEquals('the-slug', $result['slug']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('my_view', $result['action']);
+        $this->assertSame('1', $result['id']);
+        $this->assertSame('the-slug', $result['slug']);
 
         $route = new InflectedRoute(
             '/admin/:controller',
@@ -175,21 +175,21 @@ class InflectedRouteTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->parse('/admin/my_posts', 'GET');
-        $this->assertEquals('MyPosts', $result['controller']);
-        $this->assertEquals('index', $result['action']);
+        $this->assertSame('MyPosts', $result['controller']);
+        $this->assertSame('index', $result['action']);
 
         $route = new InflectedRoute(
             '/media/search/*',
             ['controller' => 'Media', 'action' => 'search_it']
         );
         $result = $route->parse('/media/search', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('search_it', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('search_it', $result['action']);
         $this->assertEquals([], $result['pass']);
 
         $result = $route->parse('/media/search/tv_shows', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('search_it', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('search_it', $result['action']);
         $this->assertEquals(['tv_shows'], $result['pass']);
     }
 
@@ -204,8 +204,8 @@ class InflectedRouteTest extends TestCase
         $this->assertNull($route->parse('/blog_posts/add_new', 'GET'));
 
         $result = $route->parse('/blog_posts/add_new', 'POST');
-        $this->assertEquals('BlogPosts', $result['controller']);
-        $this->assertEquals('add_new', $result['action']);
+        $this->assertSame('BlogPosts', $result['controller']);
+        $this->assertSame('add_new', $result['action']);
     }
 
     /**
@@ -224,8 +224,8 @@ class InflectedRouteTest extends TestCase
         $expectedUrl = '/plugin/controller_name/action_name';
         $this->assertEquals($expectedUrl, $url);
         $result = $route->parse($expectedUrl, 'GET');
-        $this->assertEquals('ControllerName', $result['controller']);
-        $this->assertEquals('action_name', $result['action']);
-        $this->assertEquals('Vendor/PluginName', $result['plugin']);
+        $this->assertSame('ControllerName', $result['controller']);
+        $this->assertSame('action_name', $result['action']);
+        $this->assertSame('Vendor/PluginName', $result['plugin']);
     }
 }

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -48,9 +48,9 @@ class PluginShortRouteTest extends TestCase
         $route = new PluginShortRoute('/:plugin', ['action' => 'index'], ['plugin' => 'foo|bar']);
 
         $result = $route->parse('/foo', 'GET');
-        $this->assertEquals('Foo', $result['plugin']);
-        $this->assertEquals('Foo', $result['controller']);
-        $this->assertEquals('index', $result['action']);
+        $this->assertSame('Foo', $result['plugin']);
+        $this->assertSame('Foo', $result['controller']);
+        $this->assertSame('index', $result['action']);
 
         $result = $route->parse('/wrong', 'GET');
         $this->assertNull($result, 'Wrong plugin name matched %s');
@@ -69,6 +69,6 @@ class PluginShortRouteTest extends TestCase
         $this->assertNull($result, 'plugin controller mismatch was converted. %s');
 
         $result = $route->match(['plugin' => 'foo', 'controller' => 'foo', 'action' => 'index']);
-        $this->assertEquals('/foo', $result);
+        $this->assertSame('/foo', $result);
     }
 }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -48,7 +48,7 @@ class RouteTest extends TestCase
     {
         $route = new Route('/:controller/:action/:id', [], ['id' => '[0-9]+']);
 
-        $this->assertEquals('/:controller/:action/:id', $route->template);
+        $this->assertSame('/:controller/:action/:id', $route->template);
         $this->assertEquals([], $route->defaults);
         $this->assertEquals(['id' => '[0-9]+', '_ext' => []], $route->options);
         $this->assertFalse($route->compiled());
@@ -126,7 +126,7 @@ class RouteTest extends TestCase
             'x' => '8',
             'y' => '42',
         ]);
-        $this->assertEquals('/fighters/123/move/8/42', $result);
+        $this->assertSame('/fighters/123/move/8/42', $result);
     }
 
     /**
@@ -150,7 +150,7 @@ class RouteTest extends TestCase
             'x' => '8',
             'y' => '42',
         ]);
-        $this->assertEquals('/fighters/123/move/8/42', $result);
+        $this->assertSame('/fighters/123/move/8/42', $result);
 
         $route = new Route(
             '/images/{id}/{x}x{y}',
@@ -165,7 +165,7 @@ class RouteTest extends TestCase
             'x' => '8',
             'y' => '42',
         ]);
-        $this->assertEquals('/images/123/8x42', $result);
+        $this->assertSame('/images/123/8x42', $result);
     }
 
     /**
@@ -230,7 +230,7 @@ class RouteTest extends TestCase
             'action' => 'open',
             'id' => 123,
         ]);
-        $this->assertEquals('/images/{open/123', $result);
+        $this->assertSame('/images/{open/123', $result);
 
         $route = new Route(
             '/fighters/{id}/move/{x}/:y',
@@ -247,7 +247,7 @@ class RouteTest extends TestCase
             'x' => '8',
             '?' => ['y' => '9'],
         ]);
-        $this->assertEquals('/fighters/123/move/8/:y?y=9', $result);
+        $this->assertSame('/fighters/123/move/8/:y?y=9', $result);
     }
 
     /**
@@ -270,16 +270,16 @@ class RouteTest extends TestCase
         $this->assertArrayNotHasKey('_ext', $result);
 
         $result = $route->setExtensions(['pdf', 'json', 'xml', 'xml.gz'])->parse('/posts/index.pdf', 'GET');
-        $this->assertEquals('pdf', $result['_ext']);
+        $this->assertSame('pdf', $result['_ext']);
 
         $result = $route->parse('/posts/index.json', 'GET');
-        $this->assertEquals('json', $result['_ext']);
+        $this->assertSame('json', $result['_ext']);
 
         $result = $route->parse('/posts/index.xml', 'GET');
-        $this->assertEquals('xml', $result['_ext']);
+        $this->assertSame('xml', $result['_ext']);
 
         $result = $route->parse('/posts/index.xml.gz', 'GET');
-        $this->assertEquals('xml.gz', $result['_ext']);
+        $this->assertSame('xml.gz', $result['_ext']);
     }
 
     /**
@@ -570,28 +570,28 @@ class RouteTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 1]);
-        $this->assertEquals('/posts/view/1', $result);
+        $this->assertSame('/posts/view/1', $result);
 
         $route = new Route('/', ['controller' => 'pages', 'action' => 'display', 'home']);
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 'home']);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
         $route = new Route('/pages/*', ['controller' => 'pages', 'action' => 'display']);
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 'home']);
-        $this->assertEquals('/pages/home', $result);
+        $this->assertSame('/pages/home', $result);
 
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 'about']);
-        $this->assertEquals('/pages/about', $result);
+        $this->assertSame('/pages/about', $result);
 
         $route = new Route('/blog/:action', ['controller' => 'posts']);
         $result = $route->match(['controller' => 'posts', 'action' => 'view']);
-        $this->assertEquals('/blog/view', $result);
+        $this->assertSame('/blog/view', $result);
 
         $result = $route->match(['controller' => 'posts', 'action' => 'view', '?' => ['id' => 2]]);
-        $this->assertEquals('/blog/view?id=2', $result);
+        $this->assertSame('/blog/view?id=2', $result);
 
         $result = $route->match(['controller' => 'nodes', 'action' => 'view']);
         $this->assertNull($result);
@@ -601,14 +601,14 @@ class RouteTest extends TestCase
 
         $route = new Route('/foo/:controller/:action', ['action' => 'index']);
         $result = $route->match(['controller' => 'posts', 'action' => 'view']);
-        $this->assertEquals('/foo/posts/view', $result);
+        $this->assertSame('/foo/posts/view', $result);
 
         $route = new Route('/:plugin/:id/*', ['controller' => 'posts', 'action' => 'view']);
         $result = $route->match(['plugin' => 'test', 'controller' => 'posts', 'action' => 'view', 'id' => '1']);
-        $this->assertEquals('/test/1/', $result);
+        $this->assertSame('/test/1/', $result);
 
         $result = $route->match(['plugin' => 'fo', 'controller' => 'posts', 'action' => 'view', 'id' => '1', '0']);
-        $this->assertEquals('/fo/1/0', $result);
+        $this->assertSame('/fo/1/0', $result);
 
         $result = $route->match(['plugin' => 'fo', 'controller' => 'nodes', 'action' => 'view', 'id' => 1]);
         $this->assertNull($result);
@@ -651,7 +651,7 @@ class RouteTest extends TestCase
             ['controller' => 'tasks', 'action' => 'add'],
             $context
         );
-        $this->assertEquals('/en/tasks/add', $result);
+        $this->assertSame('/en/tasks/add', $result);
     }
 
     /**
@@ -673,26 +673,26 @@ class RouteTest extends TestCase
             $context
         );
         // Http has port 80 as default, do not include it in the url
-        $this->assertEquals('http://example.com/posts/index', $result);
+        $this->assertSame('http://example.com/posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'posts', 'action' => 'index', '_scheme' => 'webcal'],
             $context
         );
         // Webcal is not on port 80 by default, include it in url
-        $this->assertEquals('webcal://foo.com:80/posts/index', $result);
+        $this->assertSame('webcal://foo.com:80/posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'posts', 'action' => 'index', '_port' => '8080'],
             $context
         );
-        $this->assertEquals('http://foo.com:8080/posts/index', $result);
+        $this->assertSame('http://foo.com:8080/posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'posts', 'action' => 'index', '_base' => '/dir'],
             $context
         );
-        $this->assertEquals('/dir/posts/index', $result);
+        $this->assertSame('/dir/posts/index', $result);
 
         $result = $route->match(
             [
@@ -705,7 +705,7 @@ class RouteTest extends TestCase
             ],
             $context
         );
-        $this->assertEquals('https://example.com:8080/dir/posts/index', $result);
+        $this->assertSame('https://example.com:8080/dir/posts/index', $result);
 
         $context = [
             '_host' => 'foo.com',
@@ -725,7 +725,7 @@ class RouteTest extends TestCase
             $context
         );
         // Https scheme is not on port 8080 by default, include the port
-        $this->assertEquals('https://example.com:8080/dir/posts/index', $result);
+        $this->assertSame('https://example.com:8080/dir/posts/index', $result);
     }
 
     /**
@@ -832,7 +832,7 @@ class RouteTest extends TestCase
         $result = $route->match([
             'controller' => 'posts', 'action' => 'index', 'plugin' => null, 'admin' => false,
         ]);
-        $this->assertEquals('/posts/index/', $result);
+        $this->assertSame('/posts/index/', $result);
     }
 
     /**
@@ -845,23 +845,23 @@ class RouteTest extends TestCase
         $route = new Route('/:controller/:action/*', ['plugin' => null]);
 
         $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 5]);
-        $this->assertEquals('/posts/view/5', $result);
+        $this->assertSame('/posts/view/5', $result);
 
         $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 0]);
-        $this->assertEquals('/posts/view/0', $result);
+        $this->assertSame('/posts/view/0', $result);
 
         $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, '0']);
-        $this->assertEquals('/posts/view/0', $result);
+        $this->assertSame('/posts/view/0', $result);
 
         $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 'word space']);
-        $this->assertEquals('/posts/view/word%20space', $result);
+        $this->assertSame('/posts/view/word%20space', $result);
 
         $route = new Route('/test2/*', ['controller' => 'pages', 'action' => 'display', 2]);
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 1]);
         $this->assertNull($result);
 
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 2, 'something']);
-        $this->assertEquals('/test2/something', $result);
+        $this->assertSame('/test2/something', $result);
 
         $result = $route->match(['controller' => 'pages', 'action' => 'display', 5, 'something']);
         $this->assertNull($result);
@@ -886,7 +886,7 @@ class RouteTest extends TestCase
             'id' => 1,
             'slug' => 'second',
         ]);
-        $this->assertEquals('/blog/1-second', $result);
+        $this->assertSame('/blog/1-second', $result);
 
         $result = $route->match([
             'controller' => 'Blog',
@@ -894,7 +894,7 @@ class RouteTest extends TestCase
             1,
             'second',
         ]);
-        $this->assertEquals('/blog/1-second', $result);
+        $this->assertSame('/blog/1-second', $result);
 
         $result = $route->match([
             'controller' => 'Blog',
@@ -903,7 +903,7 @@ class RouteTest extends TestCase
             'second',
             '?' => ['query' => 'string'],
         ]);
-        $this->assertEquals('/blog/1-second?query=string', $result);
+        $this->assertSame('/blog/1-second?query=string', $result);
 
         $result = $route->match([
             'controller' => 'Blog',
@@ -935,7 +935,7 @@ class RouteTest extends TestCase
             'fourth',
             '?' => ['query' => 'string'],
         ]);
-        $this->assertEquals('/blog/1-second/third/fourth?query=string', $result);
+        $this->assertSame('/blog/1-second/third/fourth?query=string', $result);
 
         $result = $route->match([
             'controller' => 'Blog',
@@ -946,7 +946,7 @@ class RouteTest extends TestCase
             'fourth',
             '?' => ['query' => 'string'],
         ]);
-        $this->assertEquals('/blog/1-second/third/fourth?query=string', $result);
+        $this->assertSame('/blog/1-second/third/fourth?query=string', $result);
     }
 
     /**
@@ -962,7 +962,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             '_ext' => 'json',
         ]);
-        $this->assertEquals('/posts/index.json', $result);
+        $this->assertSame('/posts/index.json', $result);
 
         $route = new Route('/:controller/:action/*');
         $result = $route->match([
@@ -970,7 +970,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             '_ext' => 'json',
         ]);
-        $this->assertEquals('/posts/index.json', $result);
+        $this->assertSame('/posts/index.json', $result);
 
         $result = $route->match([
             'controller' => 'posts',
@@ -978,7 +978,7 @@ class RouteTest extends TestCase
             1,
             '_ext' => 'json',
         ]);
-        $this->assertEquals('/posts/view/1.json', $result);
+        $this->assertSame('/posts/view/1.json', $result);
 
         $result = $route->match([
             'controller' => 'posts',
@@ -987,14 +987,14 @@ class RouteTest extends TestCase
             '_ext' => 'json',
             '?' => ['id' => 'b', 'c' => 'd', ],
         ]);
-        $this->assertEquals('/posts/view/1.json?id=b&c=d', $result);
+        $this->assertSame('/posts/view/1.json?id=b&c=d', $result);
 
         $result = $route->match([
             'controller' => 'posts',
             'action' => 'index',
             '_ext' => 'json.gz',
         ]);
-        $this->assertEquals('/posts/index.json.gz', $result);
+        $this->assertSame('/posts/index.json.gz', $result);
     }
 
     /**
@@ -1009,10 +1009,10 @@ class RouteTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '9']);
-        $this->assertEquals('/posts/view/9', $result);
+        $this->assertSame('/posts/view/9', $result);
 
         $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '922']);
-        $this->assertEquals('/posts/view/922', $result);
+        $this->assertSame('/posts/view/922', $result);
 
         $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 'a99']);
         $this->assertNull($result);
@@ -1172,9 +1172,9 @@ class RouteTest extends TestCase
         );
         $route->compile();
         $result = $route->parse('/posts/view/1', 'GET');
-        $this->assertEquals('posts', $result['controller']);
-        $this->assertEquals('view', $result['action']);
-        $this->assertEquals('1', $result['id']);
+        $this->assertSame('posts', $result['controller']);
+        $this->assertSame('view', $result['action']);
+        $this->assertSame('1', $result['id']);
 
         $route = new Route(
             '/admin/:controller',
@@ -1185,21 +1185,21 @@ class RouteTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->parse('/admin/posts', 'GET');
-        $this->assertEquals('posts', $result['controller']);
-        $this->assertEquals('index', $result['action']);
+        $this->assertSame('posts', $result['controller']);
+        $this->assertSame('index', $result['action']);
 
         $route = new Route(
             '/media/search/*',
             ['controller' => 'Media', 'action' => 'search']
         );
         $result = $route->parse('/media/search', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('search', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('search', $result['action']);
         $this->assertEquals([], $result['pass']);
 
         $result = $route->parse('/media/search/tv/shows', 'GET');
-        $this->assertEquals('Media', $result['controller']);
-        $this->assertEquals('search', $result['action']);
+        $this->assertSame('Media', $result['controller']);
+        $this->assertSame('search', $result['action']);
         $this->assertEquals(['tv', 'shows'], $result['pass']);
     }
 
@@ -1216,14 +1216,14 @@ class RouteTest extends TestCase
         );
         $route->compile();
         $result = $route->parse('/posts/%E2%88%82%E2%88%82', 'GET');
-        $this->assertEquals('posts', $result['controller']);
-        $this->assertEquals('view', $result['action']);
-        $this->assertEquals('∂∂', $result['slug']);
+        $this->assertSame('posts', $result['controller']);
+        $this->assertSame('view', $result['action']);
+        $this->assertSame('∂∂', $result['slug']);
 
         $result = $route->parse('/posts/∂∂', 'GET');
-        $this->assertEquals('posts', $result['controller']);
-        $this->assertEquals('view', $result['action']);
-        $this->assertEquals('∂∂', $result['slug']);
+        $this->assertSame('posts', $result['controller']);
+        $this->assertSame('view', $result['action']);
+        $this->assertSame('∂∂', $result['slug']);
     }
 
     /**
@@ -1338,21 +1338,21 @@ class RouteTest extends TestCase
             'action' => 'index',
             '_method' => 'PUT',
         ];
-        $this->assertEquals('/sample', $route->match($url));
+        $this->assertSame('/sample', $route->match($url));
 
         $url = [
             'controller' => 'posts',
             'action' => 'index',
             '_method' => 'POST',
         ];
-        $this->assertEquals('/sample', $route->match($url));
+        $this->assertSame('/sample', $route->match($url));
 
         $url = [
             'controller' => 'posts',
             'action' => 'index',
             '_method' => ['PUT', 'POST'],
         ];
-        $this->assertEquals('/sample', $route->match($url));
+        $this->assertSame('/sample', $route->match($url));
     }
 
     /**
@@ -1515,19 +1515,19 @@ class RouteTest extends TestCase
     public function testGetName()
     {
         $route = new Route('/foo/bar', [], ['_name' => 'testing']);
-        $this->assertEquals('', $route->getName());
+        $this->assertSame('', $route->getName());
 
         $route = new Route('/:controller/:action');
-        $this->assertEquals('_controller:_action', $route->getName());
+        $this->assertSame('_controller:_action', $route->getName());
 
         $route = new Route('/articles/:action', ['controller' => 'posts']);
-        $this->assertEquals('posts:_action', $route->getName());
+        $this->assertSame('posts:_action', $route->getName());
 
         $route = new Route('/articles/list', ['controller' => 'posts', 'action' => 'index']);
-        $this->assertEquals('posts:index', $route->getName());
+        $this->assertSame('posts:index', $route->getName());
 
         $route = new Route('/:controller/:action', ['action' => 'index']);
-        $this->assertEquals('_controller:_action', $route->getName());
+        $this->assertSame('_controller:_action', $route->getName());
     }
 
     /**
@@ -1541,19 +1541,19 @@ class RouteTest extends TestCase
             '/a/:controller/:action',
             ['plugin' => 'asset']
         );
-        $this->assertEquals('asset._controller:_action', $route->getName());
+        $this->assertSame('asset._controller:_action', $route->getName());
 
         $route = new Route(
             '/a/assets/:action',
             ['plugin' => 'asset', 'controller' => 'assets']
         );
-        $this->assertEquals('asset.assets:_action', $route->getName());
+        $this->assertSame('asset.assets:_action', $route->getName());
 
         $route = new Route(
             '/assets/get',
             ['plugin' => 'asset', 'controller' => 'assets', 'action' => 'get']
         );
-        $this->assertEquals('asset.assets:get', $route->getName());
+        $this->assertSame('asset.assets:get', $route->getName());
     }
 
     /**
@@ -1567,25 +1567,25 @@ class RouteTest extends TestCase
             '/admin/:controller/:action',
             ['prefix' => 'admin']
         );
-        $this->assertEquals('admin:_controller:_action', $route->getName());
+        $this->assertSame('admin:_controller:_action', $route->getName());
 
         $route = new Route(
             '/:prefix/assets/:action',
             ['controller' => 'assets']
         );
-        $this->assertEquals('_prefix:assets:_action', $route->getName());
+        $this->assertSame('_prefix:assets:_action', $route->getName());
 
         $route = new Route(
             '/admin/assets/get',
             ['prefix' => 'admin', 'plugin' => 'asset', 'controller' => 'assets', 'action' => 'get']
         );
-        $this->assertEquals('admin:asset.assets:get', $route->getName());
+        $this->assertSame('admin:asset.assets:get', $route->getName());
 
         $route = new Route(
             '/:prefix/:plugin/:controller/:action/*',
             []
         );
-        $this->assertEquals('_prefix:_plugin._controller:_action', $route->getName());
+        $this->assertSame('_prefix:_plugin._controller:_action', $route->getName());
     }
 
     /**
@@ -1635,22 +1635,22 @@ class RouteTest extends TestCase
     public function testStaticPath()
     {
         $route = new Route('/*', ['controller' => 'Pages', 'action' => 'display']);
-        $this->assertEquals('/', $route->staticPath());
+        $this->assertSame('/', $route->staticPath());
 
         $route = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
-        $this->assertEquals('/pages', $route->staticPath());
+        $this->assertSame('/pages', $route->staticPath());
 
         $route = new Route('/pages/:id/*', ['controller' => 'Pages', 'action' => 'display']);
-        $this->assertEquals('/pages/', $route->staticPath());
+        $this->assertSame('/pages/', $route->staticPath());
 
         $route = new Route('/:controller/:action/*');
-        $this->assertEquals('/', $route->staticPath());
+        $this->assertSame('/', $route->staticPath());
 
         $route = new Route('/api/{/:action/*');
-        $this->assertEquals('/api/{/', $route->staticPath());
+        $this->assertSame('/api/{/', $route->staticPath());
 
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
-        $this->assertEquals('/books/reviews', $route->staticPath());
+        $this->assertSame('/books/reviews', $route->staticPath());
     }
 
     /**
@@ -1661,13 +1661,13 @@ class RouteTest extends TestCase
     public function testStaticPathBrace()
     {
         $route = new Route('/pages/{id}/*', ['controller' => 'Pages', 'action' => 'display']);
-        $this->assertEquals('/pages/', $route->staticPath());
+        $this->assertSame('/pages/', $route->staticPath());
 
         $route = new Route('/{controller}/{action}/*');
-        $this->assertEquals('/', $route->staticPath());
+        $this->assertSame('/', $route->staticPath());
 
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
-        $this->assertEquals('/books/reviews', $route->staticPath());
+        $this->assertSame('/books/reviews', $route->staticPath());
     }
 
     /**

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -61,16 +61,16 @@ class RouteBuilderTest extends TestCase
     public function testPath()
     {
         $routes = new RouteBuilder($this->collection, '/some/path');
-        $this->assertEquals('/some/path', $routes->path());
+        $this->assertSame('/some/path', $routes->path());
 
         $routes = new RouteBuilder($this->collection, '/:book_id');
-        $this->assertEquals('/', $routes->path());
+        $this->assertSame('/', $routes->path());
 
         $routes = new RouteBuilder($this->collection, '/path/:book_id');
-        $this->assertEquals('/path/', $routes->path());
+        $this->assertSame('/path/', $routes->path());
 
         $routes = new RouteBuilder($this->collection, '/path/book:book_id');
-        $this->assertEquals('/path/book', $routes->path());
+        $this->assertSame('/path/book', $routes->path());
     }
 
     /**
@@ -160,7 +160,7 @@ class RouteBuilderTest extends TestCase
         $this->assertInstanceOf(Route::class, $route);
 
         $this->assertSame($route, $this->collection->routes()[0]);
-        $this->assertEquals('/l/:controller', $route->template);
+        $this->assertSame('/l/:controller', $route->template);
         $expected = ['prefix' => 'api', 'action' => 'index', 'plugin' => null];
         $this->assertEquals($expected, $route->defaults);
     }
@@ -428,7 +428,7 @@ class RouteBuilderTest extends TestCase
         $route = $this->collection->routes()[1];
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
-        $this->assertEquals('/forums', $route->redirect[0]);
+        $this->assertSame('/forums', $route->redirect[0]);
 
         $route = $routes->redirect('/old', '/forums');
         $this->assertInstanceOf(RedirectRoute::class, $route);
@@ -461,7 +461,7 @@ class RouteBuilderTest extends TestCase
         $res = $routes->prefix('admin', ['param' => 'value'], function ($r) {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
-            $this->assertEquals('/path/admin', $r->path());
+            $this->assertSame('/path/admin', $r->path());
             $this->assertEquals(['prefix' => 'admin', 'key' => 'value', 'param' => 'value'], $r->params());
         });
         $this->assertNull($res);
@@ -478,7 +478,7 @@ class RouteBuilderTest extends TestCase
         $res = $routes->prefix('admin', function ($r) {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
-            $this->assertEquals('/path/admin', $r->path());
+            $this->assertSame('/path/admin', $r->path());
             $this->assertEquals(['prefix' => 'admin', 'key' => 'value'], $r->params());
         });
         $this->assertNull($res);
@@ -493,9 +493,9 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
         $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function ($r) {
-            $this->assertEquals('/admin/api', $r->path());
+            $this->assertSame('/admin/api', $r->path());
             $this->assertEquals(['prefix' => 'admin/api'], $r->params());
-            $this->assertEquals('api:', $r->namePrefix());
+            $this->assertSame('api:', $r->namePrefix());
         });
         $this->assertNull($res);
     }
@@ -510,10 +510,10 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
         $res = $routes->prefix('api', function ($r) {
             $r->prefix('v10', ['path' => '/v1.0'], function ($r2) {
-                $this->assertEquals('/admin/api/v1.0', $r2->path());
+                $this->assertSame('/admin/api/v1.0', $r2->path());
                 $this->assertEquals(['prefix' => 'admin/api/v10'], $r2->params());
                 $r2->prefix('b1', ['path' => '/beta.1'], function ($r3) {
-                    $this->assertEquals('/admin/api/v1.0/beta.1', $r3->path());
+                    $this->assertSame('/admin/api/v1.0/beta.1', $r3->path());
                     $this->assertEquals(['prefix' => 'admin/api/v10/b1'], $r3->params());
                 });
             });
@@ -530,7 +530,7 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $res = $routes->plugin('Contacts', function ($r) {
-            $this->assertEquals('/b/contacts', $r->path());
+            $this->assertSame('/b/contacts', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
 
             $r->connect('/:controller');
@@ -552,7 +552,7 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->plugin('Contacts', ['path' => '/people'], function ($r) {
-            $this->assertEquals('/b/people', $r->path());
+            $this->assertSame('/b/people', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
         });
     }
@@ -570,13 +570,13 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertEquals('/api/articles', $all[0]->template);
+        $this->assertSame('/api/articles', $all[0]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[0]->defaults)
         );
-        $this->assertEquals('json', $all[0]->options['_ext']);
-        $this->assertEquals('Articles', $all[0]->defaults['controller']);
+        $this->assertSame('json', $all[0]->options['_ext']);
+        $this->assertSame('Articles', $all[0]->defaults['controller']);
     }
 
     /**
@@ -591,9 +591,9 @@ class RouteBuilderTest extends TestCase
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
-        $this->assertEquals('Articles', $all[0]->defaults['controller']);
-        $this->assertEquals('/api/posts', $all[0]->template);
-        $this->assertEquals('/api/posts/:id', $all[2]->template);
+        $this->assertSame('Articles', $all[0]->defaults['controller']);
+        $this->assertSame('/api/posts', $all[0]->template);
+        $this->assertSame('/api/posts/:id', $all[2]->template);
         $this->assertEquals(
             '/api/posts/:article_id/comments',
             $all[6]->template,
@@ -611,7 +611,7 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->resources('Articles', ['prefix' => 'rest']);
         $all = $this->collection->routes();
-        $this->assertEquals('rest', $all[0]->defaults['prefix']);
+        $this->assertSame('rest', $all[0]->defaults['prefix']);
     }
 
     /**
@@ -627,10 +627,10 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertEquals('/api/articles', $all[0]->template);
+        $this->assertSame('/api/articles', $all[0]->template);
         foreach ($all as $route) {
-            $this->assertEquals('api/rest', $route->defaults['prefix']);
-            $this->assertEquals('Articles', $route->defaults['controller']);
+            $this->assertSame('api/rest', $route->defaults['prefix']);
+            $this->assertSame('Articles', $route->defaults['controller']);
         }
     }
 
@@ -647,12 +647,12 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertEquals('/api/blog-posts', $all[0]->template);
+        $this->assertSame('/api/blog-posts', $all[0]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[0]->defaults)
         );
-        $this->assertEquals('BlogPosts', $all[0]->defaults['controller']);
+        $this->assertSame('BlogPosts', $all[0]->defaults['controller']);
     }
 
     /**
@@ -674,9 +674,9 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(10, $all);
 
-        $this->assertEquals('/api/network-objects', $all[0]->template);
-        $this->assertEquals('/api/network-objects/:id', $all[2]->template);
-        $this->assertEquals('/api/network-objects/:network_object_id/attributes', $all[5]->template);
+        $this->assertSame('/api/network-objects', $all[0]->template);
+        $this->assertSame('/api/network-objects/:id', $all[2]->template);
+        $this->assertSame('/api/network-objects/:network_object_id/attributes', $all[5]->template);
     }
 
     /**
@@ -698,21 +698,21 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(7, $all);
 
-        $this->assertEquals('/api/articles/delete_all', $all[5]->template, 'Path defaults to key name.');
+        $this->assertSame('/api/articles/delete_all', $all[5]->template, 'Path defaults to key name.');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[5]->defaults)
         );
-        $this->assertEquals('Articles', $all[5]->defaults['controller']);
-        $this->assertEquals('deleteAll', $all[5]->defaults['action']);
+        $this->assertSame('Articles', $all[5]->defaults['controller']);
+        $this->assertSame('deleteAll', $all[5]->defaults['action']);
 
-        $this->assertEquals('/api/articles/updateAll', $all[6]->template, 'Explicit path option');
+        $this->assertSame('/api/articles/updateAll', $all[6]->template, 'Explicit path option');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[6]->defaults)
         );
-        $this->assertEquals('Articles', $all[6]->defaults['controller']);
-        $this->assertEquals('updateAll', $all[6]->defaults['action']);
+        $this->assertSame('Articles', $all[6]->defaults['controller']);
+        $this->assertSame('updateAll', $all[6]->defaults['action']);
     }
 
     /**
@@ -733,7 +733,7 @@ class RouteBuilderTest extends TestCase
             '_method' => 'PUT',
             'id' => '99',
         ]);
-        $this->assertEquals('/api/articles/99', $url);
+        $this->assertSame('/api/articles/99', $url);
 
         $url = Router::url([
             'prefix' => 'api',
@@ -743,7 +743,7 @@ class RouteBuilderTest extends TestCase
             '_ext' => 'json',
             'id' => '99',
         ]);
-        $this->assertEquals('/api/articles/99.json', $url);
+        $this->assertSame('/api/articles/99.json', $url);
     }
 
     /**
@@ -757,28 +757,28 @@ class RouteBuilderTest extends TestCase
         $routes->resources('Articles');
 
         $result = $this->collection->parse('/articles', 'GET');
-        $this->assertEquals('Articles', $result['controller']);
-        $this->assertEquals('index', $result['action']);
+        $this->assertSame('Articles', $result['controller']);
+        $this->assertSame('index', $result['action']);
         $this->assertEquals([], $result['pass']);
 
         $result = $this->collection->parse('/articles/1', 'GET');
-        $this->assertEquals('Articles', $result['controller']);
-        $this->assertEquals('view', $result['action']);
+        $this->assertSame('Articles', $result['controller']);
+        $this->assertSame('view', $result['action']);
         $this->assertEquals([1], $result['pass']);
 
         $result = $this->collection->parse('/articles', 'POST');
-        $this->assertEquals('Articles', $result['controller']);
-        $this->assertEquals('add', $result['action']);
+        $this->assertSame('Articles', $result['controller']);
+        $this->assertSame('add', $result['action']);
         $this->assertEquals([], $result['pass']);
 
         $result = $this->collection->parse('/articles/1', 'PUT');
-        $this->assertEquals('Articles', $result['controller']);
-        $this->assertEquals('edit', $result['action']);
+        $this->assertSame('Articles', $result['controller']);
+        $this->assertSame('edit', $result['action']);
         $this->assertEquals([1], $result['pass']);
 
         $result = $this->collection->parse('/articles/1', 'DELETE');
-        $this->assertEquals('Articles', $result['controller']);
-        $this->assertEquals('delete', $result['action']);
+        $this->assertSame('Articles', $result['controller']);
+        $this->assertSame('delete', $result['action']);
         $this->assertEquals([1], $result['pass']);
     }
 
@@ -794,7 +794,7 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(1, $result);
-        $this->assertEquals('/articles', $result[0]->template);
+        $this->assertSame('/articles', $result[0]->template);
     }
 
     /**
@@ -809,13 +809,13 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertEquals('/articles', $result[0]->template);
-        $this->assertEquals('index', $result[0]->defaults['action']);
-        $this->assertEquals('GET', $result[0]->defaults['_method']);
+        $this->assertSame('/articles', $result[0]->template);
+        $this->assertSame('index', $result[0]->defaults['action']);
+        $this->assertSame('GET', $result[0]->defaults['_method']);
 
-        $this->assertEquals('/articles/:id', $result[1]->template);
-        $this->assertEquals('delete', $result[1]->defaults['action']);
-        $this->assertEquals('DELETE', $result[1]->defaults['_method']);
+        $this->assertSame('/articles/:id', $result[1]->template);
+        $this->assertSame('delete', $result[1]->defaults['action']);
+        $this->assertSame('DELETE', $result[1]->defaults['_method']);
     }
 
     /**
@@ -833,11 +833,11 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertEquals('/articles', $result[0]->template);
-        $this->assertEquals('showList', $result[0]->defaults['action']);
+        $this->assertSame('/articles', $result[0]->template);
+        $this->assertSame('showList', $result[0]->defaults['action']);
 
-        $this->assertEquals('/articles/:id', $result[1]->template);
-        $this->assertEquals('delete', $result[1]->defaults['action']);
+        $this->assertSame('/articles/:id', $result[1]->template);
+        $this->assertSame('delete', $result[1]->defaults['action']);
     }
 
     /**
@@ -849,12 +849,12 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
         $routes->resources('Articles', function (RouteBuilder $routes) {
-            $this->assertEquals('/api/articles/', $routes->path());
+            $this->assertSame('/api/articles/', $routes->path());
             $this->assertEquals(['prefix' => 'api'], $routes->params());
 
             $routes->resources('Comments');
             $route = $this->collection->routes()[6];
-            $this->assertEquals('/api/articles/:article_id/comments', $route->template);
+            $this->assertSame('/api/articles/:article_id/comments', $route->template);
         });
     }
 
@@ -869,8 +869,8 @@ class RouteBuilderTest extends TestCase
         $routes->fallbacks();
 
         $all = $this->collection->routes();
-        $this->assertEquals('/api/:controller', $all[0]->template);
-        $this->assertEquals('/api/:controller/:action/*', $all[1]->template);
+        $this->assertSame('/api/:controller', $all[0]->template);
+        $this->assertSame('/api/:controller/:action/*', $all[1]->template);
         $this->assertInstanceOf(Route::class, $all[0]);
     }
 
@@ -885,8 +885,8 @@ class RouteBuilderTest extends TestCase
         $routes->fallbacks('InflectedRoute');
 
         $all = $this->collection->routes();
-        $this->assertEquals('/api/:controller', $all[0]->template);
-        $this->assertEquals('/api/:controller/:action/*', $all[1]->template);
+        $this->assertSame('/api/:controller', $all[0]->template);
+        $this->assertSame('/api/:controller/:action/*', $all[1]->template);
         $this->assertInstanceOf(InflectedRoute::class, $all[0]);
     }
 
@@ -914,7 +914,7 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
         $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes) {
-            $this->assertEquals('/api/v1', $routes->path());
+            $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'api', 'version' => 1], $routes->params());
         });
     }
@@ -955,7 +955,7 @@ class RouteBuilderTest extends TestCase
         );
         $routes->scope('/v1', function (RouteBuilder $routes) {
             $this->assertAttributeEquals(['auth'], 'middleware', $routes, 'Should inherit middleware');
-            $this->assertEquals('/api/v1', $routes->path());
+            $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'api'], $routes->params());
         });
     }
@@ -969,7 +969,7 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/api', [], ['namePrefix' => 'api:']);
         $routes->scope('/v1', ['version' => 1, '_namePrefix' => 'v1:'], function (RouteBuilder $routes) {
-            $this->assertEquals('api:v1:', $routes->namePrefix());
+            $this->assertSame('api:v1:', $routes->namePrefix());
             $routes->connect('/ping', ['controller' => 'Pings'], ['_name' => 'ping']);
 
             $routes->namePrefix('web:');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -486,13 +486,13 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
 
         $result = $this->collection->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'index'], $context);
-        $this->assertEquals('b', $result);
+        $this->assertSame('b', $result);
 
         $result = $this->collection->match(
             ['id' => 'thing', 'plugin' => null, 'controller' => 'Articles', 'action' => 'view'],
             $context
         );
-        $this->assertEquals('b/thing', $result);
+        $this->assertSame('b/thing', $result);
     }
 
     /**
@@ -512,10 +512,10 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
 
         $result = $this->collection->match(['_name' => 'article:view', 'id' => '2'], $context);
-        $this->assertEquals('/b/2', $result);
+        $this->assertSame('/b/2', $result);
 
         $result = $this->collection->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'view', 'id' => '2'], $context);
-        $this->assertEquals('b/2', $result);
+        $this->assertSame('b/2', $result);
     }
 
     /**
@@ -573,7 +573,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/', ['controller' => 'Contacts']);
 
         $result = $this->collection->match(['plugin' => 'Contacts', 'controller' => 'Contacts', 'action' => 'index'], $context);
-        $this->assertEquals('contacts', $result);
+        $this->assertSame('contacts', $result);
     }
 
     /**
@@ -602,7 +602,7 @@ class RouteCollectionTest extends TestCase
             'action' => 'index',
         ];
         $result = $this->collection->match($url, $context);
-        $this->assertEquals('admin/Users', $result);
+        $this->assertSame('admin/Users', $result);
 
         $url = [
             'plugin' => null,
@@ -610,7 +610,7 @@ class RouteCollectionTest extends TestCase
             'action' => 'index',
         ];
         $result = $this->collection->match($url, $context);
-        $this->assertEquals('index', $result);
+        $this->assertSame('index', $result);
     }
 
     /**
@@ -627,7 +627,7 @@ class RouteCollectionTest extends TestCase
         $all = $this->collection->named();
         $this->assertCount(1, $all);
         $this->assertInstanceOf('Cake\Routing\Route\Route', $all['cntrl']);
-        $this->assertEquals('/l/:controller', $all['cntrl']->template);
+        $this->assertSame('/l/:controller', $all['cntrl']->template);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -83,11 +83,11 @@ class RouterTest extends TestCase
             $routes->fallbacks();
         });
         Router::fullBaseUrl('http://example.com');
-        $this->assertEquals('http://example.com/', Router::url('/', true));
-        $this->assertEquals('http://example.com', Configure::read('App.fullBaseUrl'));
+        $this->assertSame('http://example.com/', Router::url('/', true));
+        $this->assertSame('http://example.com', Configure::read('App.fullBaseUrl'));
         Router::fullBaseUrl('https://example.com');
-        $this->assertEquals('https://example.com/', Router::url('/', true));
-        $this->assertEquals('https://example.com', Configure::read('App.fullBaseUrl'));
+        $this->assertSame('https://example.com/', Router::url('/', true));
+        $this->assertSame('https://example.com', Configure::read('App.fullBaseUrl'));
     }
 
     /**
@@ -100,7 +100,7 @@ class RouterTest extends TestCase
     {
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
-        $this->assertEquals('http://example.com/cakephp/tasks', Router::url('/tasks', true));
+        $this->assertSame('http://example.com/cakephp/tasks', Router::url('/tasks', true));
     }
 
     /**
@@ -122,7 +122,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             '_method' => 'GET',
         ], true);
-        $this->assertEquals('http://example.com/cakephp/tasks', $out);
+        $this->assertSame('http://example.com/cakephp/tasks', $out);
 
         $out = Router::url([
             'controller' => 'tasks',
@@ -130,7 +130,7 @@ class RouterTest extends TestCase
             '_base' => false,
             '_method' => 'GET',
         ], true);
-        $this->assertEquals('http://example.com/tasks', $out);
+        $this->assertSame('http://example.com/tasks', $out);
     }
 
     /**
@@ -152,8 +152,8 @@ class RouterTest extends TestCase
             'url' => '/cakephp/pages/view/1',
         ]);
         Router::setRequestInfo($request);
-        $this->assertEquals('http://example.com/cakephp/pages/view/1', Router::url(null, true));
-        $this->assertEquals('/cakephp/pages/view/1', Router::url());
+        $this->assertSame('http://example.com/cakephp/pages/view/1', Router::url(null, true));
+        $this->assertSame('/cakephp/pages/view/1', Router::url());
     }
 
     /**
@@ -291,31 +291,31 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::normalize('/');
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
 
         $result = Router::normalize('http://google.com/');
-        $this->assertEquals('http://google.com/', $result);
+        $this->assertSame('http://google.com/', $result);
 
         $result = Router::normalize('http://google.com//');
-        $this->assertEquals('http://google.com//', $result);
+        $this->assertSame('http://google.com//', $result);
 
         $result = Router::normalize('/users/login/scope://foo');
-        $this->assertEquals('/users/login/scope:/foo', $result);
+        $this->assertSame('/users/login/scope:/foo', $result);
 
         $result = Router::normalize('/recipe/recipes/add');
-        $this->assertEquals('/recipe/recipes/add', $result);
+        $this->assertSame('/recipe/recipes/add', $result);
 
         $request = new ServerRequest(['base' => '/us']);
         Router::setRequestInfo($request);
         $result = Router::normalize('/us/users/logout/');
-        $this->assertEquals('/users/logout', $result);
+        $this->assertSame('/users/logout', $result);
 
         Router::reload();
 
         $request = new ServerRequest(['base' => '/cake_12']);
         Router::setRequestInfo($request);
         $result = Router::normalize('/cake_12/users/logout/');
-        $this->assertEquals('/users/logout', $result);
+        $this->assertSame('/users/logout', $result);
 
         Router::reload();
         $_back = Configure::read('App.fullBaseUrl');
@@ -324,17 +324,17 @@ class RouterTest extends TestCase
         $request = new ServerRequest();
         Router::setRequestInfo($request);
         $result = Router::normalize('users/login');
-        $this->assertEquals('/users/login', $result);
+        $this->assertSame('/users/login', $result);
         Configure::write('App.fullBaseUrl', $_back);
 
         Router::reload();
         $request = new ServerRequest(['base' => 'beer']);
         Router::setRequestInfo($request);
         $result = Router::normalize('beer/admin/beers_tags/add');
-        $this->assertEquals('/admin/beers_tags/add', $result);
+        $this->assertSame('/admin/beers_tags/add', $result);
 
         $result = Router::normalize('/admin/beers_tags/add');
-        $this->assertEquals('/admin/beers_tags/add', $result);
+        $this->assertSame('/admin/beers_tags/add', $result);
     }
 
     /**
@@ -358,22 +358,22 @@ class RouterTest extends TestCase
         Router::pushRequest($request);
 
         $result = Router::url();
-        $this->assertEquals('/magazine/subscribe', $result);
+        $this->assertSame('/magazine/subscribe', $result);
 
         $result = Router::url([]);
-        $this->assertEquals('/magazine/subscribe', $result);
+        $this->assertSame('/magazine/subscribe', $result);
 
         $result = Router::url('/');
-        $this->assertEquals('/magazine/', $result);
+        $this->assertSame('/magazine/', $result);
 
         $result = Router::url('/articles/');
-        $this->assertEquals('/magazine/articles/', $result);
+        $this->assertSame('/magazine/articles/', $result);
 
         $result = Router::url('/articles/view');
-        $this->assertEquals('/magazine/articles/view', $result);
+        $this->assertSame('/magazine/articles/view', $result);
 
         $result = Router::url(['controller' => 'articles', 'action' => 'view', 1]);
-        $this->assertEquals('/magazine/articles/view/1', $result);
+        $this->assertSame('/magazine/articles/view/1', $result);
     }
 
     /**
@@ -398,10 +398,10 @@ class RouterTest extends TestCase
         Router::setRequestContext($request);
 
         $result = Router::url(['controller' => 'Articles', 'action' => 'index']);
-        $this->assertEquals('http://foo.example.com/subdir/fallback', $result);
+        $this->assertSame('http://foo.example.com/subdir/fallback', $result);
 
         $result = Router::url(['controller' => 'Articles', 'action' => 'index'], true);
-        $this->assertEquals('http://foo.example.com/subdir/fallback', $result);
+        $this->assertSame('http://foo.example.com/subdir/fallback', $result);
     }
 
     /**
@@ -413,7 +413,7 @@ class RouterTest extends TestCase
     {
         Router::connect('/*', ['controller' => 'categories', 'action' => 'index']);
         $result = Router::url(['controller' => 'categories', 'action' => 'index', '0']);
-        $this->assertEquals('/0', $result);
+        $this->assertSame('/0', $result);
 
         $expected = [
             'plugin' => null,
@@ -440,7 +440,7 @@ class RouterTest extends TestCase
 
         Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
         $out = Router::url(['controller' => 'pages', 'action' => 'display', 'home']);
-        $this->assertEquals('/', $out);
+        $this->assertSame('/', $out);
 
         Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
         $result = Router::url(['controller' => 'pages', 'action' => 'display', 'about']);
@@ -563,7 +563,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::url(['controller' => 'posts', '0', '?' => ['var' => null]]);
-        $this->assertEquals('/posts/index/0', $result);
+        $this->assertSame('/posts/index/0', $result);
 
         $result = Router::url([
             'controller' => 'posts',
@@ -992,25 +992,25 @@ class RouterTest extends TestCase
         );
 
         $url = Router::url(['_name' => 'test', 'name' => 'mark']);
-        $this->assertEquals('/users/mark', $url);
+        $this->assertSame('/users/mark', $url);
 
         $url = Router::url([
             '_name' => 'test', 'name' => 'mark',
             '?' => ['page' => 1, 'sort' => 'title', 'dir' => 'desc', ],
         ]);
-        $this->assertEquals('/users/mark?page=1&sort=title&dir=desc', $url);
+        $this->assertSame('/users/mark?page=1&sort=title&dir=desc', $url);
 
         $url = Router::url(['_name' => 'Articles::view']);
-        $this->assertEquals('/view/', $url);
+        $this->assertSame('/view/', $url);
 
         $url = Router::url(['_name' => 'Articles::view', '1']);
-        $this->assertEquals('/view/1', $url);
+        $this->assertSame('/view/1', $url);
 
         $url = Router::url(['_name' => 'Articles::view', '_full' => true, '1']);
-        $this->assertEquals('http://localhost/view/1', $url);
+        $this->assertSame('http://localhost/view/1', $url);
 
         $url = Router::url(['_name' => 'Articles::view', '1', '#' => 'frag']);
-        $this->assertEquals('/view/1#frag', $url);
+        $this->assertSame('/view/1#frag', $url);
     }
 
     /**
@@ -1086,7 +1086,7 @@ class RouterTest extends TestCase
             return $url;
         });
         $result = Router::url(['controller' => 'tasks', 'action' => 'edit']);
-        $this->assertEquals('/en/tasks/edit/1234', $result);
+        $this->assertSame('/en/tasks/edit/1234', $result);
         $this->assertEquals(2, $calledCount);
     }
 
@@ -1176,7 +1176,7 @@ class RouterTest extends TestCase
         Router::pushRequest($request);
 
         $result = Router::url(['controller' => 'tasks', 'action' => 'edit', '1234']);
-        $this->assertEquals('/en/tasks/edit/1234', $result);
+        $this->assertSame('/en/tasks/edit/1234', $result);
     }
 
     /**
@@ -1220,7 +1220,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequestInfo($request);
         $result = Router::url(['plugin' => null, 'controller' => 'posts', 'action' => 'index']);
-        $this->assertEquals('/admin/posts', $result);
+        $this->assertSame('/admin/posts', $result);
     }
 
     /**
@@ -1656,7 +1656,7 @@ class RouterTest extends TestCase
         $this->_connectDefaultRoutes();
 
         $result = Router::parseRequest($this->makeRequest('/posts.rss', 'GET'));
-        $this->assertEquals('rss', $result['_ext']);
+        $this->assertSame('rss', $result['_ext']);
 
         $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
         $this->assertArrayNotHasKey('_ext', $result);
@@ -1704,7 +1704,7 @@ class RouterTest extends TestCase
             '_method' => 'PUT',
             'id' => '99',
         ]);
-        $this->assertEquals('/api/articles/99', $url);
+        $this->assertSame('/api/articles/99', $url);
 
         $url = Router::url([
             'prefix' => 'api',
@@ -1714,7 +1714,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
             'id' => '99',
         ]);
-        $this->assertEquals('/api/articles/99.json', $url);
+        $this->assertSame('/api/articles/99.json', $url);
     }
 
     /**
@@ -1899,12 +1899,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertEquals('https://localhost/images/index', $result);
+        $this->assertSame('https://localhost/images/index', $result);
 
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertEquals('http://localhost/images/index', $result);
+        $this->assertSame('http://localhost/images/index', $result);
     }
 
     /**
@@ -1928,7 +1928,7 @@ class RouterTest extends TestCase
             '_ssl' => true,
             '_full' => true,
         ]);
-        $this->assertEquals('https://app.localhost/images/index', $result);
+        $this->assertSame('https://app.localhost/images/index', $result);
 
         $result = Router::url([
             'controller' => 'images',
@@ -1936,7 +1936,7 @@ class RouterTest extends TestCase
             '_ssl' => false,
             '_full' => true,
         ]);
-        $this->assertEquals('http://app.localhost/images/index', $result);
+        $this->assertSame('http://app.localhost/images/index', $result);
 
         $result = Router::url([
             'controller' => 'images',
@@ -1944,7 +1944,7 @@ class RouterTest extends TestCase
             '_full' => false,
             '_ssl' => false,
         ]);
-        $this->assertEquals('http://localhost/images/index', $result);
+        $this->assertSame('http://localhost/images/index', $result);
     }
 
     /**
@@ -1969,12 +1969,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertEquals('http://localhost/images/index', $result);
+        $this->assertSame('http://localhost/images/index', $result);
 
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertEquals('https://localhost/images/index', $result);
+        $this->assertSame('https://localhost/images/index', $result);
     }
 
     /**
@@ -2168,10 +2168,10 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/:controller/:action/*');
         $result = Router::parseRequest($this->makeRequest('/posts/view/something.', 'GET'));
-        $this->assertEquals('something.', $result['pass'][0], 'Period was chopped off');
+        $this->assertSame('something.', $result['pass'][0], 'Period was chopped off');
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/something. . .', 'GET'));
-        $this->assertEquals('something. . .', $result['pass'][0], 'Period was chopped off');
+        $this->assertSame('something. . .', $result['pass'][0], 'Period was chopped off');
     }
 
     /**
@@ -2185,10 +2185,10 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/something.', 'GET'));
-        $this->assertEquals('something.', $result['pass'][0], 'Period was chopped off');
+        $this->assertSame('something.', $result['pass'][0], 'Period was chopped off');
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/something. . .', 'GET'));
-        $this->assertEquals('something. . .', $result['pass'][0], 'Period was chopped off');
+        $this->assertSame('something. . .', $result['pass'][0], 'Period was chopped off');
     }
 
     /**
@@ -2233,10 +2233,10 @@ class RouterTest extends TestCase
         );
 
         $result = Router::url(['controller' => 'blog_posts', 'action' => 'actions']);
-        $this->assertEquals('/blog/actions', $result);
+        $this->assertSame('/blog/actions', $result);
 
         $result = Router::url(['controller' => 'blog_posts', 'action' => 'foo']);
-        $this->assertEquals('/', $result);
+        $this->assertSame('/', $result);
     }
 
     /**
@@ -2359,10 +2359,10 @@ class RouterTest extends TestCase
         ]);
         Router::setRequestInfo($request);
         $result = Router::url(['controller' => 'users', 'action' => 'login']);
-        $this->assertEquals('/admin/login', $result);
+        $this->assertSame('/admin/login', $result);
 
         $result = Router::url(['controller' => 'users', 'action' => 'login']);
-        $this->assertEquals('/admin/login', $result);
+        $this->assertSame('/admin/login', $result);
     }
 
     /**
@@ -2515,7 +2515,7 @@ class RouterTest extends TestCase
             '_Token' => ['key' => 'sekret'],
         ];
         $result = Router::reverse($params);
-        $this->assertEquals('/posts/view/1', $result);
+        $this->assertSame('/posts/view/1', $result);
     }
 
     public function testReverseLocalized()
@@ -2530,7 +2530,7 @@ class RouterTest extends TestCase
             'url' => ['url' => 'eng/posts/view/1'],
         ];
         $result = Router::reverse($params);
-        $this->assertEquals('/eng/posts/view/1', $result);
+        $this->assertSame('/eng/posts/view/1', $result);
     }
 
     public function testReverseArrayQuery()
@@ -2544,7 +2544,7 @@ class RouterTest extends TestCase
             '?' => ['foo' => 'bar'],
         ];
         $result = Router::reverse($params);
-        $this->assertEquals('/eng/posts/view/1?foo=bar', $result);
+        $this->assertSame('/eng/posts/view/1?foo=bar', $result);
 
         $params = [
             'lang' => 'eng',
@@ -2556,7 +2556,7 @@ class RouterTest extends TestCase
             'models' => [],
         ];
         $result = Router::reverse($params);
-        $this->assertEquals('/eng/posts/view/1', $result);
+        $this->assertSame('/eng/posts/view/1', $result);
     }
 
     public function testReverseCakeRequestQuery()
@@ -2712,11 +2712,11 @@ class RouterTest extends TestCase
         Router::setRequestInfo($secondRequest);
 
         $result = Router::url(['_base' => false]);
-        $this->assertEquals('/comments/listing', $result, 'with second requests, the last should win.');
+        $this->assertSame('/comments/listing', $result, 'with second requests, the last should win.');
 
         Router::popRequest();
         $result = Router::url(['_base' => false]);
-        $this->assertEquals('/posts', $result, 'with second requests, the last should win.');
+        $this->assertSame('/posts', $result, 'with second requests, the last should win.');
 
         // Make sure that popping an empty request doesn't fail.
         Router::popRequest();
@@ -2802,7 +2802,7 @@ class RouterTest extends TestCase
         $this->assertNull($result);
 
         $result = $route->match(['controller' => 'blog_posts', 'action' => 'actions']);
-        $this->assertEquals('/blog/actions/', $result);
+        $this->assertSame('/blog/actions/', $result);
 
         $result = $route->parseRequest($this->makeRequest('/blog/other', 'GET'));
         $expected = [
@@ -2825,9 +2825,9 @@ class RouterTest extends TestCase
     public function testScope()
     {
         Router::scope('/path', ['param' => 'value'], function (RouteBuilder $routes) {
-            $this->assertEquals('/path', $routes->path());
+            $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
-            $this->assertEquals('', $routes->namePrefix());
+            $this->assertSame('', $routes->namePrefix());
 
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
@@ -2892,7 +2892,7 @@ class RouterTest extends TestCase
         Router::scope('/path', $options, function (RouteBuilder $routes) {
             $this->assertSame('InflectedRoute', $routes->getRouteClass());
             $this->assertSame(['json'], $routes->getExtensions());
-            $this->assertEquals('/path', $routes->path());
+            $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
         });
     }
@@ -2905,9 +2905,9 @@ class RouterTest extends TestCase
     public function testScopeNamePrefix()
     {
         Router::scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function (RouteBuilder $routes) {
-            $this->assertEquals('/path', $routes->path());
+            $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
-            $this->assertEquals('path:', $routes->namePrefix());
+            $this->assertSame('path:', $routes->namePrefix());
 
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
@@ -2921,12 +2921,12 @@ class RouterTest extends TestCase
     public function testPrefix()
     {
         Router::prefix('admin', function (RouteBuilder $routes) {
-            $this->assertEquals('/admin', $routes->path());
+            $this->assertSame('/admin', $routes->path());
             $this->assertEquals(['prefix' => 'admin'], $routes->params());
         });
 
         Router::prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {
-            $this->assertEquals('admin:', $routes->namePrefix());
+            $this->assertSame('admin:', $routes->namePrefix());
             $this->assertEquals(['prefix' => 'admin'], $routes->params());
         });
     }
@@ -2939,12 +2939,12 @@ class RouterTest extends TestCase
     public function testPrefixOptions()
     {
         Router::prefix('admin', ['param' => 'value'], function (RouteBuilder $routes) {
-            $this->assertEquals('/admin', $routes->path());
+            $this->assertSame('/admin', $routes->path());
             $this->assertEquals(['prefix' => 'admin', 'param' => 'value'], $routes->params());
         });
 
         Router::prefix('CustomPath', ['path' => '/custom-path'], function (RouteBuilder $routes) {
-            $this->assertEquals('/custom-path', $routes->path());
+            $this->assertSame('/custom-path', $routes->path());
             $this->assertEquals(['prefix' => 'custom_path'], $routes->params());
         });
     }
@@ -2957,7 +2957,7 @@ class RouterTest extends TestCase
     public function testPlugin()
     {
         Router::plugin('DebugKit', function (RouteBuilder $routes) {
-            $this->assertEquals('/debug-kit', $routes->path());
+            $this->assertSame('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
     }
@@ -2970,12 +2970,12 @@ class RouterTest extends TestCase
     public function testPluginOptions()
     {
         Router::plugin('DebugKit', ['path' => '/debugger'], function (RouteBuilder $routes) {
-            $this->assertEquals('/debugger', $routes->path());
+            $this->assertSame('/debugger', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
 
         Router::plugin('Contacts', ['_namePrefix' => 'contacts:'], function (RouteBuilder $routes) {
-            $this->assertEquals('contacts:', $routes->namePrefix());
+            $this->assertSame('contacts:', $routes->namePrefix());
         });
     }
 
@@ -2988,7 +2988,7 @@ class RouterTest extends TestCase
     {
         Router::connect('/:controller', ['action' => 'index']);
         $result = Router::url(['controller' => 'FooBar', 'action' => 'index']);
-        $this->assertEquals('/FooBar', $result);
+        $this->assertSame('/FooBar', $result);
 
         // This is needed because tests/boostrap.php sets App.namespace to 'App'
         static::setAppNamespace();
@@ -2996,10 +2996,10 @@ class RouterTest extends TestCase
         Router::defaultRouteClass('DashedRoute');
         Router::connect('/cake/:controller', ['action' => 'cake']);
         $result = Router::url(['controller' => 'FooBar', 'action' => 'cake']);
-        $this->assertEquals('/cake/foo-bar', $result);
+        $this->assertSame('/cake/foo-bar', $result);
 
         $result = Router::url(['controller' => 'FooBar', 'action' => 'index']);
-        $this->assertEquals('/FooBar', $result);
+        $this->assertSame('/FooBar', $result);
 
         Router::reload();
         Router::defaultRouteClass('DashedRoute');
@@ -3008,7 +3008,7 @@ class RouterTest extends TestCase
         });
 
         $result = Router::url(['controller' => 'FooBar', 'action' => 'index']);
-        $this->assertEquals('/foo-bar', $result);
+        $this->assertSame('/foo-bar', $result);
     }
 
     /**
@@ -3025,13 +3025,13 @@ class RouterTest extends TestCase
         ]);
         Router::setRequestContext($request);
         $result = Router::url(['controller' => 'things', 'action' => 'add']);
-        $this->assertEquals('/subdir/things/add', $result);
+        $this->assertSame('/subdir/things/add', $result);
 
         $result = Router::url(['controller' => 'things', 'action' => 'add'], true);
-        $this->assertEquals('http://localhost/subdir/things/add', $result);
+        $this->assertSame('http://localhost/subdir/things/add', $result);
 
         $result = Router::url('/pages/home');
-        $this->assertEquals('/subdir/pages/home', $result);
+        $this->assertSame('/subdir/pages/home', $result);
     }
 
     /**
@@ -3055,13 +3055,13 @@ class RouterTest extends TestCase
         Router::setRequestContext($request);
 
         $result = Router::url(['controller' => 'things', 'action' => 'add']);
-        $this->assertEquals('/subdir/things/add', $result);
+        $this->assertSame('/subdir/things/add', $result);
 
         $result = Router::url(['controller' => 'things', 'action' => 'add'], true);
-        $this->assertEquals('http://localhost/subdir/things/add', $result);
+        $this->assertSame('http://localhost/subdir/things/add', $result);
 
         $result = Router::url('/pages/home');
-        $this->assertEquals('/subdir/pages/home', $result);
+        $this->assertSame('/subdir/pages/home', $result);
     }
 
     /**

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -160,7 +160,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => [],
         ];
-        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
+        $this->assertSame($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->manager->unload($test);
 
         $this->manager->load($test);
@@ -179,7 +179,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => [],
         ];
-        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
+        $this->assertSame($expectedConstraint, $schema->getConstraint('tag_id_fk'));
 
         $this->manager->unload($test);
     }
@@ -360,7 +360,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => [],
         ];
-        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
+        $this->assertSame($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->assertCount(4, $results);
 
         $this->manager->unload($test);
@@ -385,7 +385,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => [],
         ];
-        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
+        $this->assertSame($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->assertCount(4, $results);
         $this->manager->unload($test);
     }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -156,7 +156,7 @@ class IntegrationTestTraitTest extends TestCase
             ],
         ]);
         $this->cookie('split_token', 'def345');
-        $this->session(['User' => ['id' => 1, 'username' => 'mark']]);
+        $this->session(['User' => ['id' => '1', 'username' => 'mark']]);
         $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
         $this->assertSame('abc123', $request['environment']['HTTP_X_CSRF_TOKEN']);
@@ -370,7 +370,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->get('/get/request_action/test_request_action');
         $this->assertResponseOk();
-        $this->assertSame('This is a test', $this->_response->getBody());
+        $this->assertSame('This is a test', (string)$this->_response->getBody());
     }
 
     /**
@@ -398,7 +398,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/request_action/test_request_action');
         $this->assertNotEmpty($this->_response);
         $this->assertInstanceOf('Cake\Http\Response', $this->_response);
-        $this->assertSame('This is a test', $this->_response->getBody());
+        $this->assertSame('This is a test', (string)$this->_response->getBody());
         $this->assertHeader('X-Middleware', 'true');
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -159,14 +159,14 @@ class IntegrationTestTraitTest extends TestCase
         $this->session(['User' => ['id' => 1, 'username' => 'mark']]);
         $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
-        $this->assertEquals('abc123', $request['environment']['HTTP_X_CSRF_TOKEN']);
-        $this->assertEquals('application/json', $request['environment']['CONTENT_TYPE']);
-        $this->assertEquals('/tasks/add', $request['url']);
+        $this->assertSame('abc123', $request['environment']['HTTP_X_CSRF_TOKEN']);
+        $this->assertSame('application/json', $request['environment']['CONTENT_TYPE']);
+        $this->assertSame('/tasks/add', $request['url']);
         $this->assertArrayHasKey('split_token', $request['cookies']);
-        $this->assertEquals('def345', $request['cookies']['split_token']);
-        $this->assertEquals(['id' => '1', 'username' => 'mark'], $request['session']->read('User'));
-        $this->assertEquals('foo', $request['environment']['PHP_AUTH_USER']);
-        $this->assertEquals('bar', $request['environment']['PHP_AUTH_PW']);
+        $this->assertSame('def345', $request['cookies']['split_token']);
+        $this->assertSame(['id' => '1', 'username' => 'mark'], $request['session']->read('User'));
+        $this->assertSame('foo', $request['environment']['PHP_AUTH_USER']);
+        $this->assertSame('bar', $request['environment']['PHP_AUTH_PW']);
     }
 
     /**
@@ -288,7 +288,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->get('/some_alias');
         $this->assertResponseOk();
-        $this->assertEquals('5', $this->_getBodyAsString());
+        $this->assertSame('5', $this->_getBodyAsString());
     }
 
     public function testExceptionsInMiddlewareJsonView()
@@ -370,7 +370,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->get('/get/request_action/test_request_action');
         $this->assertResponseOk();
-        $this->assertEquals('This is a test', $this->_response->getBody());
+        $this->assertSame('This is a test', $this->_response->getBody());
     }
 
     /**
@@ -398,7 +398,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/request_action/test_request_action');
         $this->assertNotEmpty($this->_response);
         $this->assertInstanceOf('Cake\Http\Response', $this->_response);
-        $this->assertEquals('This is a test', $this->_response->getBody());
+        $this->assertSame('This is a test', $this->_response->getBody());
         $this->assertHeader('X-Middleware', 'true');
     }
 
@@ -462,7 +462,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->post('/request_action/post_pass', ['title' => 'value']);
         $data = json_decode('' . $this->_response->getBody());
-        $this->assertEquals('value', $data->title);
+        $this->assertSame('value', $data->title);
         $this->assertHeader('X-Middleware', 'true');
     }
 
@@ -511,7 +511,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertHeader('X-Middleware', 'true');
         $data = json_decode((string)$this->_response->getBody(), true);
 
-        $this->assertEquals([
+        $this->assertSame([
             'file' => 'Uploaded file',
             'pictures.0.file' => 'a-file.png',
             'pictures.1.file' => 'a-moose.png',
@@ -578,7 +578,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->assertTemplate('index');
         $this->assertLayout('default');
-        $this->assertEquals('value', $this->viewVariable('test'));
+        $this->assertSame('value', $this->viewVariable('test'));
     }
 
     /**
@@ -597,7 +597,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->assertTemplate('index');
         $this->assertLayout('default');
-        $this->assertEquals('value', $this->viewVariable('test'));
+        $this->assertSame('value', $this->viewVariable('test'));
     }
 
     /**
@@ -634,7 +634,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->post(['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
         $this->assertResponseOk();
-        $this->assertEquals('value', $this->viewVariable('test'));
+        $this->assertSame('value', $this->viewVariable('test'));
     }
 
     /**
@@ -667,7 +667,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->get(['controller' => 'Posts', 'action' => 'index']);
         $this->assertResponseOk();
-        $this->assertEquals('value', $this->viewVariable('test'));
+        $this->assertSame('value', $this->viewVariable('test'));
     }
 
     /**
@@ -1027,7 +1027,7 @@ class IntegrationTestTraitTest extends TestCase
         $result = $test->run();
 
         $this->assertFalse($result->wasSuccessful());
-        $this->assertEquals(1, $result->failureCount());
+        $this->assertSame(1, $result->failureCount());
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -122,7 +122,7 @@ class TestCaseTest extends TestCase
         $manager->expects($this->once())->method('loadSingle');
         $result = $test->run();
 
-        $this->assertEquals(0, $result->errorCount());
+        $this->assertSame(0, $result->errorCount());
     }
 
     /**
@@ -140,7 +140,7 @@ class TestCaseTest extends TestCase
 
         $result = $test->run();
 
-        $this->assertEquals(0, $result->errorCount());
+        $this->assertSame(0, $result->errorCount());
         $this->assertCount(1, $result->passed());
         $this->assertFalse($test->autoFixtures);
     }
@@ -154,11 +154,11 @@ class TestCaseTest extends TestCase
     {
         $test = new FixturizedTestCase('testSkipIfTrue');
         $result = $test->run();
-        $this->assertEquals(1, $result->skippedCount());
+        $this->assertSame(1, $result->skippedCount());
 
         $test = new FixturizedTestCase('testSkipIfFalse');
         $result = $test->run();
-        $this->assertEquals(0, $result->skippedCount());
+        $this->assertSame(0, $result->skippedCount());
     }
 
     /**
@@ -357,15 +357,15 @@ class TestCaseTest extends TestCase
         $Posts->expects($this->at(0))
             ->method('save')
             ->will($this->returnValue('mocked'));
-        $this->assertEquals('mocked', $Posts->save($entity));
-        $this->assertEquals('Cake\ORM\Entity', $Posts->getEntityClass());
+        $this->assertSame('mocked', $Posts->save($entity));
+        $this->assertSame('Cake\ORM\Entity', $Posts->getEntityClass());
 
         $Posts = $this->getMockForModel('Posts', ['doSomething']);
         $this->assertInstanceOf('Cake\Database\Connection', $Posts->getConnection());
-        $this->assertEquals('test', $Posts->getConnection()->configName());
+        $this->assertSame('test', $Posts->getConnection()->configName());
 
         $Tags = $this->getMockForModel('Tags', ['doSomething']);
-        $this->assertEquals('TestApp\Model\Entity\Tag', $Tags->getEntityClass());
+        $this->assertSame('TestApp\Model\Entity\Tag', $Tags->getEntityClass());
     }
 
     /**
@@ -378,7 +378,7 @@ class TestCaseTest extends TestCase
         ConnectionManager::alias('test', 'secondary');
 
         $post = $this->getMockForModel(SecondaryPostsTable::class, ['save']);
-        $this->assertEquals('test', $post->getConnection()->configName());
+        $this->assertSame('test', $post->getConnection()->configName());
     }
 
     /**
@@ -399,7 +399,7 @@ class TestCaseTest extends TestCase
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments', ['save']);
 
         $this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $TestPluginComment);
-        $this->assertEquals('Cake\ORM\Entity', $TestPluginComment->getEntityClass());
+        $this->assertSame('Cake\ORM\Entity', $TestPluginComment->getEntityClass());
         $TestPluginComment->expects($this->at(0))
             ->method('save')
             ->will($this->returnValue(true));
@@ -413,7 +413,7 @@ class TestCaseTest extends TestCase
 
         $TestPluginAuthors = $this->getMockForModel('TestPlugin.Authors', ['doSomething']);
         $this->assertInstanceOf('TestPlugin\Model\Table\AuthorsTable', $TestPluginAuthors);
-        $this->assertEquals('TestPlugin\Model\Entity\Author', $TestPluginAuthors->getEntityClass());
+        $this->assertSame('TestPlugin\Model\Entity\Author', $TestPluginAuthors->getEntityClass());
         $this->clearPlugins();
     }
 
@@ -432,7 +432,7 @@ class TestCaseTest extends TestCase
 
         $result = $this->getTableLocator()->get('Comments');
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertEquals('Comments', $Mock->getAlias());
+        $this->assertSame('Comments', $Mock->getAlias());
 
         $Mock->expects($this->at(0))
             ->method('save')
@@ -461,7 +461,7 @@ class TestCaseTest extends TestCase
         );
         $result = $this->getTableLocator()->get('Comments');
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertEquals('Comments', $allMethodsMocks->getAlias());
+        $this->assertSame('Comments', $allMethodsMocks->getAlias());
 
         $this->assertNotEquals($allMethodsStubs, $allMethodsMocks);
     }
@@ -476,9 +476,9 @@ class TestCaseTest extends TestCase
         static::setAppNamespace();
 
         $I18n = $this->getMockForModel('I18n', ['doSomething']);
-        $this->assertEquals('custom_i18n_table', $I18n->getTable());
+        $this->assertSame('custom_i18n_table', $I18n->getTable());
 
         $Tags = $this->getMockForModel('Tags', ['doSomething']);
-        $this->assertEquals('tags', $Tags->getTable());
+        $this->assertSame('tags', $Tags->getTable());
     }
 }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -69,24 +69,24 @@ class TestFixtureTest extends TestCase
     public function testInitStaticFixture()
     {
         $Fixture = new ArticlesFixture();
-        $this->assertEquals('articles', $Fixture->table);
+        $this->assertSame('articles', $Fixture->table);
 
         $Fixture = new ArticlesFixture();
         $Fixture->table = null;
         $Fixture->init();
-        $this->assertEquals('articles', $Fixture->table);
+        $this->assertSame('articles', $Fixture->table);
 
         $schema = $Fixture->getTableSchema();
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $schema);
 
         $fields = $Fixture->fields;
         unset($fields['_constraints'], $fields['_indexes']);
-        $this->assertEquals(
+        $this->assertSame(
             array_keys($fields),
             $schema->columns(),
             'Fields do not match'
         );
-        $this->assertEquals(array_keys($Fixture->fields['_constraints']), $schema->constraints());
+        $this->assertSame(array_keys($Fixture->fields['_constraints']), $schema->constraints());
         $this->assertEmpty($schema->indexes());
     }
 
@@ -112,7 +112,7 @@ class TestFixtureTest extends TestCase
             'body',
             'published',
         ];
-        $this->assertEquals($expected, $fixture->getTableSchema()->columns());
+        $this->assertSame($expected, $fixture->getTableSchema()->columns());
     }
 
     /**
@@ -137,7 +137,7 @@ class TestFixtureTest extends TestCase
             'body',
             'published',
         ];
-        $this->assertEquals($expected, $fixture->getTableSchema()->columns());
+        $this->assertSame($expected, $fixture->getTableSchema()->columns());
     }
 
     /**
@@ -175,7 +175,7 @@ class TestFixtureTest extends TestCase
 
         $fixture = new LettersFixture();
         $fixture->init();
-        $this->assertEquals(['id', 'letter'], $fixture->getTableSchema()->columns());
+        $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
 
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->setMethods(['prepare', 'execute'])

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -53,7 +53,7 @@ class OpenSslTest extends TestCase
         $result = $this->crypt->encrypt($txt, $key);
         $this->assertNotEquals($txt, $result, 'Should be encrypted.');
         $this->assertNotEquals($result, $this->crypt->encrypt($txt, $key), 'Each result is unique.');
-        $this->assertEquals($txt, $this->crypt->decrypt($result, $key));
+        $this->assertSame($txt, $this->crypt->decrypt($result, $key));
     }
 
     /**

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -329,13 +329,13 @@ class HashTest extends TestCase
         $data = ['abc', 'def'];
 
         $result = Hash::get($data, '0');
-        $this->assertEquals('abc', $result);
+        $this->assertSame('abc', $result);
 
         $result = Hash::get($data, 0);
-        $this->assertEquals('abc', $result);
+        $this->assertSame('abc', $result);
 
         $result = Hash::get($data, '1');
-        $this->assertEquals('def', $result);
+        $this->assertSame('def', $result);
 
         $data = self::articleData();
 
@@ -349,26 +349,26 @@ class HashTest extends TestCase
         $this->assertSame('-', $result);
 
         $result = Hash::get($data, '0.Article.title');
-        $this->assertEquals('First Article', $result);
+        $this->assertSame('First Article', $result);
 
         $result = Hash::get($data, '1.Article.title');
-        $this->assertEquals('Second Article', $result);
+        $this->assertSame('Second Article', $result);
 
         $result = Hash::get($data, '5.Article.title');
         $this->assertNull($result);
 
         $default = ['empty'];
-        $this->assertEquals($default, Hash::get($data, '5.Article.title', $default));
-        $this->assertEquals($default, Hash::get([], '5.Article.title', $default));
+        $this->assertSame($default, Hash::get($data, '5.Article.title', $default));
+        $this->assertSame($default, Hash::get([], '5.Article.title', $default));
 
         $result = Hash::get($data, '1.Article.title.not_there');
         $this->assertNull($result);
 
         $result = Hash::get($data, '1.Article');
-        $this->assertEquals($data[1]['Article'], $result);
+        $this->assertSame($data[1]['Article'], $result);
 
         $result = Hash::get($data, ['1', 'Article']);
-        $this->assertEquals($data[1]['Article'], $result);
+        $this->assertSame($data[1]['Article'], $result);
 
         // Object which implements ArrayAccess
         $nested = new ArrayObject([
@@ -380,19 +380,19 @@ class HashTest extends TestCase
         ]);
 
         $return = Hash::get($data, 'name');
-        $this->assertEquals('foo', $return);
+        $this->assertSame('foo', $return);
 
         $return = Hash::get($data, 'associated');
-        $this->assertEquals($nested, $return);
+        $this->assertSame($nested, $return);
 
         $return = Hash::get($data, 'associated.user');
-        $this->assertEquals('bar', $return);
+        $this->assertSame('bar', $return);
 
         $return = Hash::get($data, 'non-existent');
         $this->assertNull($return);
 
         $data = ['a' => ['b' => ['c' => ['d' => 1]]]];
-        $this->assertEquals(1, Hash::get(new ArrayObject($data), 'a.b.c.d'));
+        $this->assertSame(1, Hash::get(new ArrayObject($data), 'a.b.c.d'));
     }
 
     /**
@@ -440,27 +440,27 @@ class HashTest extends TestCase
     public function testDimensions()
     {
         $result = Hash::dimensions([]);
-        $this->assertEquals($result, 0);
+        $this->assertSame($result, 0);
 
         $data = ['one', '2', 'three'];
         $result = Hash::dimensions($data);
-        $this->assertEquals($result, 1);
+        $this->assertSame($result, 1);
 
         $data = ['1' => '1.1', '2', '3'];
         $result = Hash::dimensions($data);
-        $this->assertEquals($result, 1);
+        $this->assertSame($result, 1);
 
         $data = ['1' => ['1.1' => '1.1.1'], '2', '3' => ['3.1' => '3.1.1']];
         $result = Hash::dimensions($data);
-        $this->assertEquals($result, 2);
+        $this->assertSame($result, 2);
 
         $data = ['1' => '1.1', '2', '3' => ['3.1' => '3.1.1']];
         $result = Hash::dimensions($data);
-        $this->assertEquals($result, 1);
+        $this->assertSame($result, 1);
 
         $data = ['1' => ['1.1' => '1.1.1'], '2', '3' => ['3.1' => ['3.1.1' => '3.1.1.1']]];
         $result = Hash::dimensions($data);
-        $this->assertEquals($result, 2);
+        $this->assertSame($result, 2);
     }
 
     /**
@@ -526,11 +526,11 @@ class HashTest extends TestCase
     {
         $data = ['Larry', 'Curly', 'Moe'];
         $result = Hash::flatten($data);
-        $this->assertEquals($result, $data);
+        $this->assertSame($result, $data);
 
         $data[9] = 'Shemp';
         $result = Hash::flatten($data);
-        $this->assertEquals($result, $data);
+        $this->assertSame($result, $data);
 
         $data = [
             [
@@ -558,7 +558,7 @@ class HashTest extends TestCase
             '1.Author.user' => 'larry',
             '1.Author.password' => null,
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = [
             [
@@ -573,7 +573,7 @@ class HashTest extends TestCase
             '0.Post.title' => 'First Post',
             '0.Author' => [],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = [
             ['Post' => ['id' => 1]],
@@ -581,10 +581,10 @@ class HashTest extends TestCase
         ];
         $result = Hash::flatten($data, '/');
         $expected = [
-            '0/Post/id' => '1',
-            '1/Post/id' => '2',
+            '0/Post/id' => 1,
+            '1/Post/id' => 2,
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -606,17 +606,17 @@ class HashTest extends TestCase
 
         $result = Hash::diff($a, []);
         $expected = $a;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::diff([], $b);
         $expected = $b;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::diff($a, $b);
         $expected = [
             2 => ['name' => 'contact'],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $b = [
             0 => ['name' => 'me'],
@@ -627,47 +627,47 @@ class HashTest extends TestCase
         $expected = [
             0 => ['name' => 'main'],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = [];
         $b = ['name' => 'bob', 'address' => 'home'];
         $result = Hash::diff($a, $b);
-        $this->assertEquals($result, $b);
+        $this->assertSame($result, $b);
 
         $a = ['name' => 'bob', 'address' => 'home'];
         $b = [];
         $result = Hash::diff($a, $b);
-        $this->assertEquals($result, $a);
+        $this->assertSame($result, $a);
 
         $a = ['key' => true, 'another' => false, 'name' => 'me'];
         $b = ['key' => 1, 'another' => 0];
         $expected = ['name' => 'me'];
         $result = Hash::diff($a, $b);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = ['key' => 'value', 'another' => null, 'name' => 'me'];
         $b = ['key' => 'differentValue', 'another' => null];
         $expected = ['key' => 'value', 'name' => 'me'];
         $result = Hash::diff($a, $b);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = ['key' => 'value', 'another' => null, 'name' => 'me'];
         $b = ['key' => 'differentValue', 'another' => 'value'];
         $expected = ['key' => 'value', 'another' => null, 'name' => 'me'];
         $result = Hash::diff($a, $b);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = ['key' => 'value', 'another' => null, 'name' => 'me'];
         $b = ['key' => 'differentValue', 'another' => 'value'];
         $expected = ['key' => 'differentValue', 'another' => 'value', 'name' => 'me'];
         $result = Hash::diff($b, $a);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = ['key' => 'value', 'another' => null, 'name' => 'me'];
         $b = [0 => 'differentValue', 1 => 'value'];
         $expected = $a + $b;
         $result = Hash::diff($a, $b);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -678,27 +678,27 @@ class HashTest extends TestCase
     public function testMerge()
     {
         $result = Hash::merge(['foo'], ['bar']);
-        $this->assertEquals($result, ['foo', 'bar']);
+        $this->assertSame($result, ['foo', 'bar']);
 
         $a = ['foo', 'foo2'];
         $b = ['bar', 'bar2'];
         $expected = ['foo', 'foo2', 'bar', 'bar2'];
-        $this->assertEquals($expected, Hash::merge($a, $b));
+        $this->assertSame($expected, Hash::merge($a, $b));
 
         $a = ['foo' => 'bar', 'bar' => 'foo'];
         $b = ['foo' => 'no-bar', 'bar' => 'no-foo'];
         $expected = ['foo' => 'no-bar', 'bar' => 'no-foo'];
-        $this->assertEquals($expected, Hash::merge($a, $b));
+        $this->assertSame($expected, Hash::merge($a, $b));
 
         $a = ['users' => ['bob', 'jim']];
         $b = ['users' => ['lisa', 'tina']];
         $expected = ['users' => ['bob', 'jim', 'lisa', 'tina']];
-        $this->assertEquals($expected, Hash::merge($a, $b));
+        $this->assertSame($expected, Hash::merge($a, $b));
 
         $a = ['users' => ['jim', 'bob']];
         $b = ['users' => 'none'];
         $expected = ['users' => 'none'];
-        $this->assertEquals($expected, Hash::merge($a, $b));
+        $this->assertSame($expected, Hash::merge($a, $b));
 
         $a = [
             'Tree',
@@ -728,7 +728,7 @@ class HashTest extends TestCase
             'Validator',
             'Transactional',
         ];
-        $this->assertEquals($expected, Hash::merge($a, $b));
+        $this->assertSame($expected, Hash::merge($a, $b));
     }
 
     /**
@@ -743,17 +743,17 @@ class HashTest extends TestCase
             ['hkuc' => 'lion']
         );
         $expected = ['hkuc' => 'lion'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::merge(
             ['hkuc' => ['lion']],
             ['hkuc' => ['lion']],
             ['hkuc' => 'lion']
         );
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::merge(['foo'], ['user' => 'bob', 'no-bar'], 'bar');
-        $this->assertEquals($result, ['foo', 'user' => 'bob', 'no-bar', 'bar']);
+        $this->assertSame($result, ['foo', 'user' => 'bob', 'no-bar', 'bar']);
 
         $a = ['users' => ['lisa' => ['id' => 5, 'pw' => 'secret']], 'cakephp'];
         $b = ['users' => ['lisa' => ['pw' => 'new-pass', 'age' => 23]], 'ice-cream'];
@@ -763,7 +763,7 @@ class HashTest extends TestCase
             'ice-cream',
         ];
         $result = Hash::merge($a, $b);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $c = [
             'users' => ['lisa' => ['pw' => 'you-will-never-guess', 'age' => 25, 'pet' => 'dog']],
@@ -775,8 +775,8 @@ class HashTest extends TestCase
             'ice-cream',
             'chocolate',
         ];
-        $this->assertEquals($expected, Hash::merge($a, $b, $c));
-        $this->assertEquals($expected, Hash::merge($a, $b, [], $c));
+        $this->assertSame($expected, Hash::merge($a, $b, $c));
+        $this->assertSame($expected, Hash::merge($a, $b, [], $c));
     }
 
     /**
@@ -788,23 +788,23 @@ class HashTest extends TestCase
     {
         $result = Hash::normalize(['one', 'two', 'three']);
         $expected = ['one' => null, 'two' => null, 'three' => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::normalize(['one', 'two', 'three'], false);
         $expected = ['one', 'two', 'three'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::normalize(['one' => 1, 'two' => 2, 'three' => 3, 'four'], false);
         $expected = ['one' => 1, 'two' => 2, 'three' => 3, 'four' => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::normalize(['one' => 1, 'two' => 2, 'three' => 3, 'four']);
         $expected = ['one' => 1, 'two' => 2, 'three' => 3, 'four' => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::normalize(['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three']);
         $expected = ['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three' => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -878,19 +878,19 @@ class HashTest extends TestCase
 
         $result = Hash::filter([1, [false]]);
         $expected = [1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::filter([1, [false, false]]);
         $expected = [1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::filter([1, ['empty', false]]);
         $expected = [1, ['empty']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::filter([1, ['2', false, [3, null]]]);
         $expected = [1, ['2', 2 => [3]]];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->assertSame([], Hash::filter([]));
     }
@@ -957,10 +957,10 @@ class HashTest extends TestCase
     public function testExtractSingleValueWithFilteringByAnotherField($data)
     {
         $result = Hash::extract($data, '{*}.Article[id=1].title');
-        $this->assertEquals([0 => 'First Article'], $result);
+        $this->assertSame([0 => 'First Article'], $result);
 
         $result = Hash::extract($data, '{*}.Article[id=2].title');
-        $this->assertEquals([0 => 'Second Article'], $result);
+        $this->assertSame([0 => 'Second Article'], $result);
     }
 
     /**
@@ -972,16 +972,16 @@ class HashTest extends TestCase
     public function testExtractBasic($data)
     {
         $result = Hash::extract($data, '');
-        $this->assertEquals($data, $result);
+        $this->assertSame($data, $result);
 
         $result = Hash::extract($data, '0.Article.title');
-        $this->assertEquals(['First Article'], $result);
+        $this->assertSame(['First Article'], $result);
 
         $result = Hash::extract($data, '1.Article.title');
-        $this->assertEquals(['Second Article'], $result);
+        $this->assertSame(['Second Article'], $result);
 
         $result = Hash::extract([false], '{n}.Something.another_thing');
-        $this->assertEquals([], $result);
+        $this->assertSame([], $result);
     }
 
     /**
@@ -998,13 +998,13 @@ class HashTest extends TestCase
             'Third Article', 'Fourth Article',
             'Fifth Article',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::extract($data, '0.Comment.{n}.user_id');
         $expected = [
             '2', '4',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1031,7 +1031,7 @@ class HashTest extends TestCase
         ];
         $result = Hash::extract($data, 'User.{n}.name');
         $expected = ['Neo', 'Morpheus'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = new ArrayObject([
             'User' => new ArrayObject([
@@ -1049,7 +1049,7 @@ class HashTest extends TestCase
             ]),
         ]);
         $result = Hash::extract($data, 'User.{n}.name');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = [
             0 => new Entity([
@@ -1062,7 +1062,7 @@ class HashTest extends TestCase
         ];
         $result = Hash::extract($data, '{n}.name');
         $expected = ['Neo'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1094,7 +1094,7 @@ class HashTest extends TestCase
         ];
         $result = Hash::extract($data, '{n}.User.name');
         $expected = ['John', 'Bob', 'Tony'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = new ArrayObject([
             1 => new ArrayObject([
@@ -1118,7 +1118,7 @@ class HashTest extends TestCase
         ]);
         $result = Hash::extract($data, '{n}.User.name');
         $expected = ['John', 'Bob', 'Tony'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1137,10 +1137,10 @@ class HashTest extends TestCase
             'mariano',
             'mariano',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::extract($data, '{n}.{s}.Nesting.test.1');
-        $this->assertEquals(['foo'], $result);
+        $this->assertSame(['foo'], $result);
     }
 
     /**
@@ -1167,7 +1167,7 @@ class HashTest extends TestCase
             'Mr. Number',
             'Ms. Bool',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = new ArrayObject([
             '02000009C5560001' => new ArrayObject(['name' => 'Mr. Alphanumeric']),
@@ -1186,7 +1186,7 @@ class HashTest extends TestCase
             'Mr. Number',
             'Ms. Bool',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1199,11 +1199,11 @@ class HashTest extends TestCase
     {
         $result = Hash::extract($data, '{n}.Article[published]');
         $expected = [$data[1]['Article']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::extract($data, '{n}.Article[id][published]');
         $expected = [$data[1]['Article']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1216,17 +1216,17 @@ class HashTest extends TestCase
     {
         $result = Hash::extract($data, '{n}.Article[id=3]');
         $expected = [$data[2]['Article']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::extract($data, '{n}.Article[id = 3]');
         $expected = [$data[2]['Article']];
-        $this->assertEquals($expected, $result, 'Whitespace should not matter.');
+        $this->assertSame($expected, $result, 'Whitespace should not matter.');
 
         $result = Hash::extract($data, '{n}.Article[id!=3]');
-        $this->assertEquals(1, $result[0]['id']);
-        $this->assertEquals(2, $result[1]['id']);
-        $this->assertEquals(4, $result[2]['id']);
-        $this->assertEquals(5, $result[3]['id']);
+        $this->assertSame('1', $result[0]['id']);
+        $this->assertSame('2', $result[1]['id']);
+        $this->assertSame('4', $result[2]['id']);
+        $this->assertSame('5', $result[3]['id']);
     }
 
     /**
@@ -1275,21 +1275,21 @@ class HashTest extends TestCase
         foreach ([$usersArray, $usersObject] as $users) {
             $result = Hash::extract($users, '{n}[active=0]');
             $this->assertCount(1, $result);
-            $this->assertEquals($users[2], $result[0]);
+            $this->assertSame($users[2], $result[0]);
 
             $result = Hash::extract($users, '{n}[active=false]');
             $this->assertCount(1, $result);
-            $this->assertEquals($users[2], $result[0]);
+            $this->assertSame($users[2], $result[0]);
 
             $result = Hash::extract($users, '{n}[active=1]');
             $this->assertCount(2, $result);
-            $this->assertEquals($users[0], $result[0]);
-            $this->assertEquals($users[1], $result[1]);
+            $this->assertSame($users[0], $result[0]);
+            $this->assertSame($users[1], $result[1]);
 
             $result = Hash::extract($users, '{n}[active=true]');
             $this->assertCount(2, $result);
-            $this->assertEquals($users[0], $result[0]);
-            $this->assertEquals($users[1], $result[1]);
+            $this->assertSame($users[0], $result[0]);
+            $this->assertSame($users[1], $result[1]);
         }
     }
 
@@ -1315,11 +1315,11 @@ class HashTest extends TestCase
 
         foreach ([$dataArray, $dataObject] as $data) {
             $result = Hash::extract($data, 'Entity[id=1].data1');
-            $this->assertEquals(['value'], $result);
+            $this->assertSame(['value'], $result);
 
             $data = ['Entity' => false];
             $result = Hash::extract($data, 'Entity[id=1].data1');
-            $this->assertEquals([], $result);
+            $this->assertSame([], $result);
         }
     }
 
@@ -1333,23 +1333,23 @@ class HashTest extends TestCase
     {
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2]');
         $expected = [$data[0]['Comment'][1]];
-        $this->assertEquals($expected, $result);
-        $this->assertEquals(4, $expected[0]['user_id']);
+        $this->assertSame($expected, $result);
+        $this->assertSame('4', $expected[0]['user_id']);
 
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id >= 4]');
         $expected = [$data[0]['Comment'][1]];
-        $this->assertEquals($expected, $result);
-        $this->assertEquals(4, $expected[0]['user_id']);
+        $this->assertSame($expected, $result);
+        $this->assertSame('4', $expected[0]['user_id']);
 
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id < 3]');
         $expected = [$data[0]['Comment'][0]];
-        $this->assertEquals($expected, $result);
-        $this->assertEquals(2, $expected[0]['user_id']);
+        $this->assertSame($expected, $result);
+        $this->assertSame('2', $expected[0]['user_id']);
 
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id <= 2]');
         $expected = [$data[0]['Comment'][0]];
-        $this->assertEquals($expected, $result);
-        $this->assertEquals(2, $expected[0]['user_id']);
+        $this->assertSame($expected, $result);
+        $this->assertSame('2', $expected[0]['user_id']);
     }
 
     /**
@@ -1365,8 +1365,8 @@ class HashTest extends TestCase
 
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2][id=2]');
         $expected = [$data[0]['Comment'][1]];
-        $this->assertEquals($expected, $result);
-        $this->assertEquals(4, $expected[0]['user_id']);
+        $this->assertSame($expected, $result);
+        $this->assertSame('4', $expected[0]['user_id']);
     }
 
     /**
@@ -1379,11 +1379,11 @@ class HashTest extends TestCase
     {
         $result = Hash::extract($data, '{n}.Article[title=/^First/]');
         $expected = [$data[0]['Article']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::extract($data, '{n}.Article[title=/^Fir[a-z]+/]');
         $expected = [$data[0]['Article']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1409,7 +1409,7 @@ class HashTest extends TestCase
                 'name' => null,
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = new ArrayObject([
             'Country' => new ArrayObject([
@@ -1419,7 +1419,7 @@ class HashTest extends TestCase
             ]),
         ]);
         $result = Hash::extract($data, 'Country.{n}[name=/Canada|^$/]');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1465,11 +1465,11 @@ class HashTest extends TestCase
                 'Level2bis' => ['test3', 'test4'],
             ],
         ];
-        $this->assertEquals(
+        $this->assertSame(
             ['test1', 'test2'],
             Hash::extract($data, 'Level1.Level2')
         );
-        $this->assertEquals(
+        $this->assertSame(
             ['test3', 'test4'],
             Hash::extract($data, 'Level1.Level2bis')
         );
@@ -1480,11 +1480,11 @@ class HashTest extends TestCase
                 'Level2bis' => ['test3', 'test4'],
             ]),
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             ['test1', 'test2'],
             Hash::extract($data, 'Level1.Level2')
         );
-        $this->assertEquals(
+        $this->assertSame(
             ['test3', 'test4'],
             Hash::extract($data, 'Level1.Level2bis')
         );
@@ -1501,10 +1501,10 @@ class HashTest extends TestCase
             ['test3', 'test4'],
             ['test5', 'test6'],
         ];
-        $this->assertEquals($expected, Hash::extract($data, 'Level1.Level2bis'));
+        $this->assertSame($expected, Hash::extract($data, 'Level1.Level2bis'));
 
         $data['Level1']['Level2'] = ['test1', 'test2'];
-        $this->assertEquals($expected, Hash::extract($data, 'Level1.Level2bis'));
+        $this->assertSame($expected, Hash::extract($data, 'Level1.Level2bis'));
 
         $data = new ArrayObject([
             'Level1' => new ArrayObject([
@@ -1514,10 +1514,10 @@ class HashTest extends TestCase
                 ],
             ]),
         ]);
-        $this->assertEquals($expected, Hash::extract($data, 'Level1.Level2bis'));
+        $this->assertSame($expected, Hash::extract($data, 'Level1.Level2bis'));
 
         $data['Level1']['Level2'] = ['test1', 'test2'];
-        $this->assertEquals($expected, Hash::extract($data, 'Level1.Level2bis'));
+        $this->assertSame($expected, Hash::extract($data, 'Level1.Level2bis'));
     }
 
     /**
@@ -1554,7 +1554,7 @@ class HashTest extends TestCase
     public function testSort()
     {
         $result = Hash::sort([], '{n}.name');
-        $this->assertEquals([], $result);
+        $this->assertSame([], $result);
 
         $a = [
             0 => [
@@ -1577,7 +1577,7 @@ class HashTest extends TestCase
             ],
         ];
         $a = Hash::sort($a, '{n}.Friend.{n}.name');
-        $this->assertEquals($a, $b);
+        $this->assertSame($a, $b);
 
         $b = [
             0 => [
@@ -1600,7 +1600,7 @@ class HashTest extends TestCase
             ],
         ];
         $a = Hash::sort($a, '{n}.Friend.{n}.name', 'desc');
-        $this->assertEquals($a, $b);
+        $this->assertSame($a, $b);
 
         $a = [
             0 => [
@@ -1631,7 +1631,7 @@ class HashTest extends TestCase
             ],
         ];
         $a = Hash::sort($a, '{n}.Person.name', 'asc');
-        $this->assertEquals($a, $b);
+        $this->assertSame($a, $b);
 
         $a = [
             0 => ['Person' => ['name' => 'Jeff']],
@@ -1721,7 +1721,7 @@ class HashTest extends TestCase
             ['Item' => ['price' => '230,888']],
             ['Item' => ['price' => '275,622']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::sort($items, '{n}.Item.price', 'desc', 'numeric');
         $expected = [
@@ -1731,7 +1731,7 @@ class HashTest extends TestCase
             ['Item' => ['price' => '139,000']],
             ['Item' => ['price' => '66,000']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1756,7 +1756,7 @@ class HashTest extends TestCase
             ['Item' => ['image' => 'img2.jpg']],
             ['Item' => ['image' => 'img1.jpg']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::sort($items, '{n}.Item.image', 'asc', 'natural');
         $expected = [
@@ -1766,7 +1766,7 @@ class HashTest extends TestCase
             ['Item' => ['image' => 'img12.jpg']],
             ['Item' => ['image' => 'img99.jpg']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1796,7 +1796,7 @@ class HashTest extends TestCase
             ['Item' => ['entry' => 'Ostfriesland']],
             ['Item' => ['entry' => 'Übergabe']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         // change to the original locale
         setlocale(LC_COLLATE, $oldLocale);
@@ -1818,7 +1818,7 @@ class HashTest extends TestCase
             1 => ['Person' => ['name' => 'Jeff']],
         ];
         $sorted = Hash::sort($a, '{n}.Person.name', 'asc', 'natural');
-        $this->assertEquals($sorted, $b);
+        $this->assertSame($sorted, $b);
     }
 
     /**
@@ -1843,10 +1843,10 @@ class HashTest extends TestCase
             ['class' => 625, 'test2' => 4],
         ];
         $result = Hash::sort($data, '{n}.class', 'asc');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::sort($data, '{n}.test2', 'asc');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1871,7 +1871,7 @@ class HashTest extends TestCase
             'five' => ['number' => 5, 'some' => 'fivesome'],
             'six' => ['number' => 6, 'some' => 'sixsome'],
         ];
-        $this->assertEquals($expected, $sorted);
+        $this->assertSame($expected, $sorted);
 
         $menus = [
             'blogs' => ['title' => 'Blogs', 'weight' => 3],
@@ -1884,7 +1884,7 @@ class HashTest extends TestCase
             'blogs' => ['title' => 'Blogs', 'weight' => 3],
         ];
         $result = Hash::sort($menus, '{s}.weight', 'ASC');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1907,7 +1907,7 @@ class HashTest extends TestCase
             ['Item' => ['name' => 'bat']],
             ['Item' => ['name' => 'Baz']],
         ];
-        $this->assertEquals($expected, $sorted);
+        $this->assertSame($expected, $sorted);
     }
 
     /**
@@ -1930,7 +1930,7 @@ class HashTest extends TestCase
             ['Item' => ['name' => 'bat']],
             ['Item' => ['name' => 'Baz']],
         ];
-        $this->assertEquals($expected, $sorted);
+        $this->assertSame($expected, $sorted);
     }
 
     /**
@@ -2001,7 +2001,7 @@ class HashTest extends TestCase
             'pages' => ['name' => 'page'],
             'files' => ['name' => 'files'],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = [
             'pages' => ['name' => 'page'],
@@ -2010,14 +2010,14 @@ class HashTest extends TestCase
         $expected = [
             'pages' => ['name' => []],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = [
             'foo' => ['bar' => 'baz'],
         ];
         $result = Hash::insert($a, 'some.0123.path', ['foo' => ['bar' => 'baz']]);
         $expected = ['foo' => ['bar' => 'baz']];
-        $this->assertEquals($expected, Hash::get($result, 'some.0123.path'));
+        $this->assertSame($expected, Hash::get($result, 'some.0123.path'));
     }
 
     /**
@@ -2030,12 +2030,12 @@ class HashTest extends TestCase
         $data = static::articleData();
 
         $result = Hash::insert($data, '{n}.Article.insert', 'value');
-        $this->assertEquals('value', $result[0]['Article']['insert']);
-        $this->assertEquals('value', $result[1]['Article']['insert']);
+        $this->assertSame('value', $result[0]['Article']['insert']);
+        $this->assertSame('value', $result[1]['Article']['insert']);
 
         $result = Hash::insert($data, '{n}.Comment.{n}.insert', 'value');
-        $this->assertEquals('value', $result[0]['Comment'][0]['insert']);
-        $this->assertEquals('value', $result[0]['Comment'][1]['insert']);
+        $this->assertSame('value', $result[0]['Comment'][0]['insert']);
+        $this->assertSame('value', $result[0]['Comment'][1]['insert']);
 
         $data = [
             0 => ['Item' => ['id' => 1, 'title' => 'first']],
@@ -2052,7 +2052,7 @@ class HashTest extends TestCase
             3 => ['Item' => ['id' => 4, 'title' => 'fourth', 'test' => 2]],
             4 => ['Item' => ['id' => 5, 'title' => 'fifth']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data[3]['testable'] = true;
         $result = Hash::insert($data, '{n}[testable].Item[id=/\b2|\b4/].test', 2);
@@ -2063,7 +2063,7 @@ class HashTest extends TestCase
             3 => ['Item' => ['id' => 4, 'title' => 'fourth', 'test' => 2], 'testable' => true],
             4 => ['Item' => ['id' => 5, 'title' => 'fifth']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2086,7 +2086,7 @@ class HashTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2105,7 +2105,7 @@ class HashTest extends TestCase
         $expected = [
             'pages' => ['name' => 'page'],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = [
             'pages' => [
@@ -2124,11 +2124,11 @@ class HashTest extends TestCase
                 1 => ['name' => 'about'],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::remove($a, 'pages.2.vars');
         $expected = $a;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $a = [
             0 => [
@@ -2145,7 +2145,7 @@ class HashTest extends TestCase
                 'name' => 'pages',
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $array = [
             0 => 'foo',
@@ -2155,16 +2155,16 @@ class HashTest extends TestCase
         ];
         $expected = $array;
         $result = Hash::remove($array, '{n}.part');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         $result = Hash::remove($array, '{n}.{n}.part');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $array = [
             'foo' => 'string',
         ];
         $expected = $array;
         $result = Hash::remove($array, 'foo.bar');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $array = [
             'foo' => 'string',
@@ -2180,7 +2180,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::remove($array, '{s}.0');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $array = [
             'foo' => [
@@ -2194,7 +2194,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::remove($array, 'foo[1=b].0');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2230,7 +2230,7 @@ class HashTest extends TestCase
             2 => ['Item' => ['id' => 3, 'title' => 'third']],
             4 => ['Item' => ['id' => 5, 'title' => 'fifth']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data[3]['testable'] = true;
         $result = Hash::remove($data, '{n}[testable].Item[id=/\b2|\b4/].title');
@@ -2241,7 +2241,7 @@ class HashTest extends TestCase
             3 => ['Item' => ['id' => 4], 'testable' => true],
             4 => ['Item' => ['id' => 5, 'title' => 'fifth']],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2288,25 +2288,25 @@ class HashTest extends TestCase
 
         $result = Hash::combine($a, '{n}.User.id');
         $expected = [2 => null, 14 => null, 25 => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.non-existant');
         $expected = [2 => null, 14 => null, 25 => null];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data');
         $expected = [
             2 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
             14 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
             25 => ['user' => 'gwoo', 'name' => 'The Gwoo']];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name');
         $expected = [
             2 => 'Mariano Iglesias',
             14 => 'Larry E. Masters',
             25 => 'The Gwoo'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2358,7 +2358,7 @@ class HashTest extends TestCase
                 14 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
@@ -2370,7 +2370,7 @@ class HashTest extends TestCase
                 14 => 'Larry E. Masters',
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data', '{n}.User.group_id');
         $expected = [
@@ -2382,7 +2382,7 @@ class HashTest extends TestCase
                 14 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
@@ -2394,7 +2394,7 @@ class HashTest extends TestCase
                 14 => 'Larry E. Masters',
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2421,7 +2421,7 @@ class HashTest extends TestCase
                 14 => 'phpnut: Larry E. Masters',
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine(
             $a,
@@ -2437,7 +2437,7 @@ class HashTest extends TestCase
             'phpnut: Larry E. Masters' => 14,
             'gwoo: The Gwoo' => 25,
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine(
             $a,
@@ -2449,7 +2449,7 @@ class HashTest extends TestCase
             'phpnut: 14' => 'Larry E. Masters',
             'gwoo: 25' => 'The Gwoo',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::combine(
             $a,
@@ -2461,7 +2461,7 @@ class HashTest extends TestCase
             '14: phpnut' => 'Larry E. Masters',
             '25: gwoo' => 'The Gwoo',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2483,7 +2483,7 @@ class HashTest extends TestCase
             'phpnut, 14',
             'gwoo, 25',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::format(
             $data,
@@ -2495,7 +2495,7 @@ class HashTest extends TestCase
             '14, phpnut',
             '25, gwoo',
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2519,11 +2519,11 @@ class HashTest extends TestCase
 
         $result = Hash::format($data, ['{n}.Person.something'], '%s');
         $expected = ['42', '', ''];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::format($data, ['{n}.Person.city', '{n}.Person.something'], '%s, %s');
         $expected = ['Boston, 42', 'Boondock, ', 'Venice Beach, '];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2537,7 +2537,7 @@ class HashTest extends TestCase
 
         $result = Hash::map($data, '{n}.Article.id', [$this, 'mapCallback']);
         $expected = [2, 4, 6, 8, 10];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2550,7 +2550,7 @@ class HashTest extends TestCase
         $data = static::articleData();
 
         $result = Hash::apply($data, '{n}.Article.id', 'array_sum');
-        $this->assertEquals(15, $result);
+        $this->assertSame(15, $result);
     }
 
     /**
@@ -2563,7 +2563,7 @@ class HashTest extends TestCase
         $data = static::articleData();
 
         $result = Hash::reduce($data, '{n}.Article.id', [$this, 'reduceCallback']);
-        $this->assertEquals(15, $result);
+        $this->assertSame(15, $result);
     }
 
     /**
@@ -2735,7 +2735,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::nest($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2846,7 +2846,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::nest($input, ['root' => 6]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2954,7 +2954,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::nest($input, ['idPath' => '{n}.id', 'parentPath' => '{n}.parent_id']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -3006,7 +3006,7 @@ class HashTest extends TestCase
                 unset($row['children']);
             }
         }
-        $this->assertEquals($input, $result);
+        $this->assertSame($input, $result);
     }
 
     /**
@@ -3051,13 +3051,13 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::mergeDiff($first, $second);
-        $this->assertEquals($result, $first + $second);
+        $this->assertSame($result, $first + $second);
 
         $result = Hash::mergeDiff($first, []);
-        $this->assertEquals($result, $first);
+        $this->assertSame($result, $first);
 
         $result = Hash::mergeDiff([], $first);
-        $this->assertEquals($result, $first);
+        $this->assertSame($result, $first);
 
         $third = [
             'ModelOne' => [
@@ -3076,7 +3076,7 @@ class HashTest extends TestCase
                 'field_three' => 'a3.m1.f3',
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $first = [
             0 => ['ModelOne' => ['id' => 1001, 'field_one' => 's1.0.m1.f1', 'field_two' => 's1.0.m1.f2']],
@@ -3088,7 +3088,7 @@ class HashTest extends TestCase
         ];
 
         $result = Hash::mergeDiff($first, $second);
-        $this->assertEquals($result, $first);
+        $this->assertSame($result, $first);
 
         $third = [
             0 => [
@@ -3122,13 +3122,13 @@ class HashTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Hash::mergeDiff($first, []);
-        $this->assertEquals($result, $first);
+        $this->assertSame($result, $first);
 
         $result = Hash::mergeDiff($first, $second);
-        $this->assertEquals($result, $first + $second);
+        $this->assertSame($result, $first + $second);
     }
 
     /**
@@ -3141,7 +3141,7 @@ class HashTest extends TestCase
         $data = ['My', 'Array', 'To', 'Flatten'];
         $flat = Hash::flatten($data);
         $result = Hash::expand($flat);
-        $this->assertEquals($data, $result);
+        $this->assertSame($data, $result);
 
         $data = [
             '0.Post.id' => '1', '0.Post.author_id' => '1', '0.Post.title' => 'First Post', '0.Author.id' => '1',
@@ -3160,7 +3160,7 @@ class HashTest extends TestCase
                 'Author' => ['id' => '3', 'user' => 'larry', 'password' => null],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = [
             '0/Post/id' => 1,
@@ -3175,7 +3175,7 @@ class HashTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $data = ['a.b.100.a' => null, 'a.b.200.a' => null];
         $expected = [
@@ -3187,7 +3187,7 @@ class HashTest extends TestCase
             ],
         ];
         $result = Hash::expand($data);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -3326,6 +3326,6 @@ class HashTest extends TestCase
         ];
         $expanded = Hash::expand($data);
         $flattened = Hash::flatten($expanded);
-        $this->assertEquals($data, $flattened);
+        $this->assertSame($data, $flattened);
     }
 }

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -94,7 +94,7 @@ class InflectorTest extends TestCase
      */
     public function testInflectingSingulars($singular, $plural)
     {
-        $this->assertEquals($singular, Inflector::singularize($plural));
+        $this->assertSame($singular, Inflector::singularize($plural));
     }
 
     /**
@@ -205,12 +205,12 @@ class InflectorTest extends TestCase
             'pregunta_frecuente' => 'preguntas_frecuentes',
             'categoria_pregunta_frecuente' => 'categorias_preguntas_frecuentes',
         ]);
-        $this->assertEquals('pregunta_frecuente', Inflector::singularize('preguntas_frecuentes'));
-        $this->assertEquals(
+        $this->assertSame('pregunta_frecuente', Inflector::singularize('preguntas_frecuentes'));
+        $this->assertSame(
             'categoria_pregunta_frecuente',
             Inflector::singularize('categorias_preguntas_frecuentes')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'faq_categoria_pregunta_frecuente',
             Inflector::singularize('faq_categorias_preguntas_frecuentes')
         );
@@ -224,7 +224,7 @@ class InflectorTest extends TestCase
      */
     public function testInflectingPlurals($plural, $singular)
     {
-        $this->assertEquals($plural, Inflector::pluralize($singular));
+        $this->assertSame($plural, Inflector::pluralize($singular));
     }
 
     /**
@@ -321,12 +321,12 @@ class InflectorTest extends TestCase
             'pregunta_frecuente' => 'preguntas_frecuentes',
             'categoria_pregunta_frecuente' => 'categorias_preguntas_frecuentes',
         ]);
-        $this->assertEquals('preguntas_frecuentes', Inflector::pluralize('pregunta_frecuente'));
-        $this->assertEquals(
+        $this->assertSame('preguntas_frecuentes', Inflector::pluralize('pregunta_frecuente'));
+        $this->assertSame(
             'categorias_preguntas_frecuentes',
             Inflector::pluralize('categoria_pregunta_frecuente')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'faq_categorias_preguntas_frecuentes',
             Inflector::pluralize('faq_categoria_pregunta_frecuente')
         );
@@ -349,13 +349,13 @@ class InflectorTest extends TestCase
             'rules' => [],
         ]);
 
-        $this->assertEquals('wisdom tooth', Inflector::singularize('wisdom teeth'));
-        $this->assertEquals('wisdom-tooth', Inflector::singularize('wisdom-teeth'));
-        $this->assertEquals('wisdom_tooth', Inflector::singularize('wisdom_teeth'));
+        $this->assertSame('wisdom tooth', Inflector::singularize('wisdom teeth'));
+        $this->assertSame('wisdom-tooth', Inflector::singularize('wisdom-teeth'));
+        $this->assertSame('wisdom_tooth', Inflector::singularize('wisdom_teeth'));
 
-        $this->assertEquals('sweet potatoes', Inflector::pluralize('sweet potato'));
-        $this->assertEquals('sweet-potatoes', Inflector::pluralize('sweet-potato'));
-        $this->assertEquals('sweet_potatoes', Inflector::pluralize('sweet_potato'));
+        $this->assertSame('sweet potatoes', Inflector::pluralize('sweet potato'));
+        $this->assertSame('sweet-potatoes', Inflector::pluralize('sweet-potato'));
+        $this->assertSame('sweet_potatoes', Inflector::pluralize('sweet_potato'));
     }
 
     /**
@@ -430,10 +430,10 @@ class InflectorTest extends TestCase
      */
     public function testVariableNaming()
     {
-        $this->assertEquals('testField', Inflector::variable('test_field'));
-        $this->assertEquals('testFieLd', Inflector::variable('test_fieLd'));
-        $this->assertEquals('testField', Inflector::variable('test field'));
-        $this->assertEquals('testField', Inflector::variable('Test_field'));
+        $this->assertSame('testField', Inflector::variable('test_field'));
+        $this->assertSame('testFieLd', Inflector::variable('test_fieLd'));
+        $this->assertSame('testField', Inflector::variable('test field'));
+        $this->assertSame('testField', Inflector::variable('Test_field'));
     }
 
     /**
@@ -443,10 +443,10 @@ class InflectorTest extends TestCase
      */
     public function testClassNaming()
     {
-        $this->assertEquals('ArtistsGenre', Inflector::classify('artists_genres'));
-        $this->assertEquals('FileSystem', Inflector::classify('file_systems'));
-        $this->assertEquals('News', Inflector::classify('news'));
-        $this->assertEquals('Bureau', Inflector::classify('bureaus'));
+        $this->assertSame('ArtistsGenre', Inflector::classify('artists_genres'));
+        $this->assertSame('FileSystem', Inflector::classify('file_systems'));
+        $this->assertSame('News', Inflector::classify('news'));
+        $this->assertSame('Bureau', Inflector::classify('bureaus'));
     }
 
     /**
@@ -456,10 +456,10 @@ class InflectorTest extends TestCase
      */
     public function testTableNaming()
     {
-        $this->assertEquals('artists_genres', Inflector::tableize('ArtistsGenre'));
-        $this->assertEquals('file_systems', Inflector::tableize('FileSystem'));
-        $this->assertEquals('news', Inflector::tableize('News'));
-        $this->assertEquals('bureaus', Inflector::tableize('Bureau'));
+        $this->assertSame('artists_genres', Inflector::tableize('ArtistsGenre'));
+        $this->assertSame('file_systems', Inflector::tableize('FileSystem'));
+        $this->assertSame('news', Inflector::tableize('News'));
+        $this->assertSame('bureaus', Inflector::tableize('Bureau'));
     }
 
     /**
@@ -469,9 +469,9 @@ class InflectorTest extends TestCase
      */
     public function testHumanization()
     {
-        $this->assertEquals('Posts', Inflector::humanize('posts'));
-        $this->assertEquals('Posts Tags', Inflector::humanize('posts_tags'));
-        $this->assertEquals('File Systems', Inflector::humanize('file_systems'));
+        $this->assertSame('Posts', Inflector::humanize('posts'));
+        $this->assertSame('Posts Tags', Inflector::humanize('posts_tags'));
+        $this->assertSame('File Systems', Inflector::humanize('file_systems'));
         $this->assertSame('Hello Wörld', Inflector::humanize('hello_wörld'));
         $this->assertSame('福岡 City', Inflector::humanize('福岡_city'));
     }
@@ -486,17 +486,17 @@ class InflectorTest extends TestCase
         Inflector::rules('plural', ['/^(custom)$/i' => '\1izables']);
         Inflector::rules('uninflected', ['uninflectable']);
 
-        $this->assertEquals('customizables', Inflector::pluralize('custom'));
-        $this->assertEquals('uninflectable', Inflector::pluralize('uninflectable'));
+        $this->assertSame('customizables', Inflector::pluralize('custom'));
+        $this->assertSame('uninflectable', Inflector::pluralize('uninflectable'));
 
         Inflector::rules('plural', ['/^(alert)$/i' => '\1ables']);
         Inflector::rules('irregular', ['amaze' => 'amazable', 'phone' => 'phonezes']);
         Inflector::rules('uninflected', ['noflect', 'abtuse']);
-        $this->assertEquals('noflect', Inflector::pluralize('noflect'));
-        $this->assertEquals('abtuse', Inflector::pluralize('abtuse'));
-        $this->assertEquals('alertables', Inflector::pluralize('alert'));
-        $this->assertEquals('amazable', Inflector::pluralize('amaze'));
-        $this->assertEquals('phonezes', Inflector::pluralize('phone'));
+        $this->assertSame('noflect', Inflector::pluralize('noflect'));
+        $this->assertSame('abtuse', Inflector::pluralize('abtuse'));
+        $this->assertSame('alertables', Inflector::pluralize('alert'));
+        $this->assertSame('amazable', Inflector::pluralize('amaze'));
+        $this->assertSame('phonezes', Inflector::pluralize('phone'));
     }
 
     /**
@@ -509,16 +509,16 @@ class InflectorTest extends TestCase
         Inflector::rules('uninflected', ['singulars']);
         Inflector::rules('singular', ['/(eple)r$/i' => '\1', '/(jente)r$/i' => '\1']);
 
-        $this->assertEquals('eple', Inflector::singularize('epler'));
-        $this->assertEquals('jente', Inflector::singularize('jenter'));
+        $this->assertSame('eple', Inflector::singularize('epler'));
+        $this->assertSame('jente', Inflector::singularize('jenter'));
 
         Inflector::rules('singular', ['/^(bil)er$/i' => '\1', '/^(inflec|contribu)tors$/i' => '\1ta']);
         Inflector::rules('irregular', ['spinor' => 'spins']);
 
-        $this->assertEquals('spinor', Inflector::singularize('spins'));
-        $this->assertEquals('inflecta', Inflector::singularize('inflectors'));
-        $this->assertEquals('contributa', Inflector::singularize('contributors'));
-        $this->assertEquals('singulars', Inflector::singularize('singulars'));
+        $this->assertSame('spinor', Inflector::singularize('spins'));
+        $this->assertSame('inflecta', Inflector::singularize('inflectors'));
+        $this->assertSame('contributa', Inflector::singularize('contributors'));
+        $this->assertSame('singulars', Inflector::singularize('singulars'));
     }
 
     /**
@@ -528,17 +528,17 @@ class InflectorTest extends TestCase
      */
     public function testRulesClearsCaches()
     {
-        $this->assertEquals('Banana', Inflector::singularize('Bananas'));
-        $this->assertEquals('bananas', Inflector::tableize('Banana'));
-        $this->assertEquals('Bananas', Inflector::pluralize('Banana'));
+        $this->assertSame('Banana', Inflector::singularize('Bananas'));
+        $this->assertSame('bananas', Inflector::tableize('Banana'));
+        $this->assertSame('Bananas', Inflector::pluralize('Banana'));
 
         Inflector::rules('singular', ['/(.*)nas$/i' => '\1zzz']);
-        $this->assertEquals('Banazzz', Inflector::singularize('Bananas'), 'Was inflected with old rules.');
+        $this->assertSame('Banazzz', Inflector::singularize('Bananas'), 'Was inflected with old rules.');
 
         Inflector::rules('plural', ['/(.*)na$/i' => '\1zzz']);
         Inflector::rules('irregular', ['corpus' => 'corpora']);
-        $this->assertEquals('Banazzz', Inflector::pluralize('Banana'), 'Was inflected with old rules.');
-        $this->assertEquals('corpora', Inflector::pluralize('corpus'), 'Was inflected with old irregular form.');
+        $this->assertSame('Banazzz', Inflector::pluralize('Banana'), 'Was inflected with old rules.');
+        $this->assertSame('corpora', Inflector::pluralize('corpus'), 'Was inflected with old irregular form.');
     }
 
     /**
@@ -556,9 +556,9 @@ class InflectorTest extends TestCase
         Inflector::rules('uninflected', $uninflected, true);
         Inflector::rules('irregular', $pluralIrregular, true);
 
-        $this->assertEquals('Alcoois', Inflector::pluralize('Alcool'));
-        $this->assertEquals('Atlas', Inflector::pluralize('Atlas'));
-        $this->assertEquals('Alcool', Inflector::singularize('Alcoois'));
-        $this->assertEquals('Atlas', Inflector::singularize('Atlas'));
+        $this->assertSame('Alcoois', Inflector::pluralize('Alcool'));
+        $this->assertSame('Atlas', Inflector::pluralize('Atlas'));
+        $this->assertSame('Alcool', Inflector::singularize('Alcoois'));
+        $this->assertSame('Atlas', Inflector::singularize('Atlas'));
     }
 }

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -76,7 +76,7 @@ class MergeVariablesTraitTest extends TestCase
                 'citrus' => 'key lime',
             ],
         ];
-        $this->assertEquals($expected, $object->nestedProperty);
+        $this->assertSame($expected, $object->nestedProperty);
     }
 
     /**
@@ -97,7 +97,7 @@ class MergeVariablesTraitTest extends TestCase
         $this->assertEquals($expected, $object->assocProperty);
 
         $expected = ['One', 'Two', 'Three', 'Four', 'Five'];
-        $this->assertSame($expected, $object->listProperty);
+        $this->assertEquals($expected, $object->listProperty);
     }
 
     /**
@@ -110,6 +110,6 @@ class MergeVariablesTraitTest extends TestCase
     {
         $object = new Child();
         $object->mergeVars(['hasBoolean']);
-        $this->assertEquals(['test'], $object->hasBoolean);
+        $this->assertSame(['test'], $object->hasBoolean);
     }
 }

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -95,7 +95,7 @@ class SecurityTest extends TestCase
         $result = Security::encrypt($txt, $key);
         $this->assertNotEquals($txt, $result, 'Should be encrypted.');
         $this->assertNotEquals($result, Security::encrypt($txt, $key), 'Each result is unique.');
-        $this->assertEquals($txt, Security::decrypt($result, $key));
+        $this->assertSame($txt, Security::decrypt($result, $key));
     }
 
     /**
@@ -228,7 +228,7 @@ class SecurityTest extends TestCase
     public function testSalt()
     {
         Security::setSalt('foobarbaz');
-        $this->assertEquals('foobarbaz', Security::getSalt());
+        $this->assertSame('foobarbaz', Security::getSalt());
     }
 
     /**
@@ -239,7 +239,7 @@ class SecurityTest extends TestCase
     public function testGetSetSalt()
     {
         Security::setSalt('foobarbaz');
-        $this->assertEquals('foobarbaz', Security::getSalt());
+        $this->assertSame('foobarbaz', Security::getSalt());
     }
 
     /**

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -81,124 +81,124 @@ class TextTest extends TestCase
         $string = 'some string';
         $expected = 'some string';
         $result = Text::insert($string, []);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = :sum. Cake is :adjective.';
         $expected = '2 + 2 = 4. Cake is yummy.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = %sum. Cake is %adjective.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = 2sum2. Cake is 9adjective9.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])%s\\1/']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = 12sum21. Cake is 23adjective45.';
         $expected = '2 + 2 = 4. Cake is 23adjective45.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])([\d])%s\\2\\1/']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':web :web_site';
         $expected = 'www http';
         $result = Text::insert($string, ['web' => 'www', 'web_site' => 'http']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = <sum. Cake is <adjective>.';
         $expected = '2 + 2 = <sum. Cake is yummy.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '<', 'after' => '>']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = \:sum. Cake is :adjective.';
         $expected = '2 + 2 = :sum. Cake is yummy.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = !:sum. Cake is :adjective.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['escape' => '!']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '2 + 2 = \%sum. Cake is %adjective.';
         $expected = '2 + 2 = %sum. Cake is yummy.';
         $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':a :b \:a :a';
         $expected = '1 2 :a 1';
         $result = Text::insert($string, ['a' => 1, 'b' => 2]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':a :b :c';
         $expected = '2 3';
         $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':a :b :c';
         $expected = '1 3';
         $result = Text::insert($string, ['a' => 1, 'c' => 3], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':a :b :c';
         $expected = '2 3';
         $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = ':a, :b and :c';
         $expected = '2 and 3';
         $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '":a, :b and :c"';
         $expected = '"1, 2"';
         $result = Text::insert($string, ['a' => 1, 'b' => 2], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '"${a}, ${b} and ${c}"';
         $expected = '"1, 2"';
         $result = Text::insert($string, ['a' => 1, 'b' => 2], ['before' => '${', 'after' => '}', 'clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '<img src=":src" alt=":alt" class="foo :extra bar"/>';
         $expected = '<img src="foo" class="foo bar"/>';
         $result = Text::insert($string, ['src' => 'foo'], ['clean' => 'html']);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '<img src=":src" class=":no :extra"/>';
         $expected = '<img src="foo"/>';
         $result = Text::insert($string, ['src' => 'foo'], ['clean' => 'html']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '<img src=":src" class=":no :extra"/>';
         $expected = '<img src="foo" class="bar"/>';
         $result = Text::insert($string, ['src' => 'foo', 'extra' => 'bar'], ['clean' => 'html']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert('this is a ? string', ['test']);
         $expected = 'this is a test string';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert('this is a ? string with a ? ? ?', ['long', 'few?', 'params', 'you know']);
         $expected = 'this is a long string with a few? params you know';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert('update saved_urls set url = :url where id = :id', ['url' => 'http://www.testurl.com/param1:url/param2:id', 'id' => 1]);
         $expected = 'update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert('update saved_urls set url = :url where id = :id', ['id' => 1, 'url' => 'http://www.testurl.com/param1:url/param2:id']);
         $expected = 'update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert(':me cake. :subject :verb fantastic.', ['me' => 'I :verb', 'subject' => 'cake', 'verb' => 'is']);
         $expected = 'I :verb cake. cake is fantastic.';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert(':I.am: :not.yet: passing.', ['I.am' => 'We are'], ['before' => ':', 'after' => ':', 'clean' => ['replacement' => ' of course', 'method' => 'text']]);
         $expected = 'We are of course passing.';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert(
             ':I.am: :not.yet: passing.',
@@ -206,31 +206,31 @@ class TextTest extends TestCase
             ['before' => ':', 'after' => ':', 'clean' => true]
         );
         $expected = 'We are passing.';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::insert('?-pended result', ['Pre']);
         $expected = 'Pre-pended result';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'switching :timeout / :timeout_count';
         $expected = 'switching 5 / 10';
         $result = Text::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'switching :timeout / :timeout_count';
         $expected = 'switching 5 / 10';
         $result = Text::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'switching :timeout_count by :timeout';
         $expected = 'switching 10 by 5';
         $result = Text::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'switching :timeout_count by :timeout';
         $expected = 'switching 10 by 5';
         $result = Text::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         $string = 'inserting a :user.email';
         $expected = 'inserting a security@example.com';
         $result = Text::insert($string, [
@@ -238,7 +238,7 @@ class TextTest extends TestCase
             'user.id' => 2,
             'user.created' => Time::parse('2016-01-01'),
         ]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -251,7 +251,7 @@ class TextTest extends TestCase
         $result = Text::cleanInsert(':incomplete', [
             'clean' => true, 'before' => ':', 'after' => '',
         ]);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = Text::cleanInsert(
             ':incomplete',
@@ -259,30 +259,30 @@ class TextTest extends TestCase
             'clean' => ['method' => 'text', 'replacement' => 'complete'],
             'before' => ':', 'after' => '']
         );
-        $this->assertEquals('complete', $result);
+        $this->assertSame('complete', $result);
 
         $result = Text::cleanInsert(':in.complete', [
             'clean' => true, 'before' => ':', 'after' => '',
         ]);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = Text::cleanInsert(
             ':in.complete and',
             [
             'clean' => true, 'before' => ':', 'after' => '']
         );
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = Text::cleanInsert(':in.complete or stuff', [
             'clean' => true, 'before' => ':', 'after' => '',
         ]);
-        $this->assertEquals('stuff', $result);
+        $this->assertSame('stuff', $result);
 
         $result = Text::cleanInsert(
             '<p class=":missing" id=":missing">Text here</p>',
             ['clean' => 'html', 'before' => ':', 'after' => '']
         );
-        $this->assertEquals('<p>Text here</p>', $result);
+        $this->assertSame('<p>Text here</p>', $result);
     }
 
     /**
@@ -295,7 +295,7 @@ class TextTest extends TestCase
     {
         $data = ['foo' => 'alpha', 'bar' => 'beta', 'fale' => []];
         $result = Text::insert('(:foo > :bar || :fale!)', $data, ['clean' => 'text']);
-        $this->assertEquals('(alpha > beta || !)', $result);
+        $this->assertSame('(alpha > beta || !)', $result);
     }
 
     /**
@@ -307,32 +307,32 @@ class TextTest extends TestCase
     {
         $result = Text::tokenize('A,(short,boring test)');
         $expected = ['A', '(short,boring test)'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::tokenize('A,(short,more interesting( test)');
         $expected = ['A', '(short,more interesting( test)'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::tokenize('A,(short,very interesting( test))');
         $expected = ['A', '(short,very interesting( test))'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::tokenize('"single tag"', ' ', '"', '"');
         $expected = ['"single tag"'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::tokenize('tagA "single tag" tagB', ' ', '"', '"');
         $expected = ['tagA', '"single tag"', 'tagB'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Text::tokenize('tagA "first tag" tagB "second tag" tagC', ' ', '"', '"');
         $expected = ['tagA', '"first tag"', 'tagB', '"second tag"', 'tagC'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         // Ideographic width space.
         $result = Text::tokenize("tagA\xe3\x80\x80\"single\xe3\x80\x80tag\"\xe3\x80\x80tagB", "\xe3\x80\x80", '"', '"');
         $expected = ['tagA', '"single　tag"', 'tagB'];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testReplaceWithQuestionMarkInString()
@@ -340,7 +340,7 @@ class TextTest extends TestCase
         $string = ':a, :b and :c?';
         $expected = '2 and 3?';
         $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -608,7 +608,7 @@ TEXT;
             'html' => true,
         ]);
         $expected = '<p><span style="font-size: medium;"><a>Iamatestwi...</a></span></p>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = '<style>text-align: center;</style><script>console.log(\'test\');</script><p>The quick brown fox jumps over the lazy dog</p>';
         $expected = '<style>text-align: center;</style><script>console.log(\'test\');</script><p>The qu...</p>';
@@ -629,7 +629,7 @@ TEXT;
             'exact' => true,
             'html' => true,
         ]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = '<a href="http://example.org">hello..</a>';
         $result = Text::truncate($text, 6, [
@@ -637,7 +637,7 @@ TEXT;
             'exact' => false,
             'html' => true,
         ]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -654,14 +654,14 @@ TEXT;
             'exact' => false,
         ]);
         $expected = '<b>&copy; 2005-2007, Cake Software...</b>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Text->truncate($text, 31, [
             'html' => true,
             'exact' => true,
         ]);
         $expected = '<b>&copy; 2005-2007, Cake Software F...</b>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -672,29 +672,29 @@ TEXT;
     public function testTruncateTrimWidth()
     {
         $text = 'The quick brown fox jumps over the lazy dog';
-        $this->assertEquals('The quick brown...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false]));
-        $this->assertEquals('The quick brown...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true]));
+        $this->assertSame('The quick brown...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false]));
+        $this->assertSame('The quick brown...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true]));
 
         $text = 'はしこい茶色の狐はのろまな犬を飛び越える';
-        $this->assertEquals('はしこい茶色の狐はのろまな犬を...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false]));
-        $this->assertEquals('はしこい茶色の...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true]));
+        $this->assertSame('はしこい茶色の狐はのろまな犬を...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false]));
+        $this->assertSame('はしこい茶色の...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true]));
 
         $text = 'はしこい茶色の狐 - The quick brown fox';
-        $this->assertEquals('はしこい茶色の狐 - The quick bro...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => false]));
-        $this->assertEquals('はしこい茶色の狐 - The q...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => true]));
-        $this->assertEquals('はしこい茶色の狐 - The...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => true, 'exact' => false]));
+        $this->assertSame('はしこい茶色の狐 - The quick bro...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => false]));
+        $this->assertSame('はしこい茶色の狐 - The q...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => true]));
+        $this->assertSame('はしこい茶色の狐 - The...', Text::truncate($text, 27, ['ellipsis' => '...', 'trimWidth' => true, 'exact' => false]));
 
         $text = '<p>はしこい<font color="brown">茶色</font>の狐はのろまな犬を飛び越える</p>';
-        $this->assertEquals('<p>はしこい<font color="brown">茶色</font>の狐はのろまな犬を...</p>', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false, 'html' => true]));
-        $this->assertEquals('<p>はしこい<font color="brown">茶色</font>の...</p>', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true, 'html' => true]));
+        $this->assertSame('<p>はしこい<font color="brown">茶色</font>の狐はのろまな犬を...</p>', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false, 'html' => true]));
+        $this->assertSame('<p>はしこい<font color="brown">茶色</font>の...</p>', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => true, 'html' => true]));
 
         $text = <<<HTML
 <IMG src="mypic.jpg">このimageタグはXHTMLに準拠していない！<br>
 <hr/><b>でも次のimageタグは準拠しているはず <img src="mypic.jpg" alt="私の、私自身そして私" /></b><br />
 素晴らしい、でしょ?
 HTML;
-        $this->assertEquals("<IMG src=\"mypic.jpg\">このimageタグはXHTMLに準拠していない！<br>\n<hr/><b>でも次の…</b>", Text::truncate($text, 30, ['html' => true]));
-        $this->assertEquals('<IMG src="mypic.jpg">このimageタグはXHTMLに準拠し…', Text::truncate($text, 30, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame("<IMG src=\"mypic.jpg\">このimageタグはXHTMLに準拠していない！<br>\n<hr/><b>でも次の…</b>", Text::truncate($text, 30, ['html' => true]));
+        $this->assertSame('<IMG src="mypic.jpg">このimageタグはXHTMLに準拠し…', Text::truncate($text, 30, ['html' => true, 'trimWidth' => true]));
     }
 
     /**
@@ -711,34 +711,34 @@ HTML;
         $text5 = 'НОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 
         $result = $this->Text->tail($text1, 13);
-        $this->assertEquals('...e lazy dog', $result);
+        $this->assertSame('...e lazy dog', $result);
 
         $result = $this->Text->tail($text1, 13, ['exact' => false]);
-        $this->assertEquals('...lazy dog', $result);
+        $this->assertSame('...lazy dog', $result);
 
         $result = $this->Text->tail($text1, 100);
-        $this->assertEquals('The quick brown fox jumps over the lazy dog', $result);
+        $this->assertSame('The quick brown fox jumps over the lazy dog', $result);
 
         $result = $this->Text->tail($text2, 10);
-        $this->assertEquals('...;mpfung', $result);
+        $this->assertSame('...;mpfung', $result);
 
         $result = $this->Text->tail($text2, 10, ['exact' => false]);
-        $this->assertEquals('...', $result);
+        $this->assertSame('...', $result);
 
         $result = $this->Text->tail($text3, 255);
-        $this->assertEquals($text3, $result);
+        $this->assertSame($text3, $result);
 
         $result = $this->Text->tail($text3, 21);
-        $this->assertEquals('...á dicho la verdad?', $result);
+        $this->assertSame('...á dicho la verdad?', $result);
 
         $result = $this->Text->tail($text4, 25);
-        $this->assertEquals('...a R' . chr(195) . chr(169) . 'publique de France', $result);
+        $this->assertSame('...a R' . chr(195) . chr(169) . 'publique de France', $result);
 
         $result = $this->Text->tail($text5, 10);
-        $this->assertEquals('...цчшщъыь', $result);
+        $this->assertSame('...цчшщъыь', $result);
 
         $result = $this->Text->tail($text5, 6, ['ellipsis' => '']);
-        $this->assertEquals('чшщъыь', $result);
+        $this->assertSame('чшщъыь', $result);
     }
 
     /**
@@ -752,28 +752,28 @@ HTML;
         $phrases = ['This', 'text'];
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>']);
         $expected = '<b>This</b> is a test <b>text</b>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $phrases = ['is', 'text'];
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>', 'regex' => "|\b%s\b|iu"]);
         $expected = 'This <b>is</b> a test <b>text</b>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text';
         $phrases = null;
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>']);
-        $this->assertEquals($text, $result);
+        $this->assertSame($text, $result);
 
         $text = 'This is a (test) text';
         $phrases = '(test';
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>']);
-        $this->assertEquals('This is a <b>(test</b>) text', $result);
+        $this->assertSame('This is a <b>(test</b>) text', $result);
 
         $text = 'Ich saß in einem Café am Übergang';
         $expected = 'Ich <b>saß</b> in einem <b>Café</b> am <b>Übergang</b>';
         $phrases = ['saß', 'café', 'übergang'];
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -787,11 +787,11 @@ HTML;
         $phrases = ['This', 'text'];
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>']);
         $expected = '<b>This</b> is a test <b>text</b> with some more <b>text</b>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Text->highlight($text, $phrases, ['format' => '<b>\1</b>', 'limit' => 1]);
         $expected = '<b>This</b> is a test <b>text</b> with some more text';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -808,17 +808,17 @@ HTML;
         $options = ['format' => '<b>\1</b>', 'html' => true];
 
         $expected = '<p><b>strong</b>bow isn&rsquo;t real cider</p>';
-        $this->assertEquals($expected, $this->Text->highlight($text1, 'strong', $options));
+        $this->assertSame($expected, $this->Text->highlight($text1, 'strong', $options));
 
         $expected = '<p><b>strong</b>bow <strong>isn&rsquo;t</strong> real cider</p>';
-        $this->assertEquals($expected, $this->Text->highlight($text2, 'strong', $options));
+        $this->assertSame($expected, $this->Text->highlight($text2, 'strong', $options));
 
-        $this->assertEquals($text3, $this->Text->highlight($text3, 'strong', $options));
+        $this->assertSame($text3, $this->Text->highlight($text3, 'strong', $options));
 
-        $this->assertEquals($text3, $this->Text->highlight($text3, ['strong', 'what'], $options));
+        $this->assertSame($text3, $this->Text->highlight($text3, ['strong', 'what'], $options));
 
         $expected = '<b>What</b> a <b>strong</b> mouse: <img src="what-a-strong-mouse.png" alt="What a strong mouse!" />';
-        $this->assertEquals($expected, $this->Text->highlight($text4, ['strong', 'what'], $options));
+        $this->assertSame($expected, $this->Text->highlight($text4, ['strong', 'what'], $options));
     }
 
     /**
@@ -832,7 +832,7 @@ HTML;
         $phrases = ['This', 'text'];
         $result = $this->Text->highlight($text, $phrases, ['format' => ['<b>\1</b>', '<em>\1</em>']]);
         $expected = '<b>This</b> is a test <em>text</em>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -846,10 +846,10 @@ HTML;
         $expected = 'This is a <b>Test</b> text';
 
         $result = $this->Text->highlight($text, 'test', ['format' => '<b>\1</b>']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Text->highlight($text, ['test'], ['format' => '<b>\1</b>']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -863,34 +863,34 @@ HTML;
 
         $expected = '...ase with test text to ...';
         $result = $this->Text->excerpt($text, 'test', 9, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = 'This is a...';
         $result = $this->Text->excerpt($text, 'not_found', 9, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = 'This is a phras...';
         $result = $this->Text->excerpt($text, '', 9, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = $text;
         $result = $this->Text->excerpt($text, '', 200, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = '...a phrase w...';
         $result = $this->Text->excerpt($text, 'phrase', 2, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $phrase = 'This is a phrase with test text';
         $expected = $text;
         $result = $this->Text->excerpt($text, $phrase, 13, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'aaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaa';
         $phrase = 'bbbbbbbb';
         $result = $this->Text->excerpt($text, $phrase, 10);
         $expected = '...aaaaaaaaaabbbbbbbbaaaaaaaaaa...';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -904,11 +904,11 @@ HTML;
 
         $expected = '...ase with test text to ...';
         $result = $this->Text->excerpt($text, 'TEST', 9, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = 'This is a...';
         $result = $this->Text->excerpt($text, 'NOT_FOUND', 9, '...');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -919,28 +919,28 @@ HTML;
     public function testListGeneration()
     {
         $result = $this->Text->toList([]);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = $this->Text->toList(['One']);
-        $this->assertEquals('One', $result);
+        $this->assertSame('One', $result);
 
         $result = $this->Text->toList(['Larry', 'Curly', 'Moe']);
-        $this->assertEquals('Larry, Curly and Moe', $result);
+        $this->assertSame('Larry, Curly and Moe', $result);
 
         $result = $this->Text->toList(['Dusty', 'Lucky', 'Ned'], 'y');
-        $this->assertEquals('Dusty, Lucky y Ned', $result);
+        $this->assertSame('Dusty, Lucky y Ned', $result);
 
         $result = $this->Text->toList([1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'], 'y');
-        $this->assertEquals('Dusty, Lucky y Ned', $result);
+        $this->assertSame('Dusty, Lucky y Ned', $result);
 
         $result = $this->Text->toList([1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'], 'and', ' + ');
-        $this->assertEquals('Dusty + Lucky and Ned', $result);
+        $this->assertSame('Dusty + Lucky and Ned', $result);
 
         $result = $this->Text->toList(['name1' => 'Dusty', 'name2' => 'Lucky']);
-        $this->assertEquals('Dusty and Lucky', $result);
+        $this->assertSame('Dusty and Lucky', $result);
 
         $result = $this->Text->toList(['test_0' => 'banana', 'test_1' => 'apple', 'test_2' => 'lemon']);
-        $this->assertEquals('banana, apple and lemon', $result);
+        $this->assertSame('banana, apple and lemon', $result);
     }
 
     /**
@@ -956,13 +956,13 @@ HTML;
                                 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82,
                                 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
                                 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
         $result = Text::utf8($string);
         $expected = [161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
                                 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
         $result = Text::utf8($string);
@@ -971,7 +971,7 @@ HTML;
                                 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263,
                                 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
         $result = Text::utf8($string);
@@ -980,7 +980,7 @@ HTML;
                                 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363,
                                 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384,
                                 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
         $result = Text::utf8($string);
@@ -989,7 +989,7 @@ HTML;
                                 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463,
                                 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484,
                                 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
         $result = Text::utf8($string);
@@ -998,30 +998,30 @@ HTML;
                                 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663,
                                 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684,
                                 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
         $result = Text::utf8($string);
         $expected = [1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
                                 1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
         $result = Text::utf8($string);
         $expected = [1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
                                 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
                                 1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'չպջռսվտ';
         $result = Text::utf8($string);
         $expected = [1401, 1402, 1403, 1404, 1405, 1406, 1407];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'فقكلمنهوىيًٌٍَُ';
         $result = Text::utf8($string);
         $expected = [1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
         $result = Text::utf8($string);
@@ -1029,7 +1029,7 @@ HTML;
                                 10045, 10046, 10047, 10048, 10049, 10050, 10051, 10052, 10053, 10054, 10055, 10056, 10057,
                                 10058, 10059, 10060, 10061, 10062, 10063, 10064, 10065, 10066, 10067, 10068, 10069, 10070,
                                 10071, 10072, 10073, 10074, 10075, 10076, 10077, 10078];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
         $result = Text::utf8($string);
@@ -1039,7 +1039,7 @@ HTML;
                                 11953, 11954, 11955, 11956, 11957, 11958, 11959, 11960, 11961, 11962, 11963, 11964, 11965, 11966, 11967, 11968,
                                 11969, 11970, 11971, 11972, 11973, 11974, 11975, 11976, 11977, 11978, 11979, 11980, 11981, 11982, 11983, 11984,
                                 11985, 11986, 11987, 11988, 11989, 11990, 11991, 11992, 11993, 11994, 11995, 11996, 11997, 11998, 11999, 12000];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
         $result = Text::utf8($string);
@@ -1047,7 +1047,7 @@ HTML;
                                 12117, 12118, 12119, 12120, 12121, 12122, 12123, 12124, 12125, 12126, 12127, 12128, 12129, 12130, 12131, 12132,
                                 12133, 12134, 12135, 12136, 12137, 12138, 12139, 12140, 12141, 12142, 12143, 12144, 12145, 12146, 12147, 12148,
                                 12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
         $result = Text::utf8($string);
@@ -1058,7 +1058,7 @@ HTML;
                                 45665, 45666, 45667, 45668, 45669, 45670, 45671, 45672, 45673, 45674, 45675, 45676, 45677, 45678, 45679, 45680,
                                 45681, 45682, 45683, 45684, 45685, 45686, 45687, 45688, 45689, 45690, 45691, 45692, 45693, 45694, 45695, 45696,
                                 45697, 45698, 45699, 45700];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
         $result = Text::utf8($string);
@@ -1067,7 +1067,7 @@ HTML;
                                 65168, 65169, 65170, 65171, 65172, 65173, 65174, 65175, 65176, 65177, 65178, 65179, 65180, 65181, 65182, 65183,
                                 65184, 65185, 65186, 65187, 65188, 65189, 65190, 65191, 65192, 65193, 65194, 65195, 65196, 65197, 65198, 65199,
                                 65200];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
         $result = Text::utf8($string);
@@ -1076,102 +1076,102 @@ HTML;
                                 65233, 65234, 65235, 65236, 65237, 65238, 65239, 65240, 65241, 65242, 65243, 65244, 65245, 65246, 65247, 65248,
                                 65249, 65250, 65251, 65252, 65253, 65254, 65255, 65256, 65257, 65258, 65259, 65260, 65261, 65262, 65263, 65264,
                                 65265, 65266, 65267, 65268, 65269, 65270, 65271, 65272, 65273, 65274, 65275, 65276];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
         $result = Text::utf8($string);
         $expected = [65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
                                 65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
         $result = Text::utf8($string);
         $expected = [65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
                                 65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
         $result = Text::utf8($string);
         $expected = [65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
                                 65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
                                 65433, 65434, 65435, 65436, 65437, 65438];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'Ĥēĺļŏ, Ŵőřļď!';
         $result = Text::utf8($string);
         $expected = [292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'Hello, World!';
         $result = Text::utf8($string);
         $expected = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '¨';
         $result = Text::utf8($string);
         $expected = [168];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '¿';
         $result = Text::utf8($string);
         $expected = [191];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'čini';
         $result = Text::utf8($string);
         $expected = [269, 105, 110, 105];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'moći';
         $result = Text::utf8($string);
         $expected = [109, 111, 263, 105];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'državni';
         $result = Text::utf8($string);
         $expected = [100, 114, 382, 97, 118, 110, 105];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '把百度设为首页';
         $result = Text::utf8($string);
         $expected = [25226, 30334, 24230, 35774, 20026, 39318, 39029];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = '一二三周永龍';
         $result = Text::utf8($string);
         $expected = [19968, 20108, 19977, 21608, 27704, 40845];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ԀԂԄԆԈԊԌԎԐԒ';
         $result = Text::utf8($string);
         $expected = [1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ԁԃԅԇԉԋԍԏԐԒ';
         $result = Text::utf8($string);
         $expected = [1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
         $result = Text::utf8($string);
         $expected = [1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346,
                                 1347, 1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364,
                                 1365, 1366, 1415];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
         $result = Text::utf8($string);
         $expected = [1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
                                 1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
                                 1413, 1414, 1415];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
         $result = Text::utf8($string);
         $expected = [4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273,
                                 4274, 4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291,
                                 4292, 4293];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
         $result = Text::utf8($string);
@@ -1182,7 +1182,7 @@ HTML;
                                 7824, 7826, 7828, 7830, 7831, 7832, 7833, 7834, 7840, 7842, 7844, 7846, 7848, 7850, 7852, 7854, 7856,
                                 7858, 7860, 7862, 7864, 7866, 7868, 7870, 7872, 7874, 7876, 7878, 7880, 7882, 7884, 7886, 7888, 7890, 7892,
                                 7894, 7896, 7898, 7900, 7902, 7904, 7906, 7908, 7910, 7912, 7914, 7916, 7918, 7920, 7922, 7924, 7926, 7928];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
         $result = Text::utf8($string);
@@ -1193,39 +1193,39 @@ HTML;
                                     7825, 7827, 7829, 7830, 7831, 7832, 7833, 7834, 7841, 7843, 7845, 7847, 7849, 7851, 7853, 7855, 7857, 7859,
                                     7861, 7863, 7865, 7867, 7869, 7871, 7873, 7875, 7877, 7879, 7881, 7883, 7885, 7887, 7889, 7891, 7893, 7895,
                                     7897, 7899, 7901, 7903, 7905, 7907, 7909, 7911, 7913, 7915, 7917, 7919, 7921, 7923, 7925, 7927, 7929];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ΩKÅℲ';
         $result = Text::utf8($string);
         $expected = [8486, 8490, 8491, 8498];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ωkåⅎ';
         $result = Text::utf8($string);
         $expected = [969, 107, 229, 8526];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
         $result = Text::utf8($string);
         $expected = [8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
         $result = Text::utf8($string);
         $expected = [8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
         $result = Text::utf8($string);
         $expected = [9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
                                 9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
         $result = Text::utf8($string);
         $expected = [9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
                                 9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
         $result = Text::utf8($string);
@@ -1233,14 +1233,14 @@ HTML;
                                 11279, 11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293,
                                 11294, 11295, 11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308,
                                 11309, 11310];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
         $result = Text::utf8($string);
         $expected = [11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
                                 11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
                                 11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
         $result = Text::utf8($string);
@@ -1248,7 +1248,7 @@ HTML;
                                     11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
                                     11452, 11454, 11456, 11458, 11460, 11462, 11464, 11466, 11468, 11470, 11472, 11474, 11476, 11478, 11480,
                                     11482, 11484, 11486, 11488, 11490];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
         $result = Text::utf8($string);
@@ -1256,12 +1256,12 @@ HTML;
                                 11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
                                 11457, 11459, 11461, 11463, 11465, 11467, 11469, 11471, 11473, 11475, 11477, 11479, 11481, 11483, 11485, 11487,
                                 11489, 11491];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
         $result = Text::utf8($string);
         $expected = [64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1278,14 +1278,14 @@ HTML;
         $result = Text::ascii($input);
 
         $expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
                                 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200];
         $result = Text::ascii($input);
 
         $expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221,
                                 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
@@ -1294,7 +1294,7 @@ HTML;
                                 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300];
         $result = Text::ascii($input);
         $expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
                                 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342,
@@ -1303,7 +1303,7 @@ HTML;
                                 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400];
         $expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421,
                                 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442,
@@ -1312,7 +1312,7 @@ HTML;
                                 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500];
         $expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621,
                                 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642,
@@ -1321,30 +1321,30 @@ HTML;
                                 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700];
         $expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
                                 1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051];
         $expected = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
                                 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
                                 1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100];
         $expected = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1401, 1402, 1403, 1404, 1405, 1406, 1407];
         $expected = 'չպջռսվտ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615];
         $expected = 'فقكلمنهوىيًٌٍَُ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [10032, 10033, 10034, 10035, 10036, 10037, 10038, 10039, 10040, 10041, 10042, 10043, 10044,
                                 10045, 10046, 10047, 10048, 10049, 10050, 10051, 10052, 10053, 10054, 10055, 10056, 10057,
@@ -1352,7 +1352,7 @@ HTML;
                                 10071, 10072, 10073, 10074, 10075, 10076, 10077, 10078];
         $expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [11904, 11905, 11906, 11907, 11908, 11909, 11910, 11911, 11912, 11913, 11914, 11915, 11916, 11917, 11918, 11919,
                                 11920, 11921, 11922, 11923, 11924, 11925, 11926, 11927, 11928, 11929, 11931, 11932, 11933, 11934, 11935, 11936,
@@ -1362,7 +1362,7 @@ HTML;
                                 11985, 11986, 11987, 11988, 11989, 11990, 11991, 11992, 11993, 11994, 11995, 11996, 11997, 11998, 11999, 12000];
         $expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [12101, 12102, 12103, 12104, 12105, 12106, 12107, 12108, 12109, 12110, 12111, 12112, 12113, 12114, 12115, 12116,
                                 12117, 12118, 12119, 12120, 12121, 12122, 12123, 12124, 12125, 12126, 12127, 12128, 12129, 12130, 12131, 12132,
@@ -1370,7 +1370,7 @@ HTML;
                                 12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159];
         $expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [45601, 45602, 45603, 45604, 45605, 45606, 45607, 45608, 45609, 45610, 45611, 45612, 45613, 45614, 45615, 45616,
                                 45617, 45618, 45619, 45620, 45621, 45622, 45623, 45624, 45625, 45626, 45627, 45628, 45629, 45630, 45631, 45632,
@@ -1381,7 +1381,7 @@ HTML;
                                 45697, 45698, 45699, 45700];
         $expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [65136, 65137, 65138, 65139, 65140, 65141, 65142, 65143, 65144, 65145, 65146, 65147, 65148, 65149, 65150, 65151,
                                 65152, 65153, 65154, 65155, 65156, 65157, 65158, 65159, 65160, 65161, 65162, 65163, 65164, 65165, 65166, 65167,
@@ -1390,7 +1390,7 @@ HTML;
                                 65200];
         $expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [65201, 65202, 65203, 65204, 65205, 65206, 65207, 65208, 65209, 65210, 65211, 65212, 65213, 65214, 65215, 65216,
                                 65217, 65218, 65219, 65220, 65221, 65222, 65223, 65224, 65225, 65226, 65227, 65228, 65229, 65230, 65231, 65232,
@@ -1399,101 +1399,101 @@ HTML;
                                 65265, 65266, 65267, 65268, 65269, 65270, 65271, 65272, 65273, 65274, 65275, 65276];
         $expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
                                 65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370];
         $expected = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
                                 65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400];
         $expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
                                 65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
                                 65433, 65434, 65435, 65436, 65437, 65438];
         $expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33];
         $expected = 'Ĥēĺļŏ, Ŵőřļď!';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
         $expected = 'Hello, World!';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [168];
         $expected = '¨';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [191];
         $expected = '¿';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [269, 105, 110, 105];
         $expected = 'čini';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [109, 111, 263, 105];
         $expected = 'moći';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [100, 114, 382, 97, 118, 110, 105];
         $expected = 'državni';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [25226, 30334, 24230, 35774, 20026, 39318, 39029];
         $expected = '把百度设为首页';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [19968, 20108, 19977, 21608, 27704, 40845];
         $expected = '一二三周永龍';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298];
         $expected = 'ԀԂԄԆԈԊԌԎԐԒ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298];
         $expected = 'ԁԃԅԇԉԋԍԏԐԒ';
         $result = Text::ascii($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347,
                             1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365,
                             1366, 1415];
         $result = Text::ascii($input);
         $expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
                                 1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
                                 1413, 1414, 1415];
         $result = Text::ascii($input);
         $expected = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273, 4274,
                             4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291, 4292, 4293];
         $result = Text::ascii($input);
         $expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [7680, 7682, 7684, 7686, 7688, 7690, 7692, 7694, 7696, 7698, 7700, 7702, 7704, 7706, 7708, 7710, 7712, 7714,
                                 7716, 7718, 7720, 7722, 7724, 7726, 7728, 7730, 7732, 7734, 7736, 7738, 7740, 7742, 7744, 7746, 7748, 7750,
@@ -1504,7 +1504,7 @@ HTML;
                                 7894, 7896, 7898, 7900, 7902, 7904, 7906, 7908, 7910, 7912, 7914, 7916, 7918, 7920, 7922, 7924, 7926, 7928];
         $result = Text::ascii($input);
         $expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [7681, 7683, 7685, 7687, 7689, 7691, 7693, 7695, 7697, 7699, 7701, 7703, 7705, 7707, 7709, 7711, 7713, 7715,
                             7717, 7719, 7721, 7723, 7725, 7727, 7729, 7731, 7733, 7735, 7737, 7739, 7741, 7743, 7745, 7747, 7749, 7751,
@@ -1515,53 +1515,53 @@ HTML;
                             7897, 7899, 7901, 7903, 7905, 7907, 7909, 7911, 7913, 7915, 7917, 7919, 7921, 7923, 7925, 7927, 7929];
         $result = Text::ascii($input);
         $expected = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [8486, 8490, 8491, 8498];
         $result = Text::ascii($input);
         $expected = 'ΩKÅℲ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [969, 107, 229, 8526];
         $result = Text::ascii($input);
         $expected = 'ωkåⅎ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579];
         $result = Text::ascii($input);
         $expected = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580];
         $result = Text::ascii($input);
         $expected = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
                             9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423];
         $result = Text::ascii($input);
         $expected = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
                             9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449];
         $result = Text::ascii($input);
         $expected = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [11264, 11265, 11266, 11267, 11268, 11269, 11270, 11271, 11272, 11273, 11274, 11275, 11276, 11277, 11278, 11279,
                             11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293, 11294, 11295,
                             11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308, 11309, 11310];
         $result = Text::ascii($input);
         $expected = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
                             11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
                             11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358];
         $result = Text::ascii($input);
         $expected = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [11392, 11394, 11396, 11398, 11400, 11402, 11404, 11406, 11408, 11410, 11412, 11414, 11416, 11418, 11420,
                                     11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
@@ -1569,7 +1569,7 @@ HTML;
                                     11482, 11484, 11486, 11488, 11490];
         $result = Text::ascii($input);
         $expected = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [11393, 11395, 11397, 11399, 11401, 11403, 11405, 11407, 11409, 11411, 11413, 11415, 11417, 11419, 11421, 11423,
                             11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
@@ -1577,12 +1577,12 @@ HTML;
                             11489, 11491];
         $result = Text::ascii($input);
         $expected = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $input = [64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279];
         $result = Text::ascii($input);
         $expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1591,10 +1591,10 @@ HTML;
      * @dataProvider filesizes
      * @return void
      */
-    public function testparseFileSize($params, $expected)
+    public function testParseFileSize($params, $expected)
     {
         $result = Text::parseFileSize($params['size'], $params['default']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1602,7 +1602,7 @@ HTML;
      *
      * @return void
      */
-    public function testparseFileSizeException()
+    public function testParseFileSizeException()
     {
         $this->expectException(\InvalidArgumentException::class);
         Text::parseFileSize('bogus', false);
@@ -1663,14 +1663,14 @@ HTML;
     public function testGetSetTransliteratorId()
     {
         $defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
-        $this->assertEquals($defaultTransliteratorId, Text::getTransliteratorId());
+        $this->assertSame($defaultTransliteratorId, Text::getTransliteratorId());
 
         $expected = 'Latin-ASCII;[\u0080-\u7fff] remove';
         Text::setTransliteratorId($expected);
-        $this->assertEquals($expected, Text::getTransliteratorId());
+        $this->assertSame($expected, Text::getTransliteratorId());
 
         $this->assertInstanceOf(\Transliterator::class, Text::getTransliterator());
-        $this->assertEquals($expected, Text::getTransliterator()->id);
+        $this->assertSame($expected, Text::getTransliterator()->id);
 
         Text::setTransliteratorId($defaultTransliteratorId);
     }
@@ -1749,7 +1749,7 @@ HTML;
     public function testTransliterate($string, $transliterator, $expected)
     {
         $result = Text::transliterate($string, $transliterator);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function slugInputProvider()
@@ -1850,7 +1850,7 @@ HTML;
     public function testSlug($string, $options, $expected)
     {
         $result = Text::slug($string, $options);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1878,16 +1878,16 @@ HTML;
         };
 
         $text = 'データベースアクセス &amp; ORM';
-        $this->assertEquals(20, $strlen($text, []));
-        $this->assertEquals(16, $strlen($text, ['html' => true]));
-        $this->assertEquals(30, $strlen($text, ['trimWidth' => true]));
-        $this->assertEquals(26, $strlen($text, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame(20, $strlen($text, []));
+        $this->assertSame(16, $strlen($text, ['html' => true]));
+        $this->assertSame(30, $strlen($text, ['trimWidth' => true]));
+        $this->assertSame(26, $strlen($text, ['html' => true, 'trimWidth' => true]));
 
         $text = '&undefined;';
-        $this->assertEquals(11, $strlen($text, []));
-        $this->assertEquals(11, $strlen($text, ['trimWidth' => true]));
-        $this->assertEquals(11, $strlen($text, ['html' => true]));
-        $this->assertEquals(11, $strlen($text, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame(11, $strlen($text, []));
+        $this->assertSame(11, $strlen($text, ['trimWidth' => true]));
+        $this->assertSame(11, $strlen($text, ['html' => true]));
+        $this->assertSame(11, $strlen($text, ['html' => true, 'trimWidth' => true]));
     }
 
     /**
@@ -1904,50 +1904,50 @@ HTML;
         };
 
         $text = 'データベースアクセス &amp; ORM';
-        $this->assertEquals('アクセス', $substr($text, 6, 4, []));
-        $this->assertEquals('アクセス', $substr($text, 6, 8, ['trimWidth' => true]));
-        $this->assertEquals('アクセス', $substr($text, 6, 4, ['html' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, 10, 7, []));
-        $this->assertEquals(' &amp; ', $substr($text, 10, 7, ['trimWidth' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, 10, 3, ['html' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, -10, 7, []));
-        $this->assertEquals(' &amp; ', $substr($text, -10, 7, ['trimWidth' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, -6, 3, ['html' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, -10, -3, []));
-        $this->assertEquals(' &amp; ', $substr($text, -10, -3, ['trimWidth' => true]));
-        $this->assertEquals(' &amp; ', $substr($text, -6, -3, ['html' => true]));
-        $this->assertEquals('ORM', $substr($text, -3, 1000, []));
-        $this->assertEquals('ORM', $substr($text, -3, 1000, ['trimWidth' => true]));
-        $this->assertEquals('ORM', $substr($text, -3, 1000, ['html' => true]));
-        $this->assertEquals('ORM', $substr($text, -3, null, []));
-        $this->assertEquals('ORM', $substr($text, -3, null, ['trimWidth' => true]));
-        $this->assertEquals('ORM', $substr($text, -3, null, ['html' => true]));
-        $this->assertEquals('データ', $substr($text, -1000, 3, []));
-        $this->assertEquals('データ', $substr($text, -1000, 6, ['trimWidth' => true]));
-        $this->assertEquals('データ', $substr($text, -1000, 3, ['html' => true]));
-        $this->assertEquals('', $substr($text, 0, 0, []));
-        $this->assertEquals('', $substr($text, 0, 0, ['trimWidth' => true]));
-        $this->assertEquals('', $substr($text, 0, 0, ['html' => true]));
-        $this->assertEquals('', $substr($text, 1000, 1, []));
-        $this->assertEquals('', $substr($text, 1000, 1, ['trimWidth' => true]));
-        $this->assertEquals('', $substr($text, 1000, 1, ['html' => true]));
-        $this->assertEquals('', $substr($text, 0, -1000, []));
-        $this->assertEquals('', $substr($text, 0, -1000, ['trimWidth' => true]));
-        $this->assertEquals('', $substr($text, 0, -1000, ['html' => true]));
+        $this->assertSame('アクセス', $substr($text, 6, 4, []));
+        $this->assertSame('アクセス', $substr($text, 6, 8, ['trimWidth' => true]));
+        $this->assertSame('アクセス', $substr($text, 6, 4, ['html' => true]));
+        $this->assertSame(' &amp; ', $substr($text, 10, 7, []));
+        $this->assertSame(' &amp; ', $substr($text, 10, 7, ['trimWidth' => true]));
+        $this->assertSame(' &amp; ', $substr($text, 10, 3, ['html' => true]));
+        $this->assertSame(' &amp; ', $substr($text, -10, 7, []));
+        $this->assertSame(' &amp; ', $substr($text, -10, 7, ['trimWidth' => true]));
+        $this->assertSame(' &amp; ', $substr($text, -6, 3, ['html' => true]));
+        $this->assertSame(' &amp; ', $substr($text, -10, -3, []));
+        $this->assertSame(' &amp; ', $substr($text, -10, -3, ['trimWidth' => true]));
+        $this->assertSame(' &amp; ', $substr($text, -6, -3, ['html' => true]));
+        $this->assertSame('ORM', $substr($text, -3, 1000, []));
+        $this->assertSame('ORM', $substr($text, -3, 1000, ['trimWidth' => true]));
+        $this->assertSame('ORM', $substr($text, -3, 1000, ['html' => true]));
+        $this->assertSame('ORM', $substr($text, -3, null, []));
+        $this->assertSame('ORM', $substr($text, -3, null, ['trimWidth' => true]));
+        $this->assertSame('ORM', $substr($text, -3, null, ['html' => true]));
+        $this->assertSame('データ', $substr($text, -1000, 3, []));
+        $this->assertSame('データ', $substr($text, -1000, 6, ['trimWidth' => true]));
+        $this->assertSame('データ', $substr($text, -1000, 3, ['html' => true]));
+        $this->assertSame('', $substr($text, 0, 0, []));
+        $this->assertSame('', $substr($text, 0, 0, ['trimWidth' => true]));
+        $this->assertSame('', $substr($text, 0, 0, ['html' => true]));
+        $this->assertSame('', $substr($text, 1000, 1, []));
+        $this->assertSame('', $substr($text, 1000, 1, ['trimWidth' => true]));
+        $this->assertSame('', $substr($text, 1000, 1, ['html' => true]));
+        $this->assertSame('', $substr($text, 0, -1000, []));
+        $this->assertSame('', $substr($text, 0, -1000, ['trimWidth' => true]));
+        $this->assertSame('', $substr($text, 0, -1000, ['html' => true]));
 
         // ABCDE
         $text = '&#65;&#66;&#67;&#68;&#69;';
-        $this->assertEquals('&#66;&#67;&#68;', $substr($text, 1, 3, ['html' => true]));
-        $this->assertEquals('&#66;&#67;&#68;', $substr($text, 1, 3, ['html' => true, 'trimWidth' => true]));
-        $this->assertEquals('&#66;&#67;&#68;', $substr($text, -4, -1, ['html' => true]));
-        $this->assertEquals('&#66;&#67;&#68;', $substr($text, -4, -1, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame('&#66;&#67;&#68;', $substr($text, 1, 3, ['html' => true]));
+        $this->assertSame('&#66;&#67;&#68;', $substr($text, 1, 3, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame('&#66;&#67;&#68;', $substr($text, -4, -1, ['html' => true]));
+        $this->assertSame('&#66;&#67;&#68;', $substr($text, -4, -1, ['html' => true, 'trimWidth' => true]));
 
         // あいうえお
         $text = '&#x3042;&#x3044;&#x3046;&#x3048;&#x304a;';
-        $this->assertEquals('&#x3044;&#x3046;&#x3048;', $substr($text, 1, 3, ['html' => true]));
-        $this->assertEquals('&#x3044;&#x3046;&#x3048;', $substr($text, 1, 6, ['html' => true, 'trimWidth' => true]));
-        $this->assertEquals('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -1, ['html' => true]));
-        $this->assertEquals('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -1, ['html' => true, 'trimWidth' => true]));
-        $this->assertEquals('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -2, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame('&#x3044;&#x3046;&#x3048;', $substr($text, 1, 3, ['html' => true]));
+        $this->assertSame('&#x3044;&#x3046;&#x3048;', $substr($text, 1, 6, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -1, ['html' => true]));
+        $this->assertSame('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -1, ['html' => true, 'trimWidth' => true]));
+        $this->assertSame('&#x3044;&#x3046;&#x3048;', $substr($text, -4, -2, ['html' => true, 'trimWidth' => true]));
     }
 }

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -90,21 +90,21 @@ class XmlTest extends TestCase
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml);
         $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
-        $this->assertEquals('tag', (string)$obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', (string)$obj->getName());
+        $this->assertSame('value', (string)$obj);
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?><tag>value</tag>';
         $this->assertEquals($obj, Xml::build($xml));
 
         $obj = Xml::build($xml, ['return' => 'domdocument']);
         $this->assertInstanceOf(\DOMDocument::class, $obj);
-        $this->assertEquals('tag', $obj->firstChild->nodeName);
-        $this->assertEquals('value', $obj->firstChild->nodeValue);
+        $this->assertSame('tag', $obj->firstChild->nodeName);
+        $this->assertSame('value', $obj->firstChild->nodeValue);
 
         $xml = CORE_TESTS . 'Fixture/sample.xml';
         $obj = Xml::build($xml, ['readFile' => true]);
-        $this->assertEquals('tags', $obj->getName());
-        $this->assertEquals(2, count($obj));
+        $this->assertSame('tags', $obj->getName());
+        $this->assertSame(2, count($obj));
 
         $this->assertEquals(
             Xml::build($xml, ['readFile' => true]),
@@ -112,7 +112,7 @@ class XmlTest extends TestCase
         );
 
         $obj = Xml::build($xml, ['return' => 'domdocument', 'readFile' => true]);
-        $this->assertEquals('tags', $obj->firstChild->nodeName);
+        $this->assertSame('tags', $obj->firstChild->nodeName);
 
         $this->assertEquals(
             Xml::build($xml, ['return' => 'domdocument', 'readFile' => true]),
@@ -121,12 +121,12 @@ class XmlTest extends TestCase
 
         $xml = ['tag' => 'value'];
         $obj = Xml::build($xml);
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('value', (string)$obj);
 
         $obj = Xml::build($xml, ['return' => 'domdocument']);
-        $this->assertEquals('tag', $obj->firstChild->nodeName);
-        $this->assertEquals('value', $obj->firstChild->nodeValue);
+        $this->assertSame('tag', $obj->firstChild->nodeName);
+        $this->assertSame('value', $obj->firstChild->nodeValue);
 
         $obj = Xml::build($xml, ['return' => 'domdocument', 'encoding' => '']);
         $this->assertNotRegExp('/encoding/', $obj->saveXML());
@@ -141,8 +141,8 @@ class XmlTest extends TestCase
     {
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml, ['parseHuge' => true]);
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('value', (string)$obj);
     }
 
     /**
@@ -167,8 +167,8 @@ class XmlTest extends TestCase
         $xml = new Collection(['tag' => 'value']);
         $obj = Xml::build($xml);
 
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('value', (string)$obj);
 
         $xml = new Collection([
             'response' => [
@@ -272,21 +272,21 @@ close to 5 million globally.
 
         $xml = Xml::loadHtml($html);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
-        $this->assertEquals($paragraph, (string)$xml->body->p);
+        $this->assertSame($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
-        $this->assertEquals($blockquote, (string)$xml->body->blockquote);
+        $this->assertSame($blockquote, (string)$xml->body->blockquote);
 
         $xml = Xml::loadHtml($html, ['parseHuge' => true]);
         $this->assertTrue(isset($xml->body->p), 'Paragraph present');
-        $this->assertEquals($paragraph, (string)$xml->body->p);
+        $this->assertSame($paragraph, (string)$xml->body->p);
         $this->assertTrue(isset($xml->body->blockquote), 'Blockquote present');
-        $this->assertEquals($blockquote, (string)$xml->body->blockquote);
+        $this->assertSame($blockquote, (string)$xml->body->blockquote);
 
         $xml = Xml::loadHtml($html);
-        $this->assertEquals($html, "<!DOCTYPE html>\n" . $xml->asXML() . "\n");
+        $this->assertSame($html, "<!DOCTYPE html>\n" . $xml->asXML() . "\n");
 
         $xml = Xml::loadHtml($html, ['return' => 'dom']);
-        $this->assertEquals($html, $xml->saveHTML());
+        $this->assertSame($html, $xml->saveHTML());
     }
 
     /**
@@ -309,18 +309,18 @@ close to 5 million globally.
     {
         $xml = ['tag' => 'value'];
         $obj = Xml::fromArray($xml);
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('value', (string)$obj);
 
         $xml = ['tag' => null];
         $obj = Xml::fromArray($xml);
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('', (string)$obj);
 
         $xml = ['tag' => ['@' => 'value']];
         $obj = Xml::fromArray($xml);
-        $this->assertEquals('tag', $obj->getName());
-        $this->assertEquals('value', (string)$obj);
+        $this->assertSame('tag', $obj->getName());
+        $this->assertSame('value', (string)$obj);
 
         $xml = [
             'tags' => [
@@ -338,8 +338,8 @@ close to 5 million globally.
         ];
         $obj = Xml::fromArray($xml, ['format' => 'attributes']);
         $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
-        $this->assertEquals('tags', $obj->getName());
-        $this->assertEquals(2, count($obj));
+        $this->assertSame('tags', $obj->getName());
+        $this->assertSame(2, count($obj));
         $xmlText = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <tags>
@@ -351,8 +351,8 @@ XML;
 
         $obj = Xml::fromArray($xml);
         $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
-        $this->assertEquals('tags', $obj->getName());
-        $this->assertEquals(2, count($obj));
+        $this->assertSame('tags', $obj->getName());
+        $this->assertSame(2, count($obj));
         $xmlText = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <tags>
@@ -373,8 +373,8 @@ XML;
             ],
         ];
         $obj = Xml::fromArray($xml);
-        $this->assertEquals('tags', $obj->getName());
-        $this->assertEquals('', (string)$obj);
+        $this->assertSame('tags', $obj->getName());
+        $this->assertSame('', (string)$obj);
 
         $xml = [
             'tags' => [
@@ -387,7 +387,7 @@ XML;
             ],
         ];
         $obj = Xml::fromArray($xml, ['format' => 'tags']);
-        $this->assertEquals(6, count($obj));
+        $this->assertSame(6, count($obj));
         $this->assertSame((string)$obj->bool, '1');
         $this->assertSame((string)$obj->int, '1');
         $this->assertSame((string)$obj->float, '10.2');
@@ -711,7 +711,7 @@ XML;
     {
         $xml = '<tag>name</tag>';
         $obj = Xml::build($xml);
-        $this->assertEquals(['tag' => 'name'], Xml::toArray($obj));
+        $this->assertSame(['tag' => 'name'], Xml::toArray($obj));
 
         $xml = CORE_TESTS . 'Fixture/sample.xml';
         $obj = Xml::build($xml, ['readFile' => true]);
@@ -729,7 +729,7 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($obj));
+        $this->assertSame($expected, Xml::toArray($obj));
 
         $array = [
             'tags' => [
@@ -745,7 +745,7 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals(Xml::toArray(Xml::fromArray($array, ['format' => 'tags'])), $array);
+        $this->assertSame(Xml::toArray(Xml::fromArray($array, ['format' => 'tags'])), $array);
 
         $expected = [
             'tags' => [
@@ -761,10 +761,10 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes'])));
-        $this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, ['return' => 'domdocument', 'format' => 'attributes'])));
-        $this->assertEquals(Xml::toArray(Xml::fromArray($array)), $array);
-        $this->assertEquals(Xml::toArray(Xml::fromArray($array, ['return' => 'domdocument'])), $array);
+        $this->assertSame($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes'])));
+        $this->assertSame($expected, Xml::toArray(Xml::fromArray($array, ['return' => 'domdocument', 'format' => 'attributes'])));
+        $this->assertSame(Xml::toArray(Xml::fromArray($array)), $array);
+        $this->assertSame(Xml::toArray(Xml::fromArray($array, ['return' => 'domdocument'])), $array);
 
         $array = [
             'tags' => [
@@ -798,8 +798,8 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes'])));
-        $this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes', 'return' => 'domdocument'])));
+        $this->assertSame($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes'])));
+        $this->assertSame($expected, Xml::toArray(Xml::fromArray($array, ['format' => 'attributes', 'return' => 'domdocument'])));
 
         $xml = <<<XML
 <root>
@@ -811,12 +811,12 @@ XML;
         $expected = [
             'root' => [
                 'tag' => [
-                    '@id' => 1,
+                    '@id' => '1',
                     '@' => 'defect',
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($obj));
+        $this->assertSame($expected, Xml::toArray($obj));
 
         $xml = <<<XML
 <root>
@@ -836,7 +836,7 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($obj));
+        $this->assertSame($expected, Xml::toArray($obj));
 
         $xml = <<<XML
 <root xmlns:cake="http://www.cakephp.org/">
@@ -849,20 +849,20 @@ XML;
         $expected = [
             'root' => [
                 'tag' => 'defect',
-                'cake:bug' => 1,
+                'cake:bug' => '1',
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($obj));
+        $this->assertSame($expected, Xml::toArray($obj));
 
         $xml = '<tag type="myType">0</tag>';
         $obj = Xml::build($xml);
         $expected = [
             'tag' => [
                 '@type' => 'myType',
-                '@' => 0,
+                '@' => '0',
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($obj));
+        $this->assertSame($expected, Xml::toArray($obj));
     }
 
     /**
@@ -874,12 +874,12 @@ XML;
     {
         $rss = file_get_contents(CORE_TESTS . 'Fixture/rss.xml');
         $rssAsArray = Xml::toArray(Xml::build($rss));
-        $this->assertEquals('2.0', $rssAsArray['rss']['@version']);
+        $this->assertSame('2.0', $rssAsArray['rss']['@version']);
         $this->assertCount(2, $rssAsArray['rss']['channel']['item']);
 
         $atomLink = ['@href' => 'http://bakery.cakephp.org/articles/rss', '@rel' => 'self', '@type' => 'application/rss+xml'];
-        $this->assertEquals($rssAsArray['rss']['channel']['atom:link'], $atomLink);
-        $this->assertEquals('http://bakery.cakephp.org/', $rssAsArray['rss']['channel']['link']);
+        $this->assertSame($rssAsArray['rss']['channel']['atom:link'], $atomLink);
+        $this->assertSame('http://bakery.cakephp.org/', $rssAsArray['rss']['channel']['link']);
 
         $expected = [
             'title' => 'Alertpay automated sales via IPN',
@@ -1045,7 +1045,7 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($xmlRequest));
+        $this->assertSame($expected, Xml::toArray($xmlRequest));
 
         $xmlResponse = Xml::build(CORE_TESTS . DS . 'Fixture/soap_response.xml', ['readFile' => true]);
         $expected = [
@@ -1058,7 +1058,7 @@ XML;
                 ],
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($xmlResponse));
+        $this->assertSame($expected, Xml::toArray($xmlResponse));
 
         $xml = [
             'soap:Envelope' => [
@@ -1134,10 +1134,10 @@ XML;
                 'ns:attr' => '1',
             ],
         ];
-        $this->assertEquals($expected, Xml::toArray($xmlResponse));
+        $this->assertSame($expected, Xml::toArray($xmlResponse));
 
         $xmlResponse = Xml::build('<root><ns:attr xmlns:ns="http://cakephp.org">1</ns:attr></root>');
-        $this->assertEquals($expected, Xml::toArray($xmlResponse));
+        $this->assertSame($expected, Xml::toArray($xmlResponse));
 
         $xml = [
             'root' => [
@@ -1149,7 +1149,7 @@ XML;
         ];
         $expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root><ns:attr xmlns:ns="http://cakephp.org">1</ns:attr></root>';
         $xmlResponse = Xml::fromArray($xml);
-        $this->assertEquals($expected, str_replace(["\r", "\n"], '', $xmlResponse->asXML()));
+        $this->assertSame($expected, str_replace(["\r", "\n"], '', $xmlResponse->asXML()));
 
         $xml = [
             'root' => [
@@ -1215,7 +1215,7 @@ XML;
             '<people><name><![CDATA[ Mark ]]></name></people>';
 
         $result = Xml::build($xml);
-        $this->assertEquals(' Mark ', (string)$result->name);
+        $this->assertSame(' Mark ', (string)$result->name);
     }
 
     /**
@@ -1276,7 +1276,7 @@ XML;
 </request>
 XML;
         $result = Xml::build($xml);
-        $this->assertEquals('', (string)$result->xxe);
+        $this->assertSame('', (string)$result->xxe);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -72,10 +72,10 @@ class ValidationRuleTest extends TestCase
         $this->assertTrue($Rule->process($data, $providers, $context));
 
         $Rule = new ValidationRule(['rule' => 'willFail3']);
-        $this->assertEquals('string', $Rule->process($data, $providers, $context));
+        $this->assertSame('string', $Rule->process($data, $providers, $context));
 
         $Rule = new ValidationRule(['rule' => 'willFail', 'message' => 'foo']);
-        $this->assertEquals('foo', $Rule->process($data, $providers, $context));
+        $this->assertSame('foo', $Rule->process($data, $providers, $context));
     }
 
     /**
@@ -183,16 +183,16 @@ class ValidationRuleTest extends TestCase
     {
         $Rule = new ValidationRule(['rule' => 'willFail', 'message' => 'foo']);
 
-        $this->assertEquals('willFail', $Rule->get('rule'));
-        $this->assertEquals('foo', $Rule->get('message'));
-        $this->assertEquals('default', $Rule->get('provider'));
+        $this->assertSame('willFail', $Rule->get('rule'));
+        $this->assertSame('foo', $Rule->get('message'));
+        $this->assertSame('default', $Rule->get('provider'));
         $this->assertEquals([], $Rule->get('pass'));
         $this->assertNull($Rule->get('non-existent'));
 
         $Rule = new ValidationRule(['rule' => ['willPass', 'param'], 'message' => 'bar']);
 
-        $this->assertEquals('willPass', $Rule->get('rule'));
-        $this->assertEquals('bar', $Rule->get('message'));
+        $this->assertSame('willPass', $Rule->get('rule'));
+        $this->assertSame('bar', $Rule->get('message'));
         $this->assertEquals(['param'], $Rule->get('pass'));
     }
 }

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -154,13 +154,13 @@ class ValidationSetTest extends TestCase
         $i = 0;
         foreach ($set as $name => $rule) {
             if ($i === 0) {
-                $this->assertEquals('notBlank', $name);
+                $this->assertSame('notBlank', $name);
             }
             if ($i === 1) {
-                $this->assertEquals('numeric', $name);
+                $this->assertSame('numeric', $name);
             }
             if ($i === 2) {
-                $this->assertEquals('other', $name);
+                $this->assertSame('other', $name);
             }
             $this->assertInstanceOf('Cake\Validation\ValidationRule', $rule);
             $i++;

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -96,7 +96,7 @@ class ValidatorTest extends TestCase
 
         $validator->add('email', 'notBlank');
         $result = $validator->field('email')->rule('notBlank')->get('rule');
-        $this->assertEquals('notBlank', $result);
+        $this->assertSame('notBlank', $result);
 
         $rule = new ValidationRule();
         $validator->add('field', 'myrule', $rule);
@@ -310,10 +310,10 @@ class ValidatorTest extends TestCase
         $this->assertFalse($validator->field('title')->isPresenceRequired());
 
         $validator->requirePresence('title', 'create');
-        $this->assertEquals('create', $validator->field('title')->isPresenceRequired());
+        $this->assertSame('create', $validator->field('title')->isPresenceRequired());
 
         $validator->requirePresence('title', 'update');
-        $this->assertEquals('update', $validator->field('title')->isPresenceRequired());
+        $this->assertSame('update', $validator->field('title')->isPresenceRequired());
     }
 
     /**
@@ -338,7 +338,7 @@ class ValidatorTest extends TestCase
             'subject',
         ], true);
         $this->assertFalse($validator->field('title')->isPresenceRequired());
-        $this->assertEquals('update', $validator->field('content')->isPresenceRequired());
+        $this->assertSame('update', $validator->field('content')->isPresenceRequired());
         $this->assertTrue($validator->field('subject')->isPresenceRequired());
     }
 
@@ -366,7 +366,7 @@ class ValidatorTest extends TestCase
         $validator->requirePresence('title', function ($context) use (&$require) {
             $this->assertEquals([], $context['data']);
             $this->assertEquals([], $context['providers']);
-            $this->assertEquals('title', $context['field']);
+            $this->assertSame('title', $context['field']);
             $this->assertTrue($context['newRecord']);
 
             return $require;
@@ -611,10 +611,10 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->field('title')->isEmptyAllowed());
 
         $validator->allowEmpty('title', 'create');
-        $this->assertEquals('create', $validator->field('title')->isEmptyAllowed());
+        $this->assertSame('create', $validator->field('title')->isEmptyAllowed());
 
         $validator->allowEmpty('title', 'update');
-        $this->assertEquals('update', $validator->field('title')->isEmptyAllowed());
+        $this->assertSame('update', $validator->field('title')->isEmptyAllowed());
     }
 
     /**
@@ -720,11 +720,11 @@ class ValidatorTest extends TestCase
                 'when' => Validator::WHEN_UPDATE,
             ],
         ], 'create', 'Cannot be empty');
-        $this->assertEquals('create', $validator->field('title')->isEmptyAllowed());
-        $this->assertEquals('create', $validator->field('subject')->isEmptyAllowed());
+        $this->assertSame('create', $validator->field('title')->isEmptyAllowed());
+        $this->assertSame('create', $validator->field('subject')->isEmptyAllowed());
         $this->assertFalse($validator->field('posted_at')->isEmptyAllowed());
         $this->assertTrue($validator->field('updated_at')->isEmptyAllowed());
-        $this->assertEquals('update', $validator->field('show_at')->isEmptyAllowed());
+        $this->assertSame('update', $validator->field('show_at')->isEmptyAllowed());
 
         $errors = $validator->errors([
             'title' => '',
@@ -1877,7 +1877,7 @@ class ValidatorTest extends TestCase
             ->getMock();
         $thing->expects($this->once())->method('isCool')
             ->will($this->returnCallback(function ($data, $context) use ($thing) {
-                $this->assertEquals('bar', $data);
+                $this->assertSame('bar', $data);
                 $expected = [
                     'default' => new \Cake\Validation\RulesProvider(),
                     'thing' => $thing,
@@ -1923,9 +1923,9 @@ class ValidatorTest extends TestCase
             ->getMock();
         $thing->expects($this->once())->method('isCool')
             ->will($this->returnCallback(function ($data, $a, $b, $context) use ($thing) {
-                $this->assertEquals('bar', $data);
-                $this->assertEquals('and', $a);
-                $this->assertEquals('awesome', $b);
+                $this->assertSame('bar', $data);
+                $this->assertSame('and', $a);
+                $this->assertSame('awesome', $b);
                 $expected = [
                     'default' => new \Cake\Validation\RulesProvider(),
                     'thing' => $thing,
@@ -1961,7 +1961,7 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $validator->add('name', 'myRule', [
             'rule' => function ($data, $provider) {
-                $this->assertEquals('foo', $data);
+                $this->assertSame('foo', $data);
 
                 return 'You fail';
             },
@@ -2918,7 +2918,7 @@ class ValidatorTest extends TestCase
         $this->assertNull($rule->get('on'), 'On clause is present when it should not be');
         $this->assertEquals($name, $rule->get('rule'), 'Rule name does not match');
         $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');
-        $this->assertEquals('default', $rule->get('provider'), 'Provider does not match');
+        $this->assertSame('default', $rule->get('provider'), 'Provider does not match');
 
         if ($extra !== null) {
             $validator->{$method}('username', $extra, 'the message', 'create');
@@ -2927,8 +2927,8 @@ class ValidatorTest extends TestCase
         }
 
         $rule = $validator->field('username')->rule($method);
-        $this->assertEquals('the message', $rule->get('message'), 'Error messages are not the same');
-        $this->assertEquals('create', $rule->get('on'), 'On clause is wrong');
+        $this->assertSame('the message', $rule->get('message'), 'Error messages are not the same');
+        $this->assertSame('create', $rule->get('on'), 'On clause is wrong');
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -74,7 +74,7 @@ class CellTest extends TestCase
         $cell = $this->View->cell('Articles::teaserList');
         $render = "{$cell}";
 
-        $this->assertEquals('teaser_list', $cell->viewBuilder()->getTemplate());
+        $this->assertSame('teaser_list', $cell->viewBuilder()->getTemplate());
         $this->assertStringContainsString('<h2>Lorem ipsum</h2>', $render);
         $this->assertStringContainsString('<h2>Usectetur adipiscing eli</h2>', $render);
         $this->assertStringContainsString('<h2>Topis semper blandit eu non</h2>', $render);
@@ -96,7 +96,7 @@ class CellTest extends TestCase
         $data = $cell->__debugInfo();
         $this->assertArrayHasKey('request', $data);
         $this->assertArrayHasKey('response', $data);
-        $this->assertEquals('teaserList', $data['action']);
+        $this->assertSame('teaserList', $data['action']);
         $this->assertEquals([], $data['args']);
     }
 
@@ -143,12 +143,12 @@ class CellTest extends TestCase
     {
         $appCell = $this->View->cell('Articles');
 
-        $this->assertEquals('display', $appCell->viewBuilder()->getTemplate());
+        $this->assertSame('display', $appCell->viewBuilder()->getTemplate());
         $this->assertStringContainsString('dummy', "{$appCell}");
 
         $pluginCell = $this->View->cell('TestPlugin.Dummy');
         $this->assertStringContainsString('dummy', "{$pluginCell}");
-        $this->assertEquals('display', $pluginCell->viewBuilder()->getTemplate());
+        $this->assertSame('display', $pluginCell->viewBuilder()->getTemplate());
     }
 
     /**
@@ -161,7 +161,7 @@ class CellTest extends TestCase
         $appCell = $this->View->cell('Articles::customTemplatePath');
 
         $this->assertStringContainsString('Articles subdir custom_template_path template', "{$appCell}");
-        $this->assertEquals('custom_template_path', $appCell->viewBuilder()->getTemplate());
+        $this->assertSame('custom_template_path', $appCell->viewBuilder()->getTemplate());
         $this->assertEquals(Cell::TEMPLATE_FOLDER . '/Articles/Subdir', $appCell->viewBuilder()->getTemplatePath());
     }
 
@@ -175,7 +175,7 @@ class CellTest extends TestCase
         $appCell = $this->View->cell('Articles::customTemplateViewBuilder');
 
         $this->assertStringContainsString('This is the alternate template', "{$appCell}");
-        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
+        $this->assertSame('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
     }
 
     /**

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -167,9 +167,9 @@ class ArrayContextTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertEquals('New title', $context->val('Articles.title'));
-        $this->assertEquals('My copy', $context->val('Articles.body'));
-        $this->assertEquals(0, $context->val('Articles.published'));
+        $this->assertSame('New title', $context->val('Articles.title'));
+        $this->assertSame('My copy', $context->val('Articles.body'));
+        $this->assertSame(0, $context->val('Articles.published'));
         $this->assertNull($context->val('Articles.nope'));
     }
 
@@ -201,12 +201,12 @@ class ArrayContextTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals('Default value', $context->val('title'));
-        $this->assertEquals('common1', $context->val('users.0.tags'));
-        $this->assertEquals('common1', $context->val('users.99.tags'));
-        $this->assertEquals('common2', $context->val('users.9.9tags'));
+        $this->assertSame('Default value', $context->val('title'));
+        $this->assertSame('common1', $context->val('users.0.tags'));
+        $this->assertSame('common1', $context->val('users.99.tags'));
+        $this->assertSame('common2', $context->val('users.9.9tags'));
         $result = $context->val('title', ['default' => 'explicit default']);
-        $this->assertEquals('explicit default', $result);
+        $this->assertSame('explicit default', $result);
     }
 
     /**
@@ -259,8 +259,8 @@ class ArrayContextTest extends TestCase
             ],
         ]);
         $this->assertNull($context->type('Comments.undefined'));
-        $this->assertEquals('integer', $context->type('Comments.id'));
-        $this->assertEquals('string', $context->type('Comments.0.tags'));
+        $this->assertSame('integer', $context->type('Comments.id'));
+        $this->assertSame('string', $context->type('Comments.0.tags'));
         $this->assertNull($context->type('Comments.comment'));
     }
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -219,7 +219,7 @@ class EntityContextTest extends TestCase
         $this->assertNull($context->val('title'));
         $this->assertFalse($context->isRequired('title'));
         $this->assertFalse($context->hasError('title'));
-        $this->assertEquals('string', $context->type('title'));
+        $this->assertSame('string', $context->type('title'));
         $this->assertEquals([], $context->error('title'));
 
         $attrs = $context->attributes('title');
@@ -265,7 +265,7 @@ class EntityContextTest extends TestCase
         ]);
 
         $result = $context->val('0.title');
-        $this->assertEquals('First post', $result);
+        $this->assertSame('First post', $result);
 
         $result = $context->error('1.body');
         $this->assertEquals(['Not long enough'], $result);
@@ -314,16 +314,16 @@ class EntityContextTest extends TestCase
         ]);
 
         $result = $context->val('0.title');
-        $this->assertEquals('First post', $result);
+        $this->assertSame('First post', $result);
 
         $result = $context->val('0.user.username');
-        $this->assertEquals('mark', $result);
+        $this->assertSame('mark', $result);
 
         $result = $context->val('1.title');
-        $this->assertEquals('Second post', $result);
+        $this->assertSame('Second post', $result);
 
         $result = $context->val('1.user.username');
-        $this->assertEquals('jose', $result);
+        $this->assertSame('jose', $result);
 
         $this->assertNull($context->val('nope'));
         $this->assertNull($context->val('99.title'));
@@ -344,16 +344,16 @@ class EntityContextTest extends TestCase
         ]);
 
         $result = $context->val('Articles.0.title');
-        $this->assertEquals('First post', $result);
+        $this->assertSame('First post', $result);
 
         $result = $context->val('Articles.0.user.username');
-        $this->assertEquals('mark', $result);
+        $this->assertSame('mark', $result);
 
         $result = $context->val('Articles.1.title');
-        $this->assertEquals('Second post', $result);
+        $this->assertSame('Second post', $result);
 
         $result = $context->val('Articles.1.user.username');
-        $this->assertEquals('jose', $result);
+        $this->assertSame('jose', $result);
 
         $this->assertNull($context->val('Articles.99.title'));
     }
@@ -397,11 +397,11 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->assertEquals('string', $context->type('0.title'));
-        $this->assertEquals('text', $context->type('1.body'));
-        $this->assertEquals('string', $context->type('0.user.username'));
-        $this->assertEquals('string', $context->type('1.user.username'));
-        $this->assertEquals('string', $context->type('99.title'));
+        $this->assertSame('string', $context->type('0.title'));
+        $this->assertSame('text', $context->type('1.body'));
+        $this->assertSame('string', $context->type('0.user.username'));
+        $this->assertSame('string', $context->type('1.user.username'));
+        $this->assertSame('string', $context->type('99.title'));
         $this->assertNull($context->type('0.nope'));
 
         $expected = ['length' => 255, 'precision' => null];
@@ -474,8 +474,8 @@ class EntityContextTest extends TestCase
             ]),
             'table' => 'Articles',
         ]);
-        $this->assertEquals('foo', $context->val('prop.title', ['default' => 'bar']));
-        $this->assertEquals('bar', $context->val('prop.nope', ['default' => 'bar']));
+        $this->assertSame('foo', $context->val('prop.title', ['default' => 'bar']));
+        $this->assertSame('bar', $context->val('prop.nope', ['default' => 'bar']));
     }
 
     /**
@@ -536,8 +536,8 @@ class EntityContextTest extends TestCase
             'entity' => $row,
             'table' => 'Articles',
         ]);
-        $this->assertEquals('New title', $context->val('title'));
-        $this->assertEquals('yes', $context->val('notInEntity'));
+        $this->assertSame('New title', $context->val('title'));
+        $this->assertSame('yes', $context->val('notInEntity'));
         $this->assertEquals($row->body, $context->val('body'));
     }
 
@@ -624,10 +624,10 @@ class EntityContextTest extends TestCase
         ]);
 
         $result = $context->val('user.articles.0.title');
-        $this->assertEquals('First post', $result);
+        $this->assertSame('First post', $result);
 
         $result = $context->val('user.articles.1.title');
-        $this->assertEquals('Second post', $result);
+        $this->assertSame('Second post', $result);
     }
 
     /**
@@ -706,7 +706,7 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
         $result = $context->val('title');
-        $this->assertEquals('default title', $result);
+        $this->assertSame('default title', $result);
     }
 
     /**
@@ -727,7 +727,7 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
         $result = $context->val('comments.0.comment');
-        $this->assertEquals('default comment', $result);
+        $this->assertSame('default comment', $result);
     }
 
     /**
@@ -753,7 +753,7 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
         $result = $context->val('tags.0._joinData.column');
-        $this->assertEquals('default join table column value', $result);
+        $this->assertSame('default join table column value', $result);
     }
 
     /**
@@ -1040,9 +1040,9 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->assertEquals('string', $context->type('title'));
-        $this->assertEquals('text', $context->type('body'));
-        $this->assertEquals('integer', $context->type('user_id'));
+        $this->assertSame('string', $context->type('title'));
+        $this->assertSame('text', $context->type('body'));
+        $this->assertSame('integer', $context->type('user_id'));
         $this->assertNull($context->type('nope'));
     }
 
@@ -1064,8 +1064,8 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->assertEquals('string', $context->type('user.username'));
-        $this->assertEquals('text', $context->type('user.bio'));
+        $this->assertSame('string', $context->type('user.username'));
+        $this->assertSame('text', $context->type('user.bio'));
         $this->assertNull($context->type('user.nope'));
     }
 
@@ -1093,12 +1093,12 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->assertEquals('integer', $context->type('tags.0._joinData.article_id'));
+        $this->assertSame('integer', $context->type('tags.0._joinData.article_id'));
         $this->assertNull($context->type('tags.0._joinData.non_existent'));
 
         // tests the fallback behavior
-        $this->assertEquals('integer', $context->type('tags.0._joinData._joinData.article_id'));
-        $this->assertEquals('integer', $context->type('tags.0._joinData.non_existent.article_id'));
+        $this->assertSame('integer', $context->type('tags.0._joinData._joinData.article_id'));
+        $this->assertSame('integer', $context->type('tags.0._joinData.non_existent.article_id'));
         $this->assertNull($context->type('tags.0._joinData._joinData.non_existent'));
         $this->assertNull($context->type('tags.0._joinData.non_existent'));
     }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -111,8 +111,8 @@ class FormContextTest extends TestCase
             ],
         ]);
         $context = new FormContext($this->request, ['entity' => new Form()]);
-        $this->assertEquals('New title', $context->val('Articles.title'));
-        $this->assertEquals('My copy', $context->val('Articles.body'));
+        $this->assertSame('New title', $context->val('Articles.title'));
+        $this->assertSame('My copy', $context->val('Articles.body'));
         $this->assertNull($context->val('Articles.nope'));
     }
 
@@ -126,7 +126,7 @@ class FormContextTest extends TestCase
 
         $context = new FormContext($this->request, ['entity' => $form]);
 
-        $this->assertEquals('set title', $context->val('title'));
+        $this->assertSame('set title', $context->val('title'));
         $this->assertNull($context->val('Articles.body'));
 
         $this->request = $this->request->withParsedBody([
@@ -134,7 +134,7 @@ class FormContextTest extends TestCase
         ]);
         $context = new FormContext($this->request, ['entity' => $form]);
 
-        $this->assertEquals('New title', $context->val('title'));
+        $this->assertSame('New title', $context->val('title'));
     }
 
     /**
@@ -163,13 +163,13 @@ class FormContextTest extends TestCase
         $this->assertNull($result);
 
         $result = $context->val('title', ['default' => 'default default']);
-        $this->assertEquals('default default', $result);
+        $this->assertSame('default default', $result);
 
         $result = $context->val('name');
-        $this->assertEquals('schema default', $result);
+        $this->assertSame('schema default', $result);
 
         $result = $context->val('name', ['default' => 'custom default']);
-        $this->assertEquals('custom default', $result);
+        $this->assertSame('custom default', $result);
 
         $result = $context->val('name', ['schemaDefault' => false]);
         $this->assertNull($result);
@@ -212,8 +212,8 @@ class FormContextTest extends TestCase
             'entity' => $form,
         ]);
         $this->assertNull($context->type('undefined'));
-        $this->assertEquals('integer', $context->type('user_id'));
-        $this->assertEquals('string', $context->type('email'));
+        $this->assertSame('integer', $context->type('user_id'));
+        $this->assertSame('string', $context->type('email'));
         $this->assertNull($context->type('Prefix.email'));
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8248,7 +8248,7 @@ class FormHelperTest extends TestCase
         $articles->patchEntity($article, ['id' => '3']);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('id', 4)->withQueryParams(['id' => 5])
+            $this->View->getRequest()->withData('id', '4')->withQueryParams(['id' => '5'])
         );
 
         $this->Form->create($article, ['valueSources' => 'query']);
@@ -8305,7 +8305,7 @@ class FormHelperTest extends TestCase
         $articles->patchEntity($article, ['id' => '3']);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('id', 10)->withQueryParams(['id' => 11])
+            $this->View->getRequest()->withData('id', '10')->withQueryParams(['id' => '11'])
         );
 
         $this->Form->setValueSources(['context'])

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -221,7 +221,7 @@ class FormHelperTest extends TestCase
             ->with($data)
             ->will($this->returnValue('HTML'));
         $result = $this->Form->widget('test', $data);
-        $this->assertEquals('HTML', $result);
+        $this->assertSame('HTML', $result);
     }
 
     /**
@@ -250,7 +250,7 @@ class FormHelperTest extends TestCase
             ->will($this->returnValue(['test']));
 
         $result = $this->Form->widget('test', $data + ['secure' => true]);
-        $this->assertEquals('HTML', $result);
+        $this->assertSame('HTML', $result);
     }
 
     /**
@@ -264,11 +264,11 @@ class FormHelperTest extends TestCase
         $this->assertEquals([], $this->Form->fields);
 
         $result = $this->Form->widget('select', ['secure' => true, 'name' => '']);
-        $this->assertEquals('<select name=""></select>', $result);
+        $this->assertSame('<select name=""></select>', $result);
         $this->assertEquals([], $this->Form->fields);
 
         $result = $this->Form->widget('select', ['secure' => true, 'name' => '0']);
-        $this->assertEquals('<select name="0"></select>', $result);
+        $this->assertSame('<select name="0"></select>', $result);
         $this->assertEquals(['0'], $this->Form->fields);
     }
 
@@ -1633,10 +1633,10 @@ class FormHelperTest extends TestCase
 
         $this->Form->create();
         $this->Form->text('Address.primary.1');
-        $this->assertEquals('Address.primary', $this->Form->fields[0]);
+        $this->assertSame('Address.primary', $this->Form->fields[0]);
 
         $this->Form->text('Address.secondary.1.0');
-        $this->assertEquals('Address.secondary', $this->Form->fields[1]);
+        $this->assertSame('Address.secondary', $this->Form->fields[1]);
     }
 
     /**
@@ -1988,10 +1988,10 @@ class FormHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom]']);
-        $this->assertEquals('User.custom', $this->Form->fields[0]);
+        $this->assertSame('User.custom', $this->Form->fields[0]);
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom][another][value]']);
-        $this->assertEquals('User.custom.another.value', $this->Form->fields[1]);
+        $this->assertSame('User.custom.another.value', $this->Form->fields[1]);
     }
 
     /**
@@ -2752,7 +2752,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($entity, ['context' => ['table' => 'Articles']]);
 
         $result = $this->Form->error('nested.foo');
-        $this->assertEquals('<div class="error-message">not a valid bar</div>', $result);
+        $this->assertSame('<div class="error-message">not a valid bar</div>', $result);
     }
 
     /**
@@ -2770,7 +2770,7 @@ class FormHelperTest extends TestCase
         $inner->setError('bar', ['not a valid one']);
         $this->Form->create($entity, ['context' => ['table' => 'Articles']]);
         $result = $this->Form->error('nested.foo.bar');
-        $this->assertEquals('<div class="error-message">not a valid one</div>', $result);
+        $this->assertSame('<div class="error-message">not a valid one</div>', $result);
     }
 
     /**
@@ -7457,7 +7457,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormEnd()
     {
-        $this->assertEquals('</form>', $this->Form->end());
+        $this->assertSame('</form>', $this->Form->end());
     }
 
     /**
@@ -8005,7 +8005,7 @@ class FormHelperTest extends TestCase
     public function testResetTemplates()
     {
         $this->Form->setTemplates(['input' => '<input/>']);
-        $this->assertEquals('<input/>', $this->Form->templater()->get('input'));
+        $this->assertSame('<input/>', $this->Form->templater()->get('input'));
 
         $this->Form->resetTemplates();
         $this->assertNotEquals('<input/>', $this->Form->templater()->get('input'));
@@ -8258,7 +8258,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('5', $result);
+        $this->assertSame('5', $result);
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article, ['valueSources' => 'query']);
@@ -8268,7 +8268,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('5', $result);
+        $this->assertSame('5', $result);
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => 'data']);
@@ -8279,7 +8279,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('4', $result);
+        $this->assertSame('4', $result);
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => ['context', 'data']]);
@@ -8289,7 +8289,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('4', $result);
+        $this->assertSame('4', $result);
     }
 
     /**
@@ -8316,7 +8316,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('11', $result);
+        $this->assertSame('11', $result);
 
         $this->View->setRequest($this->View->getRequest()->withQueryParams([]));
         $this->Form->setValueSources(['context'])
@@ -8327,7 +8327,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('10', $result);
+        $this->assertSame('10', $result);
     }
 
     /**
@@ -8402,11 +8402,11 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['query', 'context']);
         $result = $this->Form->getSourceValue('category');
-        $this->assertEquals('sesame-cookies', $result);
+        $this->assertSame('sesame-cookies', $result);
 
         $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->getSourceValue('category');
-        $this->assertEquals('sesame-cookies', $result);
+        $this->assertSame('sesame-cookies', $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -680,7 +680,7 @@ class HtmlHelperTest extends TestCase
 
         // Default is once=true
         $result = $this->Html->css('screen');
-        $this->assertSame('', $result);
+        $this->assertNull($result);
 
         $result = $this->Html->css('screen', ['once' => false]);
         $expected = [

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -578,7 +578,7 @@ class HtmlHelperTest extends TestCase
     public function testStyle()
     {
         $result = $this->Html->style(['display' => 'none', 'margin' => '10px']);
-        $this->assertEquals('display:none; margin:10px;', $result);
+        $this->assertSame('display:none; margin:10px;', $result);
 
         $result = $this->Html->style(['display' => 'none', 'margin' => '10px'], false);
         $this->assertEquals("display:none;\nmargin:10px;", $result);
@@ -680,7 +680,7 @@ class HtmlHelperTest extends TestCase
 
         // Default is once=true
         $result = $this->Html->css('screen');
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = $this->Html->css('screen', ['once' => false]);
         $expected = [

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -112,9 +112,9 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->getTemplates();
         $this->assertArrayHasKey('test', $result);
-        $this->assertEquals('val', $result['test']);
+        $this->assertSame('val', $result['test']);
 
-        $this->assertEquals('val', $this->Paginator->getTemplates('test'));
+        $this->assertSame('val', $this->Paginator->getTemplates('test'));
     }
 
     /**
@@ -577,10 +577,10 @@ class PaginatorHelperTest extends TestCase
     public function testSortKey()
     {
         $result = $this->Paginator->sortKey('Article', ['sort' => 'Article.title']);
-        $this->assertEquals('Article.title', $result);
+        $this->assertSame('Article.title', $result);
 
         $result = $this->Paginator->sortKey('Article', ['sort' => 'Article']);
-        $this->assertEquals('Article', $result);
+        $this->assertSame('Article', $result);
     }
 
     /**
@@ -593,19 +593,19 @@ class PaginatorHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.sort', 'Article.body'));
         $result = $this->Paginator->sortKey();
-        $this->assertEquals('Article.body', $result);
+        $this->assertSame('Article.body', $result);
 
         $result = $this->Paginator->sortKey('Article');
-        $this->assertEquals('Article.body', $result);
+        $this->assertSame('Article.body', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
             ->withParam('paging.Article.order', 'DESC'));
         $result = $this->Paginator->sortKey();
-        $this->assertEquals('Article.body', $result);
+        $this->assertSame('Article.body', $result);
 
         $result = $this->Paginator->sortKey('Article');
-        $this->assertEquals('Article.body', $result);
+        $this->assertSame('Article.body', $result);
     }
 
     /**
@@ -623,37 +623,37 @@ class PaginatorHelperTest extends TestCase
             ->withParam('paging.Article.sort', 'Article.title')
             ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('desc', $result);
+        $this->assertSame('desc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.title')
             ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
             ->withParam('paging.Article.direction', 'desc'));
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('desc', $result);
+        $this->assertSame('desc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'title')
             ->withParam('paging.Article.direction', 'asc'));
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
 
         $this->View->setRequest(
             $this->View->getRequest()->withParam('paging.Article.direction', null)
         );
         $result = $this->Paginator->sortDir('Article', ['direction' => 'asc']);
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
 
         $result = $this->Paginator->sortDir('Article', ['direction' => 'desc']);
-        $this->assertEquals('desc', $result);
+        $this->assertSame('desc', $result);
 
         $result = $this->Paginator->sortDir('Article', ['direction' => 'asc']);
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
     }
 
     /**
@@ -669,20 +669,20 @@ class PaginatorHelperTest extends TestCase
             ->withParam('paging.Article.direction', 'asc'));
 
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
 
         $result = $this->Paginator->sortDir('Article');
-        $this->assertEquals('asc', $result);
+        $this->assertSame('asc', $result);
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Article.sort', 'Article.body')
             ->withParam('paging.Article.direction', 'DESC'));
 
         $result = $this->Paginator->sortDir();
-        $this->assertEquals('desc', $result);
+        $this->assertSame('desc', $result);
 
         $result = $this->Paginator->sortDir('Article');
-        $this->assertEquals('desc', $result);
+        $this->assertSame('desc', $result);
     }
 
     /**
@@ -787,30 +787,30 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Paginator->generateUrl();
-        $this->assertEquals('/index', $result);
+        $this->assertSame('/index', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
         $result = $this->Paginator->generateUrl();
-        $this->assertEquals('/index?page=2', $result);
+        $this->assertSame('/index?page=2', $result);
 
         $options = ['sort' => 'Article', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
-        $this->assertEquals('/index?sort=Article&amp;direction=desc&amp;page=2', $result);
+        $this->assertSame('/index?sort=Article&amp;direction=desc&amp;page=2', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
-        $this->assertEquals('/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
+        $this->assertSame('/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, [], ['escape' => false]);
-        $this->assertEquals('/index?sort=Article.name&direction=desc&page=3', $result);
+        $this->assertSame('/index?sort=Article.name&direction=desc&page=3', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, [], ['fullBase' => true]);
-        $this->assertEquals('http://localhost/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
+        $this->assertSame('http://localhost/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
     }
 
     /**
@@ -1292,7 +1292,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Paginator->prev('<< Previous', ['disabledTitle' => false]);
-        $this->assertEquals('', $result, 'disabled + no text = no link');
+        $this->assertSame('', $result, 'disabled + no text = no link');
 
         $this->View->setRequest($this->View->getRequest()
             ->withParam('paging.Client.page', 2)
@@ -1424,7 +1424,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Paginator->next('Next >>', ['disabledTitle' => false]);
-        $this->assertEquals('', $result, 'disabled + no text = no link');
+        $this->assertSame('', $result, 'disabled + no text = no link');
     }
 
     /**
@@ -2572,7 +2572,7 @@ class PaginatorHelperTest extends TestCase
             ]));
 
         $result = $this->Paginator->first('first', ['model' => 'Article']);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = $this->Paginator->first('first', ['model' => 'Client']);
         $expected = [
@@ -2657,7 +2657,7 @@ class PaginatorHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
         $result = $this->Paginator->first(3);
-        $this->assertEquals('', $result, 'When inside the first links range, no links should be made');
+        $this->assertSame('', $result, 'When inside the first links range, no links should be made');
     }
 
     /**
@@ -2730,7 +2730,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Paginator->last(3);
-        $this->assertEquals('', $result, 'When inside the last links range, no links should be made');
+        $this->assertSame('', $result, 'When inside the last links range, no links should be made');
     }
 
     /**
@@ -2803,7 +2803,7 @@ class PaginatorHelperTest extends TestCase
             ]));
 
         $result = $this->Paginator->last('last', ['model' => 'Article']);
-        $this->assertEquals('', $result);
+        $this->assertSame('', $result);
 
         $result = $this->Paginator->last('last', ['model' => 'Client']);
         $expected = [
@@ -2856,7 +2856,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->Paginator->counter('Showing {{page}} of {{pages}} {{model}}');
-        $this->assertEquals('Showing 1 of 5 clients', $result);
+        $this->assertSame('Showing 1 of 5 clients', $result);
     }
 
     /**
@@ -2998,10 +2998,10 @@ class PaginatorHelperTest extends TestCase
         $this->assertNull($this->Paginator->defaultModel());
 
         $this->Paginator->defaultModel('Article');
-        $this->assertEquals('Article', $this->Paginator->defaultModel());
+        $this->assertSame('Article', $this->Paginator->defaultModel());
 
         $this->Paginator->options(['model' => 'Client']);
-        $this->assertEquals('Client', $this->Paginator->defaultModel());
+        $this->assertSame('Client', $this->Paginator->defaultModel());
     }
 
     /**
@@ -3122,7 +3122,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->meta($options);
         $this->assertSame($expected, $result);
 
-        $this->assertEquals('', $this->View->fetch('meta'));
+        $this->assertSame('', $this->View->fetch('meta'));
 
         $result = $this->Paginator->meta($options + ['block' => true]);
         $this->assertNull($result);

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -76,34 +76,34 @@ class UrlHelperTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $result = $this->Helper->build('/controller/action/1');
-        $this->assertEquals('/controller/action/1', $result);
+        $this->assertSame('/controller/action/1', $result);
 
         $result = $this->Helper->build('/controller/action/1?one=1&two=2');
-        $this->assertEquals('/controller/action/1?one=1&amp;two=2', $result);
+        $this->assertSame('/controller/action/1?one=1&amp;two=2', $result);
 
         $result = $this->Helper->build(['controller' => 'posts', 'action' => 'index', '?' => ['page' => '1" onclick="alert(\'XSS\');"']]);
-        $this->assertEquals('/posts?page=1%22+onclick%3D%22alert%28%27XSS%27%29%3B%22', $result);
+        $this->assertSame('/posts?page=1%22+onclick%3D%22alert%28%27XSS%27%29%3B%22', $result);
 
         $result = $this->Helper->build('/controller/action/1/param:this+one+more');
-        $this->assertEquals('/controller/action/1/param:this+one+more', $result);
+        $this->assertSame('/controller/action/1/param:this+one+more', $result);
 
         $result = $this->Helper->build('/controller/action/1/param:this%20one%20more');
-        $this->assertEquals('/controller/action/1/param:this%20one%20more', $result);
+        $this->assertSame('/controller/action/1/param:this%20one%20more', $result);
 
         $result = $this->Helper->build('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
-        $this->assertEquals('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24', $result);
+        $this->assertSame('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24', $result);
 
         $result = $this->Helper->build([
             'controller' => 'posts', 'action' => 'index',
             '?' => ['param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24'],
         ]);
-        $this->assertEquals('/posts?param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
+        $this->assertSame('/posts?param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
 
         $result = $this->Helper->build([
             'controller' => 'posts', 'action' => 'index',
             '?' => ['one' => 'value', 'two' => 'value', 'three' => 'purple', 'page' => '1'],
         ]);
-        $this->assertEquals('/posts?one=value&amp;two=value&amp;three=purple&amp;page=1', $result);
+        $this->assertSame('/posts?one=value&amp;two=value&amp;three=purple&amp;page=1', $result);
     }
 
     /**
@@ -126,7 +126,7 @@ class UrlHelperTest extends TestCase
         ]);
         Router::pushRequest($request);
 
-        $this->assertEquals('/magazine/subscribe', $this->Helper->build());
+        $this->assertSame('/magazine/subscribe', $this->Helper->build());
         $this->assertEquals(
             '/magazine/articles/add',
             $this->Helper->build(['controller' => 'articles', 'action' => 'add'])
@@ -139,7 +139,7 @@ class UrlHelperTest extends TestCase
     public function testBuildUrlConversionUnescaped()
     {
         $result = $this->Helper->build('/controller/action/1?one=1&two=2', ['escape' => false]);
-        $this->assertEquals('/controller/action/1?one=1&two=2', $result);
+        $this->assertSame('/controller/action/1?one=1&two=2', $result);
 
         $result = $this->Helper->build([
             'controller' => 'posts',
@@ -150,7 +150,7 @@ class UrlHelperTest extends TestCase
                 'param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24',
             ],
         ], ['escape' => false]);
-        $this->assertEquals('/posts/view?k=v&1=2&param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
+        $this->assertSame('/posts/view?k=v&1=2&param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
     }
 
     /**
@@ -169,7 +169,7 @@ class UrlHelperTest extends TestCase
         Configure::write('debug', false);
 
         $result = $this->Helper->assetTimestamp('/%3Cb%3E/cake.generic.css');
-        $this->assertEquals('/%3Cb%3E/cake.generic.css', $result);
+        $this->assertSame('/%3Cb%3E/cake.generic.css', $result);
 
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
         $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
@@ -213,25 +213,25 @@ class UrlHelperTest extends TestCase
         $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg', ['pathPrefix' => 'img/']);
-        $this->assertEquals('img/foo.jpg', $result);
+        $this->assertSame('img/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg', ['fullBase' => true]);
         $this->assertEquals(Router::fullBaseUrl() . '/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('style', ['ext' => '.css']);
-        $this->assertEquals('style.css', $result);
+        $this->assertSame('style.css', $result);
 
         $result = $this->Helper->assetUrl('dir/sub dir/my image', ['ext' => '.jpg']);
-        $this->assertEquals('dir/sub%20dir/my%20image.jpg', $result);
+        $this->assertSame('dir/sub%20dir/my%20image.jpg', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg?one=two&three=four');
-        $this->assertEquals('foo.jpg?one=two&amp;three=four', $result);
+        $this->assertSame('foo.jpg?one=two&amp;three=four', $result);
 
         $result = $this->Helper->assetUrl('x:"><script>alert(1)</script>');
-        $this->assertEquals('x:&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', $result);
+        $this->assertSame('x:&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', $result);
 
         $result = $this->Helper->assetUrl('dir/big+tall/image', ['ext' => '.jpg']);
-        $this->assertEquals('dir/big%2Btall/image.jpg', $result);
+        $this->assertSame('dir/big%2Btall/image.jpg', $result);
     }
 
     /**
@@ -285,10 +285,10 @@ class UrlHelperTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $result = $this->Helper->assetUrl('TestPlugin.style', ['ext' => '.css']);
-        $this->assertEquals('test_plugin/style.css', $result);
+        $this->assertSame('test_plugin/style.css', $result);
 
         $result = $this->Helper->assetUrl('TestPlugin.style', ['ext' => '.css', 'plugin' => false]);
-        $this->assertEquals('TestPlugin.style.css', $result);
+        $this->assertSame('TestPlugin.style.css', $result);
 
         $this->removePlugins(['TestPlugin']);
     }
@@ -304,7 +304,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => 'https://xyz/']);
-        $this->assertEquals('https://xyz/img/foo.jpg', $result);
+        $this->assertSame('https://xyz/img/foo.jpg', $result);
     }
 
     /**
@@ -416,25 +416,25 @@ class UrlHelperTest extends TestCase
     public function testImage()
     {
         $result = $this->Helper->image('foo.jpg');
-        $this->assertEquals('img/foo.jpg', $result);
+        $this->assertSame('img/foo.jpg', $result);
 
         $result = $this->Helper->image('foo.jpg', ['fullBase' => true]);
         $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = $this->Helper->image('dir/sub dir/my image.jpg');
-        $this->assertEquals('img/dir/sub%20dir/my%20image.jpg', $result);
+        $this->assertSame('img/dir/sub%20dir/my%20image.jpg', $result);
 
         $result = $this->Helper->image('foo.jpg?one=two&three=four');
-        $this->assertEquals('img/foo.jpg?one=two&amp;three=four', $result);
+        $this->assertSame('img/foo.jpg?one=two&amp;three=four', $result);
 
         $result = $this->Helper->image('dir/big+tall/image.jpg');
-        $this->assertEquals('img/dir/big%2Btall/image.jpg', $result);
+        $this->assertSame('img/dir/big%2Btall/image.jpg', $result);
 
         $result = $this->Helper->image('cid:foo.jpg');
-        $this->assertEquals('cid:foo.jpg', $result);
+        $this->assertSame('cid:foo.jpg', $result);
 
         $result = $this->Helper->image('CID:foo.jpg');
-        $this->assertEquals('CID:foo.jpg', $result);
+        $this->assertSame('CID:foo.jpg', $result);
     }
 
     /**
@@ -461,7 +461,7 @@ class UrlHelperTest extends TestCase
         $timestamp = false;
 
         $result = $this->Helper->image('cake.icon.png', ['timestamp' => $timestamp]);
-        $this->assertEquals('img/cake.icon.png', $result);
+        $this->assertSame('img/cake.icon.png', $result);
     }
 
     /**
@@ -472,7 +472,7 @@ class UrlHelperTest extends TestCase
     public function testCss()
     {
         $result = $this->Helper->css('style');
-        $this->assertEquals('css/style.css', $result);
+        $this->assertSame('css/style.css', $result);
     }
 
     /**
@@ -499,7 +499,7 @@ class UrlHelperTest extends TestCase
         $timestamp = false;
 
         $result = $this->Helper->css('cake.generic', ['timestamp' => $timestamp]);
-        $this->assertEquals('css/cake.generic.css', $result);
+        $this->assertSame('css/cake.generic.css', $result);
     }
 
     /**

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -105,13 +105,13 @@ class StringTemplateTest extends TestCase
             'url' => '/',
             'text' => 'example',
         ]);
-        $this->assertEquals('<a href="/">example</a>', $result);
+        $this->assertSame('<a href="/">example</a>', $result);
 
         $result = $this->template->format('custom', [
             'standard' => 'default',
             'templateVars' => ['var1' => 'foo'],
         ]);
-        $this->assertEquals('<custom default v1="foo" v2="" />', $result);
+        $this->assertSame('<custom default v1="foo" v2="" />', $result);
     }
 
     /**
@@ -146,13 +146,13 @@ class StringTemplateTest extends TestCase
             'url' => '/',
             'text' => ['example', 'text'],
         ]);
-        $this->assertEquals('<a href="/">exampletext</a>', $result);
+        $this->assertSame('<a href="/">exampletext</a>', $result);
 
         $result = $this->template->format('link', [
             'url' => '/',
             'text' => ['key' => 'example', 'text'],
         ]);
-        $this->assertEquals('<a href="/">exampletext</a>', $result);
+        $this->assertSame('<a href="/">exampletext</a>', $result);
     }
 
     /**
@@ -182,7 +182,7 @@ class StringTemplateTest extends TestCase
         $this->template->remove('compactAttribute');
         $this->assertEquals([], $this->template->get());
         $this->assertNull($this->template->load('test_templates'));
-        $this->assertEquals('<a href="{{url}}">{{text}}</a>', $this->template->get('link'));
+        $this->assertSame('<a href="{{url}}">{{text}}</a>', $this->template->get('link'));
     }
 
     /**
@@ -194,7 +194,7 @@ class StringTemplateTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         $this->assertNull($this->template->load('TestPlugin.test_templates'));
-        $this->assertEquals('<em>{{text}}</em>', $this->template->get('italic'));
+        $this->assertSame('<em>{{text}}</em>', $this->template->get('italic'));
         $this->clearPlugins();
     }
 
@@ -302,10 +302,10 @@ class StringTemplateTest extends TestCase
         $this->assertNull($this->template->push());
 
         $this->template->add(['name' => 'my name']);
-        $this->assertEquals('my name', $this->template->get('name'));
+        $this->assertSame('my name', $this->template->get('name'));
 
         $this->assertNull($this->template->pop());
-        $this->assertEquals('{{name}} is my name', $this->template->get('name'));
+        $this->assertSame('{{name}} is my name', $this->template->get('name'));
 
         $this->assertNull($this->template->pop());
         $this->assertNull($this->template->pop());

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -216,12 +216,12 @@ class ViewBuilderTest extends TestCase
             $events
         );
         $this->assertInstanceOf('Cake\View\AjaxView', $view);
-        $this->assertEquals('edit', $view->getTemplate());
-        $this->assertEquals('default', $view->getLayout());
-        $this->assertEquals('Articles/', $view->getTemplatePath());
-        $this->assertEquals('Admin/', $view->getLayoutPath());
-        $this->assertEquals('TestPlugin', $view->getPlugin());
-        $this->assertEquals('TestTheme', $view->getTheme());
+        $this->assertSame('edit', $view->getTemplate());
+        $this->assertSame('default', $view->getLayout());
+        $this->assertSame('Articles/', $view->getTemplatePath());
+        $this->assertSame('Admin/', $view->getLayoutPath());
+        $this->assertSame('TestPlugin', $view->getPlugin());
+        $this->assertSame('TestTheme', $view->getTheme());
         $this->assertSame($request, $view->getRequest());
         $this->assertInstanceOf(Response::class, $view->getResponse());
         $this->assertSame($events, $view->getEventManager());
@@ -322,10 +322,10 @@ class ViewBuilderTest extends TestCase
         $builder = new ViewBuilder();
         $builder->createFromArray(json_decode($result, true));
 
-        $this->assertEquals('default', $builder->getTemplate());
-        $this->assertEquals('test', $builder->getLayout());
+        $this->assertSame('default', $builder->getTemplate());
+        $this->assertSame('test', $builder->getLayout());
         $this->assertEquals(['Html'], $builder->getHelpers());
-        $this->assertEquals('JsonView', $builder->getClassName());
+        $this->assertSame('JsonView', $builder->getClassName());
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -659,7 +659,7 @@ class ViewTest extends TestCase
     public function testElement()
     {
         $result = $this->View->element('test_element');
-        $this->assertEquals('this is the test element', $result);
+        $this->assertSame('this is the test element', $result);
 
         $result = $this->View->element('TestPlugin.plugin_element');
         $this->assertEquals("Element in the TestPlugin\n", $result);
@@ -681,21 +681,21 @@ class ViewTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
         $result = $this->View->element('prefix_element');
-        $this->assertEquals('this is a prefixed test element', $result);
+        $this->assertSame('this is a prefixed test element', $result);
 
         $result = $this->View->element('TestPlugin.plugin_element');
-        $this->assertEquals('this is the plugin prefixed element using params[plugin]', $result);
+        $this->assertSame('this is the plugin prefixed element using params[plugin]', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('plugin', 'TestPlugin'));
         $result = $this->View->element('test_plugin_element');
-        $this->assertEquals('this is the test set using View::$plugin plugin prefixed element', $result);
+        $this->assertSame('this is the test set using View::$plugin plugin prefixed element', $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'FooPrefix/BarPrefix'));
         $result = $this->View->element('prefix_element');
-        $this->assertEquals('this is a nested prefixed test element', $result);
+        $this->assertSame('this is a nested prefixed test element', $result);
 
         $result = $this->View->element('prefix_element_in_parent');
-        $this->assertEquals('this is a nested prefixed test element in first level element', $result);
+        $this->assertSame('this is a nested prefixed test element in first level element', $result);
     }
 
     /**
@@ -754,11 +754,11 @@ class ViewTest extends TestCase
 
         $View = $Controller->createView();
         $result = $View->element('type_check', ['form' => 'string'], ['callbacks' => true]);
-        $this->assertEquals('string', $result);
+        $this->assertSame('string', $result);
 
         $View->set('form', 'string');
         $result = $View->element('type_check', [], ['callbacks' => true]);
-        $this->assertEquals('string', $result);
+        $this->assertSame('string', $result);
     }
 
     /**
@@ -771,7 +771,7 @@ class ViewTest extends TestCase
         $Controller = new ViewPostsController();
         $View = $Controller->createView();
         $result = $View->element('test_element', ['ram' => 'val', 'test' => ['foo', 'bar']]);
-        $this->assertEquals('this is the test element', $result);
+        $this->assertSame('this is the test element', $result);
     }
 
     /**
@@ -868,7 +868,7 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 
         $config = $View->Html->getConfig();
-        $this->assertEquals('bar', $config['foo']);
+        $this->assertSame('bar', $config['foo']);
     }
 
     /**
@@ -907,10 +907,10 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
 
         $config = $View->Html->getConfig();
-        $this->assertEquals('bar', $config['foo']);
+        $this->assertSame('bar', $config['foo']);
 
         $config = $View->Form->getConfig();
-        $this->assertEquals('baz', $config['foo']);
+        $this->assertSame('baz', $config['foo']);
     }
 
     /**
@@ -935,7 +935,7 @@ class ViewTest extends TestCase
     {
         $View = new TestView();
         $config = $View->Html->getConfig();
-        $this->assertEquals('myval', $config['mykey']);
+        $this->assertSame('myval', $config['mykey']);
     }
 
     /**
@@ -1040,7 +1040,7 @@ class ViewTest extends TestCase
         $View = $this->PostsController->createView();
         $View->setTemplatePath($this->PostsController->getName());
         $View->render('index');
-        $this->assertEquals('Valuation', $View->helpers()->TestBeforeAfter->property);
+        $this->assertSame('Valuation', $View->helpers()->TestBeforeAfter->property);
     }
 
     /**
@@ -1077,7 +1077,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
-        $this->assertEquals('posts index', $result);
+        $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
         // HtmlHelper is loaded in TestView::initialize()
@@ -1090,7 +1090,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
-        $this->assertEquals('posts index', $result);
+        $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
         $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
@@ -1137,7 +1137,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath($this->PostsController->getName());
         $View->setTemplate('cache_form');
 
-        $this->assertEquals('cache_form', $View->getTemplate());
+        $this->assertSame('cache_form', $View->getTemplate());
         $result = $View->render();
         $this->assertRegExp('/Add User/', $result);
     }
@@ -1269,7 +1269,7 @@ class ViewTest extends TestCase
         $this->View->end();
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('New content', $result);
+        $this->assertSame('New content', $result);
     }
 
     /**
@@ -1289,7 +1289,7 @@ class ViewTest extends TestCase
         $this->View->end();
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('Block contentNew content', $result);
+        $this->assertSame('Block contentNew content', $result);
     }
 
     /**
@@ -1304,7 +1304,7 @@ class ViewTest extends TestCase
         $this->View->end();
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('Block content', $result);
+        $this->assertSame('Block content', $result);
     }
 
     /**
@@ -1325,7 +1325,7 @@ class ViewTest extends TestCase
         $this->View->end();
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('Content appended', $result);
+        $this->assertSame('Content appended', $result);
     }
 
     /**
@@ -1339,7 +1339,7 @@ class ViewTest extends TestCase
         $this->assertSame($this->View, $result);
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('Block content', $result);
+        $this->assertSame('Block content', $result);
     }
 
     /**
@@ -1433,7 +1433,7 @@ class ViewTest extends TestCase
     {
         $this->View->assign('testWithDecimal', 1.23456789);
         $result = $this->View->fetch('testWithDecimal');
-        $this->assertEquals('1.23456789', $result);
+        $this->assertSame('1.23456789', $result);
     }
 
     /**
@@ -1526,7 +1526,7 @@ class ViewTest extends TestCase
         $this->assertSame($this->View, $result);
 
         $result = $this->View->fetch('test');
-        $this->assertEquals('Unknown', $result);
+        $this->assertSame('Unknown', $result);
     }
 
     /**
@@ -1538,7 +1538,7 @@ class ViewTest extends TestCase
     {
         $this->View->prepend('test', 'Unknown');
         $result = $this->View->fetch('test');
-        $this->assertEquals('Unknown', $result);
+        $this->assertSame('Unknown', $result);
     }
 
     /**
@@ -1569,8 +1569,8 @@ class ViewTest extends TestCase
         echo 'In first';
         $this->View->end();
 
-        $this->assertEquals('In first In first', $this->View->fetch('first'));
-        $this->assertEquals('In second', $this->View->fetch('second'));
+        $this->assertSame('In first In first', $this->View->fetch('first'));
+        $this->assertSame('In second', $this->View->fetch('second'));
     }
 
     /**

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -53,7 +53,7 @@ class ViewVarsTraitTest extends TestCase
 
         $update = ['test' => 'updated'];
         $this->subject->set($update);
-        $this->assertEquals('updated', $this->subject->viewBuilder()->getVar('test'));
+        $this->assertSame('updated', $this->subject->viewBuilder()->getVar('test'));
     }
 
     /**
@@ -103,11 +103,11 @@ class ViewVarsTraitTest extends TestCase
     {
         $expected = ['one' => 'one'];
         $this->subject->set($expected);
-        $this->assertEquals('one', $this->subject->createView()->get('one'));
+        $this->assertSame('one', $this->subject->createView()->get('one'));
 
         $expected = ['one' => 'one', 'two' => 'two'];
         $this->subject->set($expected);
-        $this->assertEquals('two', $this->subject->createView()->get('two'));
+        $this->assertSame('two', $this->subject->createView()->get('two'));
     }
 
     /**


### PR DESCRIPTION
Switching assertEquals() to assertSame() for scalar values finds quite some issues in both src return types but also the tests itself. Wrong expectations here can lead to bad coding.
It is generally a code smell to assert too weakly on scalar values, we should go away from assertEquals() here in general more and more.

I switched over a few trivial cases, we can do more batches in the future.
Especially around falsey values this is super important, but also now on all scalar returns that are not yet typehinted but expected as a type to go into another typehinted method. The stricter the checks here in tests, the more likely this will not blow up later in code that uses the return values (and trusts the documented type).