### PR TITLE
Fixed MailContains constraint when asserting against regexp characters

### DIFF
--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -41,6 +41,7 @@ class MailContains extends MailConstraintBase
         foreach ($emails as $email) {
             $message = implode("\r\n", (array)$email->message($this->type));
 
+            $other = preg_quote($other, '/');
             if (preg_match("/$other/", $message) > 0) {
                 return true;
             }

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -160,6 +160,21 @@ class EmailTraitTest extends TestCase
     }
 
     /**
+     * Tests asserting using RegExp characters doesn't break the assertion
+     *
+     * @return void
+     */
+    public function testAssertUsingRegExpCharacters()
+    {
+        (new Email())
+            ->setTo('to3@example.com')
+            ->setCc('cc3@example.com')
+            ->send('email with regexp chars $/[]');
+
+        $this->assertMailContains('$/[]');
+    }
+
+    /**
      * tests constraint failure messages
      *
      * @param string $assertion Assertion method


### PR DESCRIPTION
Fixes a bug when asserting for mail contents that contain regular expression characters.

This could be seen as a BC break if the user was already escaping the characters, in which case I can retarget.