### PR TITLE
Fix return annotation CsrfProtectionMiddlewareTest::_getRequestHandler

### DIFF
--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -58,7 +58,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
     /**
      * Provides the request handler
      *
-     * @return \Psr\Server\RequestHandlerInterface
+     * @return \Psr\Http\Server\RequestHandlerInterface
      */
     protected function _getRequestHandler()
     {


### PR DESCRIPTION
Fix return annotation CsrfProtectionMiddlewareTest::_getRequestHandler