### PR TITLE
4.x Help root

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -57,16 +57,6 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        if (!$args->getOption('xml')) {
-            $io->out('<info>Current Paths:</info>', 2);
-            $io->out('* app:  ' . Configure::read('App.dir'));
-            $io->out('* root: ' . rtrim(ROOT, DIRECTORY_SEPARATOR));
-            $io->out('* core: ' . rtrim(CORE_PATH, DIRECTORY_SEPARATOR));
-            $io->out('');
-
-            $io->out('<info>Available Commands:</info>', 2);
-        }
-
         $commands = $this->commands->getIterator();
         $commands->ksort();
 
@@ -122,8 +112,10 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
 
             $grouped[$prefix][] = $shortestName;
         }
-
         ksort($grouped);
+
+        $this->outputPaths($io);
+        $io->out('<info>Available Commands:</info>', 2);
 
         foreach ($grouped as $prefix => $names) {
             $io->out("<info>{$prefix}</info>:");
@@ -133,9 +125,39 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
             }
             $io->out('');
         }
+        $root = $this->getRootName();
 
-        $io->out('To run a command, type <info>`cake command_name [args|options]`</info>');
-        $io->out('To get help on a specific command, type <info>`cake command_name --help`</info>', 2);
+        $io->out("To run a command, type <info>`{$root} command_name [args|options]`</info>");
+        $io->out("To get help on a specific command, type <info>`{$root} command_name --help`</info>", 2);
+    }
+
+    /**
+     * Output relevant paths if defined
+     *
+     * @param \Cake\Console\ConsoleIo $io IO object.
+     * @return void
+     */
+    protected function outputPaths(ConsoleIo $io): void
+    {
+        $paths = [];
+        if (Configure::check('App.dir')) {
+            // Extra space is to align output
+            $paths['app'] = ' ' . Configure::read('App.dir');
+        }
+        if (defined('ROOT')) {
+            $paths['root'] = rtrim(ROOT, DIRECTORY_SEPARATOR);
+        }
+        if (defined('CORE_PATH')) {
+            $paths['core'] = rtrim(CORE_PATH, DIRECTORY_SEPARATOR);
+        }
+        if (!count($paths)) {
+            return;
+        }
+        $io->out('<info>Current Paths:</info>', 2);
+        foreach ($paths as $key => $value) {
+            $io->out("* {$key}: {$value}");
+        }
+        $io->out('');
     }
 
     /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -106,6 +106,18 @@ class Command
     }
 
     /**
+     * Get the root command name.
+     *
+     * @return string
+     */
+    public function getRootName(): string
+    {
+        [$root] = explode(' ', $this->name);
+
+        return $root;
+    }
+
+    /**
      * Get the command name.
      *
      * Returns the command name based on class name.

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -79,6 +79,7 @@ class CommandTest extends TestCase
         $command = new Command();
         $this->assertSame($command, $command->setName('routes show'));
         $this->assertSame('routes show', $command->getName());
+        $this->assertSame('routes', $command->getRootName());
     }
 
     /**


### PR DESCRIPTION
* Add getRootName() to Command. This method makes it simpler to get the root command name making help generation outside of a full-stack cakephp application easier.
* Make help have fewer dependencies on full stack cake. Remove hard reliance on App.dir and path constants.

Refs #10965