### PR TITLE
Document behavior of true/false values on UUIDs

### DIFF
--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -79,6 +79,12 @@ class UuidTypeTest extends TestCase
 
         $result = $this->type->toDatabase('', $this->driver);
         $this->assertNull($result);
+        
+        $result = $this->type->toDatabase(true, $this->driver);
+        $this->assertNull($result);
+        
+        $result = $this->type->toDatabase(false, $this->driver);
+        $this->assertNull($result);        
     }
 
     /**


### PR DESCRIPTION
https://github.com/UseMuffin/Footprint changed from using `false` to using `null` in case of no Footprint existing in the ORM calls - which made me check what happened before when those `false` values were moving on towards the UUID type in our db - and I found out that they actually ended up being `''` in case of `false`.

I do not know if this is desired behavior (I would have expected it to be `null` rather than `''`) - but in any case I went to the tests to check for the behavior only to find it was not covered explicitly.

Feel free to close the issue if this is obvious to everyone else, or if the behavior should rather be changed. (changing https://github.com/cakephp/cakephp/blob/master/src/Database/Type/UuidType.php#L35 to include `|| is_boolean($value)` or `|| $value`