### PR TITLE
Fix showing/clearing of custom validity message.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1467,8 +1467,8 @@ class FormHelper extends Helper
                 $options['templateVars']['customValidityMessage'] = $message;
 
                 if ($this->getConfig('autoSetCustomValidity')) {
-                    $options['oninvalid'] = "this.setCustomValidity('$message')";
-                    $options['onvalid'] = "this.setCustomValidity('')";
+                    $options['oninvalid'] = "this.setCustomValidity(''); if (!this.validity.valid) this.setCustomValidity('$message')";
+                    $options['oninput'] = "this.setCustomValidity('')";
                 }
             }
         }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8529,8 +8529,8 @@ class FormHelperTest extends TestCase
                 'type' => 'password',
                 'value' => '',
                 'required' => 'required',
-                'onvalid' => 'this.setCustomValidity(&#039;&#039;)',
-                'oninvalid' => 'this.setCustomValidity(&#039;This field is required&#039;)',
+                'oninput' => 'this.setCustomValidity(&#039;&#039;)',
+                'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.validity.valid) this.setCustomValidity(&#039;This field is required&#039;)',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -8547,8 +8547,8 @@ class FormHelperTest extends TestCase
                 'value' => '',
                 'maxlength' => 255,
                 'required' => 'required',
-                'onvalid' => 'this.setCustomValidity(&#039;&#039;)',
-                'oninvalid' => 'this.setCustomValidity(&#039;This field cannot be left empty&#039;)',
+                'oninput' => 'this.setCustomValidity(&#039;&#039;)',
+                'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.validity.valid) this.setCustomValidity(&#039;This field cannot be left empty&#039;)',
             ]
         ];
         $this->assertHtml($expected, $result);
@@ -8565,8 +8565,8 @@ class FormHelperTest extends TestCase
                 'value' => '',
                 'maxlength' => 255,
                 'required' => 'required',
-                'onvalid' => 'this.setCustomValidity(&#039;&#039;)',
-                'oninvalid' => 'this.setCustomValidity(&#039;Custom error message&#039;)',
+                'oninput' => 'this.setCustomValidity(&#039;&#039;)',
+                'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.validity.valid) this.setCustomValidity(&#039;Custom error message&#039;)',
             ]
         ];
         $this->assertHtml($expected, $result);


### PR DESCRIPTION
Clearing of custom validity message is currently broken. Once an input fails validation the error doesn't go away even after entering valid input and form can't be submitted.

I fixed the JS based on https://stackoverflow.com/questions/5272433/html5-form-required-attribute-set-custom-validation-message.
This fiddle shows the default, fixed and broken behavior https://jsfiddle.net/kshjfcL7/2/. 