### PR TITLE
Remove unused vars and assigments.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.4.10@c283f0877d543e7ab738d231ba6a3cdce5e1039a">
+<files psalm-version="3.4.11@85c9b6bb442039c773120059ae35a31f8ef9d488">
   <file src="src/Auth/BaseAuthenticate.php">
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$hidden[$key]</code>
@@ -41,18 +41,10 @@
       <code>close</code>
     </PossiblyNullReference>
   </file>
-  <file src="src/Cache/Engine/MemcachedEngine.php">
-    <MissingConstructor occurrences="1">
-      <code>$_Memcached</code>
-    </MissingConstructor>
-  </file>
   <file src="src/Cache/Engine/RedisEngine.php">
     <InvalidArgument occurrences="1">
       <code>$value</code>
     </InvalidArgument>
-    <MissingConstructor occurrences="1">
-      <code>$_Redis</code>
-    </MissingConstructor>
     <PossiblyInvalidArgument occurrences="3">
       <code>$value</code>
       <code>$value</code>
@@ -122,9 +114,6 @@
     </PossiblyNullArrayOffset>
   </file>
   <file src="src/Console/HelperRegistry.php">
-    <MissingConstructor occurrences="1">
-      <code>$_io</code>
-    </MissingConstructor>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$class</code>
     </MoreSpecificImplementedParamType>
@@ -223,11 +212,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$class</code>
     </MoreSpecificImplementedParamType>
-  </file>
-  <file src="src/Controller/Controller.php">
-    <PossiblyNullOperand occurrences="1">
-      <code>$this-&gt;name</code>
-    </PossiblyNullOperand>
   </file>
   <file src="src/Controller/ErrorController.php">
     <PossiblyNullArgument occurrences="1">
@@ -508,11 +492,6 @@
       <code>$row['default']</code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="src/Database/Schema/TableSchema.php">
-    <MissingParamType occurrences="1">
-      <code>$attrs</code>
-    </MissingParamType>
-  </file>
   <file src="src/Database/SchemaCache.php">
     <PossiblyNullArgument occurrences="2">
       <code>$table</code>
@@ -776,9 +755,6 @@
     </PossiblyNullOperand>
   </file>
   <file src="src/Http/Client/FormData.php">
-    <MissingConstructor occurrences="1">
-      <code>$_boundary</code>
-    </MissingConstructor>
     <PossiblyInvalidArgument occurrences="3">
       <code>$name</code>
       <code>$name</code>
@@ -875,9 +851,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Http/Runner.php">
-    <MissingConstructor occurrences="1">
-      <code>$queue</code>
-    </MissingConstructor>
     <PossiblyNullReference occurrences="1">
       <code>process</code>
     </PossiblyNullReference>
@@ -1380,10 +1353,9 @@
     <InternalClass occurrences="1">
       <code>BaseTestSuite</code>
     </InternalClass>
-    <InternalMethod occurrences="3">
+    <InternalMethod occurrences="2">
       <code>addTestFile</code>
       <code>addTestFile</code>
-      <code>BaseTestSuite</code>
     </InternalMethod>
   </file>
   <file src="src/Utility/CookieCryptTrait.php">
@@ -1576,11 +1548,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$class</code>
     </MoreSpecificImplementedParamType>
-  </file>
-  <file src="src/View/SerializedView.php">
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;_responseType</code>
-    </PossiblyNullArgument>
   </file>
   <file src="src/View/View.php">
     <PossiblyNullPropertyAssignmentValue occurrences="2">

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,11 +17,11 @@
     </projectFiles>
 
     <issueHandlers>
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-        <TypeCoercion errorLevel="info" />
-        <DocblockTypeContradiction errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingClosureReturnType errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="suppress" />
+        <TypeCoercion errorLevel="suppress" />
+        <DocblockTypeContradiction errorLevel="suppress" />
+        <MissingClosureParamType errorLevel="suppress" />
+        <MissingClosureReturnType errorLevel="suppress" />
         <UndefinedClass>
             <errorLevel type="suppress">
                 <referencedClass name="Memcached" />
@@ -34,6 +34,6 @@
                 <referencedClass name="Redis" />
             </errorLevel>
         </UndefinedDocblockClass>
-        <PropertyNotSetInConstructor errorLevel="info" />
+        <PropertyNotSetInConstructor errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -69,7 +69,6 @@ class CacheRegistry extends ObjectRegistry
      */
     protected function _create($class, string $alias, array $config): CacheEngine
     {
-        $instance = null;
         if (is_object($class)) {
             $instance = $class;
         } else {

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -101,7 +101,6 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
             $invert[$class][] = $name;
         }
         $grouped = [];
-        $appNamespace = Configure::read('App.namespace');
         $plugins = Plugin::loaded();
         foreach ($invert as $class => $names) {
             preg_match('/^(.+)\\\\(Command|Shell)\\\\/', $class, $matches);

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -101,7 +101,6 @@ trait ModelAwareTrait
             $modelType = $this->getModelType();
         }
 
-        $alias = null;
         $options = [];
         if (strpos($modelClass, '\\') === false) {
             [, $alias] = pluginSplit($modelClass, true);

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -131,7 +131,6 @@ class ExceptionRenderer implements ExceptionRendererInterface
         }
 
         $response = new Response();
-        $controller = null;
 
         try {
             $class = null;
@@ -160,23 +159,22 @@ class ExceptionRenderer implements ExceptionRendererInterface
             /** @var \Cake\Controller\Controller $controller */
             $controller = new $class($request, $response);
             $controller->startupProcess();
-            $startup = true;
         } catch (Throwable $e) {
-            $startup = false;
+        }
+
+        if (!isset($controller)) {
+            return new Controller($request, $response);
         }
 
         // Retry RequestHandler, as another aspect of startupProcess()
         // could have failed. Ignore any exceptions out of startup, as
         // there could be userland input data parsers.
-        if ($startup === false && !empty($controller) && isset($controller->RequestHandler)) {
+        if (isset($controller->RequestHandler)) {
             try {
                 $event = new Event('Controller.startup', $controller);
                 $controller->RequestHandler->startup($event);
             } catch (Throwable $e) {
             }
-        }
-        if (empty($controller)) {
-            $controller = new Controller($request, $response);
         }
 
         return $controller;

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -50,10 +50,8 @@ class Oauth
             $credentials['method'] = 'hmac-sha1';
         }
 
-        $value = '';
         $credentials['method'] = strtoupper($credentials['method']);
 
-        $value = null;
         switch ($credentials['method']) {
             case 'HMAC-SHA1':
                 $hasKeys = isset(

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -173,7 +173,7 @@ trait DateFormatTrait
      */
     protected function _formatObject($date, $format, ?string $locale): string
     {
-        $pattern = $dateFormat = $timeFormat = $calendar = null;
+        $pattern = $timeFormat = null;
 
         if (is_array($format)) {
             [$dateFormat, $timeFormat] = $format;

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -132,7 +132,7 @@ class FileLog extends BaseLog
         }
 
         $exists = file_exists($pathname);
-        $result = file_put_contents($pathname, $output, FILE_APPEND);
+        file_put_contents($pathname, $output, FILE_APPEND);
         static $selfError = false;
 
         if (!$selfError && !$exists && !chmod($pathname, (int)$mask)) {

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -67,7 +67,6 @@ class TransportRegistry extends ObjectRegistry
      */
     protected function _create($class, string $alias, array $config): AbstractTransport
     {
-        $instance = null;
         if (is_object($class)) {
             $instance = $class;
         } else {

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -297,7 +297,6 @@ class SelectLoader
         }
         $subquery->select($filter, true);
 
-        $conditions = null;
         if (is_array($key)) {
             $conditions = $this->_createTupleCondition($query, $key, $filter, '=');
         } else {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -383,7 +383,6 @@ class Marshaller
         $primaryKey = array_flip((array)$target->getPrimaryKey());
         $records = $conditions = [];
         $primaryCount = count($primaryKey);
-        $conditions = [];
 
         foreach ($data as $i => $row) {
             if (!is_array($row)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -471,7 +471,7 @@ class Router
             'action' => 'index',
             '_ext' => null,
         ];
-        $here = $output = $frag = null;
+        $here = $frag = null;
 
         $context = static::$_requestContext;
         // In 4.x this should be replaced with state injected via setRequestContext

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -199,17 +199,6 @@ trait IntegrationTestTrait
     protected $_disableRouterReload = false;
 
     /**
-     * Auto-detect if the HTTP middleware stack should be used.
-     *
-     * @before
-     * @return void
-     */
-    public function setupServer(): void
-    {
-        $namespace = Configure::read('App.namespace');
-    }
-
-    /**
      * Clears the state used for requests.
      *
      * @after

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2388,7 +2388,6 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $defaultMessage = __d('cake', 'This field cannot be left empty');
         }
 
-        $notBlankMessage = null;
         foreach ($this->_fields[$field] as $rule) {
             if ($rule->get('rule') === 'notBlank' && $rule->get('message')) {
                 return $rule->get('message');

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -417,7 +417,6 @@ class EntityContext implements ContextInterface
         }
 
         $len = count($path);
-        $last = $len - 1;
         $leafEntity = $entity;
         for ($i = 0; $i < $len; $i++) {
             $prop = $path[$i];

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1578,7 +1578,6 @@ class View implements EventDispatcherInterface
             return $cache;
         }
 
-        $plugin = null;
         [$plugin, $name] = $this->pluginSplit($name);
 
         $underscored = null;


### PR DESCRIPTION
Static analyzer have gotten smarter and no longer need unnecessary initialization of vars.

Changes done (mostly) using `psalm.phar --alter --issues=UnusedVariable`.