### PR TITLE
Remove unneeded class_exists() check.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -93,7 +93,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         $className = $objectName;
         if (is_string($objectName)) {
             $className = $this->_resolveClassName($objectName);
-            if ($className === null || !class_exists($className)) {
+            if ($className === null) {
                 [$plugin, $objectName] = pluginSplit($objectName);
                 $this->_throwMissingClassError($objectName, $plugin);
             }


### PR DESCRIPTION
App::className() now always does that check.