### PR TITLE
Fix wrong association and _locale properties set when using matching.

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -557,7 +557,14 @@ class EagerLoader
 
         $paths += ['aliasPath' => '', 'propertyPath' => '', 'root' => $alias];
         $paths['aliasPath'] .= '.' . $alias;
-        $paths['propertyPath'] .= '.' . $instance->getProperty();
+
+        if (isset($options['matching']) &&
+           $options['matching'] === true
+        ) {
+            $paths['propertyPath'] = '_matchingData.' . $alias;
+        } else {
+            $paths['propertyPath'] .= '.' . $instance->getProperty();
+        }
 
         $table = $instance->getTarget();
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1960,7 +1960,6 @@ class TranslateBehaviorTest extends TestCase
             ->first();
 
         $this->assertArrayNotHasKey('_locale', $result->comments);
-        $this->assertArrayHasKey('_locale', $result->_matchingData['Comments']);
         $this->assertEquals('abc', $result->_matchingData['Comments']->_locale);
     }
 
@@ -1992,8 +1991,6 @@ class TranslateBehaviorTest extends TestCase
             ->first();
 
         $this->assertArrayNotHasKey('_locale', $result->comments);
-        $this->assertArrayHasKey('_locale', $result->_matchingData['Comments']);
-        $this->assertArrayHasKey('_locale', $result->_matchingData['Authors']);
         $this->assertEquals('abc', $result->_matchingData['Comments']->_locale);
         $this->assertEquals('xyz', $result->_matchingData['Authors']->_locale);
     }
@@ -2031,7 +2028,6 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertArrayNotHasKey('_locale', $result->articles);
         $this->assertArrayNotHasKey('_locale', $result->articles[0]->tags);
-        $this->assertArrayHasKey('_locale', $result->articles[0]->_matchingData['Tags']);
         $this->assertEquals('abc', $result->articles[0]->_locale);
         $this->assertEquals('xyz', $result->articles[0]->_matchingData['Tags']->_locale);
     }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -530,6 +530,40 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
+     * Tests that the paths for matching containments point to _matchingData.
+     *
+     * @return void
+     */
+    public function testNormalizedMatchingPath()
+    {
+        $loader = new EagerLoader();
+        $loader->setMatching('Clients');
+        $assocs = $loader->attachableAssociations($this->table);
+
+        $this->assertEquals('Clients', $assocs['Clients']->aliasPath());
+        $this->assertEquals('_matchingData.Clients', $assocs['Clients']->propertyPath());
+    }
+
+    /**
+     * Tests that the paths for deep matching containments point to _matchingData.
+     *
+     * @return void
+     */
+    public function testNormalizedDeepMatchingPath()
+    {
+        $loader = new EagerLoader();
+        $loader->setMatching('Clients.Orders');
+        $assocs = $loader->attachableAssociations($this->table);
+
+        $this->assertEquals('Clients', $assocs['Clients']->aliasPath());
+        $this->assertEquals('_matchingData.Clients', $assocs['Clients']->propertyPath());
+
+        $assocs = $assocs['Clients']->associations();
+        $this->assertEquals('Clients.Orders', $assocs['Orders']->aliasPath());
+        $this->assertEquals('_matchingData.Orders', $assocs['Orders']->propertyPath());
+    }
+
+    /**
      * Test clearing containments but not matching joins.
      *
      * @return void


### PR DESCRIPTION
When using matching, the translate behavior sets wrong association and `_locale` properties, because the eager loadables hold wrong property paths that point to the properties that are used for regular containments, instead of the `_matchingData` property where matching records are set.

I think that `EagerLoader::_normalizeContain()` is the right place to fix this, as it seems to be the place where the path is initially being created, and containments for matching only ever seem to be placed in the `_matchingData` property, but I have to admit that I'm not 100% sure.

refs #12954