### PR TITLE
3.x: Backport of "Make metadata cache key configurable"

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -107,7 +107,6 @@ class Connection implements ConnectionInterface
     /**
      * Constructor.
      *
-     * @param array $config Configuration array.
      * ### Available options:
      * - `driver` Sort name or FCQN for driver.
      * - `log` Boolean indicating whether to use query logging.
@@ -115,6 +114,8 @@ class Connection implements ConnectionInterface
      * - `cacheMetaData` Boolean indicating whether metadata (datasource schemas) should be cached.
      *    If set to a string it will be used as the name of cache config to use.
      * - `cacheKeyPrefix` Custom prefix to use when generation cache keys. Defaults to connection name.
+     *
+     * @param array $config Configuration array.
      */
     public function __construct($config)
     {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -107,7 +107,14 @@ class Connection implements ConnectionInterface
     /**
      * Constructor.
      *
-     * @param array $config configuration for connecting to database
+     * @param array $config Configuration array.
+     * ### Available options:
+     * - `driver` Sort name or FCQN for driver.
+     * - `log` Boolean indicating whether to use query logging.
+     * - `name` Connection name.
+     * - `cacheMetaData` Boolean indicating whether metadata (datasource schemas) should be cached.
+     *    If set to a string it will be used as the name of cache config to use.
+     * - `cacheKeyPrefix` Custom prefix to use when generation cache keys. Defaults to connection name.
      */
     public function __construct($config)
     {

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -77,7 +77,12 @@ class CachedCollection extends Collection
      */
     public function cacheKey($name)
     {
-        return $this->_connection->configName() . '_' . $name;
+        $cachePrefix = $this->_connection->configName();
+        $config = $this->_connection->config();
+        if (isset($config['cacheKeyPrefix'])) {
+            $cachePrefix = $config['cacheKeyPrefix'];
+        }
+        return $cachePrefix . '_' . $name;
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\NestedTransactionRollbackException;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
+use Cake\Database\Schema\CachedCollection;
 use Cake\Database\StatementInterface;
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Datasource\ConnectionManager;
@@ -1165,6 +1166,43 @@ class ConnectionTest extends TestCase
             $connection->schemaCollection($schema);
             $this->assertSame($schema, $connection->schemaCollection());
         });
+    }
+
+    /**
+     * Test CachedCollection creation with default and custom cache key prefix.
+     *
+     * @return void
+     */
+    public function testGetCachedCollection()
+    {
+        $driver = $this->getMockFormDriver();
+        $connection = $this->getMockBuilder(Connection::class)
+            ->setMethods(['connect'])
+            ->setConstructorArgs([[
+                'driver' => $driver,
+                'name' => 'default',
+                'cacheMetadata' => true,
+            ]])
+            ->getMock();
+
+        $schema = $connection->getSchemaCollection();
+        $this->assertInstanceOf(CachedCollection::class, $schema);
+        $this->assertSame('default_key', $schema->cacheKey('key'));
+
+        $driver = $this->getMockFormDriver();
+        $connection = $this->getMockBuilder(Connection::class)
+            ->setMethods(['connect'])
+            ->setConstructorArgs([[
+                'driver' => $driver,
+                'name' => 'default',
+                'cacheMetadata' => true,
+                'cacheKeyPrefix' => 'foo',
+            ]])
+            ->getMock();
+
+        $schema = $connection->getSchemaCollection();
+        $this->assertInstanceOf(CachedCollection::class, $schema);
+        $this->assertSame('foo_key', $schema->cacheKey('key'));
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/cakephp/cakephp/issues/13471

https://github.com/cakephp/cakephp/pull/13472 4.x backport to 3.x

[edited by dereuromark - please always add these things into description instead of title]