### PR TITLE
Adding SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+We support fixing security issues on the following releases:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.7.x   | :white_check_mark: |
+| 3.6.x   | :white_check_mark: |
+| <= 3.5  | :x:                |
+| 2.10.x  | :white_check_mark: |
+| <= 2.9  | :x:                |
+
+## Reporting a Vulnerability
+
+If you’ve found a security issue in CakePHP, please use the following procedure 
+instead of the normal bug reporting system. Instead of using the bug tracker, 
+mailing list or IRC please send an email to security [at] cakephp.org. Emails 
+sent to this address go to the CakePHP core team on a private mailing list.
+
+For each report, we try to first confirm the vulnerability. Once confirmed, 
+the CakePHP team will take the following actions:
+
+* Acknowledge to the reporter that we’ve received the issue, and are 
+  working on a fix. We ask that the reporter keep the issue confidential until we announce it.
+* Get a fix/patch prepared.
+* Prepare a post describing the vulnerability, and the possible exploits.
+* Release new versions of all affected versions.
+* Prominently feature the problem in the release announcement


### PR DESCRIPTION
This file integrates with the new security tab in Github :tada: I've ported over the security issue content from the cookbook. If folks are happy with this I'll make the book pages a link to this file.

