### PR TITLE
4.x mail

### DIFF
--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -60,9 +60,9 @@ abstract class AbstractTransport
      */
     protected function checkRecipient(Message $message): void
     {
-        if (empty($message->getTo())
-            && empty($message->getCc())
-            && empty($message->getBcc())
+        if ($message->getTo() === []
+            && $message->getCc() === []
+            && $message->getBcc() === []
         ) {
             throw new Exception('You must specify at least one recipient of to, cc or bcc.');
         }

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -64,7 +64,7 @@ abstract class AbstractTransport
             && $message->getCc() === []
             && $message->getBcc() === []
         ) {
-            throw new Exception('You must specify at least one recipient of to, cc or bcc.');
+            throw new Exception('You must specify at least one recipient. Use one of `setTo`, `setCc` or `setBcc` to define a recipient.');
         }
     }
 

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer;
 
+use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 
 /**
@@ -48,6 +49,23 @@ abstract class AbstractTransport
     public function __construct(array $config = [])
     {
         $this->setConfig($config);
+    }
+
+    /**
+     * Check that at least one destination header is set.
+     *
+     * @param \Cake\Mailer\Message $message
+     * @return void
+     * @throws \Cake\Core\Exception\Exception If at least one of to, cc or bcc is not specified.
+     */
+    protected function checkRecipient(Message $message): void
+    {
+        if (empty($message->getTo())
+            && empty($message->getCc())
+            && empty($message->getBcc())
+        ) {
+            throw new Exception('You must specify at least one recipient of to, cc or bcc.');
+        }
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -371,10 +371,6 @@ class Email implements JsonSerializable, Serializable
      */
     public function send($content = null): array
     {
-        if (empty($this->message->getFrom())) {
-            throw new BadMethodCallException('From is not specified.');
-        }
-
         if (empty($this->message->getTo())
             && empty($this->message->getCc())
             && empty($this->message->getBcc())

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -371,13 +371,6 @@ class Email implements JsonSerializable, Serializable
      */
     public function send($content = null): array
     {
-        if (empty($this->message->getTo())
-            && empty($this->message->getCc())
-            && empty($this->message->getBcc())
-        ) {
-            throw new BadMethodCallException('You need specify one destination on to, cc or bcc.');
-        }
-
         if (is_array($content)) {
             $content = implode("\n", $content) . "\n";
         }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -402,7 +402,7 @@ class Email implements JsonSerializable, Serializable
         }
 
         $this->message->setBody(
-            $this->getRenderer()->getContent(
+            $this->getRenderer()->render(
                 (string)$content,
                 $this->message->getBodyTypes()
             )

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer;
 
+use Cake\View\ViewBuilder;
 use Cake\View\ViewVarsTrait;
 
 /**
@@ -31,6 +32,16 @@ class Renderer
      * @var string
      */
     public const TEMPLATE_FOLDER = 'email';
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\View\ViewBuilder|null $viewBuilder View builder instance.
+     */
+    public function __construct(?ViewBuilder $viewBuilder = null)
+    {
+        $this->_viewBuilder = $viewBuilder;
+    }
 
     /**
      * Build and set all the view properties needed to render the templated emails.

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -83,7 +83,7 @@ class Renderer
             $view->setTemplatePath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
             $view->setLayoutPath(static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . $type);
 
-            $rendered[$type] = (string)$view->render();
+            $rendered[$type] = $view->render();
         }
 
         return $rendered;

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -44,15 +44,16 @@ class Renderer
     }
 
     /**
-     * Build and set all the view properties needed to render the templated emails.
+     * Render text/HTML content.
+     *
      * If there is no template set, the $content will be returned in a hash
-     * of the text content types for the email.
+     * of the specified content types for the email.
      *
      * @param string $content The content.
      * @param array $types Content types to render.
      * @return array{html?: string, text?: string} The rendered content with "html" and/or "text" keys.
      */
-    public function getContent(string $content, array $types = []): array
+    public function render(string $content, array $types = []): array
     {
         $rendered = [];
         $template = $this->viewBuilder()->getTemplate();

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -32,6 +32,8 @@ class MailTransport extends AbstractTransport
      */
     public function send(Message $message): array
     {
+        $this->checkRecipient($message);
+
         $eol = PHP_EOL;
         if (isset($this->_config['eol'])) {
             $eol = $this->_config['eol'];

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -173,6 +173,8 @@ class SmtpTransport extends AbstractTransport
      */
     public function send(Message $message): array
     {
+        $this->checkRecipient($message);
+
         if (!$this->connected()) {
             $this->_connect();
             $this->_auth();

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1087,21 +1087,6 @@ class EmailTest extends TestCase
     }
 
     /**
-     * testSendWithoutFrom method
-     *
-     * @return void
-     */
-    public function testSendWithoutFrom()
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->Email->setTransport('debug');
-        $this->Email->setTo('cake@cakephp.org');
-        $this->Email->setSubject('My title');
-        $this->Email->setProfile(['empty']);
-        $this->Email->send('Forgot to set From');
-    }
-
-    /**
      * testSendWithoutTo method
      *
      * @return void

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1087,21 +1087,6 @@ class EmailTest extends TestCase
     }
 
     /**
-     * testSendWithoutTo method
-     *
-     * @return void
-     */
-    public function testSendWithoutTo()
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->Email->setTransport('debug');
-        $this->Email->setFrom('cake@cakephp.org');
-        $this->Email->setSubject('My title');
-        $this->Email->setProfile(['empty']);
-        $this->Email->send('Forgot to set To');
-    }
-
-    /**
      * test send without a transport method
      *
      * @return void

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         2.0.0
+ * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Mailer;

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -49,7 +49,7 @@ class MailTransportTest extends TestCase
     public function testSendWithoutRecipient()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('You must specify at least one recipient of to, cc or bcc.');
+        $this->expectExceptionMessage('You must specify at least one recipient. Use one of `setTo`, `setCc` or `setBcc` to define a recipient.');
 
         $message = new Message();
         $this->MailTransport->send($message);

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Mailer\Transport;
 
+use Cake\Core\Exception\Exception;
 use Cake\Mailer\Message;
 use Cake\TestSuite\TestCase;
 
@@ -38,6 +39,20 @@ class MailTransportTest extends TestCase
             ->setMethods(['_mail'])
             ->getMock();
         $this->MailTransport->setConfig(['additionalParameters' => '-f']);
+    }
+
+    /**
+     * testSendWithoutRecipient method
+     *
+     * @return void
+     */
+    public function testSendWithoutRecipient()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You must specify at least one recipient of to, cc or bcc.');
+
+        $message = new Message();
+        $this->MailTransport->send($message);
     }
 
     /**


### PR DESCRIPTION
- Remove exception if `From` is not set. It's not mandatory for sending mails.
- Moved check that at least one recipient/destination is set to transport. IMO that's the concern of transport not Email class. This allows possibility to use custom transport for services where you can specify pre-made recipient lists without having to set a dummy `To` in email/message.
- Made view builder instance injectable through `Mailer\Renderer`'s constructor.