### PR TITLE
2.x - Moves creation of ControllerTestDispatcher to its own protected method

### DIFF
--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -265,7 +265,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 				->will($this->returnValue($options['data']));
 		}
 
-		$Dispatch = new ControllerTestDispatcher();
+		$Dispatch = $this->createDispatcher();
 		foreach (Router::$routes as $route) {
 			if ($route instanceof RedirectRoute) {
 				$route->response = $this->getMock('CakeResponse', array('send'));
@@ -313,6 +313,15 @@ abstract class ControllerTestCase extends CakeTestCase {
 		$_POST = $restore['post'];
 
 		return $this->{$options['return']};
+	}
+
+/**
+ * Creates the test dispatcher class
+ *
+ * @return Dispatcher
+ */
+	protected function createDispatcher() {
+		return new ControllerTestDispatcher();
 	}
 
 /**

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -265,7 +265,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 				->will($this->returnValue($options['data']));
 		}
 
-		$Dispatch = $this->createDispatcher();
+		$Dispatch = $this->_createDispatcher();
 		foreach (Router::$routes as $route) {
 			if ($route instanceof RedirectRoute) {
 				$route->response = $this->getMock('CakeResponse', array('send'));
@@ -320,7 +320,7 @@ abstract class ControllerTestCase extends CakeTestCase {
  *
  * @return Dispatcher
  */
-	protected function createDispatcher() {
+	protected function _createDispatcher() {
 		return new ControllerTestDispatcher();
 	}
 


### PR DESCRIPTION
We've extended the core `Dispatcher` class in our application and we now have some incompatibilities with the test dispatcher. Moving the creation to a protected method will allow us to extend the test dispatcher and fix those incompatibilities.