### PR TITLE
Marshal array to null in StringType.

### DIFF
--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -90,11 +90,8 @@ class StringType extends BaseType implements OptionalConvertInterface
      */
     public function marshal($value): ?string
     {
-        if ($value === null) {
+        if ($value === null || is_array($value)) {
             return null;
-        }
-        if (is_array($value)) {
-            return '';
         }
 
         return (string)$value;

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -86,9 +86,9 @@ class StringTypeTest extends TestCase
     public function testMarshal()
     {
         $this->assertNull($this->type->marshal(null));
+        $this->assertNull($this->type->marshal([1, 2, 3]));
         $this->assertSame('word', $this->type->marshal('word'));
         $this->assertSame('2.123', $this->type->marshal(2.123));
-        $this->assertSame('', $this->type->marshal([1, 2, 3]));
     }
 
     /**


### PR DESCRIPTION
Marshaling an invalid value to null instead of empty string makes more sense.