### PR TITLE
Revert to using Database\Connection for typehinting in classes under /Database.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,6 +36,7 @@ parameters:
         - '#Parameter \#2 \$assoc of method Cake\\ORM\\Marshaller::_mergeBelongsToMany\(\) expects .+BelongsToMany, Cake\\ORM\\Association given.#'
         - '#Parameter \#1 \$table of method Cake\\ORM\\Query::addDefaultTypes\(\) expects Cake\\ORM\\Table, .+RepositoryInterface given.#'
         - '#Parameter \#1 \$table of method Cake\\ORM\\Query::_addAssociationsToTypeMap\(\) expects Cake\\ORM\\Table, .+RepositoryInterface given.#'
+        - '#Parameter \#1 \$connection of method Cake\\Database\\Schema\\SqlGeneratorInterface::(create|drop|truncate)Sql\(\) expects Cake\\Database\\Connection, Cake\\Datasource\\ConnectionInterface given#'
         -
             message: '#Right side of && is always false#'
             path: 'src/Cache/Engine/MemcachedEngine.php'

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,7 @@
 <psalm
     allowCoercionFromStringToClassConst="true"
     allowStringToStandInForClass="true"
+    usePhpDocMethodsWithoutMagicCall="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Database/Schema/SqlGeneratorInterface.php
+++ b/src/Database/Schema/SqlGeneratorInterface.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Datasource\ConnectionInterface;
+use Cake\Database\Connection;
 
 /**
  * An interface used by TableSchema objects.
@@ -29,11 +29,11 @@ interface SqlGeneratorInterface
      * Uses the connection to access the schema dialect
      * to generate platform specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array List of SQL statements to create the table and the
      *    required indexes.
      */
-    public function createSql(ConnectionInterface $connection): array;
+    public function createSql(Connection $connection): array;
 
     /**
      * Generate the SQL to drop a table.
@@ -41,32 +41,32 @@ interface SqlGeneratorInterface
      * Uses the connection to access the schema dialect to generate platform
      * specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
-    public function dropSql(ConnectionInterface $connection): array;
+    public function dropSql(Connection $connection): array;
 
     /**
      * Generate the SQL statements to truncate a table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to truncate a table.
      */
-    public function truncateSql(ConnectionInterface $connection): array;
+    public function truncateSql(Connection $connection): array;
 
     /**
      * Generate the SQL statements to add the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to add the constraints.
      */
-    public function addConstraintSql(ConnectionInterface $connection): array;
+    public function addConstraintSql(Connection $connection): array;
 
     /**
      * Generate the SQL statements to drop the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
-    public function dropConstraintSql(ConnectionInterface $connection): array;
+    public function dropConstraintSql(Connection $connection): array;
 }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Connection;
 use Cake\Database\Exception;
 use Cake\Database\TypeFactory;
-use Cake\Datasource\ConnectionInterface;
 
 /**
  * Represents a single table in a database schema.
@@ -703,7 +703,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function createSql(ConnectionInterface $connection): array
+    public function createSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
         $columns = $constraints = $indexes = [];
@@ -723,7 +723,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function dropSql(ConnectionInterface $connection): array
+    public function dropSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
 
@@ -733,7 +733,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function truncateSql(ConnectionInterface $connection): array
+    public function truncateSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
 
@@ -743,7 +743,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function addConstraintSql(ConnectionInterface $connection): array
+    public function addConstraintSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
 
@@ -753,7 +753,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function dropConstraintSql(ConnectionInterface $connection): array
+    public function dropConstraintSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
 


### PR DESCRIPTION
This reverts the typehint changes to Database classes in #13254. I have explained the reason in comments https://github.com/cakephp/cakephp/pull/13254#discussion_r285338384