### PR TITLE
Add missing -p plugin short key

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -361,7 +361,8 @@ class ExtractTask extends Shell
             'default' => true,
             'help' => 'Ignores all files in plugins if this command is run inside from the same app directory.'
         ])->addOption('plugin', [
-            'help' => 'Extracts tokens only from the plugin specified and puts the result in the plugin\'s Locale directory.'
+            'help' => 'Extracts tokens only from the plugin specified and puts the result in the plugin\'s Locale directory.',
+            'short' => 'p',
         ])->addOption('ignore-model-validation', [
             'boolean' => true,
             'default' => false,


### PR DESCRIPTION
The i18n shell contains the short key "p"
```php
'plugin' => [
    'help' => 'Plugin name.',
    'short' => 'p'
],
```
just as others as well

But the extract task has been missing it, leading to unexpected long usage here.
This fixed this.

    bin/cake i18n extract -p Queue