### PR TITLE
Improve error message for missing associations.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2532,10 +2532,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (!$association) {
             throw new RuntimeException(sprintf(
                 'Undefined property `%s`. ' .
-                'You have tried to use the `%s` property on %s, but that association does not exist.',
+                'You have not defined the `%s` association on `%s`.',
                 $property,
                 $property,
-                get_class($this),
+                static::class
             ));
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2531,9 +2531,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $association = $this->_associations->get($property);
         if (!$association) {
             throw new RuntimeException(sprintf(
-                'Table "%s" is not associated with "%s"',
+                'Undefined property `%s`. ' .
+                'You have tried to use the `%s` property on %s, but that association does not exist.',
+                $property,
+                $property,
                 get_class($this),
-                $property
             ));
         }
 

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -68,7 +68,7 @@ class AssociationProxyTest extends TestCase
     public function testGetBadAssociation()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Table "Cake\ORM\Table" is not associated with "posts"');
+        $this->expectExceptionMessage('association does not exist');
         $articles = $this->getTableLocator()->get('articles');
         $articles->posts;
     }

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -68,7 +68,7 @@ class AssociationProxyTest extends TestCase
     public function testGetBadAssociation()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('association does not exist');
+        $this->expectExceptionMessage('You have not defined');
         $articles = $this->getTableLocator()->get('articles');
         $articles->posts;
     }


### PR DESCRIPTION
Try to make the missing association error message clearer. Indicate that the property is undefined and that it was interpreted as an association.

Refs #13256