### PR TITLE
Update docblock.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -616,7 +616,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the display field.
      *
-     * @return string|string[]
+     * @return string|string[]|null
      */
     public function getDisplayField()
     {


### PR DESCRIPTION
If table doesn't have field named "title" or "name" and no primary key
then Table::$_displayField property would be null.