### PR TITLE
Set expiration atomically in RedisEngine::add()

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -258,7 +258,7 @@ class RedisEngine extends CacheEngine
      * @param string $key Identifier for the data.
      * @param mixed $value Data to be cached.
      * @return bool True if the data was successfully cached, false on failure.
-     * @link https://github.com/phpredis/phpredis#setnx
+     * @link https://github.com/phpredis/phpredis#set
      */
     public function add($key, $value)
     {
@@ -269,9 +269,8 @@ class RedisEngine extends CacheEngine
             $value = serialize($value);
         }
 
-        // setNx() doesn't have an expiry option, so follow up with an expiry
-        if ($this->_Redis->setNx($key, $value)) {
-            return $this->_Redis->expire($key, $duration);
+        if ($this->_Redis->set($key, $value, ['nx', 'ex' => $duration])) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
My company has observed occasions where the `RedisEngine::add()` method sets a key but fails to set its expiration. That is very bad for simple locking implementations because the lock will never expire. This PR uses newer (Redis version >= 2.6.12) options in `Redis::set()` to set the expiration atomically when the key is set.