### PR TITLE
Add convenience wrappers for plugin loading.

### DIFF
--- a/src/Core/PluginApplicationInterface.php
+++ b/src/Core/PluginApplicationInterface.php
@@ -38,9 +38,20 @@ interface PluginApplicationInterface extends EventDispatcherInterface
      *
      * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
      * @param array $config The configuration data for the plugin if using a string for $name
+     * @param bool $optional If an exception for missing plugin should not be thrown.
      * @return $this
      */
-    public function addPlugin($name, array $config = []);
+    public function addPlugin($name, array $config = [], bool $optional = false);
+
+    /**
+     * Adds a plugin, but only when in CLI mode.
+     *
+     * @param string|\Cake\Core\PluginInterface $name The plugin name or plugin object.
+     * @param array $config The configuration data for the plugin if using a string for $name
+     * @param bool $optional If an exception for missing plugin should not be thrown.
+     * @return $this
+     */
+    public function addCliPlugin($name, array $config = [], bool $optional = false);
 
     /**
      * Run bootstrap logic for loaded plugins.

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -162,6 +162,7 @@ abstract class BaseApplication implements
         } catch (MissingPluginException $e) {
             // Do not halt if the plugin is missing
         }
+
         return $this;
     }
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -109,7 +109,7 @@ abstract class BaseApplication implements
      */
     public function addCliPlugin($name, array $config = [], bool $optional = false)
     {
-        if (PHP_SAPI !== 'cli') {
+        if (!$this->isCli()) {
             return $this;
         }
 
@@ -272,5 +272,13 @@ abstract class BaseApplication implements
     protected function getDispatcher(): ActionDispatcher
     {
         return new ActionDispatcher();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isCli(): bool
+    {
+        return PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg';
     }
 }


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/13468 for a simpler API since this is not that often used in all 4 flavors.

Could be backported either to 3.next core or in Shim plugin.

I added a more complete CLI check similar to other places in core (`$this->_isCLI = (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg');` etc) and also made a wrapper method that allows easier customization here on project level.