### PR TITLE
Backport 4.x model aware fix for inflected assignment.

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -66,7 +66,7 @@ trait ModelAwareTrait
      */
     protected function _setModelClass($name)
     {
-        if (empty($this->modelClass)) {
+        if ($this->modelClass === null) {
             $this->modelClass = $name;
         }
     }


### PR DESCRIPTION
Backports 4.x fix of assignment only on true null (not on disable value)
See
https://github.com/cakephp/cakephp/blob/4.x/src/Datasource/ModelAwareTrait.php

Found via https://github.com/dereuromark/cakephp-ide-helper/issues/128 and that the inflected value is overwriting the false here which it shouldnt.

This should be fully BC for proper use of the designed functionality.