### PR TITLE
Cleanup ignore list. Add missing inline annotation for IDE.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,7 +20,6 @@ parameters:
         - '#Call to an undefined method Cake\\Auth\\Storage\\StorageInterface::setConfig\(\)#'
         - '#Variable \$_SESSION in isset\(\) always exists and is not nullable#'
         - '#PHPDoc tag @throws with type PHPUnit\\Exception|Throwable is not subtype of Throwable#'
-        - '#Binary operation "\+" between array|false and array results in an error#'
         - '#Call to an undefined method Cake\\Chronos\\DifferenceFormatterInterface::dateAgoInWords\(\)#'
         - '#Call to an undefined method Cake\\Chronos\\DifferenceFormatterInterface::timeAgoInWords\(\)#'
         - '#Return type \(void\) of method Cake\\Shell\\[A-Za-z]+Shell::main\(\) should be compatible with return type \(bool|int|null\) of method Cake\\Console\\Shell::main\(\)#'

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -1015,6 +1015,7 @@ trait CollectionTrait
      */
     protected function optimizeUnwrap(): iterable
     {
+        /** @var \ArrayObject $iterator */
         $iterator = $this->unwrap();
 
         if (get_class($iterator) === ArrayIterator::class) {

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -101,6 +101,7 @@ class ExtractIterator extends Collection
         $callback = $this->_extractor;
         $res = [];
 
+        /** @var \ArrayObject $iterator */
         foreach ($iterator->getArrayCopy() as $k => $v) {
             $res[$k] = $callback($v);
         }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1169,7 +1169,7 @@ class BelongsToMany extends Association
                     $inserted = array_combine(
                         array_keys($inserts),
                         (array)$sourceEntity->get($property)
-                    );
+                    ) ?: [];
                     $targetEntities = $inserted + $targetEntities;
                 }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1921,7 +1921,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $id = (array)$this->_newId($primary) + $keys;
 
         // Generate primary keys preferring values in $data.
-        $primary = array_combine($primary, $id);
+        $primary = array_combine($primary, $id) ?: [];
         $primary = array_intersect_key($data, $primary) + $primary;
 
         $filteredKeys = array_filter($primary, function ($v) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -791,12 +791,16 @@ class View implements EventDispatcherInterface
      * @param mixed $value Value in case $name is a string (which then works as the key).
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
+     * @throws \RuntimeException If the array combine operation failed.
      */
     public function set($name, $value = null)
     {
         if (is_array($name)) {
             if (is_array($value)) {
-                $data = array_combine($name, $value) ?: [];
+                $data = array_combine($name, $value);
+                if ($data === false) {
+                    throw new RuntimeException('Invalid data provided for array_combine() to work: Both $name and $value require same count.');
+                }
             } else {
                 $data = $name;
             }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -796,7 +796,7 @@ class View implements EventDispatcherInterface
     {
         if (is_array($name)) {
             if (is_array($value)) {
-                $data = array_combine($name, $value);
+                $data = array_combine($name, $value) ?: [];
             } else {
                 $data = $name;
             }


### PR DESCRIPTION
The alternative would be to throw an exception if false, but given that this would never really happen in these cases, the ternary seems to be the easier way to keep return type clean.