### PR TITLE
Make sure we are not accidently reusing other property content.

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -89,7 +89,7 @@ trait ModelAwareTrait
      * @throws \UnexpectedValueException If $modelClass argument is not provided
      *   and ModelAwareTrait::$modelClass property value is empty.
      */
-    public function loadModel(?string $modelClass = null, ?string $modelType = null)
+    public function loadModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
     {
         if ($modelClass === null) {
             $modelClass = $this->modelClass;

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
+use Cake\Datasource\RepositoryInterface;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use TestApp\Stub\Stub;
 
@@ -111,15 +113,15 @@ class FactoryLocatorTest extends TestCase
         $stub->setProps('Articles');
 
         $stub->modelFactory('Table', function ($name) {
-            $mock = new \StdClass();
+            $mock = new Table();
             $mock->name = $name;
 
             return $mock;
         });
 
         $result = $stub->loadModel('Magic', 'Table');
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertInstanceOf('stdClass', $stub->Magic);
+        $this->assertInstanceOf(RepositoryInterface::class, $result);
+        $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
         $this->assertSame('Magic', $stub->Magic->name);
     }
 
@@ -134,7 +136,7 @@ class FactoryLocatorTest extends TestCase
         $stub->setProps('Articles');
 
         FactoryLocator::add('Test', function ($name) {
-            $mock = new \StdClass();
+            $mock = new Table();
             $mock->name = $name;
 
             return $mock;
@@ -142,8 +144,8 @@ class FactoryLocatorTest extends TestCase
         $stub->setModelType('Test');
 
         $result = $stub->loadModel('Magic');
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertInstanceOf('stdClass', $stub->Magic);
+        $this->assertInstanceOf(RepositoryInterface::class, $result);
+        $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
         $this->assertSame('Magic', $stub->Magic->name);
     }
 

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
+use Cake\Datasource\RepositoryInterface;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Table\PaginatorPostsTable;
 use TestApp\Stub\Stub;
@@ -116,15 +118,15 @@ class ModelAwareTraitTest extends TestCase
         $stub->setProps('Articles');
 
         $stub->modelFactory('Table', function ($name) {
-            $mock = new \StdClass();
+            $mock = new Table();
             $mock->name = $name;
 
             return $mock;
         });
 
         $result = $stub->loadModel('Magic', 'Table');
-        $this->assertInstanceOf('stdClass', $result);
-        $this->assertInstanceOf('stdClass', $stub->Magic);
+        $this->assertInstanceOf(RepositoryInterface::class, $result);
+        $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
         $this->assertSame('Magic', $stub->Magic->name);
     }
 
@@ -139,7 +141,7 @@ class ModelAwareTraitTest extends TestCase
         $stub->setProps('Articles');
 
         FactoryLocator::add('Test', function ($name) {
-            $mock = new \StdClass();
+            $mock = new Table();
             $mock->name = $name;
 
             return $mock;


### PR DESCRIPTION
We should use a return type hint to avoid accidental use of existing properties for
```php
        if (isset($this->{$alias})) {
            return $this->{$alias};
        }
```
E.g. a loaded component or service with a colliding name.