### PR TITLE
Ensure Association::$_className is always set.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -226,7 +226,7 @@ abstract class Association
             }
         }
 
-        if (empty($this->_className) && strpos($alias, '.')) {
+        if (empty($this->_className)) {
             $this->_className = $alias;
         }
 
@@ -378,7 +378,7 @@ abstract class Association
     public function getTarget(): Table
     {
         if ($this->_targetTable === null) {
-            if (strpos((string)$this->_className, '.')) {
+            if (strpos($this->_className, '.')) {
                 [$plugin] = pluginSplit($this->_className, true);
                 $registryAlias = $plugin . $this->_name;
             } else {
@@ -395,7 +395,7 @@ abstract class Association
             $this->_targetTable = $tableLocator->get($registryAlias, $config);
 
             if ($exists) {
-                $className = $this->_getClassName($registryAlias, ['className' => $this->_className]);
+                $className = App::className($this->_className, 'Model/Table', 'Table') ?: Table::class;
 
                 if (!$this->_targetTable instanceof $className) {
                     $errorMessage = '%s association "%s" of type "%s" to "%s" doesn\'t match the expected class "%s". ';
@@ -1123,24 +1123,6 @@ abstract class Association
         }
 
         return [key($finderData), current($finderData)];
-    }
-
-    /**
-     * Gets the table class name.
-     *
-     * @param string $alias The alias name you want to get.
-     * @param array $options Table options array.
-     * @return string
-     */
-    protected function _getClassName(string $alias, array $options = []): string
-    {
-        if (empty($options['className'])) {
-            $options['className'] = Inflector::camelize($alias);
-        }
-
-        $className = App::className($options['className'], 'Model/Table', 'Table') ?: Table::class;
-
-        return ltrim($className, '\\');
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Core\Configure;
+use Cake\ORM\Association;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Table\AuthorsTable;
@@ -49,7 +50,7 @@ class AssociationTest extends TestCase
             'sourceTable' => $this->source,
             'joinType' => 'INNER',
         ];
-        $this->association = $this->getMockBuilder('Cake\ORM\Association')
+        $this->association = $this->getMockBuilder(Association::class)
             ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
@@ -128,6 +129,22 @@ class AssociationTest extends TestCase
         $alias = $this->association->getTarget()->getAlias();
         $this->association->setName($alias);
         $this->assertEquals($alias, $this->association->getName());
+    }
+
+    /**
+     * Test that _className property is set to alias when "className" config
+     * if not explicitly set.
+     *
+     * @return void
+     */
+    public function testSetttingClassNameFromAlias()
+    {
+        $association = $this->getMockBuilder(Association::class)
+            ->setMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setConstructorArgs(['Foo'])
+            ->getMock();
+
+        $this->assertSame('Foo', $association->getClassName());
     }
 
     /**


### PR DESCRIPTION
I don't see a reason why currently `$_className` is set to alias only when alias has plugin prefix.