### PR TITLE
Implement a `removeClass()` option in addition to `addClass()` in src/View/StringTemplate.php

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -369,4 +369,46 @@ class StringTemplate
 
         return $input;
     }
+
+    /**
+     * Removes a class and returns a unique list either in array or space separated
+     *
+     * @param array|string $input The array or string to remove the class from
+     * @param array|string $removeClass the new class or classes to remove
+     * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
+     * @return array|string
+     */
+    public function removeClass($input, $removeClass, $useIndex = 'class')
+    {
+        // NOOP
+        if (empty($removeClass)) {
+            return $input;
+        }
+
+        if (is_array($input)) {
+            $class = Hash::get($input, $useIndex, []);
+        } else {
+            $class = $input;
+            $input = [];
+        }
+
+        // Convert and sanitise the inputs
+        if (!is_array($class)) {
+            if (is_string($class) && !empty($class)) {
+                $class = explode(' ', $class);
+            } else {
+                $class = [];
+            }
+        }
+
+        if (is_string($removeClass)) {
+            $removeClass = explode(' ', $removeClass);
+        }
+
+        $class = array_unique(array_diff($class, $removeClass));
+
+        $input = Hash::insert($input, $useIndex, $class);
+
+        return $input;
+    }
 }

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -331,10 +331,10 @@ class StringTemplate
     /**
      * Adds a class and returns a unique list either in array or space separated
      *
-     * @param array|string $input The array or string to add the class to
-     * @param array|string $newClass the new class or classes to add
+     * @param string[]|string $input The array or string to add the class to
+     * @param string[]|string $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
-     * @return array|string
+     * @return string[]|string
      */
     public function addClass($input, $newClass, $useIndex = 'class')
     {
@@ -373,10 +373,10 @@ class StringTemplate
     /**
      * Removes a class and returns a unique list either in array or space separated
      *
-     * @param array|string $input The array or string to remove the class from
-     * @param array|string $removeClass the new class or classes to remove
+     * @param string[]|string $input The array or string to remove the class from
+     * @param string[]|string $removeClass the new class or classes to remove
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
-     * @return array|string
+     * @return string[]|string
      */
     public function removeClass($input, $removeClass, $useIndex = 'class')
     {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -360,7 +360,7 @@ class StringTemplateTest extends TestCase
         $result = $this->template->addClass(false, 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
 
-        $result = $this->template->addClass(new \StdClass(), 'new_class');
+        $result = $this->template->addClass(new \stdClass(), 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
     }
 
@@ -465,7 +465,7 @@ class StringTemplateTest extends TestCase
         $result = $this->template->removeClass(false, 'remove_class');
         $this->assertEquals($result, ['class' => []]);
 
-        $result = $this->template->removeClass(new \StdClass(), 'remove_class');
+        $result = $this->template->removeClass(new \stdClass(), 'remove_class');
         $this->assertEquals($result, ['class' => []]);
     }
 

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -18,6 +18,9 @@ use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 
+/**
+ * @property StringTemplate $template
+ */
 class StringTemplateTest extends TestCase
 {
 
@@ -438,6 +441,100 @@ class StringTemplateTest extends TestCase
                 'text'
             ],
             'non-existent' => ['new_class']
+        ]);
+    }
+
+    /**
+     * Test removeClass method input parameter
+     *
+     * Tests null, string, array, false and object
+     *
+     * @return void
+     */
+    public function testRemoveClassMethodCurrentClass()
+    {
+        $result = $this->template->removeClass(['class' => ['keep_class', 'remove_class']], 'remove_class');
+        $this->assertEquals($result, ['class' => ['keep_class']]);
+
+        $result = $this->template->removeClass('keep_class remove_class', 'remove_class');
+        $this->assertEquals($result, ['class' => ['keep_class']]);
+
+        $result = $this->template->removeClass(null, 'remove_class');
+        $this->assertEquals($result, ['class' => []]);
+
+        $result = $this->template->removeClass(false, 'remove_class');
+        $this->assertEquals($result, ['class' => []]);
+
+        $result = $this->template->removeClass(new \StdClass(), 'remove_class');
+        $this->assertEquals($result, ['class' => []]);
+    }
+
+    /**
+     * Test removeClass method string parameter, it should fallback to string
+     *
+     * @return void
+     */
+    public function testRemoveClassMethodFallbackToString()
+    {
+        $result = $this->template->removeClass('keep_class remove_class', 'remove_class');
+        $this->assertEquals($result, ['class' => ['keep_class']]);
+    }
+
+    /**
+     * Test removeClass method useIndex param
+     *
+     * Tests for useIndex being the default, 'keep_class' and false
+     *
+     * @return void
+     */
+    public function testRemoveClassMethodUseIndex()
+    {
+        $result = $this->template->removeClass(
+            [
+                'class' => 'keep_class remove_class',
+                'other_index1' => false,
+                'type' => 'text'
+            ],
+            'remove_class',
+            'class'
+        );
+        $this->assertEquals($result, [
+            'class' => ['keep_class'],
+            'other_index1' => false,
+            'type' => 'text'
+        ]);
+
+        $result = $this->template->removeClass(
+            [
+                'my_class' => 'keep_class remove_class',
+                'other_index1' => false,
+                'type' => 'text'
+            ],
+            'remove_class',
+            'my_class'
+        );
+        $this->assertEquals($result, [
+            'other_index1' => false,
+            'type' => 'text',
+            'my_class' => ['keep_class']
+        ]);
+
+        $result = $this->template->removeClass(
+            [
+                'class' => [
+                    'keep_class',
+                    'remove_class'
+                ]
+            ],
+            'remove_class',
+            'non-existent'
+        );
+        $this->assertEquals($result, [
+            'class' => [
+                'keep_class',
+                'remove_class'
+            ],
+            'non-existent' => []
         ]);
     }
 }


### PR DESCRIPTION
Implement the option to remove default classes as well as adding them. Uses similar logic as `addClass()`, except that it will `array_diff()` instead of `array_merge()`

A example case where this comes in handy are custom Bootstrap helpers. Perhaps a button usually gets class `btn-primary` assigned by default, and it may be desirable to remove that in order to use a different or blank button class