### PR TITLE
Remove invalid throws. Restore typehint for IDE.

### DIFF
--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -181,7 +181,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      */
     protected function _parseValue(string $value): string
     {
-        /* @var \Cake\I18n\Number $class */
+        /** @var \Cake\I18n\Number $class */
         $class = static::$numberClass;
 
         return (string)$class::parseFloat($value);

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -81,7 +81,6 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
-     * @throws \Cake\Core\Exception\Exception
      */
     public function toPHP($value, DriverInterface $driver): ?string
     {
@@ -152,6 +151,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      *
      * @param bool $enable Whether or not to enable
      * @return $this
+     * @throws \RuntimeException
      */
     public function useLocaleParser(bool $enable = true)
     {
@@ -181,6 +181,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      */
     protected function _parseValue(string $value): string
     {
+        /* @var \Cake\I18n\Number $class */
         $class = static::$numberClass;
 
         return (string)$class::parseFloat($value);


### PR DESCRIPTION
Not sure who removed the `@var` annotations. Probably because static analyzers might not need them.
But they must be restored for IDE to follow however.

//EDIT: ah found it - https://github.com/cakephp/cakephp/commit/8360cf4f97db48a3269b505f753f4bdb6edcd8ca#diff-abd55522587e2c355864dcf606281ee9L183 - looks like the only one.