### PR TITLE
Make View::setPlugin argument type compatible with View::plugin

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1248,11 +1248,11 @@ class View implements EventDispatcherInterface
     /**
      * Sets the plugin name.
      *
-     * @param string $name Plugin name.
+     * @param string|null $name Plugin name.
      * @return $this
      * @since 3.7.0
      */
-    public function setPlugin(string $name)
+    public function setPlugin(?string $name)
     {
         $this->plugin = $name;
 


### PR DESCRIPTION
Setter type for setPlugin should still accept both null or string.
