### PR TITLE
Set reponse instance returned by action to Controller::$response.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -607,7 +607,12 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         /* @var callable $callable */
         $callable = [$this, $request->getParam('action')];
 
-        return $callable(...array_values($request->getParam('pass')));
+        $result = $callable(...array_values($request->getParam('pass')));
+        if ($result instanceof Response) {
+            $this->response = $result;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -131,7 +131,7 @@ class TestController extends ControllerTestAppController
 
     public function returner()
     {
-        return 'I am from the controller.';
+        return $this->response->withStringBody('I am from the controller.');
     }
 
     //@codingStandardsIgnoreStart
@@ -923,11 +923,13 @@ class ControllerTest extends TestCase
                 'pass' => []
             ]
         ]);
-        $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
+        $response = new Response();
 
         $Controller = new TestController($url, $response);
         $result = $Controller->invokeAction();
-        $this->assertEquals('I am from the controller.', $result);
+
+        $this->assertEquals('I am from the controller.', (string)$result);
+        $this->assertEquals('I am from the controller.', (string)$Controller->getResponse());
     }
 
     /**


### PR DESCRIPTION
This ensures afterFilter() has access to the updated response.
Closes #13249.