### PR TITLE
[ref: #13392] Hash::sort with const dir

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -928,8 +928,8 @@ class Hash
      *
      * ### Sort directions
      *
-     * - `asc` Sort ascending.
-     * - `desc` Sort descending.
+     * - `asc` or `\SORT_ASC` Sort ascending.
+     * - `desc` or `\SORT_DESC` Sort descending.
      *
      * ### Sort types
      *
@@ -951,7 +951,7 @@ class Hash
      *
      * @param array $data An array of data to sort
      * @param string $path A Set-compatible path to the array value
-     * @param string $dir See directions above. Defaults to 'asc'.
+     * @param string|int $dir See directions above. Defaults to 'asc'.
      * @param array|string $type See direction types above. Defaults to 'regular'.
      * @return array Sorted array of data
      * @link https://book.cakephp.org/3.0/en/core-libraries/hash.html#Cake\Utility\Hash::sort
@@ -985,7 +985,13 @@ class Hash
         $keys = static::extract($result, '{n}.id');
         $values = static::extract($result, '{n}.value');
 
-        $dir = strtolower($dir);
+        if (is_string($dir)) {
+            $dir = strtolower($dir);
+        }
+        if (!in_array($dir, [\SORT_ASC, \SORT_DESC], true)) {
+            $dir = (strtolower($dir) === 'asc') ? \SORT_ASC : \SORT_DESC;
+        }
+
         $ignoreCase = false;
 
         // $type can be overloaded for case insensitive sort
@@ -995,12 +1001,6 @@ class Hash
             $type = $type['type'];
         }
         $type = strtolower($type);
-
-        if ($dir === 'asc') {
-            $dir = \SORT_ASC;
-        } else {
-            $dir = \SORT_DESC;
-        }
         if ($type === 'numeric') {
             $type = \SORT_NUMERIC;
         } elseif ($type === 'string') {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -989,7 +989,7 @@ class Hash
             $dir = strtolower($dir);
         }
         if (!in_array($dir, [\SORT_ASC, \SORT_DESC], true)) {
-            $dir = (strtolower($dir) === 'asc') ? \SORT_ASC : \SORT_DESC;
+            $dir = ($dir === 'asc') ? \SORT_ASC : \SORT_DESC;
         }
 
         $ignoreCase = false;

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1849,6 +1849,30 @@ class HashTest extends TestCase
     }
 
     /**
+     * test sorting direction by constants value.
+     *
+     * @return void
+     */
+    public function testSortWithDirectionConst()
+    {
+        $data = [
+            ['class' => 510, 'test' => 2],
+            ['class' => 500, 'test' => 1],
+            ['class' => 600, 'test' => 2],
+            ['class' => 625, 'test' => 4],
+            ['class' => 605, 'test' => 3],
+        ];
+
+        $expected = Hash::sort($data, '{n}.test', 'asc');
+        $result = Hash::sort($data, '{n}.test', \SORT_ASC);
+        $this->assertSame($expected, $result);
+
+        $expected = Hash::sort($data, '{n}.test', 'desc');
+        $result = Hash::sort($data, '{n}.test', \SORT_DESC);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * test sorting with string keys.
      *
      * @return void


### PR DESCRIPTION
Described in #13392 

To improve `Hash::sort()`,  make it correspond to `$dir` with `\SORT_ASC`(or `\SORT_DESC`).
Please check `testSortWithDirectionConst` test case, it shows you  "Hash::sort() with 'desc'" equals "Hash::sort() with '\SORT_DESC'" now.