### PR TITLE
Fix array typehints to be more precise, string array check strictness

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -139,8 +139,8 @@ abstract class BaseAuthenticate implements EventListenerInterface
             $result->unsetProperty($passwordField);
         }
         $hidden = $result->getHidden();
-        if ($password === null && in_array($passwordField, $hidden)) {
-            $key = array_search($passwordField, $hidden);
+        if ($password === null && in_array($passwordField, $hidden, true)) {
+            $key = array_search($passwordField, $hidden, true);
             unset($hidden[$key]);
             $result->setHidden($hidden);
         }

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -284,7 +284,7 @@ class FileEngine extends CacheEngine
             }
 
             $path = $path->getRealPath() . DIRECTORY_SEPARATOR;
-            if (!in_array($path, $cleared)) {
+            if (!in_array($path, $cleared, true)) {
                 $this->_clearDirectory($path, $now, $threshold);
                 $cleared[] = $path;
             }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -199,7 +199,7 @@ class AuthComponent extends Component
     /**
      * Controller actions for which user validation is not required.
      *
-     * @var array
+     * @var string[]
      * @see \Cake\Controller\Component\AuthComponent::allow()
      */
     public $allowedActions = [];
@@ -616,7 +616,7 @@ class AuthComponent extends Component
      * $this->Auth->allow();
      * ```
      *
-     * @param string|array|null $actions Controller action name or array of actions
+     * @param string|string[]|null $actions Controller action name or array of actions
      * @return void
      * @link https://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-public
      */
@@ -646,7 +646,7 @@ class AuthComponent extends Component
      * ```
      * to remove all items from the allowed list
      *
-     * @param string|array|null $actions Controller action name or array of actions
+     * @param string|string[]|null $actions Controller action name or array of actions
      * @return void
      * @see \Cake\Controller\Component\AuthComponent::allow()
      * @link https://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-require-authorization
@@ -659,7 +659,7 @@ class AuthComponent extends Component
             return;
         }
         foreach ((array)$actions as $action) {
-            $i = array_search($action, $this->allowedActions);
+            $i = array_search($action, $this->allowedActions, true);
             if (is_int($i)) {
                 unset($this->allowedActions[$i]);
             }

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -122,7 +122,7 @@ class Mysql extends Driver
      */
     public function enabled()
     {
-        return in_array('mysql', PDO::getAvailableDrivers());
+        return in_array('mysql', PDO::getAvailableDrivers(), true);
     }
 
     /**

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -95,7 +95,7 @@ class Postgres extends Driver
      */
     public function enabled()
     {
-        return in_array('pgsql', PDO::getAvailableDrivers());
+        return in_array('pgsql', PDO::getAvailableDrivers(), true);
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -91,7 +91,7 @@ class Sqlite extends Driver
      */
     public function enabled()
     {
-        return in_array('sqlite', PDO::getAvailableDrivers());
+        return in_array('sqlite', PDO::getAvailableDrivers(), true);
     }
 
     /**

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -132,7 +132,7 @@ class Sqlserver extends Driver
      */
     public function enabled()
     {
-        return in_array('sqlsrv', PDO::getAvailableDrivers());
+        return in_array('sqlsrv', PDO::getAvailableDrivers(), true);
     }
 
     /**

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -40,7 +40,7 @@ class BodyParserMiddleware
     /**
      * The HTTP methods to parse data on.
      *
-     * @var array
+     * @var string[]
      */
     protected $methods = ['PUT', 'POST', 'PATCH', 'DELETE'];
 
@@ -79,7 +79,7 @@ class BodyParserMiddleware
     /**
      * Set the HTTP methods to parse request bodies on.
      *
-     * @param array $methods The methods to parse data on.
+     * @param string[] $methods The methods to parse data on.
      * @return $this
      */
     public function setMethods(array $methods)
@@ -104,7 +104,7 @@ class BodyParserMiddleware
      * });
      * ```
      *
-     * @param array $types An array of content-type header values to match. eg. application/json
+     * @param string[] $types An array of content-type header values to match. eg. application/json
      * @param callable $parser The parser function. Must return an array of data to be inserted
      *   into the request.
      * @return $this
@@ -131,7 +131,7 @@ class BodyParserMiddleware
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
-        if (!in_array($request->getMethod(), $this->methods)) {
+        if (!in_array($request->getMethod(), $this->methods, true)) {
             return $next($request, $response);
         }
         list($type) = explode(';', $request->getHeaderLine('Content-Type'));

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -147,7 +147,7 @@ class CsrfProtectionMiddleware
      */
     protected function _validateAndUnsetTokenField(ServerRequest $request)
     {
-        if (in_array($request->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH']) || $request->getData()) {
+        if (in_array($request->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH'], true) || $request->getData()) {
             $this->_validateToken($request);
             $body = $request->getParsedBody();
             if (is_array($body)) {

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -227,7 +227,7 @@ class SecurityHeadersMiddleware
      *
      * @throws \InvalidArgumentException Thrown when a value is invalid.
      * @param string $value Value to check
-     * @param array $allowed List of allowed values
+     * @param string[] $allowed List of allowed values
      * @return void
      */
     protected function checkValues($value, array $allowed)

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1934,7 +1934,7 @@ class Response implements ResponseInterface
     public function outputCompressed()
     {
         return strpos(env('HTTP_ACCEPT_ENCODING'), 'gzip') !== false
-            && (ini_get('zlib.output_compression') === '1' || in_array('ob_gzhandler', ob_list_handlers()));
+            && (ini_get('zlib.output_compression') === '1' || in_array('ob_gzhandler', ob_list_handlers(), true));
     }
 
     /**
@@ -2082,7 +2082,7 @@ class Response implements ResponseInterface
         $responseTag = $this->getHeaderLine('Etag');
         $etagMatches = null;
         if ($responseTag) {
-            $etagMatches = in_array('*', $etags) || in_array($responseTag, $etags);
+            $etagMatches = in_array('*', $etags, true) || in_array($responseTag, $etags, true);
         }
 
         $modifiedSince = $request->getHeaderLine('If-Modified-Since');

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -110,7 +110,7 @@ class HasMany extends Association
      */
     public function setSaveStrategy($strategy)
     {
-        if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE])) {
+        if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
             $msg = sprintf('Invalid save strategy "%s"', $strategy);
             throw new InvalidArgumentException($msg);
         }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -459,8 +459,8 @@ class SelectLoader
     protected function _buildResultMap($fetchQuery, $options)
     {
         $resultMap = [];
-        $singleResult = in_array($this->associationType, [Association::MANY_TO_ONE, Association::ONE_TO_ONE]);
-        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY]) ?
+        $singleResult = in_array($this->associationType, [Association::MANY_TO_ONE, Association::ONE_TO_ONE], true);
+        $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY], true) ?
             $this->foreignKey :
             $this->bindingKey;
         $key = (array)$keys;

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -403,7 +403,7 @@ class Behavior implements EventListenerInterface
 
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             $methodName = $method->getName();
-            if (in_array($methodName, $baseMethods) ||
+            if (in_array($methodName, $baseMethods, true) ||
                 isset($eventMethods[$methodName])
             ) {
                 continue;

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -309,7 +309,7 @@ class Marshaller
         $targetTable = $assoc->getTarget();
         $marshaller = $targetTable->marshaller();
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
-        if (in_array($assoc->type(), $types)) {
+        if (in_array($assoc->type(), $types, true)) {
             return $marshaller->one($value, (array)$options);
         }
         if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
@@ -747,7 +747,7 @@ class Marshaller
         $targetTable = $assoc->getTarget();
         $marshaller = $targetTable->marshaller();
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
-        if (in_array($assoc->type(), $types)) {
+        if (in_array($assoc->type(), $types, true)) {
             return $marshaller->merge($original, $value, (array)$options);
         }
         if ($assoc->type() === Association::MANY_TO_MANY) {
@@ -792,7 +792,7 @@ class Marshaller
             return [];
         }
 
-        if (!empty($associated) && !in_array('_joinData', $associated) && !isset($associated['_joinData'])) {
+        if (!empty($associated) && !in_array('_joinData', $associated, true) && !isset($associated['_joinData'])) {
             return $this->mergeMany($original, $value, $options);
         }
 

--- a/src/TestSuite/EmailAssertTrait.php
+++ b/src/TestSuite/EmailAssertTrait.php
@@ -72,7 +72,7 @@ trait EmailAssertTrait
     {
         $name = current(array_slice(explode('\\', $className), -1));
 
-        if (!in_array('profile', $methods)) {
+        if (!in_array('profile', $methods, true)) {
             $methods[] = 'profile';
         }
 

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -50,7 +50,7 @@ class FixtureInjector extends BaseTestListener
     public function __construct(FixtureManager $manager)
     {
         if (isset($_SERVER['argv'])) {
-            $manager->setDebug(in_array('--debug', $_SERVER['argv']));
+            $manager->setDebug(in_array('--debug', $_SERVER['argv'], true));
         }
         $this->_fixtureManager = $manager;
         $this->_fixtureManager->shutDown();

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -556,7 +556,7 @@ class Inflector
 
         if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $word, $regs)) {
             static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) .
-                substr(array_search(strtolower($regs[2]), static::$_irregular), 1);
+                substr(array_search(strtolower($regs[2]), static::$_irregular, true), 1);
 
             return static::$_cache['singularize'][$word];
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -647,7 +647,7 @@ class Text
                         if (preg_match('/<[\w]+[^>]*>/', $tag[0])) {
                             array_unshift($openTags, $tag[2]);
                         } elseif (preg_match('/<\/([\w]+)[^>]*>/', $tag[0], $closeTag)) {
-                            $pos = array_search($closeTag[1], $openTags);
+                            $pos = array_search($closeTag[1], $openTags, true);
                             if ($pos !== false) {
                                 array_splice($openTags, $pos, 1);
                             }
@@ -1045,10 +1045,10 @@ class Text
         $size = strtoupper($size);
 
         $l = -2;
-        $i = array_search(substr($size, -2), ['KB', 'MB', 'GB', 'TB', 'PB']);
+        $i = array_search(substr($size, -2), ['KB', 'MB', 'GB', 'TB', 'PB'], true);
         if ($i === false) {
             $l = -1;
-            $i = array_search(substr($size, -1), ['K', 'M', 'G', 'T', 'P']);
+            $i = array_search(substr($size, -1), ['K', 'M', 'G', 'T', 'P'], true);
         }
         if ($i !== false) {
             $size = (float)substr($size, 0, $l);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -217,7 +217,7 @@ class FormHelper extends Helper
      *
      * @see \Cake\View\Helper\FormHelper::_secure()
      * @see \Cake\Controller\Component\SecurityComponent::validatePost()
-     * @var array
+     * @var string[]
      */
     protected $_unlockedFields = [];
 
@@ -253,14 +253,14 @@ class FormHelper extends Helper
     /**
      * The sources to be used when retrieving prefilled input values.
      *
-     * @var array
+     * @var string[]
      */
     protected $_valueSources = ['context'];
 
     /**
      * Grouped input types.
      *
-     * @var array
+     * @var string[]
      */
     protected $_groupedInputTypes = ['radio', 'multicheckbox', 'date', 'time', 'datetime'];
 
@@ -706,10 +706,10 @@ class FormHelper extends Helper
         if ($name === null) {
             return $this->_unlockedFields;
         }
-        if (!in_array($name, $this->_unlockedFields)) {
+        if (!in_array($name, $this->_unlockedFields, true)) {
             $this->_unlockedFields[] = $name;
         }
-        $index = array_search($name, $this->fields);
+        $index = array_search($name, $this->fields, true);
         if ($index !== false) {
             unset($this->fields[$index]);
         }
@@ -748,7 +748,7 @@ class FormHelper extends Helper
         $field = preg_replace('/(\.\d+)+$/', '', $field);
 
         if ($lock) {
-            if (!in_array($field, $this->fields)) {
+            if (!in_array($field, $this->fields, true)) {
                 if ($value !== null) {
                     $this->fields[$field] = $value;
 
@@ -2921,7 +2921,7 @@ class FormHelper extends Helper
      *
      * Returns a list, but at least one item, of valid sources, such as: `'context'`, `'data'` and `'query'`.
      *
-     * @return array List of value sources.
+     * @return string[] List of value sources.
      */
     public function getValueSources()
     {
@@ -2934,7 +2934,7 @@ class FormHelper extends Helper
      * Valid values are `'context'`, `'data'` and `'query'`.
      * You need to supply one valid context or multiple, as a list of strings. Order sets priority.
      *
-     * @param string|array $sources A string or a list of strings identifying a source.
+     * @param string|string[] $sources A string or a list of strings identifying a source.
      * @return $this
      */
     public function setValueSources($sources)

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1167,7 +1167,7 @@ class View implements EventDispatcherInterface
         $c = 1;
         $url = Router::url($url);
         $hash = $object . substr(md5($object . $url), 0, 10);
-        while (in_array($hash, $this->uuids)) {
+        while (in_array($hash, $this->uuids, true)) {
             $hash = $object . substr(md5($object . $url . $c), 0, 10);
             $c++;
         }


### PR DESCRIPTION
Only done for cases where the needle+haystack are already 100% string only based to avoid side effects on wrong usage, as this is not safe for bugfix releases.
In future versions we can then add more complete strictness also for other cases.

This avoids false positives on string vs int with some casting bugs in PHP.

Also clarified some doc blocks for PHPStan and alike.