### PR TITLE
Remove deprecated method of 3.x.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -531,17 +531,6 @@ trait EntityTrait
     }
 
     /**
-     * Gets the list of visible fields.
-     *
-     * @deprecated 4.0.0 Use getVisible() instead. Will be removed in 5.0.
-     * @return string[]
-     */
-    public function visibleProperties(): array
-    {
-        return $this->getVisible();
-    }
-
-    /**
      * Returns an array with all the fields that have been set
      * to this entity
      *

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1178,21 +1178,6 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests the deprecated visibleProperties() method
-     *
-     * @return void
-     */
-    public function testVisiblePropertiesDeprecated()
-    {
-        $entity = new Entity();
-        $entity->foo = 'foo';
-        $entity->bar = 'bar';
-
-        $expected = $entity->visibleProperties();
-        $this->assertSame(['foo', 'bar'], $expected);
-    }
-
-    /**
      * Tests setting virtual properties with merging.
      *
      * @return void


### PR DESCRIPTION
With https://github.com/cakephp/cakephp/pull/13324 and 3.8 landing before 4.0, we can safely remove this then as it was deprecated in 3.x.
One less thing to keep along until 5.0
