### PR TITLE
4.x fixtures

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2072,29 +2072,6 @@
     <NoInterfaceProperties occurrences="1">
       <code>$test-&gt;fixtureManager</code>
     </NoInterfaceProperties>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$_first</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/TestSuite/Fixture/FixtureManager.php">
-    <MissingClosureParamType occurrences="7">
-      <code>$fixtures</code>
-      <code>$db</code>
-      <code>$fixtures</code>
-      <code>$db</code>
-      <code>$db</code>
-      <code>$fixtures</code>
-      <code>$fixtures</code>
-    </MissingClosureParamType>
-    <PossiblyFalseArgument occurrences="1">
-      <code>strrchr($fixture, '\\')</code>
-    </PossiblyFalseArgument>
-    <RedundantCondition occurrences="1">
-      <code>$exists &amp;&amp; !$isFixtureSetup &amp;&amp; $hasSchema</code>
-    </RedundantCondition>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$test-&gt;fixtures</code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="src/TestSuite/Fixture/TestFixture.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -2103,19 +2080,9 @@
     <MismatchingDocblockReturnType occurrences="1">
       <code>TableSchemaInterface</code>
     </MismatchingDocblockReturnType>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;table</code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$this-&gt;_schema-&gt;getColumn($field)['type']</code>
-    </PossiblyNullArrayAccess>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$table</code>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$_schema</code>
     </PropertyNotSetInConstructor>
-    <UninitializedProperty occurrences="1">
-      <code>$this-&gt;table</code>
-    </UninitializedProperty>
   </file>
   <file src="src/TestSuite/IntegrationTestTrait.php">
     <InvalidCatch occurrences="1"/>

--- a/src/Database/ConstraintsInterface.php
+++ b/src/Database/ConstraintsInterface.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database;
+
+use Cake\Datasource\ConnectionInterface;
+
+/**
+ * Defines the interface for managing constraints.
+ */
+interface ConstraintsInterface
+{
+    /**
+     * Build and execute SQL queries necessary to create the constraints for the
+     * fixture
+     *
+     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
+     *  into which the constraints will be created.
+     * @return bool on success or if there are no constraints to create, or false on failure
+     */
+    public function createConstraints(ConnectionInterface $db): bool;
+
+    /**
+     * Build and execute SQL queries necessary to drop the constraints for the
+     * fixture
+     *
+     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
+     *  into which the constraints will be dropped.
+     * @return bool on success or if there are no constraints to drop, or false on failure
+     */
+    public function dropConstraints(ConnectionInterface $db): bool;
+}

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -50,26 +50,6 @@ interface FixtureInterface
     public function insert(ConnectionInterface $db);
 
     /**
-     * Build and execute SQL queries necessary to create the constraints for the
-     * fixture
-     *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
-     *  into which the constraints will be created.
-     * @return bool on success or if there are no constraints to create, or false on failure
-     */
-    public function createConstraints(ConnectionInterface $db): bool;
-
-    /**
-     * Build and execute SQL queries necessary to drop the constraints for the
-     * fixture
-     *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
-     *  into which the constraints will be dropped.
-     * @return bool on success or if there are no constraints to drop, or false on failure
-     */
-    public function dropConstraints(ConnectionInterface $db): bool;
-
-    /**
      * Truncates the current fixture.
      *
      * @param \Cake\Datasource\ConnectionInterface $db A reference to a db instance

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -40,7 +40,7 @@ class FixtureInjector implements TestListener
     /**
      * Holds a reference to the container test suite
      *
-     * @var \PHPUnit\Framework\TestSuite
+     * @var \PHPUnit\Framework\TestSuite|null
      */
     protected $_first;
 

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
+use Cake\Database\ConstraintsInterface;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaAwareInterface;
 use Cake\Datasource\ConnectionInterface;
@@ -294,6 +295,10 @@ class FixtureManager
 
                 /** @var \Cake\TestSuite\Fixture\TestFixture[] $fixtures */
                 foreach ($fixtures as $fixture) {
+                    if (!$fixture instanceof ConstraintsInterface) {
+                        continue;
+                    }
+
                     if (in_array($fixture->table, $tables, true)) {
                         try {
                             $fixture->dropConstraints($db);
@@ -318,6 +323,10 @@ class FixtureManager
                 }
 
                 foreach ($fixtures as $fixture) {
+                    if (!$fixture instanceof ConstraintsInterface) {
+                        continue;
+                    }
+
                     try {
                         $fixture->createConstraints($db);
                     } catch (PDOException $e) {
@@ -422,7 +431,9 @@ class FixtureManager
             $configName = $db->configName();
 
             foreach ($fixtures as $name => $fixture) {
-                if ($this->isFixtureSetup($configName, $fixture)) {
+                if ($this->isFixtureSetup($configName, $fixture)
+                    && $fixture instanceof ConstraintsInterface
+                ) {
                     $fixture->dropConstraints($db);
                 }
             }
@@ -463,11 +474,15 @@ class FixtureManager
         }
 
         if (!$dropTables) {
-            $fixture->dropConstraints($db);
+            if ($fixture instanceof ConstraintsInterface) {
+                $fixture->dropConstraints($db);
+            }
             $fixture->truncate($db);
         }
 
-        $fixture->createConstraints($db);
+        if ($fixture instanceof ConstraintsInterface) {
+            $fixture->createConstraints($db);
+        }
         $fixture->insert($db);
     }
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\Exception as CakeException;
+use Cake\Database\ConstraintsInterface;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaAwareInterface;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -31,7 +32,7 @@ use Exception;
  * Cake TestFixture is responsible for building and destroying tables to be used
  * during testing.
  */
-class TestFixture implements FixtureInterface, TableSchemaAwareInterface
+class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchemaAwareInterface
 {
     use LocatorAwareTrait;
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -47,6 +47,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
      * Full Table Name
      *
      * @var string
+     * @psalm-suppress PropertyNotSetInConstructor
      */
     public $table;
 
@@ -106,7 +107,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
                 $message = sprintf(
                     'Invalid datasource name "%s" for "%s" fixture. Fixture datasource names must begin with "test".',
                     $connection,
-                    $this->table
+                    static::class
                 );
                 throw new CakeException($message);
             }
@@ -333,7 +334,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             [$fields, $values, $types] = $this->_getRecords();
             $query = $db->newQuery()
                 ->insert($fields, $types)
-                ->into($this->table);
+                ->into($this->sourceName());
 
             foreach ($values as $row) {
                 $query->values($row);
@@ -413,7 +414,9 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
         }
         $fields = array_values(array_unique($fields));
         foreach ($fields as $field) {
-            $types[$field] = $this->_schema->getColumn($field)['type'];
+            /** @var array $column */
+            $column = $this->_schema->getColumn($field);
+            $types[$field] = $column['type'];
         }
         $default = array_fill_keys($fields, null);
         foreach ($this->records as $record) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -46,6 +46,13 @@ abstract class TestCase extends BaseTestCase
     public $fixtureManager;
 
     /**
+     * Fixtures used by this test case.
+     *
+     * @var string[]
+     */
+    public $fixtures = [];
+
+    /**
      * By default, all fixtures attached to this class will be truncated and reloaded after each test.
      * Set this to false to handle manually
      *


### PR DESCRIPTION
The relational DB specific `createConstraints()` and `dropConstraints()` methods of `FixtureInterface` have been moved to new `Cake\Database\ConstraintsInterface` (suggestions for alternate name for interface are welcome).

This will allow removing no-op methods 
`Cake\ElasticSearch\TestSuite\TestFixture::createConstraints()/dropConstraints()`.