### PR TITLE
Remove --routes and --bootstrap options

### DIFF
--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -70,11 +70,9 @@ class PluginLoadCommand extends Command
             return static::CODE_ERROR;
         }
 
-        $options = $this->makeOptions($args);
-
         $app = APP . 'Application.php';
         if (file_exists($app)) {
-            $this->modifyApplication($app, $plugin, $options);
+            $this->modifyApplication($app, $plugin);
 
             return static::CODE_SUCCESS;
         }
@@ -83,33 +81,18 @@ class PluginLoadCommand extends Command
     }
 
     /**
-     * Create options string for the load call.
-     *
-     * @param \Cake\Console\Arguments $args The command arguments.
-     * @return string
-     */
-    protected function makeOptions(Arguments $args): string
-    {
-        $bootstrapString = $args->getOption('bootstrap') ? "'bootstrap' => true" : '';
-        $routesString = $args->getOption('routes') ? "'routes' => true" : '';
-
-        return implode(', ', array_filter([$bootstrapString, $routesString]));
-    }
-
-    /**
      * Modify the application class
      *
      * @param string $app The Application file to modify.
      * @param string $plugin The plugin name to add.
-     * @param string $options The plugin options to add
      * @return void
      */
-    protected function modifyApplication(string $app, string $plugin, string $options): void
+    protected function modifyApplication(string $app, string $plugin): void
     {
         $contents = file_get_contents($app);
 
-        $append = "\n        \$this->addPlugin('%s', [%s]);\n";
-        $insert = str_replace(', []', '', sprintf($append, $plugin, $options));
+        $append = "\n        \$this->addPlugin('%s');\n";
+        $insert = str_replace(', []', '', sprintf($append, $plugin));
 
         if (!preg_match('/function bootstrap\(\)(?:\s*)\:(?:\s*)void/m', $contents)) {
             $this->io->err('Your Application class does not have a bootstrap() method. Please add one.');
@@ -137,18 +120,6 @@ class PluginLoadCommand extends Command
     {
         $parser->setDescription([
             'Command for loading plugins.',
-        ])
-        ->addOption('bootstrap', [
-            'short' => 'b',
-            'help' => 'Will load bootstrap.php from plugin.',
-            'boolean' => true,
-            'default' => false,
-        ])
-        ->addOption('routes', [
-            'short' => 'r',
-            'help' => 'Will load routes.php from plugin.',
-            'boolean' => true,
-            'default' => false,
         ])
         ->addArgument('plugin', [
             'help' => 'Name of the plugin to load.',

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -69,6 +69,18 @@ class PluginLoadCommandTest extends TestCase
     }
 
     /**
+     * Test generating help succeeds
+     *
+     * @return void
+     */
+    public function testHelp()
+    {
+        $this->exec('plugin load --help');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContains('plugin load');
+    }
+
+    /**
      * Test loading the app
      *
      * @return void
@@ -80,33 +92,5 @@ class PluginLoadCommandTest extends TestCase
 
         $contents = file_get_contents($this->app);
         $this->assertStringContainsString("\$this->addPlugin('TestPlugin');", $contents);
-    }
-
-    /**
-     * Test loading the app
-     *
-     * @return void
-     */
-    public function testLoadAppBootstrap()
-    {
-        $this->exec('plugin load --bootstrap TestPlugin');
-        $this->assertExitCode(Command::CODE_SUCCESS);
-
-        $contents = file_get_contents($this->app);
-        $this->assertStringContainsString("\$this->addPlugin('TestPlugin', ['bootstrap' => true]);", $contents);
-    }
-
-    /**
-     * Test loading the app
-     *
-     * @return void
-     */
-    public function testLoadAppRoutes()
-    {
-        $this->exec('plugin load --routes TestPlugin');
-        $this->assertExitCode(Command::CODE_SUCCESS);
-
-        $contents = file_get_contents($this->app);
-        $this->assertStringContainsString("\$this->addPlugin('TestPlugin', ['routes' => true]);", $contents);
     }
 }


### PR DESCRIPTION
In 4.x plugins define their default behavior so there isn't really a need to enable the bootstrap/routes options unless you're turning hooks off which isn't something the command supported historically.
