### PR TITLE
Fix Validation::isInteger() for boolean values

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1552,7 +1552,7 @@ class Validation
      */
     public static function isInteger($value)
     {
-        if (!is_scalar($value) || is_float($value) || is_bool($value)) {
+        if (!is_numeric($value) || is_float($value)) {
             return false;
         }
         if (is_int($value)) {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1552,7 +1552,7 @@ class Validation
      */
     public static function isInteger($value)
     {
-        if (!is_scalar($value) || is_float($value)) {
+        if (!is_scalar($value) || is_float($value) || is_bool($value)) {
             return false;
         }
         if (is_int($value)) {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2971,6 +2971,8 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::isInteger([]));
         $this->assertFalse(Validation::isInteger(new \StdClass));
         $this->assertFalse(Validation::isInteger('2 bears'));
+        $this->assertFalse(Validation::isInteger(true));
+        $this->assertFalse(Validation::isInteger(false));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2968,6 +2968,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::isInteger('-012'));
 
         $this->assertFalse(Validation::isInteger('2.5'));
+        $this->assertFalse(Validation::isInteger(2.5));
         $this->assertFalse(Validation::isInteger([]));
         $this->assertFalse(Validation::isInteger(new \StdClass));
         $this->assertFalse(Validation::isInteger('2 bears'));


### PR DESCRIPTION
Issue link: https://github.com/cakephp/cakephp/issues/13351

Validation::isInteger() method will now return `false` when provided with a boolean value.