### PR TITLE
Use coveralls instead of scrutinizer for code coverage reporting.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,3 @@
-tools:
-  external_code_coverage:
-    timeout: 1800
-    runs: 3
-
 build:
   environment:
     php:
@@ -33,7 +28,3 @@ build:
 build_failure_conditions:
   # Issues reported by any analyzer (which generates report in checkstyle format) like phpcs
   - 'issues.count > 0'
-  # Code Coverage decreased from previous inspection
-  - 'project.metric_change("scrutinizer.test_coverage", < -0.01)'
-  # Code Coverage drops below 90%
-  - 'project.metric("scrutinizer.test_coverage", < 0.90)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,9 @@ script:
 after_script:
   - |
       if [[ $CODECOVERAGE == 1 ]]; then
-        wget https://scrutinizer-ci.com/ocular.phar
-        php ocular.phar code-coverage:upload --format=php-clover clover.xml
+        wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
+        chmod +x php-coveralls.phar
+        ./php-coveralls.phar
       fi
 
 notifications:


### PR DESCRIPTION
Reason for this change is scrutinizer doesn't show code coverage report on the PR itself plus using another service provides more parallelism.