### PR TITLE
Check types when looking for 'return'

### DIFF
--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -108,7 +108,8 @@ trait RequestActionTrait
         if (empty($url)) {
             return false;
         }
-        if (($index = array_search('return', $extra)) !== false) {
+        $isReturn = array_search('return', $extra, true);
+        if ($isReturn !== false) {
             $extra['return'] = 0;
             $extra['autoRender'] = 1;
             unset($extra[$index]);

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -112,7 +112,7 @@ trait RequestActionTrait
         if ($isReturn !== false) {
             $extra['return'] = 0;
             $extra['autoRender'] = 1;
-            unset($extra[$index]);
+            unset($extra[$isReturn]);
         }
         $extra += ['autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1];
 


### PR DESCRIPTION
Without the type check we'll get false positives when looking for `return`.

Fixes #13304