### PR TITLE
Make ConnectionInterface use LoggerInterface instance.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -718,22 +718,22 @@
       <code>function ($part, &amp;$field) {</code>
     </MissingClosureReturnType>
   </file>
+  <file src="src/Database/Log/LoggedQuery.php">
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($p) {</code>
+    </MissingClosureReturnType>
+  </file>
   <file src="src/Database/Log/LoggingStatement.php">
     <InvalidScalarArgument occurrences="2">
       <code>$type</code>
       <code>$type</code>
     </InvalidScalarArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>log</code>
-    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$_logger</code>
+    </PropertyNotSetInConstructor>
     <UndefinedPropertyAssignment occurrences="1">
       <code>$e-&gt;queryString</code>
     </UndefinedPropertyAssignment>
-  </file>
-  <file src="src/Database/Log/QueryLogger.php">
-    <MissingClosureReturnType occurrences="1">
-      <code>function ($p) {</code>
-    </MissingClosureReturnType>
   </file>
   <file src="src/Database/Query.php">
     <ImplementedReturnTypeMismatch occurrences="1">

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -32,6 +32,7 @@ use Cake\Database\Schema\CollectionInterface as SchemaCollectionInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Log\Log;
 use Exception;
+use Psr\Log\LoggerInterface;
 
 /**
  * Represents a connection with a database server.
@@ -87,7 +88,7 @@ class Connection implements ConnectionInterface
     /**
      * Logger object instance.
      *
-     * @var \Cake\Database\Log\QueryLogger|null
+     * @var \Psr\Log\LoggerInterface|null
      */
     protected $_logger;
 
@@ -828,10 +829,10 @@ class Connection implements ConnectionInterface
     /**
      * Sets a logger
      *
-     * @param \Cake\Database\Log\QueryLogger|null $logger Logger object
+     * @param \Psr\Log\LoggerInterface $logger Logger object
      * @return $this
      */
-    public function setLogger(?QueryLogger $logger)
+    public function setLogger(LoggerInterface $logger)
     {
         $this->_logger = $logger;
 
@@ -841,9 +842,9 @@ class Connection implements ConnectionInterface
     /**
      * Gets the logger object
      *
-     * @return \Cake\Database\Log\QueryLogger logger instance
+     * @return \Psr\Log\LoggerInterface logger instance
      */
-    public function getLogger(): QueryLogger
+    public function getLogger(): LoggerInterface
     {
         if ($this->_logger === null) {
             $this->_logger = new QueryLogger();
@@ -862,7 +863,7 @@ class Connection implements ConnectionInterface
     {
         $query = new LoggedQuery();
         $query->query = $sql;
-        $this->getLogger()->log($query);
+        $this->getLogger()->debug((string)$query, ['query' => $query]);
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -831,6 +831,7 @@ class Connection implements ConnectionInterface
      *
      * @param \Psr\Log\LoggerInterface $logger Logger object
      * @return $this
+     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function setLogger(LoggerInterface $logger)
     {

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -16,13 +16,15 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Log;
 
+use JsonSerializable;
+
 /**
  * Contains a query string, the params used to executed it, time taken to do it
  * and the number of rows found or affected by its execution.
  *
  * @internal
  */
-class LoggedQuery
+class LoggedQuery implements JsonSerializable
 {
     /**
      * Query string that was executed
@@ -97,6 +99,31 @@ class LoggedQuery
         }
 
         return preg_replace($keys, $params, $this->query, $limit);
+    }
+
+    /**
+     * Returns data that will be serialized as JSON
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        $error = $this->error;
+        if ($error !== null) {
+            $error = [
+                'class' => get_class($error),
+                'message' => $error->getMessage(),
+                'code' => $error->getCode(),
+            ];
+        }
+
+        return [
+            'query' => $this->query,
+            'numRows' => $this->numRows,
+            'params' => $this->params,
+            'took' => $this->took,
+            'error' => $error,
+        ];
     }
 
     /**

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -29,7 +29,7 @@ class LoggingStatement extends StatementDecorator
     /**
      * Logger instance responsible for actually doing the logging task
      *
-     * @var \Cake\Database\Log\QueryLogger|null
+     * @var \Cake\Database\Log\QueryLogger
      */
     protected $_logger;
 
@@ -82,7 +82,7 @@ class LoggingStatement extends StatementDecorator
         $query->took = (int)round((microtime(true) - $startTime) * 1000, 0);
         $query->params = $params ?: $this->_compiledParams;
         $query->query = $this->queryString;
-        $this->getLogger()->log($query);
+        $this->getLogger()->debug((string)$query, ['query' => $query]);
     }
 
     /**
@@ -120,9 +120,9 @@ class LoggingStatement extends StatementDecorator
     /**
      * Gets the logger object
      *
-     * @return \Cake\Database\Log\QueryLogger|null logger instance
+     * @return \Cake\Database\Log\QueryLogger logger instance
      */
-    public function getLogger(): ?QueryLogger
+    public function getLogger(): QueryLogger
     {
         return $this->_logger;
     }

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Log;
 
 use Cake\Database\Statement\StatementDecorator;
 use Exception;
+use Psr\Log\LoggerInterface;
 
 /**
  * Statement decorator used to
@@ -29,7 +30,7 @@ class LoggingStatement extends StatementDecorator
     /**
      * Logger instance responsible for actually doing the logging task
      *
-     * @var \Cake\Database\Log\QueryLogger
+     * @var \Psr\Log\LoggerInterface
      */
     protected $_logger;
 
@@ -109,10 +110,10 @@ class LoggingStatement extends StatementDecorator
     /**
      * Sets a logger
      *
-     * @param \Cake\Database\Log\QueryLogger $logger Logger object
+     * @param \Psr\Log\LoggerInterface $logger Logger object
      * @return void
      */
-    public function setLogger(QueryLogger $logger): void
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->_logger = $logger;
     }
@@ -120,9 +121,9 @@ class LoggingStatement extends StatementDecorator
     /**
      * Gets the logger object
      *
-     * @return \Cake\Database\Log\QueryLogger logger instance
+     * @return \Psr\Log\LoggerInterface logger instance
      */
-    public function getLogger(): QueryLogger
+    public function getLogger(): LoggerInterface
     {
         return $this->_logger;
     }

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Log;
 
+use Cake\Log\Engine\BaseLog;
 use Cake\Log\Log;
 
 /**
@@ -24,72 +25,29 @@ use Cake\Log\Log;
  *
  * @internal
  */
-class QueryLogger
+class QueryLogger extends BaseLog
 {
     /**
-     * Writes a LoggedQuery into a log
+     * Constructor.
      *
-     * @param \Cake\Database\Log\LoggedQuery $query to be written in log
-     * @return void
+     * @param array $config Configuration array
      */
-    public function log(LoggedQuery $query): void
+    public function __construct(array $config = [])
     {
-        if (!empty($query->params)) {
-            $query->query = $this->_interpolate($query);
-        }
-        $this->_log($query);
+        $this->_defaultConfig['scopes'] = ['queriesLog'];
+
+        parent::__construct($config);
     }
 
     /**
-     * Wrapper function for the logger object, useful for unit testing
-     * or for overriding in subclasses.
-     *
-     * @param \Cake\Database\Log\LoggedQuery $query to be written in log
-     * @return void
+     * @inheritDoc
      */
-    protected function _log(LoggedQuery $query): void
+    public function log($level, $message, array $context = [])
     {
-        Log::write('debug', $query, ['queriesLog']);
-    }
-
-    /**
-     * Helper function used to replace query placeholders by the real
-     * params used to execute the query
-     *
-     * @param \Cake\Database\Log\LoggedQuery $query The query to log
-     * @return string
-     */
-    protected function _interpolate(LoggedQuery $query): string
-    {
-        $params = array_map(function ($p) {
-            if ($p === null) {
-                return 'NULL';
-            }
-            if (is_bool($p)) {
-                return $p ? '1' : '0';
-            }
-
-            if (is_string($p)) {
-                $replacements = [
-                    '$' => '\\$',
-                    '\\' => '\\\\\\\\',
-                    "'" => "''",
-                ];
-
-                $p = strtr($p, $replacements);
-
-                return "'$p'";
-            }
-
-            return $p;
-        }, $query->params);
-
-        $keys = [];
-        $limit = is_int(key($params)) ? 1 : -1;
-        foreach ($params as $key => $param) {
-            $keys[] = is_string($key) ? "/:$key\b/" : '/[?]/';
-        }
-
-        return preg_replace($keys, $params, $query->query, $limit);
+        Log::write(
+            'debug',
+            (string)$context['query'],
+            ['scope' => $this->scopes() ?: ['queriesLog']]
+        );
     }
 }

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
-use Cake\Database\Log\QueryLogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * This interface defines the methods you can depend on in
@@ -35,17 +35,17 @@ interface ConnectionInterface
     /**
      * Set a logger, or clear the current logger.
      *
-     * @param \Cake\Database\Log\QueryLogger|null $logger Logger object
+     * @param \Psr\Log\LoggerInterface $logger Logger object
      * @return $this
      */
-    public function setLogger(?QueryLogger $logger);
+    public function setLogger(LoggerInterface $logger);
 
     /**
      * Gets the current logger object.
      *
-     * @return \Cake\Database\Log\QueryLogger logger instance
+     * @return \Psr\Log\LoggerInterface logger instance
      */
-    public function getLogger(): QueryLogger;
+    public function getLogger(): LoggerInterface;
 
     /**
      * Get the configuration name for this connection.

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,16 +31,8 @@ use Psr\Log\LoggerInterface;
  * @method string quote($value, $type = null)
  * @method \Cake\Database\DriverInterface getDriver()
  */
-interface ConnectionInterface
+interface ConnectionInterface extends LoggerAwareInterface
 {
-    /**
-     * Set a logger, or clear the current logger.
-     *
-     * @param \Psr\Log\LoggerInterface $logger Logger object
-     * @return $this
-     */
-    public function setLogger(LoggerInterface $logger);
-
     /**
      * Gets the current logger object.
      *

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -124,7 +124,11 @@ class LoggedQueryTest extends TestCase
             'numRows' => 4,
             'params' => $query->params,
             'took' => 0,
-            'error' => $query->error,
+            'error' => [
+                'class' => get_class($query->error),
+                'message' => $query->error->getMessage(),
+                'code' => $query->error->getCode(),
+            ],
         ]);
 
         $this->assertEquals($expected, json_encode($query));

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -110,4 +110,23 @@ class LoggedQueryTest extends TestCase
         $expected = "duration=0 rows=0 SELECT a FROM b where a = '\$2y\$10\$dUAIj' AND b = '\$0.23' AND c = 'a\\\\0b\\\\1c\\\\d' AND d = 'a''b'";
         $this->assertEquals($expected, (string)$query);
     }
+
+    public function testJsonSerialize()
+    {
+        $query = new LoggedQuery();
+        $query->query = 'SELECT a FROM b where a = :p1';
+        $query->params = ['p1' => '$2y$10$dUAIj'];
+        $query->numRows = 4;
+        $query->error = new \Exception('You fail!');
+
+        $expected = json_encode([
+            'query' => $query->query,
+            'numRows' => 4,
+            'params' => $query->params,
+            'took' => 0,
+            'error' => $query->error,
+        ]);
+
+        $this->assertEquals($expected, json_encode($query));
+    }
 }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\QueryLogger;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use Psr\Log\LogLevel;
 
 /**
  * Tests QueryLogger class
@@ -49,106 +50,6 @@ class QueryLoggerTest extends TestCase
     }
 
     /**
-     * Tests that query placeholders are replaced when logged
-     *
-     * @return void
-     */
-    public function testStringInterpolation()
-    {
-        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
-            ->setMethods(['_log'])
-            ->getMock();
-        $query = new LoggedQuery();
-        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4 AND e = :p5 AND f = :p6';
-        $query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3, 'p4' => true, 'p5' => false, 'p6' => 0];
-
-        $logger->expects($this->once())->method('_log')->with($query);
-        $logger->log($query);
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 3 AND c = NULL AND d = 1 AND e = 0 AND f = 0";
-        $this->assertEquals($expected, (string)$query);
-    }
-
-    /**
-     * Tests that positional placeholders are replaced when logging a query
-     *
-     * @return void
-     */
-    public function testStringInterpolationNotNamed()
-    {
-        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
-            ->setMethods(['_log'])
-            ->getMock();
-        $query = new LoggedQuery();
-        $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ? AND d = ? AND e = ? AND f = ?';
-        $query->params = ['string', '3', null, true, false, 0];
-
-        $logger->expects($this->once())->method('_log')->with($query);
-        $logger->log($query);
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = '3' AND c = NULL AND d = 1 AND e = 0 AND f = 0";
-        $this->assertEquals($expected, (string)$query);
-    }
-
-    /**
-     * Tests that repeated placeholders are correctly replaced
-     *
-     * @return void
-     */
-    public function testStringInterpolationDuplicate()
-    {
-        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
-            ->setMethods(['_log'])
-            ->getMock();
-        $query = new LoggedQuery();
-        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p1 AND c = :p2 AND d = :p2';
-        $query->params = ['p1' => 'string', 'p2' => 3];
-
-        $logger->expects($this->once())->method('_log')->with($query);
-        $logger->log($query);
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 'string' AND c = 3 AND d = 3";
-        $this->assertEquals($expected, (string)$query);
-    }
-
-    /**
-     * Tests that named placeholders
-     *
-     * @return void
-     */
-    public function testStringInterpolationNamed()
-    {
-        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
-            ->setMethods(['_log'])
-            ->getMock();
-        $query = new LoggedQuery();
-        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p11 AND c = :p20 AND d = :p2';
-        $query->params = ['p11' => 'test', 'p1' => 'string', 'p2' => 3, 'p20' => 5];
-
-        $logger->expects($this->once())->method('_log')->with($query);
-        $logger->log($query);
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 'test' AND c = 5 AND d = 3";
-        $this->assertEquals($expected, (string)$query);
-    }
-
-    /**
-     * Tests that placeholders are replaced with correctly escaped strings
-     *
-     * @return void
-     */
-    public function testStringInterpolationSpecialChars()
-    {
-        $logger = $this->getMockBuilder('Cake\Database\Log\QueryLogger')
-            ->setMethods(['_log'])
-            ->getMock();
-        $query = new LoggedQuery();
-        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4';
-        $query->params = ['p1' => '$2y$10$dUAIj', 'p2' => '$0.23', 'p3' => 'a\\0b\\1c\\d', 'p4' => "a'b"];
-
-        $logger->expects($this->once())->method('_log')->with($query);
-        $logger->log($query);
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = '\$2y\$10\$dUAIj' AND b = '\$0.23' AND c = 'a\\\\0b\\\\1c\\\\d' AND d = 'a''b'";
-        $this->assertEquals($expected, (string)$query);
-    }
-
-    /**
      * Tests that the logged query object is passed to the built-in logger using
      * the correct scope
      *
@@ -174,6 +75,6 @@ class QueryLoggerTest extends TestCase
         Log::engine('queryLoggerTest2');
 
         $engine2->expects($this->never())->method('log');
-        $logger->log($query);
+        $logger->log(LogLevel::DEBUG, (string)$query, compact('query'));
     }
 }


### PR DESCRIPTION
Update the internal class QueryLogger to implement LoggerInterface.
Query interpolation code has been moved to LoggedQuery itself.

This would allow people to use any PSR-3 complaint logger for the database package and remove hard dependency on `cakephp/log`.

I can finish up and update tests if the change seems reasonable.