### PR TITLE
Add @throws tag to Table::findOrCreate

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1687,6 +1687,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   is persisted.
      * @param array $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface An entity.
+     * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      */
     public function findOrCreate($search, callable $callback = null, $options = [])
     {
@@ -1716,6 +1717,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   is persisted.
      * @param array $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface An entity.
+     * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      */
     protected function _processFindOrCreate($search, callable $callback = null, $options = [])
     {


### PR DESCRIPTION
ref: d840670 / #12914

Since 3.8.0, Table::findOrCreate() throws exception when the data was not saved.
To follow this change, update phpdoc.