### PR TITLE
3.next - Add success/error exit code assertions

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\TestSuite;
 
+use Cake\Console\Command;
 use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleInput;
 use Cake\Console\ConsoleIo;
@@ -139,6 +140,28 @@ trait ConsoleIntegrationTestTrait
     public function assertExitCode($expected, $message = '')
     {
         $this->assertThat($expected, new ExitCode($this->_exitCode), $message);
+    }
+
+    /**
+     * Asserts shell exited with the Command::CODE_SUCCESS
+     *
+     * @param string $message Failure message
+     * @return void
+     */
+    public function assertExitSuccess($message = '')
+    {
+        $this->assertThat(Command::CODE_SUCCESS, new ExitCode($this->_exitCode), $message);
+    }
+
+    /**
+     * Asserts shell exited with Command::CODE_ERROR
+     *
+     * @param string $message Failure message
+     * @return void
+     */
+    public function assertExitError($message = '')
+    {
+        $this->assertThat(Command::CODE_ERROR, new ExitCode($this->_exitCode), $message);
     }
 
     /**

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -45,6 +45,7 @@ class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
         $this->exec('routes');
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitSuccess();
     }
 
     /**
@@ -58,6 +59,7 @@ class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
 
         $this->assertOutputContains('Welcome to CakePHP');
         $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitError();
     }
 
     /**


### PR DESCRIPTION
I use the assertExitCode() method quite a bit in my tests. However using those methods requires that I import Command, type out the constant names quite a bit. Having more specific assertions would help make tests terser and require fewer imports.
