### PR TITLE
3.next - Improve console testing with interactive input

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -15,7 +15,6 @@ namespace Cake\TestSuite;
 
 use Cake\Console\Command;
 use Cake\Console\CommandRunner;
-use Cake\Console\ConsoleInput;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Core\Configure;
@@ -25,6 +24,7 @@ use Cake\TestSuite\Constraint\Console\ContentsEmpty;
 use Cake\TestSuite\Constraint\Console\ContentsNotContain;
 use Cake\TestSuite\Constraint\Console\ContentsRegExp;
 use Cake\TestSuite\Constraint\Console\ExitCode;
+use Cake\TestSuite\Stub\ConsoleInput;
 use Cake\TestSuite\Stub\ConsoleOutput;
 
 /**
@@ -81,18 +81,7 @@ trait ConsoleIntegrationTestTrait
 
         $this->_out = new ConsoleOutput();
         $this->_err = new ConsoleOutput();
-        $this->_in = $this->getMockBuilder(ConsoleInput::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['read'])
-            ->getMock();
-
-        $i = 0;
-        foreach ($input as $in) {
-            $this->_in
-                ->expects($this->at($i++))
-                ->method('read')
-                ->will($this->returnValue($in));
-        }
+        $this->_in = new ConsoleInput($input);
 
         $args = $this->commandStringToArgs("cake $command");
         $io = new ConsoleIo($this->_out, $this->_err, $this->_in);

--- a/src/TestSuite/Stub/ConsoleInput.php
+++ b/src/TestSuite/Stub/ConsoleInput.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Stub;
+
+use Cake\Console\ConsoleInput as ConsoleInputBase;
+use Cake\Console\Exception\ConsoleException;
+
+/**
+ * Stub class used by the console integration harness.
+ *
+ * This class enables input to be stubbed and have exceptions
+ * raised when no answer is available.
+ */
+class ConsoleInput extends ConsoleInputBase
+{
+    /**
+     * Reply values for ask() and askChoice()
+     *
+     * @var array
+     */
+    protected $replies = [];
+
+    /**
+     * Current message index
+     *
+     * @var int
+     */
+    protected $currentIndex = -1;
+
+    /**
+     * Constructor
+     *
+     * @param string[] $replies A list of replies for read()
+     */
+    public function __construct(array $replies)
+    {
+        $this->replies = $replies;
+    }
+
+    /**
+     * Read a reply
+     *
+     * @return mixed The value of the reply
+     */
+    public function read()
+    {
+        $this->currentIndex += 1;
+
+        if (!isset($this->replies[$this->currentIndex])) {
+            $total = count($this->replies);
+            $replies = implode(', ', $this->replies);
+            $message = "There are no more input replies available. Only {$total} replies were set, " .
+                "this is the {$this->currentIndex} read operation. The provided replies are: {$replies}";
+            throw new ConsoleException($message);
+        }
+
+        return $this->replies[$this->currentIndex];
+    }
+
+    /**
+     * Check if data is available on stdin
+     *
+     * @param int $timeout An optional time to wait for data
+     * @return bool True for data available, false otherwise
+     */
+    public function dataAvailable($timeout = 0)
+    {
+        return true;
+    }
+}

--- a/src/TestSuite/Stub/ConsoleInput.php
+++ b/src/TestSuite/Stub/ConsoleInput.php
@@ -45,6 +45,8 @@ class ConsoleInput extends ConsoleInputBase
      */
     public function __construct(array $replies)
     {
+        parent::__construct();
+
         $this->replies = $replies;
     }
 

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Test\TestCase\TestSuite;
 
+use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
@@ -140,6 +141,18 @@ class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
 
         $this->assertErrorContains('No!');
         $this->assertExitCode(Shell::CODE_ERROR);
+    }
+
+    /**
+     * tests exec with fewer inputs than questions
+     *
+     * @return void
+     */
+    public function testExecWithMissingInput()
+    {
+        $this->expectException(ConsoleException::class);
+        $this->expectExceptionMessage('no more input');
+        $this->exec('integration bridge', ['cake']);
     }
 
     /**


### PR DESCRIPTION
Currently testing shells/commands that use interactive input is tedious as if you don't provide enough input values the process will lock waiting for input. This change will raise an exception when you don't have enough input values making it easier to build tests.
