### PR TITLE
Remove invalid code for setting output type of ConsoleOutput.

### DIFF
--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -32,7 +32,7 @@ class ConsoleLog extends BaseLog
         'stream' => 'php://stderr',
         'levels' => null,
         'scopes' => [],
-        'outputAs' => 'see constructor'
+        'outputAs' => null,
     ];
 
     /**
@@ -57,14 +57,6 @@ class ConsoleLog extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        if ((DIRECTORY_SEPARATOR === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
-            (function_exists('posix_isatty') && !posix_isatty($this->_output))
-        ) {
-            $this->_defaultConfig['outputAs'] = ConsoleOutput::PLAIN;
-        } else {
-            $this->_defaultConfig['outputAs'] = ConsoleOutput::COLOR;
-        }
-
         parent::__construct($config);
 
         $config = $this->_config;
@@ -75,7 +67,10 @@ class ConsoleLog extends BaseLog
         } else {
             throw new InvalidArgumentException('`stream` not a ConsoleOutput nor string');
         }
-        $this->_output->setOutputAs($config['outputAs']);
+
+        if (isset($config['outputAs'])) {
+            $this->_output->setOutputAs($config['outputAs']);
+        }
     }
 
     /**

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -30,11 +30,8 @@ class ConsoleLogTest extends TestCase
     {
         $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
-        $output->expects($this->at(0))
-            ->method('outputAs');
-
         $message = ' Error: oh noes</error>';
-        $output->expects($this->at(1))
+        $output->expects($this->at(0))
             ->method('write')
             ->with($this->stringContains($message));
 
@@ -62,27 +59,20 @@ class ConsoleLogTest extends TestCase
     }
 
     /**
-     * test default value of stream 'outputAs'
+     * test value of stream 'outputAs'
      */
     public function testDefaultOutputAs()
     {
-        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
-            (function_exists('posix_isatty') && !posix_isatty(null))
-        ) {
-            $expected = ConsoleOutput::PLAIN;
-        } else {
-            $expected = ConsoleOutput::COLOR;
-        }
-        $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
+        $output = $this->getMockBuilder(ConsoleOutput::class)->getMock();
 
         $output->expects($this->at(0))
             ->method('setOutputAs')
-            ->with($expected);
+            ->with(ConsoleOutput::RAW);
 
         $log = new ConsoleLog([
             'stream' => $output,
+            'outputAs' => ConsoleOutput::RAW,
         ]);
-        $config = $log->getConfig();
-        $this->assertEquals($expected, $config['outputAs']);
+        $this->assertEquals(ConsoleOutput::RAW, $log->getConfig('outputAs'));
     }
 }


### PR DESCRIPTION
Constructor of ConsoleOutput already handles setting appropriate default output type.