### PR TITLE
[2.x]Fix When PHPUnit 5.2.0+, test ends before calling FixtureManager::shutdown()

### DIFF
--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -53,6 +53,7 @@ class CakeTestRunner extends PHPUnit_TextUI_TestRunner {
  * @param PHPUnit_Framework_Test $suite The test suite to run
  * @param array $arguments The CLI arguments
  * @param bool $exit Exits by default or returns the results
+ * This argument is ignored if >PHPUnit5.2.0
  * @return void
  */
 	public function doRun(PHPUnit_Framework_Test $suite, array $arguments = array(), $exit = true) {
@@ -72,7 +73,7 @@ class CakeTestRunner extends PHPUnit_TextUI_TestRunner {
 			}
 		}
 
-		$return = parent::doRun($suite, $arguments);
+		$return = parent::doRun($suite, $arguments, $exit);
 		$fixture->shutdown();
 		return $return;
 	}

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -95,7 +95,7 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
 		unset($this->arguments['testFile']);
 
 		try {
-			$result = $runner->doRun($suite, $this->arguments);
+			$result = $runner->doRun($suite, $this->arguments, false);
 		} catch (PHPUnit_Framework_Exception $e) {
 			print $e->getMessage() . "\n";
 		}


### PR DESCRIPTION
In PHPUnit 5.2.0+, program termination at the end of `TestRunner::doRun()` is the default behavior.

https://github.com/sebastianbergmann/phpunit/blob/5.2.0/src/TextUI/TestRunner.php#L566-L586

`CakeTestRunner` calls `FixtureManager::shutdown()` after calling `parent::doRun()`.
Therefore, in PHPUnit 5.2.0+, the table remains after the test.

https://github.com/cakephp/cakephp/blob/2.x/lib/Cake/TestSuite/CakeTestRunner.php#L76

It causes the programmer not to notice the lack of fixtures when creating test cases.