### PR TITLE
Improve dev error page styling

### DIFF
--- a/templates/element/exception_stack_trace.php
+++ b/templates/element/exception_stack_trace.php
@@ -41,7 +41,7 @@ foreach ($error->getTrace() as $i => $stack):
         endif;
     endif;
 ?>
-    <div id="stack-frame-<?= $i ?>" style="display:none;" class="stack-details">
+    <div id="stack-frame-<?= $i ?>" style="display:<?= $i === 0 ? 'block' : 'none'; ?>;" class="stack-details">
         <div class="stack-frame-header">
             <span class="stack-frame-file"><?= h($file) ?></span>
             <a href="#" class="toggle-link stack-frame-args" data-target="stack-args-<?= $i ?>">Toggle Arguments</a>

--- a/templates/element/exception_stack_trace_nav.php
+++ b/templates/element/exception_stack_trace_nav.php
@@ -18,18 +18,21 @@ use Cake\Error\Debugger;
 
 <ul class="stack-trace">
 <?php foreach ($error->getTrace() as $i => $stack): ?>
-    <?php $class = (isset($stack['file']) && strpos($stack['file'], APP) === false) ? 'vendor-frame' : 'app-frame'; ?>
+    <?php
+    $class = isset($stack['file']) && strpos($stack['file'], APP) === false ? 'vendor-frame' : 'app-frame';
+    $class .= $i == 0 ? ' active' : '';
+    ?>
     <li class="stack-frame <?= $class ?>">
     <?php if (isset($stack['function'])): ?>
         <a href="#" data-target="stack-frame-<?= $i ?>">
             <?php if (isset($stack['class'])): ?>
-                <span class="stack-function">&rang; <?= h($stack['class'] . $stack['type'] . $stack['function']) ?></span>
+                <span class="stack-function"><?= h($stack['class'] . $stack['type'] . $stack['function']) ?></span>
             <?php else: ?>
-                <span class="stack-function">&rang; <?= h($stack['function']) ?></span>
+                <span class="stack-function"><?= h($stack['function']) ?></span>
             <?php endif; ?>
             <span class="stack-file">
             <?php if (isset($stack['file'], $stack['line'])): ?>
-                <?= h(Debugger::trimPath($stack['file'])) ?>, line <?= $stack['line'] ?>
+                <?= h(Debugger::trimPath($stack['file'])) ?>:<?= $stack['line'] ?>
             <?php else: ?>
                 [internal function]
             <?php endif ?>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -61,28 +61,27 @@
     .col-left,
     .col-right {
         overflow-y: auto;
-        padding: 15px;
+        padding: 10px;
     }
     .col-left {
+        background: #ececec;
         flex: 0 0 30%;
     }
     .col-right {
         flex: 1;
     }
 
-    .toggle-link {
+    .toggle-vendor-frames {
+        color: #404041;
         display: block;
-        padding: 8px 14px;
-        text-decoration: none;
-        background-color: #606c76;
-        border-radius: 4px;
-        cursor: pointer;
-        color: #fff;
-        text-align: center;
+        padding: 5px;
         margin-bottom: 10px;
+        text-align: center;
+        text-decoration: none;
     }
-    .toggle-link:hover {
-        background-color: #D33C47;
+    .toggle-vendor-frames:hover,
+    .toggle-vendor-frames:active {
+        background: #e5e5e5;
     }
 
     .code-dump,
@@ -91,7 +90,6 @@
         border-radius: 4px;
         padding: 5px;
         white-space: pre-wrap;
-        box-shadow: 0 7px 14px 0 rgba(60,66,87, 0.1), 0 3px 6px 0 rgba(0, 0, 0, .07);
         margin: 0;
     }
 
@@ -130,7 +128,9 @@
         padding: 0;
     }
     .stack-frame {
-        padding: 15px 10px;
+        background: #e5e5e5;
+        padding: 10px;
+        margin-bottom: 5px;
     }
     .stack-frame:last-child {
         border-bottom: none;
@@ -141,8 +141,7 @@
         text-decoration: none;
     }
     .stack-frame.active {
-        background: #e5e5e5;
-        border-radius: 4px;
+        background: #F5F7FA;
     }
     .stack-frame a:hover {
         text-decoration: underline;
@@ -151,9 +150,23 @@
         display: flex;
         align-items: center;
     }
+
     .stack-frame-args {
         flex: 0 0 150px;
+        display: block;
+        padding: 8px 14px;
+        text-decoration: none;
+        background-color: #606c76;
+        border-radius: 4px;
+        cursor: pointer;
+        color: #fff;
+        text-align: center;
+        margin-bottom: 10px;
     }
+    .stack-frame-args:hover {
+        background-color: #D33C47;
+    }
+
     .stack-frame-file {
         flex: 1;
         word-break:break-all;
@@ -174,13 +187,15 @@
     }
     .stack-file {
         font-size: 0.9em;
-        word-wrap: break-word;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        direction: rtl;
     }
 
     .stack-details {
         background: #ececec;
         border-radius: 4px;
-        box-shadow: 0 7px 14px 0 rgba(60,66,87, 0.1), 0 3px 6px 0 rgba(0, 0, 0, .07);
         padding: 10px;
         margin-bottom: 18px;
     }
@@ -195,7 +210,7 @@
         background: #fff59d;
     }
     .excerpt-line {
-        padding-left: 2px;
+        padding: 0;
     }
     .excerpt-number {
         background: #f6f6f6;


### PR DESCRIPTION
* Reduce contrast of 'toggle vendor frames' button. It is not the
  primary action on the page.
* Add better separation between frame buttons.
* Remove decorative > it wasn't adding anything.
* Make file paths fit on a single line. Instead of wrapping use a text
  ellipsis to trim the left side off.
* Select the first stack frame by default so we have some useful content
  to show.

![Screen Shot 2019-07-25 at 22 40 28](https://user-images.githubusercontent.com/24086/61922095-4eaf2100-af2d-11e9-914a-619b51143ed8.png)
