### PR TITLE
Fix backward incompatibility for allowEmpty* methods

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -814,6 +814,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 is_callable($second)
             ) && (
                 is_string($first) || $first === null
+            ) && (
+                $first !== 'create' && $first !== 'update'
             )
         ) {
             return [$first, $second];
@@ -823,6 +825,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             "You should reverse the order of your `when` and `message` arguments " .
             "so that they are `message, when`."
         );
+
+        // Called without the second argument.
+        if (is_bool($second)) {
+            $second = null;
+        }
 
         // Called with `$when, $message`. Reverse the
         // order to match the expected return value.

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -822,6 +822,30 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Same as testAllowEmptyDateUpdateDeprecatedArguments but without message
+     *
+     * @return void
+     */
+    public function testAllowEmptyStringDeprecatedArgumentsWithoutMessage()
+    {
+        $validator = new Validator();
+        $this->deprecated(function () use ($validator) {
+            $validator->allowEmptyString('title', 'update');
+        });
+        $this->assertFalse($validator->isEmptyAllowed('title', true));
+        $this->assertTrue($validator->isEmptyAllowed('title', false));
+
+        $data = [
+            'title' => null,
+        ];
+        $expected = [
+            'title' => ['_empty' => 'This field cannot be left empty'],
+        ];
+        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertEmpty($validator->errors($data, false));
+    }
+
+    /**
      * Tests the notEmptyString method
      *
      * @return void


### PR DESCRIPTION
If the second argument is 'create' or 'update', it should be assumed as
the `when` argument for backward compatibility.

Though this change makes`create` and `update` as reserved keywords in 3.x series, I don't think people use such messages when a field is empty.

Relates to #12990 