### PR TITLE
cakephp/utility should suggest ext-simplexml

### DIFF
--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -26,12 +26,12 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "ext-simplexml": "*",
         "cakephp/core": "^3.6.0"
     },
     "suggest": {
         "ext-intl": "To use Text::transliterate() or Text::slug()",
-        "lib-ICU": "To use Text::transliterate() or Text::slug()"
+        "lib-ICU": "To use Text::transliterate() or Text::slug()",
+        "ext-simplexml": "To use Xml::build(), Xml::loadHtml(), Xml::fromArray(), or Xml::toArray() with default options",
     },
     "autoload": {
         "psr-4": {

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -26,6 +26,7 @@
     },
     "require": {
         "php": ">=5.6.0",
+        "ext-simplexml": "*",
         "cakephp/core": "^3.6.0"
     },
     "suggest": {


### PR DESCRIPTION
The Xml utility relies on the SimpleXMLElement class existing, which is only available if the SimpleXML extension is installed. Therefore the package should be requiring that `ext-simplexml` is present.