### PR TITLE
4.x Update i18n shell tests to use integration style

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -184,12 +184,12 @@ class ExtractTask extends Shell
         if (!empty($this->params['exclude'])) {
             $this->_exclude = explode(',', $this->params['exclude']);
         }
-        if (isset($this->params['files']) && !is_array($this->params['files'])) {
+        if (!empty($this->params['files']) && !is_array($this->params['files'])) {
             $this->_files = explode(',', $this->params['files']);
         }
-        if (isset($this->params['paths'])) {
+        if (!empty($this->params['paths'])) {
             $this->_paths = explode(',', $this->params['paths']);
-        } elseif (isset($this->params['plugin'])) {
+        } elseif (!empty($this->params['plugin'])) {
             $plugin = Inflector::camelize($this->params['plugin']);
             if (!Plugin::isLoaded($plugin)) {
                 throw new MissingPluginException(['plugin' => $plugin]);
@@ -251,7 +251,7 @@ class ExtractTask extends Shell
             }
         }
 
-        if (isset($this->params['merge'])) {
+        if (!empty($this->params['merge'])) {
             $this->_merge = !(strtolower((string)$this->params['merge']) === 'no');
         } else {
             $this->out();

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -48,7 +48,7 @@ class DriverTest extends TestCase
      */
     public function testConstructorException()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Please pass "username" instead of "login" for connecting to the database');
         $arg = ['login' => 'Bear'];
         $this->getMockForAbstractClass(Driver::class, [$arg]);

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -48,10 +48,15 @@ class DriverTest extends TestCase
      */
     public function testConstructorException()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Please pass "username" instead of "login" for connecting to the database');
         $arg = ['login' => 'Bear'];
-        $this->getMockForAbstractClass(Driver::class, [$arg]);
+        try {
+            $this->getMockForAbstractClass(Driver::class, [$arg]);
+        } catch (\Exception $e) {
+            $this->assertStringContainsString(
+                'Please pass "username" instead of "login" for connecting to the database',
+                $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -17,12 +17,12 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Shell;
 
 use Cake\Shell\I18nShell;
-use Cake\TestSuite\TestCase;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
 
 /**
  * I18nShell test.
  */
-class I18nShellTest extends TestCase
+class I18nShellTest extends ConsoleIntegrationTestCase
 {
     /**
      * setup method
@@ -79,16 +79,13 @@ class I18nShellTest extends TestCase
             unlink($deDir . 'cake.po');
         }
 
-        $this->shell->getIo()->expects($this->at(0))
-            ->method('ask')
-            ->will($this->returnValue('de_DE'));
-        $this->shell->getIo()->expects($this->at(1))
-            ->method('ask')
-            ->will($this->returnValue($this->localeDir));
+        $this->exec('i18n init --verbose', [
+            'de_DE',
+            $this->localeDir,
+        ]);
 
-        $this->shell->params['verbose'] = true;
-        $this->shell->init();
-
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Generated 2 PO files');
         $this->assertFileExists($deDir . 'default.po');
         $this->assertFileExists($deDir . 'cake.po');
     }
@@ -100,9 +97,49 @@ class I18nShellTest extends TestCase
      */
     public function testGetOptionParser()
     {
-        $this->shell->loadTasks();
-        $parser = $this->shell->getOptionParser();
-        $this->assertArrayHasKey('init', $parser->subcommands());
-        $this->assertArrayHasKey('extract', $parser->subcommands());
+        $this->exec('i18n -h');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('init');
+        $this->assertOutputContains('extract');
+    }
+
+    /**
+     * Tests main interactive mode
+     *
+     * @return void
+     */
+    public function testInteractiveQuit()
+    {
+        $this->exec('i18n', ['q']);
+        $this->assertExitSuccess();
+    }
+
+    /**
+     * Tests main interactive mode
+     *
+     * @return void
+     */
+    public function testInteractiveHelp()
+    {
+        $this->exec('i18n', ['h', 'q']);
+        $this->assertExitSuccess();
+        $this->assertOutputContains('cake i18n');
+        $this->assertOutputContains('init');
+    }
+
+    /**
+     * Tests main interactive mode
+     *
+     * @return void
+     */
+    public function testInteractiveInit()
+    {
+        $this->exec('i18n', [
+            'i',
+            'q',
+        ]);
+        $this->assertExitError();
+        $this->assertErrorContains('Invalid language code');
     }
 }

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Shell\Task;
 
 use Cake\Filesystem\Folder;
-use Cake\TestSuite\TestCase;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
 
 /**
  * ExtractTaskTest class
@@ -26,7 +26,7 @@ use Cake\TestSuite\TestCase;
  * @property \Cake\Console\ConsoleIo|MockObject $io
  * @property string $path
  */
-class ExtractTaskTest extends TestCase
+class ExtractTaskTest extends ConsoleIntegrationTestCase
 {
     /**
      * setUp method
@@ -36,19 +36,6 @@ class ExtractTaskTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $progress = $this->getMockBuilder('Cake\Shell\Helper\ProgressHelper')
-            ->setConstructorArgs([$this->io])
-            ->getMock();
-        $this->io->method('helper')
-            ->will($this->returnValue($progress));
-
-        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
-            ->setMethods(['in', 'out', 'err', '_stop'])
-            ->setConstructorArgs([$this->io])
-            ->getMock();
         $this->path = TMP . 'tests/extract_task_test';
         new Folder($this->path . DS . 'locale', true);
     }
@@ -75,17 +62,14 @@ class ExtractTaskTest extends TestCase
      */
     public function testExecute()
     {
-        $this->Task->params['paths'] = TEST_APP . 'templates' . DS . 'Pages';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['merge'] = 'no';
-
-        $this->Task->expects($this->never())->method('err');
-        $this->Task->expects($this->any())->method('in')
-            ->will($this->returnValue('y'));
-        $this->Task->expects($this->never())->method('_stop');
-
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--merge=no ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'templates' . DS . 'Pages ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
         $result = file_get_contents($this->path . DS . 'default.pot');
 
@@ -146,17 +130,14 @@ class ExtractTaskTest extends TestCase
      */
     public function testExecuteMerge()
     {
-        $this->Task->params['paths'] = TEST_APP . 'templates' . DS . 'Pages';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['merge'] = 'yes';
-
-        $this->Task->expects($this->never())->method('err');
-        $this->Task->expects($this->any())->method('in')
-            ->will($this->returnValue('y'));
-        $this->Task->expects($this->never())->method('_stop');
-
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--merge=yes ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'templates' . DS . 'Pages ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
         $this->assertFileNotExists($this->path . DS . 'cake.pot');
         $this->assertFileNotExists($this->path . DS . 'domain.pot');
@@ -169,17 +150,14 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractWithExclude()
     {
-        $this->Task->interactive = false;
-
-        $this->Task->params['paths'] = TEST_APP . 'templates';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['exclude'] = 'Pages,Layout';
-        $this->Task->params['extract-core'] = 'no';
-
-        $this->Task->expects($this->any())->method('in')
-            ->will($this->returnValue('y'));
-
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--exclude=Pages,Layout ' .
+            '--paths=' . TEST_APP . 'templates' . DS . ' ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
         $result = file_get_contents($this->path . DS . 'default.pot');
 
@@ -197,17 +175,15 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractWithoutLocations()
     {
-        $this->Task->params['paths'] = TEST_APP . 'templates';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['exclude'] = 'Pages,Layout';
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['no-location'] = true;
-
-        $this->Task->expects($this->never())->method('err');
-        $this->Task->expects($this->any())->method('in')
-            ->will($this->returnValue('y'));
-
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--no-location=true ' .
+            '--exclude=Pages,Layout ' .
+            '--paths=' . TEST_APP . 'templates' . DS . ' ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
 
         $result = file_get_contents($this->path . DS . 'default.pot');
@@ -223,18 +199,15 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractMultiplePaths()
     {
-        $this->Task->interactive = false;
-
-        $this->Task->params['paths'] =
-            TEST_APP . 'templates/Pages,' .
-            TEST_APP . 'templates/Posts';
-
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->expects($this->never())->method('err');
-        $this->Task->expects($this->never())->method('_stop');
-        $this->Task->main();
-
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--exclude=Pages,Layout ' .
+            '--paths=' . TEST_APP . 'templates/Pages,' .
+                TEST_APP . 'templates/Posts ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
         $result = file_get_contents($this->path . DS . 'default.pot');
 
         $pattern = '/msgid "Add User"/';
@@ -249,19 +222,15 @@ class ExtractTaskTest extends TestCase
     public function testExtractExcludePlugins()
     {
         static::setAppNamespace();
-        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
-            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
-            ->setConstructorArgs([$this->io])
-            ->getMock();
-        $this->Task->expects($this->exactly(1))
-            ->method('_isExtractingApp')
-            ->will($this->returnValue(true));
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--exclude-plugins=true ' .
+            '--paths=' . TEST_APP . 'TestApp/ ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
 
-        $this->Task->params['paths'] = TEST_APP . 'TestApp/';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['exclude-plugins'] = true;
-
-        $this->Task->main();
         $result = file_get_contents($this->path . DS . 'default.pot');
         $this->assertNotRegExp('#TestPlugin#', $result);
     }
@@ -276,15 +245,14 @@ class ExtractTaskTest extends TestCase
         static::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
 
-        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
-            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
-            ->setConstructorArgs([$this->io])
-            ->getMock();
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--plugin=TestPlugin ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
 
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['plugin'] = 'TestPlugin';
-
-        $this->Task->main();
         $result = file_get_contents($this->path . DS . 'default.pot');
         $this->assertNotRegExp('#Pages#', $result);
         $this->assertRegExp('/translate\.php:\d+/', $result);
@@ -301,15 +269,14 @@ class ExtractTaskTest extends TestCase
         static::setAppNamespace();
         $this->loadPlugins(['Company/TestPluginThree']);
 
-        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
-            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
-            ->setConstructorArgs([$this->io])
-            ->getMock();
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--plugin=Company/TestPluginThree ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
 
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['plugin'] = 'Company/TestPluginThree';
-
-        $this->Task->main();
         $result = file_get_contents($this->path . DS . 'test_plugin_three.pot');
         $this->assertNotRegExp('#Pages#', $result);
         $this->assertRegExp('/default\.php:\d+/', $result);
@@ -317,25 +284,27 @@ class ExtractTaskTest extends TestCase
     }
 
     /**
-     *  Test that the extract shell overwrites existing files with the overwrite parameter
+     * Test that the extract shell overwrites existing files with the overwrite parameter
      *
      * @return void
      */
     public function testExtractOverwrite()
     {
         static::setAppNamespace();
-        $this->Task->interactive = false;
-
-        $this->Task->params['paths'] = TEST_APP . 'TestApp/';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['overwrite'] = true;
 
         file_put_contents($this->path . DS . 'default.pot', 'will be overwritten');
         $this->assertFileExists($this->path . DS . 'default.pot');
         $original = file_get_contents($this->path . DS . 'default.pot');
 
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--overwrite ' .
+            '--paths=' . TEST_APP . 'TestApp/ ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
+
         $result = file_get_contents($this->path . DS . 'default.pot');
         $this->assertNotEquals($original, $result);
     }
@@ -348,13 +317,14 @@ class ExtractTaskTest extends TestCase
     public function testExtractCore()
     {
         static::setAppNamespace();
-        $this->Task->interactive = false;
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=yes ' .
+            '--paths=' . TEST_APP . 'TestApp/ ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
 
-        $this->Task->params['paths'] = TEST_APP . 'TestApp/';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'yes';
-
-        $this->Task->main();
         $this->assertFileExists($this->path . DS . 'cake.pot');
         $result = file_get_contents($this->path . DS . 'cake.pot');
 
@@ -372,27 +342,17 @@ class ExtractTaskTest extends TestCase
      */
     public function testMarkerErrorSets()
     {
-        $this->Task->method('err')
-            ->will($this->returnCallback([$this, 'echoTest']));
-
-        $this->Task->params['paths'] = TEST_APP . 'templates' . DS . 'Pages';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['merge'] = 'no';
-        $this->Task->params['marker-error'] = true;
-
-        $this->expectOutputRegex('/.*Invalid marker content in .*extract\.php.*/');
-        $this->Task->main();
-    }
-
-    /**
-     * A useful function to mock/replace err or out function that allows to use expectOutput
-     * @param string $val
-     * @param int $nbLines
-     */
-    public function echoTest($val = '', $nbLines = 1)
-    {
-        echo $val . str_repeat(PHP_EOL, $nbLines);
+        $this->exec(
+            'i18n extract ' .
+            '--marker-error ' .
+            '--merge=no ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'templates/Pages ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
+        $this->assertErrorContains('Invalid marker content in');
+        $this->assertErrorContains('extract.php');
     }
 
     /**
@@ -402,17 +362,14 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractWithRelativePaths()
     {
-        $this->Task->interactive = false;
-
-        $this->Task->params['paths'] = TEST_APP . 'templates';
-        $this->Task->params['output'] = $this->path . DS;
-        $this->Task->params['extract-core'] = 'no';
-        $this->Task->params['relative-paths'] = true;
-
-        $this->Task->method('in')
-            ->will($this->returnValue('y'));
-
-        $this->Task->main();
+        $this->exec(
+            'i18n extract ' .
+            '--relative-paths ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'templates ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
         $result = file_get_contents($this->path . DS . 'default.pot');
 

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -249,7 +249,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--plugin=TestPlugin ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
 
@@ -273,7 +273,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--plugin=Company/TestPluginThree ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
 
@@ -301,7 +301,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             '--extract-core=no ' .
             '--overwrite ' .
             '--paths=' . TEST_APP . 'TestApp/ ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
 
@@ -321,7 +321,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             'i18n extract ' .
             '--extract-core=yes ' .
             '--paths=' . TEST_APP . 'TestApp/ ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
 
@@ -348,7 +348,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             '--merge=no ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates/Pages ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
         $this->assertErrorContains('Invalid marker content in');
@@ -367,7 +367,7 @@ class ExtractTaskTest extends ConsoleIntegrationTestCase
             '--relative-paths ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates ' .
-            '--output=' . $this->path . DS,
+            '--output=' . $this->path . DS
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');


### PR DESCRIPTION
Convert the i18n shell tests to use the integration style. This will make switching the implementation simpler, which is what I'll be doing next.