### PR TITLE
Correct phpdoc for env()

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -205,7 +205,9 @@ if (!function_exists('env')) {
                 return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
             }
 
-            return (strpos((string)env('SCRIPT_URI'), 'https://') === 0);
+            $val = env('SCRIPT_URI');
+
+            return is_string($val) ? (strpos($val, 'https://') === 0) : false;
         }
 
         if ($key === 'SCRIPT_NAME' && env('CGI_MODE') && isset($_ENV['SCRIPT_URL'])) {
@@ -234,16 +236,23 @@ if (!function_exists('env')) {
 
         switch ($key) {
             case 'DOCUMENT_ROOT':
+                /** @var string|null $name */
                 $name = env('SCRIPT_NAME');
+                /** @var string|null $filename */
                 $filename = env('SCRIPT_FILENAME');
                 $offset = 0;
-                if (!strpos($name, '.php')) {
+                if (is_string($name) && !strpos($name, '.php')) {
                     $offset = 4;
                 }
 
-                return substr($filename, 0, -(strlen($name) + $offset));
+                return substr((string)$filename, 0, -(strlen((string)$name) + $offset));
             case 'PHP_SELF':
-                return str_replace(env('DOCUMENT_ROOT'), '', env('SCRIPT_FILENAME'));
+                /** @var string|null $root */
+                $root = env('DOCUMENT_ROOT');
+                /** @var string|null $filename */
+                $filename = env('SCRIPT_FILENAME');
+
+                return str_replace((string)$root, '', (string)$filename);
             case 'CGI_MODE':
                 return (PHP_SAPI === 'cgi');
         }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -195,7 +195,7 @@ if (!function_exists('env')) {
      *
      * @param string $key Environment variable name.
      * @param string|null $default Specify a default value in case the environment variable is not defined.
-     * @return string|bool|null Environment variable setting.
+     * @return string|array|bool|null Environment variable setting.
      * @link https://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
      */
     function env($key, $default = null)


### PR DESCRIPTION
The function can return array as `getenv()`'s value.
e.g. 

```
bash-4.2# bin/cake console
You can exit with `CTRL-C` or `exit`

Psy Shell v0.9.9 (PHP 7.1.28 — cli) by Justin Hileman
env>>> env('argv')
=> [
     "/var/www/html/bin/cake.php",
     "console",
   ]
```

FYI:
But, as [php.net/getenv](https://www.php.net/manual/en/function.getenv.php), the return value is  a string unless `$varname` is omitted 🤔 

IMO, because this function can be used to get array value In the real world, so it is reliable to refer about the return value type in phpdoc.