### PR TITLE
4.x Add scoped middleware to the app queue

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -158,6 +158,6 @@ class RoutingMiddleware implements MiddlewareInterface
         $middleware = new MiddlewareQueue($matching);
         $runner = new Runner();
 
-        return $runner->run($middleware, $request, $this->app);
+        return $runner->run($middleware, $request, $handler);
     }
 }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -289,13 +289,13 @@ class RoutingMiddlewareTest extends TestCase
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/api/ping',
         ]);
-        $handler = new TestRequestHandler();
-        $middleware = new RoutingMiddleware($this->app(function ($req) {
+        $app = $this->app(function ($req) {
             $this->log[] = 'last';
 
             return new Response();
-        }));
-        $result = $middleware->process($request, $handler);
+        });
+        $middleware = new RoutingMiddleware($app);
+        $result = $middleware->process($request, $app);
         $this->assertSame(['second', 'first', 'last'], $this->log);
     }
 
@@ -422,13 +422,13 @@ class RoutingMiddlewareTest extends TestCase
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => $url,
         ]);
-        $handler = new TestRequestHandler();
-        $middleware = new RoutingMiddleware($this->app(function ($req) {
+        $app = $this->app(function ($req) {
             $this->log[] = 'last';
 
             return new Response();
-        }));
-        $result = $middleware->process($request, $handler);
+        });
+        $middleware = new RoutingMiddleware($app);
+        $result = $middleware->process($request, $app);
         $this->assertSame($expected, $this->log);
     }
 


### PR DESCRIPTION
Applying a scoped middleware inside a route scope skips all remaining middleware from being invoked, that are applied after the `RoutingMiddleware`.

The `RoutingMiddleware::process`  method creates a new `MiddlewareQueue` and `Runner` instance, if the current `RouteCollection` contains applicable middleware.
Doing so results in the second `Runner` instance being created that drains a second `MiddlewareQueue` and calling `BaseApplication::handle`, which invokes the Cake application.

All remaining items in the first  `MiddlewareQueue` are ignored and not invoked.

I tested it in a Cake 4.x app, which seems to work fine.