### PR TITLE
php-redis 'delete' alias function is deprecated since php-redis v5. 

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -214,7 +214,7 @@ class RedisEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return $this->_Redis->delete($key) > 0;
+        return $this->_Redis->del($key) > 0;
     }
 
     /**
@@ -232,7 +232,7 @@ class RedisEngine extends CacheEngine
 
         $result = [];
         foreach ($keys as $key) {
-            $result[] = $this->_Redis->delete($key) > 0;
+            $result[] = $this->_Redis->del($key) > 0;
         }
 
         return !in_array(false, $result);


### PR DESCRIPTION
The php-redis 'delete' alias function is deprecated since php-redis v5.
Use the php-redis 'del' function instead.