### PR TITLE
4.x error handler

### DIFF
--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -36,16 +36,17 @@ class ConsoleErrorHandler extends BaseErrorHandler
     /**
      * Constructor
      *
-     * @param array $options Options for the error handler.
+     * @param array $config Config options for the error handler.
      */
-    public function __construct(array $options = [])
+    public function __construct(array $config = [])
     {
-        $options += [
+        $config += [
             'stderr' => new ConsoleOutput('php://stderr'),
             'log' => false,
         ];
-        $this->_stderr = $options['stderr'];
-        $this->_options = $options + $this->_options;
+
+        $this->setConfig($config);
+        $this->_stderr = $this->_config['stderr'];
     }
 
     /**

--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -60,7 +60,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
     public function handleException(Throwable $exception): void
     {
         $this->_displayException($exception);
-        $this->_logException($exception);
+        $this->logException($exception);
         $code = $exception->getCode();
         $code = $code && is_int($code) ? $code : 1;
         $this->_stop($code);

--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -34,24 +34,18 @@ class ConsoleErrorHandler extends BaseErrorHandler
     protected $_stderr;
 
     /**
-     * Options for this instance.
-     *
-     * @var array
-     */
-    protected $_options;
-
-    /**
      * Constructor
      *
      * @param array $options Options for the error handler.
      */
     public function __construct(array $options = [])
     {
-        if (empty($options['stderr'])) {
-            $options['stderr'] = new ConsoleOutput('php://stderr');
-        }
+        $options += [
+            'stderr' => new ConsoleOutput('php://stderr'),
+            'log' => false,
+        ];
         $this->_stderr = $options['stderr'];
-        $this->_options = $options;
+        $this->_options = $options + $this->_options;
     }
 
     /**

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -331,7 +331,7 @@ abstract class BaseErrorHandler
      *
      * @return \Cake\Error\ErrorLogger
      */
-    protected function getLogger()
+    public function getLogger()
     {
         if ($this->logger === null) {
             /** @var \Cake\Error\ErrorLogger $logger */

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -19,6 +19,7 @@ namespace Cake\Error;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 /**
@@ -203,7 +204,7 @@ abstract class BaseErrorHandler
     public function handleException(Throwable $exception): void
     {
         $this->_displayException($exception);
-        $this->_logException($exception);
+        $this->logException($exception);
         $code = $exception->getCode() ?: 1;
         $this->_stop((int)$code);
     }
@@ -311,19 +312,20 @@ abstract class BaseErrorHandler
     }
 
     /**
-     * Handles exception logging
+     * Log an error for the exception if applicable.
      *
-     * @param \Throwable $exception Exception instance.
+     * @param \Throwable $exception The exception to log a message for.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
      * @return bool
      */
-    protected function _logException(Throwable $exception): bool
+    public function logException(Throwable $exception, ?ServerRequestInterface $request = null): bool
     {
         $config = $this->_options;
         if (empty($config['log'])) {
             return false;
         }
 
-        return $this->getLogger()->log($exception, Router::getRequest());
+        return $this->getLogger()->log($exception, $request ?? Router::getRequest());
     }
 
     /**

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -96,11 +96,9 @@ class ErrorHandler extends BaseErrorHandler
     public function __construct(array $options = [])
     {
         $defaults = [
-            'log' => true,
-            'trace' => false,
             'exceptionRenderer' => ExceptionRenderer::class,
         ];
-        $this->_options = $options + $defaults;
+        $this->_options = $options + $defaults + $this->_options;
     }
 
     /**

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -143,34 +143,6 @@ class ErrorHandler extends BaseErrorHandler
     }
 
     /**
-     * Handles exception logging
-     *
-     * @param \Throwable $exception Exception instance.
-     * @return bool
-     */
-    protected function _logException(Throwable $exception): bool
-    {
-        return $this->logException($exception);
-    }
-
-    /**
-     * Log an error for the exception if applicable.
-     *
-     * @param \Throwable $exception The exception to log a message for.
-     * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
-     * @return bool
-     */
-    public function logException(Throwable $exception, ?ServerRequestInterface $request = null): bool
-    {
-        $config = $this->_options;
-        if (empty($config['log'])) {
-            return false;
-        }
-
-        return $this->getLogger()->log($exception, $request ?? Router::getRequest());
-    }
-
-    /**
      * Get a renderer instance.
      *
      * @param \Throwable $exception The exception being rendered.

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -131,7 +131,6 @@ class ErrorHandler extends BaseErrorHandler
     {
         try {
             $renderer = $this->getRenderer(
-                $this->_options['exceptionRenderer'],
                 $exception,
                 Router::getRequest()
             );
@@ -144,20 +143,47 @@ class ErrorHandler extends BaseErrorHandler
     }
 
     /**
+     * Handles exception logging
+     *
+     * @param \Throwable $exception Exception instance.
+     * @return bool
+     */
+    protected function _logException(Throwable $exception): bool
+    {
+        return $this->logException($exception);
+    }
+
+    /**
+     * Log an error for the exception if applicable.
+     *
+     * @param \Throwable $exception The exception to log a message for.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
+     * @return bool
+     */
+    public function logException(Throwable $exception, ?ServerRequestInterface $request = null): bool
+    {
+        $config = $this->_options;
+        if (empty($config['log'])) {
+            return false;
+        }
+
+        return $this->getLogger()->log($exception, $request ?? Router::getRequest());
+    }
+
+    /**
      * Get a renderer instance.
      *
-     * @param string|callable $renderer The renderer or class name
-     *   to use or a callable factory.
      * @param \Throwable $exception The exception being rendered.
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The request.
      * @return \Cake\Error\ExceptionRendererInterface The exception renderer.
      * @throws \Exception When the renderer class cannot be found.
      */
     public function getRenderer(
-        $renderer,
         Throwable $exception,
         ?ServerRequestInterface $request = null
     ): ExceptionRendererInterface {
+        $renderer = $this->_options['exceptionRenderer'];
+
         if (is_string($renderer)) {
             $class = App::className($renderer, 'Error');
             if (!$class) {

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -93,14 +93,15 @@ class ErrorHandler extends BaseErrorHandler
     /**
      * Constructor
      *
-     * @param array $options The options for error handling.
+     * @param array $config The options for error handling.
      */
-    public function __construct(array $options = [])
+    public function __construct(array $config = [])
     {
-        $defaults = [
+        $config += [
             'exceptionRenderer' => ExceptionRenderer::class,
         ];
-        $this->_options = $options + $defaults + $this->_options;
+
+        $this->setConfig($config);
     }
 
     /**
@@ -154,7 +155,7 @@ class ErrorHandler extends BaseErrorHandler
         Throwable $exception,
         ?ServerRequestInterface $request = null
     ): ExceptionRendererInterface {
-        $renderer = $this->_options['exceptionRenderer'];
+        $renderer = $this->_config['exceptionRenderer'];
 
         if (is_string($renderer)) {
             $class = App::className($renderer, 'Error');
@@ -198,7 +199,7 @@ class ErrorHandler extends BaseErrorHandler
     protected function _logInternalError(Throwable $exception): void
     {
         // Disable trace for internal errors.
-        $this->_options['trace'] = false;
+        $this->_config['trace'] = false;
         $message = sprintf(
             "[%s] %s\n%s", // Keeping same message format
             get_class($exception),

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error;
+
+use Cake\Core\Configure;
+use Cake\Core\Exception\Exception;
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\ServerRequest;
+use Cake\Log\Log;
+use Throwable;
+
+/**
+ * Log errors.
+ */
+class ErrorLogger
+{
+    use InstanceConfigTrait;
+
+    /**
+     * Default configuration values.
+     *
+     * - `skipLog` List of exceptions to skip logging. Exceptions that
+     *   extend one of the listed exceptions will also not be logged.
+     * - `trace` Should error logs include stack traces?
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'skipLog' => [],
+        'trace' => false,
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param array $config Config array.
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setConfig($config);
+    }
+
+    /**
+     * Generate the error log message.
+     *
+     * @param \Throwable $exception The exception to log a message for.
+     * @param \Cake\Http\ServerRequest|null $request The current request if available.
+     * @return bool
+     */
+    public function log(Throwable $exception, ?ServerRequest $request = null): bool
+    {
+        foreach ($this->getConfig('skipLog') as $class) {
+            if ($exception instanceof $class) {
+                return false;
+            }
+        }
+
+        $message = $this->getMessage($exception);
+
+        if ($request !== null) {
+            $message .= $this->getRequestContext($request);
+        }
+
+        $message .= "\n\n";
+
+        return Log::error($message);
+    }
+
+    /**
+     * Generate the message for the exception
+     *
+     * @param \Throwable $exception The exception to log a message for.
+     * @param bool $isPrevious False for original exception, true for previous
+     * @return string Error message
+     */
+    protected function getMessage(Throwable $exception, bool $isPrevious = false): string
+    {
+        $message = sprintf(
+            '%s[%s] %s in %s on line %s',
+            $isPrevious ? "\nCaused by: " : '',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
+        $debug = Configure::read('debug');
+
+        if ($debug && $exception instanceof Exception) {
+            $attributes = $exception->getAttributes();
+            if ($attributes) {
+                $message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);
+            }
+        }
+
+        if ($this->getConfig('trace')) {
+            $message .= "\nStack Trace:\n" . $exception->getTraceAsString();
+        }
+
+        $previous = $exception->getPrevious();
+        if ($previous) {
+            $message .= $this->getMessage($previous, true);
+        }
+
+        return $message;
+    }
+
+    /**
+     * Get the request context for an error/exception trace.
+     *
+     * @param \Cake\Http\ServerRequest $request The request to read from.
+     * @return string
+     */
+    public function getRequestContext(ServerRequest $request): string
+    {
+        $message = "\nRequest URL: " . $request->getRequestTarget();
+
+        $referer = $request->getHeaderLine('Referer');
+        if ($referer) {
+            $message .= "\nReferer URL: " . $referer;
+        }
+
+        $clientIp = $request->clientIp();
+        if ($clientIp && $clientIp !== '::1') {
+            $message .= "\nClient IP: " . $clientIp;
+        }
+
+        return $message;
+    }
+}

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -19,8 +19,8 @@ namespace Cake\Error;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Http\ServerRequest;
 use Cake\Log\Log;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 /**
@@ -58,10 +58,10 @@ class ErrorLogger
      * Generate the error log message.
      *
      * @param \Throwable $exception The exception to log a message for.
-     * @param \Cake\Http\ServerRequest|null $request The current request if available.
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
      * @return bool
      */
-    public function log(Throwable $exception, ?ServerRequest $request = null): bool
+    public function log(Throwable $exception, ?ServerRequestInterface $request = null): bool
     {
         foreach ($this->getConfig('skipLog') as $class) {
             if ($exception instanceof $class) {
@@ -121,10 +121,10 @@ class ErrorLogger
     /**
      * Get the request context for an error/exception trace.
      *
-     * @param \Cake\Http\ServerRequest $request The request to read from.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request to read from.
      * @return string
      */
-    public function getRequestContext(ServerRequest $request): string
+    public function getRequestContext(ServerRequestInterface $request): string
     {
         $message = "\nRequest URL: " . $request->getRequestTarget();
 
@@ -133,9 +133,11 @@ class ErrorLogger
             $message .= "\nReferer URL: " . $referer;
         }
 
-        $clientIp = $request->clientIp();
-        if ($clientIp && $clientIp !== '::1') {
-            $message .= "\nClient IP: " . $clientIp;
+        if (method_exists($request, 'clientIp')) {
+            $clientIp = $request->clientIp();
+            if ($clientIp && $clientIp !== '::1') {
+                $message .= "\nClient IP: " . $clientIp;
+            }
         }
 
         return $message;

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 /**
- * Log errors.
+ * Log errors and unhandled exceptions to `Cake\Log\Log`
  */
 class ErrorLogger
 {

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -50,7 +50,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      *
      * - `trace` Should error logs include stack traces?
      * - `exceptionRenderer` The renderer instance or class name to use or a callable factory
-     *   which return \Cake\Error\ExceptionRendererInterface instance.
+     *   which returns a \Cake\Error\ExceptionRendererInterface instance.
      *   Defaults to \Cake\Error\ExceptionRenderer
      *
      * @var array

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -104,6 +104,20 @@ class ErrorHandlerTest extends TestCase
     }
 
     /**
+     * Test an invalid rendering class.
+     *
+     * @return void
+     */
+    public function testInvalidRenderer()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
+
+        $errorHandler = new ErrorHandler(['exceptionRenderer' => 'TotallyInvalid']);
+        $errorHandler->getRenderer(new \Exception('Something bad'));
+    }
+
+    /**
      * test error handling when debug is on, an error should be printed from Debugger.
      *
      * @return void

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Error\Middleware;
 
+use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRendererInterface;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\Response;
@@ -80,23 +81,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
     }
 
     /**
-     * Test an invalid rendering class.
-     *
-     */
-    public function testInvalidRenderer()
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
-        $request = ServerRequestFactory::fromGlobals();
-
-        $middleware = new ErrorHandlerMiddleware('TotallyInvalid');
-        $handler = new TestRequestHandler(function ($req) {
-            throw new \Exception('Something bad');
-        });
-        $middleware->process($request, $handler);
-    }
-
-    /**
      * Test using a factory method to make a renderer.
      *
      * @return void
@@ -117,7 +101,9 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
             return $mock;
         };
-        $middleware = new ErrorHandlerMiddleware($factory);
+        $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
+            'exceptionRenderer' => $factory,
+        ]));
         $handler = new TestRequestHandler(function ($req) {
             throw new LogicException('Something bad');
         });
@@ -310,7 +296,9 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
             return $mock;
         };
-        $middleware = new ErrorHandlerMiddleware($factory);
+        $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
+            'exceptionRenderer' => $factory,
+        ]));
         $handler = new TestRequestHandler(function ($req) {
             throw new \Cake\Http\Exception\ServiceUnavailableException('whoops');
         });


### PR DESCRIPTION
Made code DRY by making `ErrorHandlerMiddleware` use `ErrorHandler`. Also delegated error logging to new `ErrorLogger`.

Refs #11323.