### PR TITLE
Fix JsonType to not express null as string.

### DIFF
--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -33,11 +33,16 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
+     * @throws \InvalidArgumentException
      */
     public function toDatabase($value, DriverInterface $driver): ?string
     {
         if (is_resource($value)) {
             throw new InvalidArgumentException('Cannot convert a resource value to JSON');
+        }
+
+        if ($value === null) {
+            return null;
         }
 
         return json_encode($value);

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -91,7 +91,7 @@ class JsonTypeTest extends TestCase
      */
     public function testToDatabase()
     {
-        $this->assertSame('null', $this->type->toDatabase(null, $this->driver));
+        $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertSame(json_encode('word'), $this->type->toDatabase('word', $this->driver));
         $this->assertSame(json_encode(2.123), $this->type->toDatabase(2.123, $this->driver));
         $this->assertSame(json_encode(['a' => 'b']), $this->type->toDatabase(['a' => 'b'], $this->driver));
@@ -117,6 +117,7 @@ class JsonTypeTest extends TestCase
     public function testMarshal()
     {
         $this->assertNull($this->type->marshal(null));
+        $this->assertSame('', $this->type->marshal(''));
         $this->assertSame('word', $this->type->marshal('word'));
         $this->assertSame(2.123, $this->type->marshal(2.123));
         $this->assertSame([1, 2, 3], $this->type->marshal([1, 2, 3]));


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/13519

Refs https://github.com/dereuromark/cakephp-shim/blob/master/docs/Database/Json.md shim for 3.x and how to adjust DB for migration. That snippet we could copy and paste into migration guide.