### PR TITLE
Fix translate behavior tests.

### DIFF
--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1859,29 +1859,6 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
-     * Tests that using matching doesn't cause an association property to be created.
-     *
-     * @return void
-     */
-    public function testMatchingDoesNotCreateAssociationProperty()
-    {
-        $table = $this->getTableLocator()->get('Articles');
-        $table->hasMany('Comments');
-
-        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->Comments->setLocale('abc');
-
-        $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
-
-        $result = $table
-            ->find()
-            ->matching('Comments')
-            ->first();
-
-        $this->assertArrayNotHasKey('comments', $result->toArray());
-    }
-
-    /**
      * Tests that using deep matching doesn't cause an association property to be created.
      *
      * @return void
@@ -1908,34 +1885,6 @@ class TranslateBehaviorTest extends TestCase
             ->first();
 
         $this->assertArrayNotHasKey('author', $result->comments);
-    }
-
-    /**
-     * Tests that using contained matching doesn't cause an association property to be created.
-     *
-     * @return void
-     */
-    public function testContainedMatchingDoesNotCreateAssociationProperty()
-    {
-        $table = $this->getTableLocator()->get('Authors');
-        $table->hasMany('Comments')->setForeignKey('user_id');
-        $table->Comments->belongsTo('Articles');
-
-        $table->Comments->Articles->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->Comments->Articles->setLocale('xyz');
-
-        $this->assertNotEquals($table->Comments->Articles->getLocale(), I18n::getLocale());
-
-        $result = $table
-            ->find()
-            ->contain([
-                'Comments' => function ($query) {
-                    return $query->matching('Articles');
-                },
-            ])
-            ->first();
-
-        $this->assertArrayNotHasKey('article', $result->comments[0]->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1868,7 +1868,7 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
 
-        $table->Comments->addBehavior('Translate');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
         $table->Comments->setLocale('abc');
 
         $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
@@ -1892,10 +1892,10 @@ class TranslateBehaviorTest extends TestCase
         $table->hasMany('Comments');
         $table->Comments->belongsTo('Authors')->setForeignKey('user_id');
 
-        $table->Comments->addBehavior('Translate');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
         $table->Comments->setLocale('abc');
 
-        $table->Comments->Authors->addBehavior('Translate');
+        $table->Comments->Authors->addBehavior('Translate', ['fields' => ['name']]);
         $table->Comments->Authors->setLocale('xyz');
 
         $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
@@ -1921,7 +1921,7 @@ class TranslateBehaviorTest extends TestCase
         $table->hasMany('Comments')->setForeignKey('user_id');
         $table->Comments->belongsTo('Articles');
 
-        $table->Comments->Articles->addBehavior('Translate');
+        $table->Comments->Articles->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->Comments->Articles->setLocale('xyz');
 
         $this->assertNotEquals($table->Comments->Articles->getLocale(), I18n::getLocale());
@@ -1931,7 +1931,7 @@ class TranslateBehaviorTest extends TestCase
             ->contain([
                 'Comments' => function ($query) {
                     return $query->matching('Articles');
-                }
+                },
             ])
             ->first();
 
@@ -1948,7 +1948,7 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
 
-        $table->Comments->addBehavior('Translate');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
         $table->Comments->setLocale('abc');
 
         $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
@@ -1975,10 +1975,10 @@ class TranslateBehaviorTest extends TestCase
         $table->hasMany('Comments');
         $table->Comments->belongsTo('Authors')->setForeignKey('user_id');
 
-        $table->Comments->addBehavior('Translate');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
         $table->Comments->setLocale('abc');
 
-        $table->Comments->Authors->addBehavior('Translate');
+        $table->Comments->Authors->addBehavior('Translate', ['fields' => ['name']]);
         $table->Comments->Authors->setLocale('xyz');
 
         $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
@@ -2007,10 +2007,10 @@ class TranslateBehaviorTest extends TestCase
         $table->hasMany('Articles');
         $table->Articles->belongsToMany('Tags');
 
-        $table->Articles->addBehavior('Translate');
+        $table->Articles->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->Articles->setLocale('abc');
 
-        $table->Articles->Tags->addBehavior('Translate');
+        $table->Articles->Tags->addBehavior('Translate', ['fields' => ['name']]);
         $table->Articles->Tags->setLocale('xyz');
 
         $this->assertNotEquals($table->Articles->getLocale(), I18n::getLocale());
@@ -2022,7 +2022,7 @@ class TranslateBehaviorTest extends TestCase
                 'Articles' => function ($query) {
                     return $query->matching('Tags');
                 },
-                'Articles.Tags'
+                'Articles.Tags',
             ])
             ->first();
 


### PR DESCRIPTION
EavStrategy of TranslateBehavior needs translated fields to be explicity specified.

Refs #13422

//cc @ndm2 