### PR TITLE
Typehint using DriverInterface instead of Driver.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -51,7 +51,7 @@ class Connection implements ConnectionInterface
      * Driver object, responsible for creating the real connection
      * and provide specific SQL dialect.
      *
-     * @var \Cake\Database\Driver
+     * @var \Cake\Database\DriverInterface
      */
     protected $_driver;
 
@@ -162,7 +162,7 @@ class Connection implements ConnectionInterface
      * Sets the driver instance. If a string is passed it will be treated
      * as a class name and will be instantiated.
      *
-     * @param \Cake\Database\Driver|string $driver The driver instance to use.
+     * @param \Cake\Database\DriverInterface|string $driver The driver instance to use.
      * @param array $config Config for a new driver.
      * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
      * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
@@ -200,9 +200,9 @@ class Connection implements ConnectionInterface
     /**
      * Gets the driver instance.
      *
-     * @return \Cake\Database\Driver
+     * @return \Cake\Database\DriverInterface
      */
-    public function getDriver(): Driver
+    public function getDriver(): DriverInterface
     {
         return $this->_driver;
     }

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -53,7 +53,7 @@ class FieldTypeConverter
     /**
      * The driver object to be used in the type conversion
      *
-     * @var \Cake\Database\Driver
+     * @var \Cake\Database\DriverInterface
      */
     protected $_driver;
 
@@ -61,9 +61,9 @@ class FieldTypeConverter
      * Builds the type map
      *
      * @param \Cake\Database\TypeMap $typeMap Contains the types to use for converting results
-     * @param \Cake\Database\Driver $driver The driver to use for the type conversion
+     * @param \Cake\Database\DriverInterface $driver The driver to use for the type conversion
      */
-    public function __construct(TypeMap $typeMap, Driver $driver)
+    public function __construct(TypeMap $typeMap, DriverInterface $driver)
     {
         $this->_driver = $driver;
         $map = $typeMap->toArray();

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Statement;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeConverterTrait;
 use Iterator;
@@ -48,7 +48,7 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * The driver for the statement
      *
-     * @var \Cake\Database\Driver
+     * @var \Cake\Database\DriverInterface
      */
     protected $_driver;
 
@@ -77,9 +77,9 @@ class BufferedStatement implements Iterator, StatementInterface
      * Constructor
      *
      * @param \Cake\Database\StatementInterface $statement Statement implementation such as PDOStatement
-     * @param \Cake\Database\Driver $driver Driver instance
+     * @param \Cake\Database\DriverInterface $driver Driver instance
      */
-    public function __construct(StatementInterface $statement, Driver $driver)
+    public function __construct(StatementInterface $statement, DriverInterface $driver)
     {
         $this->statement = $statement;
         $this->_driver = $driver;

--- a/src/Database/Statement/CallbackStatement.php
+++ b/src/Database/Statement/CallbackStatement.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Statement;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Database\StatementInterface;
 
 /**
@@ -38,10 +38,10 @@ class CallbackStatement extends StatementDecorator
      * Constructor
      *
      * @param \Cake\Database\StatementInterface $statement The statement to decorate.
-     * @param \Cake\Database\Driver $driver The driver instance used by the statement.
+     * @param \Cake\Database\DriverInterface $driver The driver instance used by the statement.
      * @param callable $callback The callback to apply to results before they are returned.
      */
-    public function __construct(StatementInterface $statement, Driver $driver, callable $callback)
+    public function __construct(StatementInterface $statement, DriverInterface $driver, callable $callback)
     {
         parent::__construct($statement, $driver);
         $this->_callback = $callback;

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -47,7 +47,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
     /**
      * Reference to the driver object associated to this statement.
      *
-     * @var \Cake\Database\Driver|null
+     * @var \Cake\Database\DriverInterface|null
      */
     protected $_driver;
 
@@ -63,7 +63,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      *
      * @param \Cake\Database\StatementInterface|\PDOStatement|null $statement Statement implementation
      *  such as PDOStatement.
-     * @param \Cake\Database\Driver|null $driver Driver instance
+     * @param \Cake\Database\DriverInterface|null $driver Driver instance
      */
     public function __construct($statement = null, $driver = null)
     {

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Database\TypeInterface;
 use PDO;
 
@@ -61,7 +61,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
-    public function toStatement($value, Driver $driver)
+    public function toStatement($value, DriverInterface $driver)
     {
         if ($value === null) {
             return PDO::PARAM_NULL;

--- a/src/Database/Type/BatchCastingInterface.php
+++ b/src/Database/Type/BatchCastingInterface.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 
 /**
  * Denotes type objects capable of converting many values from their original
@@ -30,8 +30,8 @@ interface BatchCastingInterface
      *
      * @param array $values The original array of values containing the fields to be casted
      * @param array $fields The field keys to cast
-     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
+     * @param \Cake\Database\DriverInterface $driver Object from which database preferences and configuration will be extracted.
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array;
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array;
 }

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Core\Exception\Exception;
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use PDO;
 
 /**
@@ -34,10 +34,10 @@ class BinaryType extends BaseType
      * As PDO will handle reading file handles.
      *
      * @param string|resource $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|resource
      */
-    public function toDatabase($value, Driver $driver)
+    public function toDatabase($value, DriverInterface $driver)
     {
         return $value;
     }
@@ -46,11 +46,11 @@ class BinaryType extends BaseType
      * Convert binary into resource handles
      *
      * @param null|string|resource $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return resource|null
      * @throws \Cake\Core\Exception\Exception
      */
-    public function toPHP($value, Driver $driver)
+    public function toPHP($value, DriverInterface $driver)
     {
         if ($value === null) {
             return null;
@@ -68,10 +68,10 @@ class BinaryType extends BaseType
      * Get the correct PDO binding type for Binary data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_LOB;
     }

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Core\Exception\Exception;
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Utility\Text;
 use PDO;
 
@@ -35,10 +35,10 @@ class BinaryUuidType extends BaseType
      * As PDO will handle reading file handles.
      *
      * @param string|resource $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|resource
      */
-    public function toDatabase($value, Driver $driver)
+    public function toDatabase($value, DriverInterface $driver)
     {
         if (is_string($value)) {
             return $this->convertStringToBinaryUuid($value);
@@ -61,11 +61,11 @@ class BinaryUuidType extends BaseType
      * Convert binary uuid into resource handles
      *
      * @param null|string|resource $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return resource|string|null
      * @throws \Cake\Core\Exception\Exception
      */
-    public function toPHP($value, Driver $driver)
+    public function toPHP($value, DriverInterface $driver)
     {
         if ($value === null) {
             return null;
@@ -84,10 +84,10 @@ class BinaryUuidType extends BaseType
      * Get the correct PDO binding type for Binary data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_LOB;
     }

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -31,10 +31,10 @@ class BoolType extends BaseType implements BatchCastingInterface
      * Convert bool data into the database format.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return bool|null
      */
-    public function toDatabase($value, Driver $driver): ?bool
+    public function toDatabase($value, DriverInterface $driver): ?bool
     {
         if ($value === true || $value === false || $value === null) {
             return $value;
@@ -54,10 +54,10 @@ class BoolType extends BaseType implements BatchCastingInterface
      * Convert bool values to PHP booleans
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return bool|null
      */
-    public function toPHP($value, Driver $driver): ?bool
+    public function toPHP($value, DriverInterface $driver): ?bool
     {
         if ($value === null || $value === true || $value === false) {
             return $value;
@@ -75,7 +75,7 @@ class BoolType extends BaseType implements BatchCastingInterface
      *
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field]) || $values[$field] === true || $values[$field] === false) {
@@ -108,10 +108,10 @@ class BoolType extends BaseType implements BatchCastingInterface
      * Get the correct PDO binding type for bool data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         if ($value === null) {
             return PDO::PARAM_NULL;

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use DateTime;
@@ -106,10 +106,10 @@ class DateTimeType extends BaseType
      * Convert DateTime instance into strings.
      *
      * @param string|int|\DateTime|\DateTimeImmutable $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      */
-    public function toDatabase($value, Driver $driver): ?string
+    public function toDatabase($value, DriverInterface $driver): ?string
     {
         if ($value === null || is_string($value)) {
             return $value;
@@ -159,10 +159,10 @@ class DateTimeType extends BaseType
      * Convert strings into DateTime instances.
      *
      * @param string|int|null $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return \Cake\I18n\Time|\DateTime|null
      */
-    public function toPHP($value, Driver $driver)
+    public function toPHP($value, DriverInterface $driver)
     {
         if ($value === null || strpos($value, '0000-00-00') === 0) {
             return null;
@@ -186,7 +186,7 @@ class DateTimeType extends BaseType
      *
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver)
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver)
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {
@@ -409,11 +409,11 @@ class DateTimeType extends BaseType
      * Casts given value to Statement equivalent
      *
      * @param mixed $value value to be converted to PDO statement
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
+     * @param \Cake\Database\DriverInterface $driver object from which database preferences and configuration will be extracted
      *
      * @return mixed
      */
-    public function toStatement($value, Driver $driver)
+    public function toStatement($value, DriverInterface $driver)
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use InvalidArgumentException;
 use PDO;
 use RuntimeException;
@@ -47,11 +47,11 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * Convert integer data into the database format.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return mixed
      * @throws \InvalidArgumentException
      */
-    public function toDatabase($value, Driver $driver)
+    public function toDatabase($value, DriverInterface $driver)
     {
         if ($value === null || $value === '') {
             return null;
@@ -78,11 +78,11 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * Convert float values to PHP floats
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      * @throws \Cake\Core\Exception\Exception
      */
-    public function toPHP($value, Driver $driver): ?string
+    public function toPHP($value, DriverInterface $driver): ?string
     {
         if ($value === null) {
             return null;
@@ -96,7 +96,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      *
      * @return string[]
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {
@@ -113,10 +113,10 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * Get the correct PDO binding type for integer data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use PDO;
 use RuntimeException;
 
@@ -46,10 +46,10 @@ class FloatType extends BaseType implements BatchCastingInterface
      * Convert integer data into the database format.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return float|null
      */
-    public function toDatabase($value, Driver $driver): ?float
+    public function toDatabase($value, DriverInterface $driver): ?float
     {
         if ($value === null || $value === '') {
             return null;
@@ -62,11 +62,11 @@ class FloatType extends BaseType implements BatchCastingInterface
      * Convert float values to PHP integers
      *
      * @param null|string|resource $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return float|null
      * @throws \Cake\Core\Exception\Exception
      */
-    public function toPHP($value, Driver $driver): ?float
+    public function toPHP($value, DriverInterface $driver): ?float
     {
         if ($value === null) {
             return null;
@@ -80,7 +80,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      *
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {
@@ -97,10 +97,10 @@ class FloatType extends BaseType implements BatchCastingInterface
      * Get the correct PDO binding type for integer data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -48,10 +48,10 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * Convert integer data into the database format.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return int|null
      */
-    public function toDatabase($value, Driver $driver): ?int
+    public function toDatabase($value, DriverInterface $driver): ?int
     {
         if ($value === null || $value === '') {
             return null;
@@ -66,10 +66,10 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * Convert integer values to PHP integers
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return int|null
      */
-    public function toPHP($value, Driver $driver): ?int
+    public function toPHP($value, DriverInterface $driver): ?int
     {
         if ($value === null) {
             return $value;
@@ -83,7 +83,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      *
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {
@@ -102,10 +102,10 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * Get the correct PDO binding type for integer data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_INT;
     }

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -31,10 +31,10 @@ class JsonType extends BaseType implements BatchCastingInterface
      * Convert a value data into a JSON string
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      */
-    public function toDatabase($value, Driver $driver): ?string
+    public function toDatabase($value, DriverInterface $driver): ?string
     {
         if (is_resource($value)) {
             throw new InvalidArgumentException('Cannot convert a resource value to JSON');
@@ -47,10 +47,10 @@ class JsonType extends BaseType implements BatchCastingInterface
      * Convert string values to PHP arrays.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null|array
      */
-    public function toPHP($value, Driver $driver)
+    public function toPHP($value, DriverInterface $driver)
     {
         if (!is_string($value)) {
             return null;
@@ -64,7 +64,7 @@ class JsonType extends BaseType implements BatchCastingInterface
      *
      * @return array
      */
-    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {
@@ -81,10 +81,10 @@ class JsonType extends BaseType implements BatchCastingInterface
      * Get the correct PDO binding type for string data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use InvalidArgumentException;
 use PDO;
 
@@ -31,10 +31,10 @@ class StringType extends BaseType implements OptionalConvertInterface
      * Convert string data into the database format.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      */
-    public function toDatabase($value, Driver $driver): ?string
+    public function toDatabase($value, DriverInterface $driver): ?string
     {
         if ($value === null || is_string($value)) {
             return $value;
@@ -58,10 +58,10 @@ class StringType extends BaseType implements OptionalConvertInterface
      * Convert string values to PHP strings.
      *
      * @param mixed $value The value to convert.
-     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      */
-    public function toPHP($value, Driver $driver): ?string
+    public function toPHP($value, DriverInterface $driver): ?string
     {
         if ($value === null) {
             return null;
@@ -74,10 +74,10 @@ class StringType extends BaseType implements OptionalConvertInterface
      * Get the correct PDO binding type for string data.
      *
      * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
+     * @param \Cake\Database\DriverInterface $driver The driver.
      * @return int
      */
-    public function toStatement($value, Driver $driver): int
+    public function toStatement($value, DriverInterface $driver): int
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/UuidType.php
+++ b/src/Database/Type/UuidType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Utility\Text;
 
 /**
@@ -28,10 +28,10 @@ class UuidType extends StringType
      * Casts given value from a PHP type to one acceptable by database
      *
      * @param mixed $value value to be converted to database equivalent
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
+     * @param \Cake\Database\DriverInterface $driver object from which database preferences and configuration will be extracted
      * @return string|null
      */
-    public function toDatabase($value, Driver $driver): ?string
+    public function toDatabase($value, DriverInterface $driver): ?string
     {
         if ($value === null || $value === '') {
             return null;

--- a/src/Database/TypeConverterTrait.php
+++ b/src/Database/TypeConverterTrait.php
@@ -26,7 +26,7 @@ trait TypeConverterTrait
      * and return relevant internal statement type
      *
      * @param mixed $value The value to cast
-     * @param \Cake\Database\Type\BaseType|string $type The type name or type instance to use.
+     * @param \Cake\Database\TypeInterface|string $type The type name or type instance to use.
      * @return array list containing converted value and internal type
      */
     public function cast($value, $type): array

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -26,28 +26,28 @@ interface TypeInterface
      * Casts given value from a PHP type to one acceptable by a database.
      *
      * @param mixed $value Value to be converted to a database equivalent.
-     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
+     * @param \Cake\Database\DriverInterface $driver Object from which database preferences and configuration will be extracted.
      * @return mixed Given PHP type casted to one acceptable by a database.
      */
-    public function toDatabase($value, Driver $driver);
+    public function toDatabase($value, DriverInterface $driver);
 
     /**
      * Casts given value from a database type to a PHP equivalent.
      *
      * @param mixed $value Value to be converted to PHP equivalent
-     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted
+     * @param \Cake\Database\DriverInterface $driver Object from which database preferences and configuration will be extracted
      * @return mixed Given value casted from a database to a PHP equivalent.
      */
-    public function toPHP($value, Driver $driver);
+    public function toPHP($value, DriverInterface $driver);
 
     /**
      * Casts given value to its Statement equivalent.
      *
      * @param mixed $value Value to be converted to PDO statement.
-     * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
+     * @param \Cake\Database\DriverInterface $driver Object from which database preferences and configuration will be extracted.
      * @return mixed Given value casted to its Statement equivalent.
      */
-    public function toStatement($value, Driver $driver);
+    public function toStatement($value, DriverInterface $driver);
 
     /**
      * Marshalls flat data into PHP objects.

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -28,7 +28,7 @@ use Cake\Database\Log\QueryLogger;
  * @method \Cake\Database\StatementInterface prepare($sql)
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = [])
  * @method string quote($value, $type = null)
- * @method \Cake\Database\Driver getDriver()
+ * @method \Cake\Database\DriverInterface getDriver()
  */
 interface ConnectionInterface
 {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -156,7 +156,7 @@ class ResultSet implements ResultSetInterface
      *
      * Cached in a property to avoid multiple calls to the same function.
      *
-     * @var \Cake\Database\Driver
+     * @var \Cake\Database\DriverInterface
      */
     protected $_driver;
 

--- a/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
+++ b/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Database\Type;
 
-use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\BaseType;
@@ -14,7 +14,7 @@ use Cake\Database\Type\ExpressionTypeInterface;
  */
 class OrderedUuidType extends BaseType implements ExpressionTypeInterface
 {
-    public function toPHP($value, Driver $d)
+    public function toPHP($value, DriverInterface $d)
     {
         return new UuidValue($value);
     }
@@ -43,7 +43,7 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
         return $value;
     }
 
-    public function toDatabase($value, Driver $d)
+    public function toDatabase($value, DriverInterface $d)
     {
         return $value;
     }


### PR DESCRIPTION
While trying to revert [this](https://github.com/cakephp/cakephp/pull/13254/files#diff-955dfed9e9166267f0c48631fb15e957R51) docblock change I found that the interface could be used instead of concrete class throughout the Database package.