### PR TITLE
Remove incorrect example

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1960,16 +1960,9 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Associates a query placeholder to a value and a type.
      *
-     * If type is expressed as "atype[]" (note braces) then it will cause the
-     * placeholder to be re-written dynamically so if the value is an array, it
-     * will create as many placeholders as values are in it. For example:
-     *
      * ```
-     * $query->bind(':id', [1, 2, 3], 'int[]');
+     * $query->bind(':id', 1, 'integer');
      * ```
-     *
-     * Will create 3 int placeholders. When using named placeholders, this method
-     * requires that the placeholders include `:` e.g. `:value`.
      *
      * @param string|int $param placeholder to be replaced with quoted version
      *   of $value


### PR DESCRIPTION
From what I can tell Query::bind() has never supported `integer[]` style types. Those type names have only been available in where clause and join condition generation.

Refs #13307