### PR TITLE
Throw exception if context cannot be generated for given entity.

### DIFF
--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -60,17 +60,27 @@ class ContextFactory
             [
                 'type' => 'orm',
                 'callable' => function ($request, $data) {
+                    if ($data['entity'] instanceof EntityInterface) {
+                        return new EntityContext($request, $data);
+                    }
+                    if (isset($data['table'])) {
+                        return new EntityContext($request, $data);
+                    }
                     if (is_iterable($data['entity'])) {
                         $pass = (new Collection($data['entity']))->first() !== null;
                         if ($pass) {
                             return new EntityContext($request, $data);
+                        } else {
+                            return new NullContext($request, $data);
                         }
                     }
-                    if ($data['entity'] instanceof EntityInterface) {
-                        return new EntityContext($request, $data);
-                    }
-                    if (is_array($data['entity']) && empty($data['entity']['schema'])) {
-                        return new EntityContext($request, $data);
+                },
+            ],
+            [
+                'type' => 'form',
+                'callable' => function ($request, $data) {
+                    if ($data['entity'] instanceof Form) {
+                        return new FormContext($request, $data);
                     }
                 },
             ],
@@ -83,10 +93,10 @@ class ContextFactory
                 },
             ],
             [
-                'type' => 'form',
+                'type' => 'null',
                 'callable' => function ($request, $data) {
-                    if ($data['entity'] instanceof Form) {
-                        return new FormContext($request, $data);
+                    if ($data['entity'] === null) {
+                        return new NullContext($request, $data);
                     }
                 },
             ],
@@ -126,8 +136,8 @@ class ContextFactory
      * @param \Cake\Http\ServerRequest $request Request instance.
      * @param array $data The data to get a context provider for.
      * @return \Cake\View\Form\ContextInterface Context provider.
-     * @throws \RuntimeException when the context class does not implement the
-     *   ContextInterface.
+     * @throws \RuntimeException When a context instace cannot be generated for
+     *   given entity or context class does not implement the ContextInterface.
      */
     public function get(ServerRequest $request, array $data = []): ContextInterface
     {
@@ -141,7 +151,10 @@ class ContextFactory
             }
         }
         if (!isset($context)) {
-            $context = new NullContext($request, $data);
+            throw new RuntimeException(sprintf(
+                'No context provider found for entity of type `%s`.',
+                getTypeName($data['entity'])
+            ));
         }
         if (!($context instanceof ContextInterface)) {
             throw new RuntimeException(sprintf(

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -136,8 +136,7 @@ class ContextFactory
      * @param \Cake\Http\ServerRequest $request Request instance.
      * @param array $data The data to get a context provider for.
      * @return \Cake\View\Form\ContextInterface Context provider.
-     * @throws \RuntimeException When a context instace cannot be generated for
-     *   given entity or context class does not implement the ContextInterface.
+     * @throws \RuntimeException When a context instace cannot be generated for given entity.
      */
     public function get(ServerRequest $request, array $data = []): ContextInterface
     {
@@ -150,17 +149,11 @@ class ContextFactory
                 break;
             }
         }
+
         if (!isset($context)) {
             throw new RuntimeException(sprintf(
                 'No context provider found for entity of type `%s`.',
                 getTypeName($data['entity'])
-            ));
-        }
-        if (!($context instanceof ContextInterface)) {
-            throw new RuntimeException(sprintf(
-                'Context providers must return object implementing %s. Got "%s" instead.',
-                ContextInterface::class,
-                getTypeName($context)
             ));
         }
 

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -152,7 +152,8 @@ class ContextFactory
 
         if (!isset($context)) {
             throw new RuntimeException(sprintf(
-                'No context provider found for entity of type `%s`.',
+                'No context provider found for value of type `%s`.'
+                . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',
                 getTypeName($data['entity'])
             ));
         }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -349,7 +349,7 @@ class FormHelper extends Helper
      *
      * @param mixed $context The context for which the form is being defined.
      *   Can be a ContextInterface instance, ORM entity, ORM resultset, or an
-     *   array of meta data. You can use `null `to make a context-less form.
+     *   array of meta data. You can use `null` to make a context-less form.
      * @param array $options An array of html attributes and options.
      * @return string An formatted opening FORM tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#Cake\View\Helper\FormHelper::create

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -349,7 +349,7 @@ class FormHelper extends Helper
      *
      * @param mixed $context The context for which the form is being defined.
      *   Can be a ContextInterface instance, ORM entity, ORM resultset, or an
-     *   array of meta data. You can use false or null to make a context-less form.
+     *   array of meta data. You can use `null `to make a context-less form.
      * @param array $options An array of html attributes and options.
      * @return string An formatted opening FORM tag.
      * @link https://book.cakephp.org/3.0/en/views/helpers/form.html#Cake\View\Helper\FormHelper::create

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1776,7 +1776,7 @@ class FormHelper extends Helper
             $formOptions = $options['form'] + $formOptions;
             unset($options['form']);
         }
-        $out = $this->create(false, $formOptions);
+        $out = $this->create(null, $formOptions);
         if (isset($options['data']) && is_array($options['data'])) {
             foreach (Hash::flatten($options['data']) as $key => $value) {
                 $out .= $this->hidden($key, ['value' => $value]);

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Form;
+
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\View\Form\ContextFactory;
+
+/**
+ * ContextFactory test case.
+ */
+class ContextFactoryTest extends TestCase
+{
+    public function testGetException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No context provider found for entity of type `boolean`.');
+
+        $factory = new ContextFactory();
+        $factory->get(new ServerRequest(), ['entity' => false]);
+    }
+}

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -28,7 +28,10 @@ class ContextFactoryTest extends TestCase
     public function testGetException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('No context provider found for entity of type `boolean`.');
+        $this->expectExceptionMessage(
+            'No context provider found for value of type `boolean`.'
+            . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.'
+        );
 
         $factory = new ContextFactory();
         $factory->get(new ServerRequest(), ['entity' => false]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -382,10 +382,8 @@ class FormHelperTest extends TestCase
             'collection' => [$collection, 'Cake\View\Form\EntityContext'],
             'empty_collection' => [$emptyCollection, 'Cake\View\Form\NullContext'],
             'array' => [$data, 'Cake\View\Form\ArrayContext'],
-            'array_object' => [$arrayObject, 'Cake\View\Form\NullContext'],
             'form' => [$form, 'Cake\View\Form\FormContext'],
             'none' => [null, 'Cake\View\Form\NullContext'],
-            'false' => [false, 'Cake\View\Form\NullContext'],
             'custom' => [$custom, get_class($custom)],
         ];
     }
@@ -427,7 +425,7 @@ class FormHelperTest extends TestCase
     public function testCreateFile()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $result = $this->Form->create(false, ['type' => 'file']);
+        $result = $this->Form->create(null, ['type' => 'file']);
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/articles/add',
@@ -448,7 +446,7 @@ class FormHelperTest extends TestCase
     public function testCreateGet()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $result = $this->Form->create(false, ['type' => 'get']);
+        $result = $this->Form->create(null, ['type' => 'get']);
         $expected = ['form' => [
             'method' => 'get', 'action' => '/articles/add',
             'accept-charset' => $encoding,
@@ -466,7 +464,7 @@ class FormHelperTest extends TestCase
     public function testCreateExplicitMethodEnctype()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $result = $this->Form->create(false, [
+        $result = $this->Form->create(null, [
             'type' => 'get',
             'method' => 'put',
             'enctype' => 'multipart/form-data',
@@ -631,7 +629,7 @@ class FormHelperTest extends TestCase
     public function testCreateTypeOptions($type, $method, $override)
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $result = $this->Form->create(false, ['type' => $type]);
+        $result = $this->Form->create(null, ['type' => $type]);
         $expected = [
             'form' => [
                 'method' => $method, 'action' => '/articles/add',
@@ -786,7 +784,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateNoUrl()
     {
-        $result = $this->Form->create(false, ['url' => false]);
+        $result = $this->Form->create(null, ['url' => false]);
         $expected = [
             'form' => [
                 'method' => 'post',
@@ -812,7 +810,7 @@ class FormHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()
             ->withParam('controller', 'users'));
 
-        $result = $this->Form->create(false, ['url' => ['action' => 'login']]);
+        $result = $this->Form->create(null, ['url' => ['action' => 'login']]);
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/login',
@@ -829,7 +827,7 @@ class FormHelperTest extends TestCase
             ['controller' => 'articles', 'action' => 'myaction'],
             ['_name' => 'my-route']
         );
-        $result = $this->Form->create(false, ['url' => ['_name' => 'my-route']]);
+        $result = $this->Form->create(null, ['url' => ['_name' => 'my-route']]);
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/new-article',
@@ -1005,7 +1003,7 @@ class FormHelperTest extends TestCase
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $this->View->setRequest($this->View->getRequest()->withParam('controller', 'contact_test'));
-        $result = $this->Form->create(false, [
+        $result = $this->Form->create(null, [
             'type' => 'get', 'url' => ['controller' => 'contact_test'],
         ]);
 
@@ -1481,7 +1479,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
 
-        $this->Form->create('Addresses');
+        $this->Form->create();
         $this->Form->button('Test', ['type' => 'submit', 'name' => 'Address[button]']);
         $result = $this->Form->unlockField();
         $this->assertEquals(['Address.button'], $result);
@@ -1511,7 +1509,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
 
-        $this->Form->create(false);
+        $this->Form->create();
         $result = $this->Form->submit('save.png');
         $expected = [
             'div' => ['class' => 'submit'],
@@ -2427,12 +2425,12 @@ class FormHelperTest extends TestCase
         ]));
 
         $this->Form->unlockField('Contact.id');
-        $this->Form->create('Contact');
+        $this->Form->create();
         $this->Form->hidden('Contact.id', ['value' => 1]);
         $this->assertEmpty($this->Form->fields, 'Field should be unlocked');
         $this->Form->end();
 
-        $this->Form->create('Contact');
+        $this->Form->create(null);
         $this->Form->hidden('Contact.id', ['value' => 1]);
         $this->assertEquals(1, $this->Form->fields['Contact.id'], 'Hidden input should be secured.');
     }
@@ -3155,7 +3153,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateIdPrefix()
     {
-        $this->Form->create(false, ['idPrefix' => 'prefix']);
+        $this->Form->create(null, ['idPrefix' => 'prefix']);
 
         $result = $this->Form->control('field');
         $expected = [
@@ -3447,7 +3445,7 @@ class FormHelperTest extends TestCase
             ->setConstructorArgs([new View()])
             ->getMock();
 
-        $this->Form->create(false, ['idPrefix' => 'prefix']);
+        $this->Form->create(null, ['idPrefix' => 'prefix']);
 
         $this->Form->expects($this->once())->method('datetime')
             ->with('prueba', [
@@ -4096,7 +4094,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->create(false);
+        $this->Form->create();
         $expected = [
             'fieldset' => [],
             ['div' => ['class' => 'input text']],
@@ -6954,7 +6952,7 @@ class FormHelperTest extends TestCase
         $hash .= '%3A';
         $this->View->setRequest($this->View->getRequest()->withParam('_Token.key', 'test'));
 
-        $this->Form->create('Post', ['url' => ['action' => 'add']]);
+        $this->Form->create(null, ['url' => ['action' => 'add']]);
         $this->Form->control('title');
         $this->Form->postLink('Delete', '/posts/delete/1', ['block' => true]);
         $result = $this->View->fetch('postLink');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -349,8 +349,8 @@ class FormHelperTest extends TestCase
      */
     public function testAddContextProviderInvalid()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Context providers must return object implementing Cake\View\Form\ContextInterface. Got "stdClass" instead.');
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Return value of Cake\View\Form\ContextFactory::get() must implement interface Cake\View\Form\ContextInterface, instance of stdClass returned');
         $context = 'My data';
         $this->Form->addContextProvider('test', function ($request, $data) use ($context) {
             return new \StdClass();

--- a/tests/test_app/templates/Posts/cache_form.php
+++ b/tests/test_app/templates/Posts/cache_form.php
@@ -1,5 +1,5 @@
 <div class="users form">
-    <?= $this->Form->create(false); ?>
+    <?= $this->Form->create(); ?>
         <fieldset>
             <legend><?= __('Add User'); ?></legend>
         </fieldset>


### PR DESCRIPTION
Currently if you pass `false` or `string` value as 1st argument to `FormHelper::create()` it gets silently ignored. Primarily apps upgraded from 2.x (and the core itself) are often littered with such invalid usage.

So I made this change to throw an exception if `ContextFactory` is unable create a context for provided entity.