### PR TITLE
Psalm fixes.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -26,9 +26,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Auth/DigestAuthenticate.php">
-    <PossiblyNullArgument occurrences="1">
-      <code>$request-&gt;getEnv('ORIGINAL_REQUEST_METHOD')</code>
-    </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>DigestAuthenticate</code>
     </PropertyNotSetInConstructor>
@@ -46,9 +43,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$user</code>
     </MoreSpecificImplementedParamType>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$_user</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Cache/CacheRegistry.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -56,10 +50,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Cache/Engine/FileEngine.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
-      <code>void</code>
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
     <PossiblyInvalidOperand occurrences="1">
       <code>$this-&gt;_File-&gt;current()</code>
     </PossiblyInvalidOperand>
@@ -76,9 +66,6 @@
     <MissingConstructor occurrences="1">
       <code>$_Memcached</code>
     </MissingConstructor>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$name</code>
-    </PossiblyInvalidArgument>
     <UndefinedConstant occurrences="3">
       <code>DAY</code>
       <code>DAY</code>
@@ -2479,15 +2466,12 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Utility/Inflector.php">
-    <NullableReturnStatement occurrences="4">
+    <NullableReturnStatement occurrences="3">
       <code>static::$_cache['pluralize'][$word]</code>
       <code>static::$_cache['pluralize'][$word]</code>
       <code>static::$_cache['singularize'][$word]</code>
       <code>static::$_cache['singularize'][$word]</code>
     </NullableReturnStatement>
-    <PossiblyFalseArgument occurrences="1">
-      <code>array_search(strtolower($regs[2]), static::$_irregular, true)</code>
-    </PossiblyFalseArgument>
   </file>
   <file src="src/Utility/Security.php">
     <LessSpecificReturnStatement occurrences="1">
@@ -2677,8 +2661,7 @@
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$options['templates']</code>
     </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$_defaultModel</code>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>PaginatorHelper</code>
     </PropertyNotSetInConstructor>
   </file>
@@ -2688,9 +2671,6 @@
     </LessSpecificImplementedReturnType>
   </file>
   <file src="src/View/Helper/TimeHelper.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$format</code>
-    </InvalidScalarArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>TimeHelper</code>
     </PropertyNotSetInConstructor>
@@ -2746,11 +2726,6 @@
     <UnresolvableInclude occurrences="1">
       <code>include func_get_arg(0)</code>
     </UnresolvableInclude>
-  </file>
-  <file src="src/View/Widget/MultiCheckboxWidget.php">
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$labelAttrs</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/View/XmlView.php">
     <PossiblyUndefinedMethod occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2466,7 +2466,7 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Utility/Inflector.php">
-    <NullableReturnStatement occurrences="3">
+    <NullableReturnStatement occurrences="4">
       <code>static::$_cache['pluralize'][$word]</code>
       <code>static::$_cache['pluralize'][$word]</code>
       <code>static::$_cache['singularize'][$word]</code>

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -105,7 +105,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
     {
         $result = $this->_query($username)->first();
 
-        if (empty($result)) {
+        if ($result === null) {
             // Waste time hashing the password, to prevent
             // timing side-channels. However, don't hash
             // null passwords as authentication systems

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -123,7 +123,7 @@ class DigestAuthenticate extends BasicAuthenticate
         $password = $user[$field];
         unset($user[$field]);
 
-        $hash = $this->generateResponseHash($digest, $password, $request->getEnv('ORIGINAL_REQUEST_METHOD'));
+        $hash = $this->generateResponseHash($digest, $password, (string)$request->getEnv('ORIGINAL_REQUEST_METHOD'));
         if (hash_equals($hash, $digest['response'])) {
             return $user;
         }

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -33,7 +33,7 @@ class SessionStorage implements StorageInterface
      * Stores user record array if fetched from session or false if session
      * does not have user record.
      *
-     * @var \ArrayAccess|array|false
+     * @var \ArrayAccess|array|false|null
      */
     protected $_user;
 

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -321,10 +321,10 @@ class FileEngine extends CacheEngine
      *
      * @param string $key The key to decrement
      * @param int $offset The number to offset
-     * @return void
+     * @return int|false
      * @throws \LogicException
      */
-    public function decrement(string $key, int $offset = 1): void
+    public function decrement(string $key, int $offset = 1)
     {
         throw new LogicException('Files cannot be atomically decremented.');
     }
@@ -334,10 +334,10 @@ class FileEngine extends CacheEngine
      *
      * @param string $key The key to increment
      * @param int $offset The number to offset
-     * @return void
+     * @return int|false
      * @throws \LogicException
      */
-    public function increment(string $key, int $offset = 1): void
+    public function increment(string $key, int $offset = 1)
     {
         throw new LogicException('Files cannot be atomically incremented.');
     }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -266,10 +266,11 @@ class MemcachedEngine extends CacheEngine
     /**
      * Read an option value from the memcached connection.
      *
-     * @param string|int $name The option name to read.
+     * @param int $name The option name to read.
      * @return string|int|null|bool
+     * @see https://secure.php.net/manual/en/memcached.getoption.php
      */
-    public function getOption($name)
+    public function getOption(int $name)
     {
         return $this->_Memcached->getOption($name);
     }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -559,7 +559,7 @@ class Inflector
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
             $suffix = array_search(strtolower($regs[2]), static::$_irregular, true);
-            $suffix = $suffix === false ? '' : substr($suffix, 1);
+            $suffix = !$suffix ? '' : substr($suffix, 1);
             static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . $suffix;
 
             return static::$_cache['singularize'][$word];

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -559,7 +559,7 @@ class Inflector
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
             $suffix = array_search(strtolower($regs[2]), static::$_irregular, true);
-            $suffix = $word === false ? '' : substr($suffix, 1);
+            $suffix = $suffix === false ? '' : substr($suffix, 1);
             static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . $suffix;
 
             return static::$_cache['singularize'][$word];

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -558,8 +558,9 @@ class Inflector
         }
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
-            static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) .
-                substr(array_search(strtolower($regs[2]), static::$_irregular, true), 1);
+            $suffix = array_search(strtolower($regs[2]), static::$_irregular, true);
+            $suffix = $word === false ? '' : substr($suffix, 1);
+            static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . $suffix;
 
             return static::$_cache['singularize'][$word];
         }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -559,7 +559,7 @@ class Inflector
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
             $suffix = array_search(strtolower($regs[2]), static::$_irregular, true);
-            $suffix = !$suffix ? '' : substr($suffix, 1);
+            $suffix = $suffix ? substr($suffix, 1) : '';
             static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . $suffix;
 
             return static::$_cache['singularize'][$word];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -91,7 +91,7 @@ class PaginatorHelper extends Helper
     /**
      * Default model of the paged sets
      *
-     * @var string
+     * @var string|null
      */
     protected $_defaultModel;
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -372,7 +372,7 @@ class TimeHelper extends Helper
      * UNIX timestamp or a valid strtotime() date string.
      *
      * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
-     * @param string|null $format Intl compatible format string.
+     * @param string|int|null $format Intl compatible format string.
      * @param false|string $invalid Default value to display on invalid dates
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return string|int|false Formatted and translated date string or value for `$invalid` on failure.

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -206,7 +206,7 @@ class MultiCheckboxWidget implements WidgetInterface
             ];
 
             if ($checkbox['checked']) {
-                $labelAttrs = $this->_templates->addClass($labelAttrs, 'selected');
+                $labelAttrs = (array)$this->_templates->addClass($labelAttrs, 'selected');
             }
 
             $label = $this->_label->render($labelAttrs, $context);

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -108,7 +108,7 @@ class XmlView extends SerializedView
             );
 
             if (empty($serialize)) {
-                $serialize = null;
+                $serialize = '';
             } elseif (count($serialize) === 1) {
                 $serialize = current($serialize);
             }


### PR DESCRIPTION
Removing 10-15 lines of the basefile seems like a small win compared to its 2700 lines.
But here we go.

Given that we enabled strict mode, we need to fix more possible type issues, as they will blow up in userland code sooner than later if we release 4.0.