### PR TITLE
[4.next] Add a convenience method to load plugins

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
  * @since         3.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Http;
 
 use Cake\Console\CommandCollection;
 use Cake\Controller\ControllerFactory;
 use Cake\Core\ConsoleApplicationInterface;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
@@ -117,6 +119,60 @@ abstract class BaseApplication implements
             $plugin = $name;
         }
         $this->plugins->add($plugin);
+
+        return $this;
+    }
+
+    /**
+     * Add an optional plugin
+     *
+     * If it isn't available, ignore it.
+     *
+     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
+     * @param array $config The configuration data for the plugin if using a string for $name
+     * @return $this
+     */
+    public function addOptionalPlugin($name, array $config = [])
+    {
+        try {
+            $this->addPlugin($name, $config);
+        } catch (MissingPluginException $e) {
+            // Do not halt if the plugin is missing
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a plugin, when in CLI
+     *
+     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
+     * @param array $config The configuration data for the plugin if using a string for $name
+     * @return $this
+     */
+    public function addCliPlugin($name, array $config = [])
+    {
+        if (PHP_SAPI === 'cli') {
+            $this->addPlugin($name, $config);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an optional plugin, when in CLI
+     *
+     * If it isn't available, ignore it.
+     *
+     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
+     * @param array $config The configuration data for the plugin if using a string for $name
+     * @return $this
+     */
+    public function addOptionalCliPlugin($name, array $config = [])
+    {
+        if (PHP_SAPI === 'cli') {
+            $this->addOptionalCliPlugin($name, $config);
+        }
 
         return $this;
     }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -144,40 +144,6 @@ abstract class BaseApplication implements
     }
 
     /**
-     * Add a plugin, when in CLI
-     *
-     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
-     * @param array $config The configuration data for the plugin if using a string for $name
-     * @return $this
-     */
-    public function addCliPlugin($name, array $config = [])
-    {
-        if (PHP_SAPI === 'cli') {
-            $this->addPlugin($name, $config);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add an optional plugin, when in CLI
-     *
-     * If it isn't available, ignore it.
-     *
-     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
-     * @param array $config The configuration data for the plugin if using a string for $name
-     * @return $this
-     */
-    public function addOptionalCliPlugin($name, array $config = [])
-    {
-        if (PHP_SAPI === 'cli') {
-            $this->addOptionalCliPlugin($name, $config);
-        }
-
-        return $this;
-    }
-
-    /**
      * Get the plugin collection in use.
      *
      * @return \Cake\Core\PluginCollection

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -29,6 +29,8 @@ use TestPlugin\Plugin as TestPlugin;
 
 /**
  * Base application test.
+ *
+ * @coversDefaultClass \Cake\Http\BaseApplication
  */
 class BaseApplicationTest extends TestCase
 {
@@ -192,5 +194,36 @@ class BaseApplicationTest extends TestCase
             Configure::check('PluginTest.test_plugin_two.bootstrap'),
             'Nested plugin should have bootstrap run'
         );
+    }
+
+    /**
+     * Tests that loading a non existing plugin through addOptionalPlugin() does not throw an exception
+     *
+     * @return void
+     * @covers ::addOptionalPlugin
+     */
+    public function testAddOptionalPluginLoadingNonExistingPlugin()
+    {
+        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $pluginCountBefore = count($app->getPlugins());
+        $nonExistingPlugin = 'NonExistingPlugin';
+        $app->addOptionalPlugin($nonExistingPlugin);
+        $pluginCountAfter = count($app->getPlugins());
+        $this->assertSame($pluginCountBefore, $pluginCountAfter);
+    }
+
+    /**
+     * Tests that loading an existing plugin through addOptionalPlugin() works
+     *
+     * @return void
+     * @covers ::addOptionalPlugin
+     */
+    public function testAddOptionalPluginLoadingNonExistingPluginValid()
+    {
+        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app->addOptionalPlugin(TestPlugin::class);
+
+        $this->assertCount(1, $app->getPlugins());
+        $this->assertTrue($app->getPlugins()->has('TestPlugin'));
     }
 }


### PR DESCRIPTION
This is an RFC to add three convenience methods to load plugins:

- ``addOptionalPlugin()``, do not halt when the plugin is not installed
- ``addCliPlugin()``, only load the plugin when in CLI
- ``addOptionalCliPlugin()``, only load the plugin when in CLI and do not halt when the plugin is not installed

TODO:

- ~It will need tests~.
- ~I didn't extend the ``PluginApplicationInterface`` where ``addPlugin()`` is located.~