### PR TITLE
Fix curl protocol version selection

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -72,7 +72,7 @@ class Curl implements AdapterInterface
 
         $out = [
             CURLOPT_URL => (string)$request->getUri(),
-            CURLOPT_HTTP_VERSION => $request->getProtocolVersion(),
+            CURLOPT_HTTP_VERSION => $this->getProtocolVersion($request),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => $headers
@@ -133,6 +133,29 @@ class Curl implements AdapterInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Convert HTTP version number into curl value.
+     *
+     * @param \Cake\Http\Client\Request $request The request to get a protocol version for.
+     * @return int
+     */
+    protected function getProtocolVersion(Request $request)
+    {
+        switch ($request->getProtocolVersion()) {
+            case '1.0':
+                return CURL_HTTP_VERSION_1_0;
+            case '1.1':
+                return CURL_HTTP_VERSION_1_1;
+            case '2.0':
+                if (defined('CURL_HTTP_VERSION_2_0')) {
+                    return CURL_HTTP_VERSION_2_0;
+                }
+                throw new HttpException('libcurl 7.33 needed for HTTP 2.0 support');
+        }
+
+        return CURL_HTTP_VERSION_NONE;
     }
 
     /**

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -99,7 +99,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -131,7 +131,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -163,7 +163,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -196,7 +196,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -230,7 +230,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -263,7 +263,7 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [
@@ -291,10 +291,12 @@ class CurlTest extends TestCase
             ]
         ];
         $request = new Request('http://localhost/things', 'GET');
+        $request = $request->withProtocolVersion('1.0');
+
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
             CURLOPT_URL => 'http://localhost/things',
-            CURLOPT_HTTP_VERSION => '1.1',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => [


### PR DESCRIPTION
Convert the http version numbres into the equivalent curl constant so that curl actually uses the right Http version.

Fixes #13398