### PR TITLE
Move "join" constants from Datsource\Queryinterface to Database\Query.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -22,7 +22,6 @@ use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Statement\CallbackStatement;
-use Cake\Datasource\QueryInterface;
 use InvalidArgumentException;
 use IteratorAggregate;
 use RuntimeException;
@@ -36,6 +35,10 @@ use RuntimeException;
 class Query implements ExpressionInterface, IteratorAggregate
 {
     use TypeMapTrait;
+
+    public const JOIN_TYPE_INNER = 'INNER';
+    public const JOIN_TYPE_LEFT = 'LEFT';
+    public const JOIN_TYPE_RIGHT = 'RIGHT';
 
     /**
      * Connection instance to be used to execute this query.
@@ -647,7 +650,7 @@ class Query implements ExpressionInterface, IteratorAggregate
                 $t['conditions'] = $this->newExpr()->add($t['conditions'], $types);
             }
             $alias = is_string($alias) ? $alias : null;
-            $joins[$alias ?: $i++] = $t + ['type' => QueryInterface::JOIN_TYPE_INNER, 'alias' => $alias];
+            $joins[$alias ?: $i++] = $t + ['type' => static::JOIN_TYPE_INNER, 'alias' => $alias];
         }
 
         if ($overwrite) {
@@ -717,7 +720,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function leftJoin($table, $conditions = [], $types = [])
     {
-        $this->join($this->_makeJoin($table, $conditions, QueryInterface::JOIN_TYPE_LEFT), $types);
+        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
 
         return $this;
     }
@@ -739,7 +742,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function rightJoin($table, $conditions = [], $types = [])
     {
-        $this->join($this->_makeJoin($table, $conditions, QueryInterface::JOIN_TYPE_RIGHT), $types);
+        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
 
         return $this;
     }
@@ -761,7 +764,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function innerJoin($table, $conditions = [], $types = [])
     {
-        $this->join($this->_makeJoin($table, $conditions, QueryInterface::JOIN_TYPE_INNER), $types);
+        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
 
         return $this;
     }

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -24,10 +24,6 @@ namespace Cake\Datasource;
  */
 interface QueryInterface
 {
-    public const JOIN_TYPE_INNER = 'INNER';
-    public const JOIN_TYPE_LEFT = 'LEFT';
-    public const JOIN_TYPE_RIGHT = 'RIGHT';
-
     /**
      * Adds fields to be selected from datasource.
      *

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -21,7 +21,6 @@ use Cake\Core\App;
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\QueryInterface;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
@@ -161,7 +160,7 @@ abstract class Association
      *
      * @var string
      */
-    protected $_joinType = QueryInterface::JOIN_TYPE_LEFT;
+    protected $_joinType = Query::JOIN_TYPE_LEFT;
 
     /**
      * The property name that should be filled with data from the target table

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -20,7 +20,6 @@ use Cake\Core\App;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\QueryInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectWithPivotLoader;
 use Cake\ORM\Query;
@@ -57,7 +56,7 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_joinType = QueryInterface::JOIN_TYPE_INNER;
+    protected $_joinType = Query::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.
@@ -1063,7 +1062,7 @@ class BelongsToMany extends Association
             $name => [
                 'table' => $this->junction()->getTable(),
                 'conditions' => $conditions,
-                'type' => QueryInterface::JOIN_TYPE_INNER,
+                'type' => Query::JOIN_TYPE_INNER,
             ],
         ];
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -21,9 +21,9 @@ use Cake\Collection\Collection;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\QueryInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectLoader;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Closure;
 use InvalidArgumentException;
@@ -48,7 +48,7 @@ class HasMany extends Association
      *
      * @var string
      */
-    protected $_joinType = QueryInterface::JOIN_TYPE_INNER;
+    protected $_joinType = Query::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -21,7 +21,6 @@ use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\QueryInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -130,7 +129,7 @@ class EavStrategy implements TranslateStrategyInterface
             $this->table->hasOne($name, [
                 'targetTable' => $fieldTable,
                 'foreignKey' => 'foreign_key',
-                'joinType' => $filter ? QueryInterface::JOIN_TYPE_INNER : QueryInterface::JOIN_TYPE_LEFT,
+                'joinType' => $filter ? Query::JOIN_TYPE_INNER : Query::JOIN_TYPE_LEFT,
                 'conditions' => $conditions,
                 'propertyName' => $field . '_translation',
             ]);
@@ -204,8 +203,8 @@ class EavStrategy implements TranslateStrategyInterface
 
             if ($changeFilter) {
                 $filter = $options['filterByCurrentLocale']
-                    ? QueryInterface::JOIN_TYPE_INNER
-                    : QueryInterface::JOIN_TYPE_LEFT;
+                    ? Query::JOIN_TYPE_INNER
+                    : Query::JOIN_TYPE_LEFT;
                 $contain[$name]['joinType'] = $filter;
             }
         }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -19,7 +19,6 @@ namespace Cake\ORM;
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Database\Statement\CallbackStatement;
 use Cake\Database\StatementInterface;
-use Cake\Datasource\QueryInterface;
 use Closure;
 use InvalidArgumentException;
 
@@ -246,7 +245,7 @@ class EagerLoader
         }
 
         if (!isset($options['joinType'])) {
-            $options['joinType'] = QueryInterface::JOIN_TYPE_INNER;
+            $options['joinType'] = Query::JOIN_TYPE_INNER;
         }
 
         $assocs = explode('.', $assoc);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -627,7 +627,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
-                'joinType' => QueryInterface::JOIN_TYPE_LEFT,
+                'joinType' => Query::JOIN_TYPE_LEFT,
                 'fields' => false,
             ])
             ->getMatching();
@@ -676,7 +676,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
-                'joinType' => QueryInterface::JOIN_TYPE_INNER,
+                'joinType' => Query::JOIN_TYPE_INNER,
                 'fields' => false,
             ])
             ->getMatching();
@@ -740,7 +740,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     {
         $result = $this->getEagerLoader()
             ->setMatching($assoc, $builder, [
-                'joinType' => QueryInterface::JOIN_TYPE_LEFT,
+                'joinType' => Query::JOIN_TYPE_LEFT,
                 'fields' => false,
                 'negateMatch' => true,
             ])


### PR DESCRIPTION
Joins are specific to relational databases and having constants for it in generic datasource interface felt wrong to me.

Now PHP doesn't allow keeping the constants in the interface as as well as the concrete class so this change isn't backwards compatible. But the chances of these constants being used in userland code is quite low.