### PR TITLE
Revised ExtractTask::_extractTokens() to delegate pass FormHelper::in…

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -385,6 +385,9 @@ class ExtractTask extends Shell
                 }
             }
             unset($allTokens);
+            $this->_parse(array('Form', 'input'), array('singular'));
+            $this->_parse(array('Form', 'radio'), array('singular'));
+            $this->_parse(array('Paginator', 'sort'), array('singular'));
             $this->_parse('__', ['singular']);
             $this->_parse('__n', ['singular', 'plural']);
             $this->_parse('__d', ['domain', 'singular']);
@@ -422,6 +425,21 @@ class ExtractTask extends Shell
             }
 
             list($type, $string, $line) = $countToken;
+            if (($type == T_OBJECT_OPERATOR) && is_array($functionName) && isset($this->_tokens[$count + 1][1], $this->_tokens[$count + 3][1], $this->_tokens[$count + 5][1])) {
+                if (($this->_tokens[$count + 1][1] === $functionName[0]) && ($this->_tokens[$count + 3][1] === $functionName[1])) {
+                    if ($this->_tokens[$i = $count + 7][0] == T_ARRAY || $this->_tokens[$i = $count + 7][0] == '[') {
+                        while ($this->_tokens[$i] !== ')') {
+                            ++$i;
+                            if (is_array($this->_tokens[$i]) && $this->_tokens[$i][0] == T_CONSTANT_ENCAPSED_STRING && preg_match('/label|legend/', $this->_tokens[$i][1])) {
+                                $count++;
+                                continue 2;
+                            }
+                        }
+                    }
+                    $this->_addTranslation('LC_MESSAGES', 'default', $this->_formatLabel($this->_formatString($this->_tokens[$count + 5][1])), array('file' => $this->_file, 'line' => $line));
+                }
+            }
+
             if (($type == T_STRING) && ($string === $functionName) && ($firstParenthesis === '(')) {
                 $position = $count;
                 $depth = 0;
@@ -641,6 +659,26 @@ class ExtractTask extends Shell
         }
 
         return $strings;
+    }
+
+    /**
+     * Format a label from a FormHelper::input(), ::radio() or PaginatorHelper::sort() field name
+     * to be added as a translatable string
+     *
+     * @param string $fieldName Field name label to format
+     * @return string Formatted string
+     */
+    protected function _formatLabel($fieldName) {
+        if (strpos($fieldName, '.') !== false) {
+            $fieldElements = explode('.', $fieldName);
+            $text = array_pop($fieldElements);
+        } else {
+            $text = $fieldName;
+        }
+        if (substr($text, -3) === '_id') {
+            $text = substr($text, 0, -3);
+        }
+        return Inflector::humanize(Inflector::underscore($text));
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -71,6 +71,16 @@ class PostsController extends AppController
 
         return $this->redirect(['action' => 'index']);
     }
+    
+    /**
+     * View template for I18n parsing FormHelper::radio(), FormHelper::input() and Paginator::sort()
+     *
+     * @return void
+     */
+    public function add()
+    {
+        // Do nothing.
+    }
 
     /**
      * Stub get method

--- a/tests/test_app/TestApp/Template/Posts/add.ctp
+++ b/tests/test_app/TestApp/Template/Posts/add.ctp
@@ -1,0 +1,22 @@
+<div>
+	<h1><?= __('Add I18n Post') ?></h1>
+    <?php
+    echo $this->Form->create(false) . $this->Form->radio('Model.radio_field', [
+        __('An Option'),
+        __('Another Option'),
+        __('Last Option')
+    ]) . $this->Form->radio('no_model_prefix_radio_field', [
+        __('Red'),
+        __('Green'),
+        __('Blue')
+    ]) . $this->Form->input('OtherModel.field_name_to_inflect_and_add_to_pot') . $this->Form->input('field_name_to_exclude_from_pot', [
+        'label' => __('Custom Label To Add To Pot')
+    ]) . $this->Form->input('inflect_and_add_to_pot') . $this->Form->submit(__('Submit')) . $this->Form->end();
+    ?>
+</div>
+<div>
+	<h1><?= __('Paginate I18n') ?></h1>
+    <?php
+    echo $this->Paginator->sort('some_sort_field_name_to_add_to_pot') . $this->Paginator->sort('Model.sort_field_to_ignore_parse_custom', __('Custom Sort Name To Parse'));
+    ?>
+</div>


### PR DESCRIPTION
…put(), ::radio() and PaginatorHelper::sort() as array callables to ExtractTask::_parse()

Revised ExtractTask::_parse() to check for and match T_OBJECT_OPERATOR tokens against passed array callables skipping any 'label' or 'legend' strings passed in $options array (in either full or short array syntax) passing labels that would be generated by these helpers to new protected ::_formatLabel() before passing to ::_addTranslation()

Fixes #13303 pull requested for 3.next and 2.10.20 milestone