### PR TITLE
Fix recusion when exporting configuration data.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -120,7 +120,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     {
         /** @var \Cake\Core\InstanceConfigTrait $existing */
         $existing = $this->_loaded[$name];
-        $msg = sprintf('The "%s" alias has already been loaded', $name);
+        $msg = sprintf('The "%s" alias has already been loaded.', $name);
         $hasConfig = method_exists($existing, 'config');
         if (!$hasConfig) {
             throw new RuntimeException($msg);
@@ -131,22 +131,24 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         $existingConfig = $existing->getConfig();
         unset($config['enabled'], $existingConfig['enabled']);
 
-        $fail = false;
+        $failure = null;
         foreach ($config as $key => $value) {
             if (!array_key_exists($key, $existingConfig)) {
-                $fail = true;
+                $failure = " The `{$key}` was not defined in the previous configuration data.";
                 break;
             }
             if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
-                $fail = true;
+                $failure = sprintf(
+                    ' The `%s` key has a value of `%s` but previously had a value of `%s`',
+                    $key,
+                    json_encode($value),
+                    json_encode($existingConfig[$key])
+                );
                 break;
             }
         }
-        if ($fail) {
-            $msg .= ' with the following config: ';
-            $msg .= var_export($existingConfig, true);
-            $msg .= ' which differs from ' . var_export($config, true);
-            throw new RuntimeException($msg);
+        if ($failure) {
+            throw new RuntimeException($msg . $failure);
         }
     }
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -117,7 +117,7 @@ class ComponentTest extends TestCase
     public function testDuplicateComponentInitialize()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "Banana" alias has already been loaded with the following config:');
+        $this->expectExceptionMessage('The "Banana" alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry();
         $Collection->load('Banana', ['property' => ['closure' => function () {
         }]]);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -334,7 +334,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigured()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded with the following');
+        $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html');
         $this->Helpers->load('Html', ['same' => 'stuff']);
     }
@@ -347,7 +347,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigValues()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded with the following');
+        $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);
     }


### PR DESCRIPTION
Stop infinite recursion when creating an error message about different configuration values when the configuration data has the component object inside an option/closure.

Fixes #13452