### PR TITLE
Improve Psalm bootstrapping

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.x-dev@56e66af6a2233a65378c16b1d5329a5aa8facbec">
+<files psalm-version="3.4.5@a0866da88e605adaa648e9f1ad37f4990650f55c">
   <file src="src/Auth/BaseAuthenticate.php">
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$hidden[$key]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.4.4@c21e9917fa05ba4d97da464725471f53ab4fe0d8">
+<files psalm-version="3.x-dev@56e66af6a2233a65378c16b1d5329a5aa8facbec">
   <file src="src/Auth/BaseAuthenticate.php">
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$hidden[$key]</code>
@@ -66,24 +66,11 @@
     <MissingConstructor occurrences="1">
       <code>$_Memcached</code>
     </MissingConstructor>
-    <UndefinedConstant occurrences="3">
-      <code>DAY</code>
-      <code>DAY</code>
-      <code>DAY</code>
-    </UndefinedConstant>
   </file>
   <file src="src/Cache/Engine/RedisEngine.php">
-    <InvalidArgument occurrences="1">
-      <code>$value</code>
-    </InvalidArgument>
     <MissingConstructor occurrences="1">
       <code>$_Redis</code>
     </MissingConstructor>
-    <PossiblyInvalidArgument occurrences="3">
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Cache/Engine/WincacheEngine.php">
     <NullArgument occurrences="1">
@@ -419,11 +406,6 @@
       <code>$name</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Core/Configure.php">
-    <UnresolvableInclude occurrences="1">
-      <code>require CORE_PATH . 'config/config.php'</code>
-    </UnresolvableInclude>
-  </file>
   <file src="src/Core/Configure/Engine/IniConfig.php">
     <LoopInvalidation occurrences="1">
       <code>$values</code>
@@ -746,6 +728,10 @@
       <code>$num</code>
       <code>$num</code>
     </MoreSpecificImplementedParamType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$key</code>
+      <code>$types</code>
+    </PossiblyInvalidArgument>
     <PossiblyInvalidFunctionCall occurrences="2">
       <code>$key($exp)</code>
       <code>$append($this-&gt;newExpr(), $this)</code>
@@ -1744,9 +1730,6 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="src/ORM/Marshaller.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$key</code>
-    </InvalidScalarArgument>
     <MissingClosureParamType occurrences="11">
       <code>$value</code>
       <code>$entity</code>
@@ -2172,9 +2155,10 @@
       <code>$mock</code>
       <code>$mock</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="3">
       <code>$prefix[0]</code>
       <code>$prefix[1]</code>
+      <code>$expression</code>
     </PossiblyNullArgument>
     <PossiblyUndefinedMethod occurrences="4">
       <code>getEntityClass</code>
@@ -2182,13 +2166,6 @@
       <code>getTable</code>
       <code>setTable</code>
     </PossiblyUndefinedMethod>
-    <UndefinedFunction occurrences="2">
-      <code>debug($string, true)</code>
-      <code>debug($string)</code>
-    </UndefinedFunction>
-    <UndefinedVariable occurrences="1">
-      <code>$len</code>
-    </UndefinedVariable>
   </file>
   <file src="src/TestSuite/TestSuite.php">
     <InternalClass occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -68,9 +68,17 @@
     </MissingConstructor>
   </file>
   <file src="src/Cache/Engine/RedisEngine.php">
+    <InvalidArgument occurrences="1">
+      <code>$value</code>
+    </InvalidArgument>
     <MissingConstructor occurrences="1">
       <code>$_Redis</code>
     </MissingConstructor>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Cache/Engine/WincacheEngine.php">
     <NullArgument occurrences="1">
@@ -908,9 +916,13 @@
     <InvalidScalarArgument occurrences="1">
       <code>$type</code>
     </InvalidScalarArgument>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>bindParam</code>
+      <code>bindValue</code>
     </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>bindParam</code>
+    </PossiblyUndefinedMethod>
     <UndefinedConstant occurrences="1">
       <code>PDO::SQLSRV_ENCODING_BINARY</code>
     </UndefinedConstant>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    autoloader="tests/bootstrap.php"
 >
     <projectFiles>
         <directory name="src" />
@@ -16,14 +17,22 @@
         </ignoreFiles>
     </projectFiles>
 
-    <stubs>
-        <file name="tests/bootstrap.php" />
-    </stubs>
-
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
         <TypeCoercion errorLevel="info" />
         <DocblockTypeContradiction errorLevel="info" />
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Memcached" />
+                <referencedClass name="Redis" />
+            </errorLevel>
+        </UndefinedClass>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Memcached" />
+                <referencedClass name="Redis" />
+            </errorLevel>
+        </UndefinedDocblockClass>
     </issueHandlers>
 </psalm>

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -598,6 +598,11 @@ abstract class TestCase extends BaseTestCase
                 continue;
             }
 
+            /**
+             * If 'attrs' is not present then the array is just a regular int-offset one
+             *
+             * @var array<int, string> $assertion
+             */
             [$description, $expressions, $itemNum] = $assertion;
             $expression = null;
             foreach ((array)$expressions as $expression) {

--- a/src/basics.php
+++ b/src/basics.php
@@ -42,6 +42,7 @@ if (!function_exists('debug')) {
      * @return mixed The same $var that was passed
      * @link https://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#debug
+     * @psalm-suppress MissingReturnType
      */
     function debug($var, $showHtml = null, $showFrom = true)
     {


### PR DESCRIPTION
This helps Psalm recognise the import paths, so it can understand `debug` function calls etc.

It also allows `Memcached` and `Redis` to not exist wherever Psalm is run. That second change may not be ideal, happy to undo it (though neither extension is required in your composer.json).
