### PR TITLE
4.x - Add click to copy on error text.

### DIFF
--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -47,6 +47,12 @@
         font-size: 30px;
         margin: 0;
     }
+    .header-title:hover:after {
+        content: attr(data-content);
+        font-size: 18px;
+        vertical-align: middle;
+        cursor: pointer;
+    }
     .header-type {
         display: block;
         font-size: 16px;
@@ -237,7 +243,7 @@
 </head>
 <body>
     <header>
-        <h1 class="header-title">
+        <h1 class="header-title" data-content="&#128203">
             <?= h($this->fetch('title')) ?>
         </h1>
         <span class="header-type"><?= get_class($error) ?></span>
@@ -323,6 +329,36 @@
                     }
                 });
                 event.preventDefault();
+            });
+
+            bindEvent('.header-title', 'click', function(event) {
+                event.preventDefault();
+                var text = '';
+                each(this.childNodes, function(el) {
+                    text += el.textContent.trim();
+                });
+
+                // Use execCommand(copy) as it has the widest support.
+                var textArea = document.createElement("textarea");
+                textArea.value = text;
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+                var el = this;
+                try {
+                    document.execCommand('copy');
+
+                    // Show a success icon and then revert
+                    var original = el.getAttribute('data-content');
+                    el.setAttribute('data-content', '\ud83c\udf70');
+                    setTimeout(function () {
+                        el.setAttribute('data-content', original);
+                    }, 1000);
+                } catch (err) {
+                    alert('Unable to update clipboard ' + err);
+                }
+                document.body.removeChild(textArea);
+                this.parentNode.scrollIntoView(true);
             });
         });
     </script>


### PR DESCRIPTION
Add copy icon and click handler to error page messages. This should make it slightly easier to take an error and look for a solution.

![Screen Shot 2019-07-30 at 23 04 50](https://user-images.githubusercontent.com/24086/62180565-754ecc80-b31e-11e9-8da4-7988ad001d33.png)

The clipboard icon becomes 🍰 when the copy succeeds or an alert if it fails.