### PR TITLE
4.x - Update tests to not use deprecated PHPUnit features

### DIFF
--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -94,6 +94,16 @@ class BodyParserMiddleware implements MiddlewareInterface
     }
 
     /**
+     * Get the HTTP methods to parse request bodies on.
+     *
+     * @return array
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+
+    /**
      * Add a parser.
      *
      * Map a set of content-type header values to be parsed by the $parser.
@@ -121,6 +131,16 @@ class BodyParserMiddleware implements MiddlewareInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Get the current parsers
+     *
+     * @return array
+     */
+    public function getParsers(): array
+    {
+        return $this->parsers;
     }
 
     /**

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -1007,6 +1007,16 @@ class RouteBuilder
     }
 
     /**
+     * Get the middleware that this builder will apply to routes.
+     *
+     * @return array
+     */
+    public function getMiddleware(): array
+    {
+        return $this->middleware;
+    }
+
+    /**
      * Apply a set of middleware to a group
      *
      * @param string $name Name of the middleware group

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -493,25 +494,21 @@ class ControllerTest extends TestCase
         $eventManager = $this->getMockBuilder('Cake\Event\EventManagerInterface')->getMock();
         $controller = new Controller(null, null, null, $eventManager);
 
-        $eventManager->expects($this->at(0))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'Controller.initialize'),
-                    $this->attributeEqualTo('_subject', $controller)
-                )
-            )
-            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
+        $eventManager
+            ->expects($this->at(0))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'Controller.initialize';
+            }))
+            ->will($this->returnValue(new Event('stub')));
 
-        $eventManager->expects($this->at(1))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'Controller.startup'),
-                    $this->attributeEqualTo('_subject', $controller)
-                )
-            )
-            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
+        $eventManager
+            ->expects($this->at(1))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'Controller.startup';
+            }))
+            ->will($this->returnValue(new Event('stub')));
 
         $controller->startupProcess();
     }
@@ -526,15 +523,12 @@ class ControllerTest extends TestCase
         $eventManager = $this->getMockBuilder('Cake\Event\EventManagerInterface')->getMock();
         $controller = new Controller(null, null, null, $eventManager);
 
-        $eventManager->expects($this->once())->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'Controller.shutdown'),
-                    $this->attributeEqualTo('_subject', $controller)
-                )
-            )
-            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
+        $eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'Controller.shutdown';
+            }))
+            ->will($this->returnValue(new Event('stub')));
 
         $controller->shutdownProcess();
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -28,6 +28,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use DateTimeImmutable;
 use InvalidArgumentException;
+use ReflectionProperty;
 use TestApp\Database\Type\BarType;
 
 /**
@@ -2321,11 +2322,13 @@ class QueryTest extends TestCase
             ->limit(1)
             ->offset(1)
             ->execute();
-        $dirty = $this->readAttribute($query, '_dirty');
-        $this->assertFalse($dirty);
+
+        $reflect = new ReflectionProperty($query, '_dirty');
+        $reflect->setAccessible(true);
+        $this->assertFalse($reflect->getvalue($query));
+
         $query->offset(2);
-        $dirty = $this->readAttribute($query, '_dirty');
-        $this->assertTrue($dirty);
+        $this->assertTrue($reflect->getvalue($query));
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2325,10 +2325,10 @@ class QueryTest extends TestCase
 
         $reflect = new ReflectionProperty($query, '_dirty');
         $reflect->setAccessible(true);
-        $this->assertFalse($reflect->getvalue($query));
+        $this->assertFalse($reflect->getValue($query));
 
         $query->offset(2);
-        $this->assertTrue($reflect->getvalue($query));
+        $this->assertTrue($reflect->getValue($query));
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -34,10 +34,10 @@ class ModelAwareTraitTest extends TestCase
     public function testSetModelClass()
     {
         $stub = new Stub();
-        $this->assertAttributeEquals(null, 'modelClass', $stub);
+        $this->assertNull($stub->getModelClass());
 
         $stub->setProps('StubArticles');
-        $this->assertAttributeEquals('StubArticles', 'modelClass', $stub);
+        $this->assertEquals('StubArticles', $stub->getModelClass());
     }
 
     /**

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -43,16 +43,6 @@ class EventDispatcherTraitTest extends TestCase
     }
 
     /**
-     * testIsInitiallyEmpty
-     *
-     * @return void
-     */
-    public function testIsInitiallyEmpty()
-    {
-        $this->assertAttributeEmpty('_eventManager', $this->subject);
-    }
-
-    /**
      * testGetEventManager
      *
      * @return void

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use ReflectionProperty;
 
 /**
  * Test case for the ActionDispatcher.
@@ -50,7 +51,9 @@ class ActionDispatcherTest extends TestCase
         $factory = $this->getMockBuilder('Cake\Http\ControllerFactory')->getMock();
         $dispatcher = new ActionDispatcher($factory);
 
-        $this->assertAttributeSame($factory, 'factory', $dispatcher);
+        $reflect = new ReflectionProperty($dispatcher, 'factory');
+        $reflect->setAccessible(true);
+        $this->assertSame($factory, $reflect->getValue($dispatcher));
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -63,7 +63,7 @@ class BodyParserMiddlewareTest extends TestCase
     public function testConstructorMethodsOption()
     {
         $parser = new BodyParserMiddleware(['methods' => ['PUT']]);
-        $this->assertAttributeEquals(['PUT'], 'methods', $parser);
+        $this->assertEquals(['PUT'], $parser->getMethods());
     }
 
     /**
@@ -74,17 +74,17 @@ class BodyParserMiddlewareTest extends TestCase
     public function testConstructorXmlOption()
     {
         $parser = new BodyParserMiddleware(['json' => false]);
-        $this->assertAttributeEquals([], 'parsers', $parser, 'Xml off by default');
+        $this->assertEquals([], $parser->getParsers(), 'Xml off by default');
 
         $parser = new BodyParserMiddleware(['json' => false, 'xml' => false]);
-        $this->assertAttributeEquals([], 'parsers', $parser, 'No Xml types set.');
+        $this->assertEquals([], $parser->getParsers(), 'No Xml types set.');
 
         $parser = new BodyParserMiddleware(['json' => false, 'xml' => true]);
         $expected = [
             'application/xml' => [$parser, 'decodeXml'],
             'text/xml' => [$parser, 'decodeXml'],
         ];
-        $this->assertAttributeEquals($expected, 'parsers', $parser, 'Xml types are incorrect.');
+        $this->assertEquals($expected, $parser->getParsers(), 'Xml types are incorrect.');
     }
 
     /**
@@ -95,14 +95,14 @@ class BodyParserMiddlewareTest extends TestCase
     public function testConstructorJsonOption()
     {
         $parser = new BodyParserMiddleware(['json' => false]);
-        $this->assertAttributeEquals([], 'parsers', $parser, 'No JSON types set.');
+        $this->assertEquals([], $parser->getParsers(), 'No JSON types set.');
 
         $parser = new BodyParserMiddleware([]);
         $expected = [
             'application/json' => [$parser, 'decodeJson'],
             'text/json' => [$parser, 'decodeJson'],
         ];
-        $this->assertAttributeEquals($expected, 'parsers', $parser, 'JSON types are incorrect.');
+        $this->assertEquals($expected, $parser->getParsers(), 'JSON types are incorrect.');
     }
 
     /**
@@ -114,7 +114,7 @@ class BodyParserMiddlewareTest extends TestCase
     {
         $parser = new BodyParserMiddleware();
         $this->assertSame($parser, $parser->setMethods(['PUT']));
-        $this->assertAttributeEquals(['PUT'], 'methods', $parser);
+        $this->assertEquals(['PUT'], $parser->getMethods());
     }
 
     /**
@@ -139,7 +139,7 @@ class BodyParserMiddlewareTest extends TestCase
         $parser->addParser(['application/json'], 'json_decode');
         $parser->addParser(['application/json'], 'strpos');
 
-        $this->assertAttributeEquals(['application/json' => 'strpos'], 'parsers', $parser);
+        $this->assertEquals(['application/json' => 'strpos'], $parser->getParsers());
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Mailer\Transport;
 use Cake\Mailer\Message;
 use Cake\Network\Exception\SocketException;
 use Cake\TestSuite\TestCase;
+use ReflectionProperty;
 use TestApp\Mailer\Transport\SmtpTestTransport;
 
 /**
@@ -701,7 +702,10 @@ class SmtpTransportTest extends TestCase
         $smtpTransport->connect();
 
         $result = unserialize(serialize($smtpTransport));
-        $this->assertAttributeEquals(null, '_socket', $result);
+
+        $reflect = new ReflectionProperty($result, '_socket');
+        $reflect->setAccessible(true);
+        $this->assertNull($reflect->getValue($result));
         $this->assertFalse($result->connected());
     }
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -31,6 +31,7 @@ use Cake\I18n\Time;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
+use ReflectionProperty;
 
 /**
  * Tests Query class
@@ -2858,9 +2859,12 @@ class QueryTest extends TestCase
         $loader = $query->getEagerLoader();
         $this->assertEquals($copyLoader, $loader, 'should be equal');
         $this->assertNotSame($copyLoader, $loader, 'should be clones');
+
+        $reflect = new ReflectionProperty($loader, '_matching');
+        $reflect->setAccessible(true);
         $this->assertNotSame(
-            $this->readAttribute($copyLoader, '_matching'),
-            $this->readAttribute($loader, '_matching'),
+            $reflect->getValue($copyLoader),
+            $reflect->getValue($loader),
             'should be clones'
         );
         $this->assertNull($copy->clause('offset'));

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2998,28 +2998,22 @@ class TableTest extends TestCase
         $mock->expects($this->at(2))
             ->method('dispatch')
             ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
-                return (
-                    $event->getName() === 'Model.beforeDelete' &&
-                    $event->getData() == ['entity' => $entity, 'options' => $options]
-                );
+                return $event->getName() === 'Model.beforeDelete' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options];
             }));
 
         $mock->expects($this->at(3))
             ->method('dispatch')
             ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
-                return (
-                    $event->getName() === 'Model.afterDelete' &&
-                    $event->getData() == ['entity' => $entity, 'options' => $options]
-                );
+                return $event->getName() === 'Model.afterDelete' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options];
             }));
 
         $mock->expects($this->at(4))
             ->method('dispatch')
             ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
-                return (
-                    $event->getName() === 'Model.afterDeleteCommit' &&
-                    $event->getData() == ['entity' => $entity, 'options' => $options]
-                );
+                return $event->getName() === 'Model.afterDeleteCommit' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options];
             }));
 
         $table = $this->getTableLocator()->get('users', ['eventManager' => $mock]);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2997,33 +2997,30 @@ class TableTest extends TestCase
 
         $mock->expects($this->at(2))
             ->method('dispatch')
-            ->with($this->logicalAnd(
-                $this->attributeEqualTo('_name', 'Model.beforeDelete'),
-                $this->attributeEqualTo(
-                    '_data',
-                    ['entity' => $entity, 'options' => $options]
-                )
-            ));
+            ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
+                return (
+                    $event->getName() === 'Model.beforeDelete' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options]
+                );
+            }));
 
         $mock->expects($this->at(3))
             ->method('dispatch')
-            ->with($this->logicalAnd(
-                $this->attributeEqualTo('_name', 'Model.afterDelete'),
-                $this->attributeEqualTo(
-                    '_data',
-                    ['entity' => $entity, 'options' => $options]
-                )
-            ));
+            ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
+                return (
+                    $event->getName() === 'Model.afterDelete' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options]
+                );
+            }));
 
         $mock->expects($this->at(4))
             ->method('dispatch')
-            ->with($this->logicalAnd(
-                $this->attributeEqualTo('_name', 'Model.afterDeleteCommit'),
-                $this->attributeEqualTo(
-                    '_data',
-                    ['entity' => $entity, 'options' => $options]
-                )
-            ));
+            ->with($this->callback(function (EventInterface $event) use ($entity, $options) {
+                return (
+                    $event->getName() === 'Model.afterDeleteCommit' &&
+                    $event->getData() == ['entity' => $entity, 'options' => $options]
+                );
+            }));
 
         $table = $this->getTableLocator()->get('users', ['eventManager' => $mock]);
         $entity->isNew(false);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -954,7 +954,7 @@ class RouteBuilderTest extends TestCase
             ['middleware' => ['auth']]
         );
         $routes->scope('/v1', function (RouteBuilder $routes) {
-            $this->assertAttributeEquals(['auth'], 'middleware', $routes, 'Should inherit middleware');
+            $this->assertSame(['auth'], $routes->getMiddleware(), 'Should inherit middleware');
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'api'], $routes->params());
         });
@@ -1078,7 +1078,7 @@ class RouteBuilderTest extends TestCase
         $routes->applyMiddleware('test');
         $routes->applyMiddleware('test2');
 
-        $this->assertAttributeEquals(['test', 'test2'], 'middleware', $routes);
+        $this->assertSame(['test', 'test2'], $routes->getMiddleware());
     }
 
     /**
@@ -1097,7 +1097,7 @@ class RouteBuilderTest extends TestCase
         $routes->applyMiddleware('test', 'test2');
         $routes->applyMiddleware('test2', 'test');
 
-        $this->assertAttributeEquals(['test', 'test2'], 'middleware', $routes);
+        $this->assertEquals(['test', 'test2'], $routes->getMiddleware());
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -31,6 +31,7 @@ use Cake\View\Form\EntityContext;
 use Cake\View\Helper\FormHelper;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
+use ReflectionProperty;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
@@ -6960,7 +6961,9 @@ class FormHelperTest extends TestCase
 
         $this->assertEquals(['title'], $this->Form->fields);
         $this->assertStringContainsString($hash, $result, 'Should contain the correct hash.');
-        $this->assertAttributeEquals('/articles/add', '_lastAction', $this->Form, 'lastAction was should be restored.');
+        $reflect = new ReflectionProperty($this->Form, '_lastAction');
+        $reflect->setAccessible(true);
+        $this->assertEquals('/articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -951,77 +951,53 @@ class ViewTest extends TestCase
         $manager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $View->setEventManager($manager);
 
-        $manager->expects($this->at(0))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.beforeRender'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(0))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.beforeRender';
+            }));
 
-        $manager->expects($this->at(1))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.beforeRenderFile'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(1))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.beforeRenderFile';
+            }));
 
-        $manager->expects($this->at(2))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.afterRenderFile'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(2))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.afterRenderFile';
+            }));
 
-        $manager->expects($this->at(3))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.afterRender'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(3))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.afterRender';
+            }));
 
-        $manager->expects($this->at(4))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.beforeLayout'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(4))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.beforeLayout';
+            }));
 
-        $manager->expects($this->at(5))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.beforeRenderFile'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(5))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.beforeRenderFile';
+            }));
 
-        $manager->expects($this->at(6))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.afterRenderFile'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(6))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.afterRenderFile';
+            }));
 
-        $manager->expects($this->at(7))->method('dispatch')
-            ->with(
-                $this->logicalAnd(
-                    $this->isInstanceOf('Cake\Event\Event'),
-                    $this->attributeEqualTo('_name', 'View.afterLayout'),
-                    $this->attributeEqualTo('_subject', $View)
-                )
-            );
+        $manager->expects($this->at(7))
+            ->method('dispatch')
+            ->with($this->callback(function (EventInterface $event) {
+                return $event->getName() === 'View.afterLayout';
+            }));
 
         $View->render('index');
     }

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -20,4 +20,9 @@ class Stub
     {
         $this->_setModelClass($name);
     }
+
+    public function getModelClass(): ?string
+    {
+        return $this->modelClass;
+    }
 }


### PR DESCRIPTION
Fix the various deprecation warnings we're getting from PHPUnit about
methods that are now deprecated.