### PR TITLE
Allow HtmlHelper::tableHeaders to accept cell attributes in HtmlHelper::tableCells format

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -905,7 +905,7 @@ class HtmlHelper extends Helper
             if (!is_array($arg)) {
                 $content = $arg;
                 $attrs = $thOptions;
-            } else if (isset($arg[0], $arg[1])) {
+            } elseif (isset($arg[0], $arg[1])) {
                 $content = $arg[0];
                 $attrs = $arg[1];
             } else {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -891,7 +891,7 @@ class HtmlHelper extends Helper
     /**
      * Returns a row of formatted and named TABLE headers.
      *
-     * @param array $names Array of tablenames. Each tablename also can be a key that points to an array with a set
+     * @param array $names Array of tablenames. Each tablename can be string, or array with name and an array with a set
      *     of attributes to its specific tag
      * @param array|null $trOptions HTML options for TR elements.
      * @param array|null $thOptions HTML options for TH elements.
@@ -903,16 +903,20 @@ class HtmlHelper extends Helper
         $out = [];
         foreach ($names as $arg) {
             if (!is_array($arg)) {
-                $out[] = $this->formatTemplate('tableheader', [
-                    'attrs' => $this->templater()->formatAttributes($thOptions),
-                    'content' => $arg
-                ]);
+                $content = $arg;
+                $attrs = $thOptions;
+            } else if (isset($arg[0], $arg[1])) {
+                $content = $arg[0];
+                $attrs = $arg[1];
             } else {
-                $out[] = $this->formatTemplate('tableheader', [
-                    'attrs' => $this->templater()->formatAttributes(current($arg)),
-                    'content' => key($arg)
-                ]);
+                $content = key($arg);
+                $attrs = current($arg);
             }
+
+            $out[] = $this->formatTemplate('tableheader', [
+                'attrs' => $this->templater()->formatAttributes($attrs),
+                'content' => $content
+            ]);
         }
 
         return $this->tableRow(implode(' ', $out), (array)$trOptions);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1894,17 +1894,35 @@ class HtmlHelperTest extends TestCase
         $expected = ['<tr', '<th', 'ID', '/th', '<th', 'Name', '/th', '<th', 'Date', '/th', '/tr'];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->tableHeaders(['ID', ['Name' => ['class' => 'highlight']], 'Date']);
         $expected = ['<tr', '<th', 'ID', '/th', '<th class="highlight"', 'Name', '/th', '<th', 'Date', '/th', '/tr'];
-        $this->assertHtml($expected, $result);
+        $resultComma = $this->Html->tableHeaders(['ID', ['Name', ['class' => 'highlight']], 'Date']);
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['Name' => ['class' => 'highlight']], 'Date']);
+        $this->assertHtml($expected, $resultComma);
+        $this->assertHtml($expected, $resultAssoc);
 
-        $result = $this->Html->tableHeaders(['ID', ['Name' => ['class' => 'highlight', 'width' => '120px']], 'Date']);
         $expected = ['<tr', '<th', 'ID', '/th', '<th class="highlight" width="120px"', 'Name', '/th', '<th', 'Date', '/th', '/tr'];
-        $this->assertHtml($expected, $result);
+        $resultComma = $this->Html->tableHeaders(['ID', ['Name', ['class' => 'highlight', 'width' => '120px']], 'Date']);
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['Name' => ['class' => 'highlight', 'width' => '120px']], 'Date']);
+        $this->assertHtml($expected, $resultComma);
+        $this->assertHtml($expected, $resultAssoc);
 
-        $result = $this->Html->tableHeaders(['ID', ['Name' => []], 'Date']);
         $expected = ['<tr', '<th', 'ID', '/th', '<th', 'Name', '/th', '<th', 'Date', '/th', '/tr'];
-        $this->assertHtml($expected, $result);
+        $resultComma = $this->Html->tableHeaders(['ID', ['Name', []], 'Date']);
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['Name' => []], 'Date']);
+        $this->assertHtml($expected, $resultComma);
+        $this->assertHtml($expected, $resultAssoc);
+
+        $expected = ['<tr', '<th', 'ID', '/th', '<th class="highlight"', '0', '/th', '<th', 'Date', '/th', '/tr'];
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['0' => ['class' => 'highlight']], 'Date']);
+        $this->assertHtml($expected, $resultAssoc);
+
+        $expected = ['<tr', '<th', 'ID', '/th', '<th class="highlight" width="120px"', '0', '/th', '<th', 'Date', '/th', '/tr'];
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['0' => ['class' => 'highlight', 'width' => '120px']], 'Date']);
+        $this->assertHtml($expected, $resultAssoc);
+
+        $expected = ['<tr', '<th', 'ID', '/th', '<th', '0', '/th', '<th', 'Date', '/th', '/tr'];
+        $resultAssoc = $this->Html->tableHeaders(['ID', ['0' => []], 'Date']);
+        $this->assertHtml($expected, $resultAssoc);
     }
 
     /**


### PR DESCRIPTION
HtmlHelper::tableHeaders() and HtmlHelper::tableCells() required different array format to specify cell attributes.

HtmlHelper::tableHeaders() accepted `['name' => ['attribute' => 'value']]`
HtmlHelper::tableCells() accepted `['name', ['attribute' => 'value']]`

Now HtmlHelper::tableHeaders() accepts both formats.

Fixes #13465