### PR TITLE
[REDIS] Use SCAN instead of KEYS to find all matching keys

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ install:
 
   - cd C:\projects\cakephp
   - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+  - del composer.lock
   - php composer.phar install --no-progress
   - php -i | grep "ICU version"
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -236,7 +236,7 @@ class RedisEngine extends CacheEngine
         $pattern = $this->_config['prefix'] . '*';
 
         while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern));
+            $keys = $this->_Redis->scan($iterator, $pattern);
 
             if ($keys === false) {
                 break;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -235,7 +235,13 @@ class RedisEngine extends CacheEngine
         $iterator = null;
         $pattern = $this->_config['prefix'] . '*';
 
-        while ($keys = $this->_Redis->scan($iterator, $pattern)) {
+        while (true) {
+            $keys = $this->_Redis->scan($iterator, $pattern));
+
+            if ($keys === false) {
+                break;
+            }
+
             foreach ($keys as $key) {
                 $isDeleted = ($this->_Redis->del($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -229,7 +229,7 @@ class RedisEngine extends CacheEngine
             return true;
         }
 
-        $result = true;
+        $isAllDeleted = true;
         $iterator = null;
         $pattern = $this->_config['prefix'] . '*';
         do {
@@ -238,12 +238,13 @@ class RedisEngine extends CacheEngine
             // Redis may return empty results, so protect against that
             if ($keys !== false) {
                 foreach($keys as $key) {
-                    $result = $result && ($this->_Redis->del($key) > 0);
+                    $isDeleted = ($this->_Redis->del($key) > 0);
+                    $isAllDeleted = $isAllDeleted && $isDeleted;
                 }
             }
         } while ($iterator > 0);
 
-        return $result;
+        return $isAllDeleted;
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -237,7 +237,7 @@ class RedisEngine extends CacheEngine
 
             // Redis may return empty results, so protect against that
             if ($keys !== false) {
-                foreach($keys as $key) {
+                foreach ($keys as $key) {
                     $isDeleted = ($this->_Redis->del($key) > 0);
                     $isAllDeleted = $isAllDeleted && $isDeleted;
                 }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -229,6 +229,7 @@ class RedisEngine extends CacheEngine
             return true;
         }
 
+        $result = true;
         $iterator = null;
         $pattern = $this->_config['prefix'] . '*';
         do {
@@ -237,12 +238,12 @@ class RedisEngine extends CacheEngine
             // Redis may return empty results, so protect against that
             if ($keys !== false) {
                 foreach($keys as $key) {
-                    $this->_Redis->delete($key);
+                    $result = $result && ($this->_Redis->del($key) > 0);
                 }
             }
         } while ($iterator > 0);
 
-        return true;
+        return $result;
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -229,20 +229,18 @@ class RedisEngine extends CacheEngine
             return true;
         }
 
+        $this->_Redis->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
+
         $isAllDeleted = true;
         $iterator = null;
         $pattern = $this->_config['prefix'] . '*';
-        do {
-            $keys = $this->_Redis->scan($iterator, $pattern);
 
-            // Redis may return empty results, so protect against that
-            if ($keys !== false) {
-                foreach ($keys as $key) {
-                    $isDeleted = ($this->_Redis->del($key) > 0);
-                    $isAllDeleted = $isAllDeleted && $isDeleted;
-                }
+        while ($keys = $this->_Redis->scan($iterator, $pattern)) {
+            foreach ($keys as $key) {
+                $isDeleted = ($this->_Redis->del($key) > 0);
+                $isAllDeleted = $isAllDeleted && $isDeleted;
             }
-        } while ($iterator > 0);
+        }
 
         return $isAllDeleted;
     }


### PR DESCRIPTION
This PR changes the way how cache is cleared. First the inefficient KEYS command was used to find all matching keys in Redis.

According to the [Redis docs](https://redis.io/commands/keys), this doesn't perform well and they advice to use the `SCAN` command.

> Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using SCAN or sets.

Fixes: https://github.com/cakephp/cakephp/issues/13404

Used sample code from PhpRedis https://github.com/phpredis/phpredis#scan