### PR TITLE
Always ensure FQCN returned by App::className() actually exits.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -305,7 +305,7 @@ class Shell
     {
         foreach ($this->_taskMap as $taskName => $task) {
             $class = App::className($task['class'], 'Shell/Task', 'Task');
-            if ($class === null || !class_exists($class)) {
+            if ($class === null) {
                 throw new RuntimeException(sprintf(
                     'Task `%s` not found. Maybe you made a typo or a plugin is missing or not loaded?',
                     $taskName

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -364,7 +364,7 @@ class ShellDispatcher
     protected function _shellExists(string $shell): ?string
     {
         $class = App::className($shell, 'Shell', 'Shell');
-        if ($class && class_exists($class)) {
+        if ($class) {
             return $class;
         }
 

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -532,7 +532,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
                 $class = $alias;
             }
             $className = App::className($class, 'Auth', 'Authorize');
-            if ($className === null || !class_exists($className)) {
+            if ($className === null) {
                 throw new Exception(sprintf('Authorization adapter "%s" was not found.', $class));
             }
             if (!method_exists($className, 'authorize')) {
@@ -826,7 +826,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
                 $class = $alias;
             }
             $className = App::className($class, 'Auth', 'Authenticate');
-            if ($className === null || !class_exists($className)) {
+            if ($className === null) {
                 throw new Exception(sprintf('Authentication adapter "%s" was not found.', $class));
             }
             if (!method_exists($className, 'authenticate')) {

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -54,7 +54,7 @@ class App
     public static function className(string $class, string $type = '', string $suffix = ''): ?string
     {
         if (strpos($class, '\\') !== false) {
-            return $class;
+            return class_exists($class) ? $class : null;
         }
 
         [$plugin, $name] = pluginSplit($class);

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -172,7 +172,7 @@ class Connection implements ConnectionInterface
     {
         if (is_string($driver)) {
             $className = App::className($driver, 'Database/Driver');
-            if ($className === null || !class_exists($className)) {
+            if ($className === null) {
                 throw new MissingDriverException(['driver' => $driver]);
             }
             $driver = new $className($config);

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -69,7 +69,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
     {
         if (is_string($middleware)) {
             $className = App::className($middleware, 'Middleware', 'Middleware');
-            if ($className === null || !class_exists($className)) {
+            if ($className === null) {
                 throw new RuntimeException(sprintf(
                     'Middleware "%s" was not found.',
                     $middleware

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -185,7 +185,7 @@ class WidgetLocator
 
         $class = array_shift($widget);
         $className = App::className($class, 'View/Widget', 'Widget');
-        if ($className === null || !class_exists($className)) {
+        if ($className === null) {
             throw new RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
         }
         if ($type === 'array' && count($widget)) {

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -67,6 +67,12 @@ class AppTest extends TestCase
         $this->assertSame($expected === false ? null : $expected, $return);
     }
 
+    public function testClassnameWithFqcn()
+    {
+        $this->assertSame(TestCase::class, App::className(TestCase::class));
+        $this->assertNull(App::className('\Foo'));
+    }
+
     /**
      * testShortName
      *


### PR DESCRIPTION
Earlier `class_exists()` check was done only when interpolating short name to FQCN
but not when argument passed to the method is already a FQCN.