### PR TITLE
4.x mailer

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1133,16 +1133,6 @@
       <code>$other</code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="src/TestSuite/Constraint/Email/MailContainsHtml.php">
-    <DeprecatedConstant occurrences="1">
-      <code>Email::MESSAGE_HTML</code>
-    </DeprecatedConstant>
-  </file>
-  <file src="src/TestSuite/Constraint/Email/MailContainsText.php">
-    <DeprecatedConstant occurrences="1">
-      <code>Email::MESSAGE_TEXT</code>
-    </DeprecatedConstant>
-  </file>
   <file src="src/TestSuite/Constraint/EventFired.php">
     <InternalClass occurrences="1"/>
     <PossiblyNullReference occurrences="1">

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -64,33 +64,10 @@ abstract class AbstractTransport
             && $message->getCc() === []
             && $message->getBcc() === []
         ) {
-            throw new Exception('You must specify at least one recipient. Use one of `setTo`, `setCc` or `setBcc` to define a recipient.');
+            throw new Exception(
+                'You must specify at least one recipient.'
+                . ' Use one of `setTo`, `setCc` or `setBcc` to define a recipient.'
+            );
         }
-    }
-
-    /**
-     * Help to convert headers in string
-     *
-     * @param array $headers Headers in format key => value
-     * @param string $eol End of line string.
-     * @return string
-     */
-    protected function _headersToString(array $headers, string $eol = "\r\n"): string
-    {
-        $out = '';
-        foreach ($headers as $key => $value) {
-            if ($value === false || $value === null || $value === '') {
-                continue;
-            }
-
-            foreach ((array)$value as $val) {
-                $out .= $key . ': ' . $val . $eol;
-            }
-        }
-        if (!empty($out)) {
-            $out = substr($out, 0, -1 * strlen($eol));
-        }
-
-        return $out;
     }
 }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -39,6 +39,8 @@ use SimpleXMLElement;
  * Email::config() can be used to add or read a configuration profile for Email instances.
  * Once made configuration profiles can be used to re-use across various email messages your
  * application sends.
+ *
+ * @deprecated 4.0.0 This class will be removed in CakePHP 4.0, use Mailer instead.
  */
 class Email implements JsonSerializable, Serializable
 {

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -132,12 +132,6 @@ class Email implements JsonSerializable, Serializable
             $config = static::getConfig('default');
         }
 
-        $this->getRenderer()->viewBuilder()
-            ->setClassName(View::class)
-            ->setTemplate('')
-            ->setLayout('default')
-            ->setHelpers(['Html']);
-
         if ($config) {
             $this->setProfile($config);
         }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -18,7 +18,6 @@ namespace Cake\Mailer;
 
 use BadMethodCallException;
 use Cake\Log\Log;
-use Cake\View\View;
 use Cake\View\ViewBuilder;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -277,7 +276,13 @@ class Email implements JsonSerializable, Serializable
      */
     public function message(?string $type = null)
     {
-        return $this->message->getBody($type);
+        if ($type === null) {
+            return $this->message->getBody();
+        }
+
+        $method = 'getBody' . ucfirst($type);
+
+        return $this->message->$method();
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Mailer;
 
 use BadMethodCallException;
-use Cake\Core\StaticConfigTrait;
 use Cake\Log\Log;
 use Cake\View\View;
 use Cake\View\ViewBuilder;
@@ -44,8 +43,6 @@ use SimpleXMLElement;
  */
 class Email implements JsonSerializable, Serializable
 {
-    use StaticConfigTrait;
-
     /**
      * Type of message - HTML
      *
@@ -77,13 +74,6 @@ class Email implements JsonSerializable, Serializable
      * @deprecated 4.0.0 Use Message::EMAIL_PATTERN instead.
      */
     public const EMAIL_PATTERN = '/^((?:[\p{L}0-9.!#$%&\'*+\/=?^_`{|}~-]+)*@[\p{L}0-9-._]+)$/ui';
-
-    /**
-     * Email driver class map.
-     *
-     * @var array
-     */
-    protected static $_dsnClassMap = [];
 
     /**
      * The transport instance to use for sending mail.
@@ -131,7 +121,7 @@ class Email implements JsonSerializable, Serializable
         $this->message = new $this->messageClass();
 
         if ($config === null) {
-            $config = static::getConfig('default');
+            $config = Mailer::getConfig('default');
         }
 
         if ($config) {
@@ -301,7 +291,7 @@ class Email implements JsonSerializable, Serializable
     {
         if (is_string($config)) {
             $name = $config;
-            $config = static::getConfig($name);
+            $config = Mailer::getConfig($name);
             if (empty($config)) {
                 throw new InvalidArgumentException(sprintf('Unknown email configuration "%s".', $name));
             }
@@ -614,5 +604,17 @@ class Email implements JsonSerializable, Serializable
     public function unserialize($data): void
     {
         $this->createFromArray(unserialize($data));
+    }
+
+    /**
+     * Proxy all static method calls (for methods provided by StaticConfigTrat) to Mailer.
+     *
+     * @param string $name Method name.
+     * @param array $arguments Method argument.
+     * @return mixed
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        return call_user_func_array('\Cake\Mailer\Mailer::' . $name, $arguments);
     }
 }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -528,16 +528,11 @@ class Email implements JsonSerializable, Serializable
     public function reset()
     {
         $this->message->reset();
+        if ($this->renderer !== null) {
+            $this->renderer->reset();
+        }
         $this->_transport = null;
         $this->_profile = [];
-
-        $this->getRenderer()->viewBuilder()
-            ->setLayout('default')
-            ->setTemplate('')
-            ->setClassName(View::class)
-            ->setTheme(null)
-            ->setHelpers(['Html'], false)
-            ->setVars([], false);
 
         return $this;
     }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -40,7 +40,7 @@ use SimpleXMLElement;
  * Once made configuration profiles can be used to re-use across various email messages your
  * application sends.
  *
- * @deprecated 4.0.0 This class will be removed in CakePHP 4.0, use Mailer instead.
+ * @deprecated 4.0.0 This class will be removed in CakePHP 5.0, use Cake\Mailer\Mailer instead.
  */
 class Email implements JsonSerializable, Serializable
 {

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer;
 
+use BadMethodCallException;
 use Cake\Core\Exception\Exception;
 use Cake\Core\StaticConfigTrait;
 use Cake\Datasource\ModelAwareTrait;
@@ -164,11 +165,24 @@ class Mailer implements EventListenerInterface
      */
     protected $renderer;
 
+    /**
+     * Hold message, renderer and transport instance for restoring after runnning
+     * a mailer action.
+     *
+     * @var array
+     */
     protected $clonedInstances = [
         'message' => null,
         'renderer' => null,
         'transport' => null,
     ];
+
+    /**
+     * Mailer driver class map.
+     *
+     * @var array
+     */
+    protected static $_dsnClassMap = [];
 
     /**
      * Constructor
@@ -290,7 +304,7 @@ class Mailer implements EventListenerInterface
      * @param string $action The name of the mailer action to trigger.
      * @param array $args Arguments to pass to the triggered mailer action.
      * @param array $headers Headers to set.
-     * @return string[]
+     * @return array{headers: string, message: string}
      * @throws \Cake\Mailer\Exception\MissingActionException
      * @throws \BadMethodCallException
      */
@@ -326,7 +340,7 @@ class Mailer implements EventListenerInterface
     }
 
     /**
-     * Send email directly without using a mailer method.
+     * Send email directly without using a mailer action.
      *
      * @param string $content
      * @return array{headers: string, message: string}
@@ -450,7 +464,7 @@ class Mailer implements EventListenerInterface
     }
 
     /**
-     * Restore instances.
+     * Restore message, renderer, transport instances to state before an action was run.
      *
      * @return $this
      */
@@ -463,6 +477,8 @@ class Mailer implements EventListenerInterface
                 $this->{$key} = clone $this->clonedInstances[$key];
             }
         }
+
+        return $this;
     }
 
     /**

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -203,24 +203,6 @@ class Mailer implements EventListenerInterface
     }
 
     /**
-     * Returns the mailer's name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        if (!static::$name) {
-            static::$name = str_replace(
-                'Mailer',
-                '',
-                implode('', array_slice(explode('\\', static::class), -1))
-            );
-        }
-
-        return static::$name;
-    }
-
-    /**
      * Get the view builder.
      *
      * @return \Cake\View\ViewBuilder

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -124,7 +124,7 @@ use InvalidArgumentException;
  * @method $this setAttachments($attachments)
  * @method array getAttachments()
  * @method $this addAttachments($attachments)
- * @method $this getBody(?string $type = null)
+ * @method string|array getBody(?string $type = null)
  */
 class Mailer implements EventListenerInterface
 {

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -494,7 +494,8 @@ class Mailer implements EventListenerInterface
     {
         if ($this->transport === null) {
             throw new BadMethodCallException(
-                'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.'
+                'Transport was not defined. '
+                . 'You must set on using setTransport() or set `transport` option in your mailer profile.'
             );
         }
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -291,8 +291,21 @@ class Mailer implements EventListenerInterface
      * @param string|array $key Variable name or hash of view variables.
      * @param mixed $value View variable value.
      * @return $this
+     * @deprecated 4.0.0 Use Mailer::setViewVars() instead.
      */
     public function set($key, $value = null)
+    {
+        return $this->setViewVars($key, $value);
+    }
+
+    /**
+     * Sets email view vars.
+     *
+     * @param string|array $key Variable name or hash of view variables.
+     * @param mixed $value View variable value.
+     * @return $this
+     */
+    public function setViewVars($key, $value = null)
     {
         $this->getRenderer()->set($key, $value);
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -324,7 +324,7 @@ class Mailer implements EventListenerInterface
     /**
      * Send email directly without using a mailer action.
      *
-     * @param string $content
+     * @param string $content Content.
      * @return array{headers: string, message: string}
      */
     public function deliver(string $content = '')

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -481,7 +481,7 @@ class Mailer implements EventListenerInterface
     {
         if ($this->transport === null) {
             throw new BadMethodCallException(
-                'Transport was not defined. You must set on using setTransport() or set `transport` option in profile.'
+                'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.'
             );
         }
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -265,6 +265,19 @@ class Mailer implements EventListenerInterface
     }
 
     /**
+     * Set message instance.
+     *
+     * @param \Cake\Mailer\Message $message Message instance.
+     * @return $this
+     */
+    public function setMessage(Message $message)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    /**
      * Magic method to forward method class to Message instance.
      *
      * @param string $method Method name.

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -475,6 +475,7 @@ class Mailer implements EventListenerInterface
                 $this->{$key} = null;
             } else {
                 $this->{$key} = clone $this->clonedInstances[$key];
+                $this->clonedInstances[$key] = null;
             }
         }
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -392,6 +392,8 @@ class Mailer implements EventListenerInterface
     /**
      * Set message body.
      *
+     * Setting body content explicity will disable auto rendering.
+     *
      * @param array $content Content array with keys "text" and/or "html" with
      *   content string of respective type.
      * @return $this
@@ -407,6 +409,8 @@ class Mailer implements EventListenerInterface
     /**
      * Set text body for message.
      *
+     * Setting body content explicity will disable auto rendering.
+     *
      * @param string $content Content string
      * @return $this
      */
@@ -419,6 +423,8 @@ class Mailer implements EventListenerInterface
 
     /**
      * Set HTML body for message.
+     *
+     * Setting body content explicity will disable auto rendering.
      *
      * @param string $content Content string
      * @return $this

--- a/src/Mailer/MailerAwareTrait.php
+++ b/src/Mailer/MailerAwareTrait.php
@@ -24,7 +24,7 @@ use Cake\Mailer\Exception\MissingMailerException;
  * onto properties of the host object.
  *
  * Example users of this trait are Cake\Controller\Controller and
- * Cake\Console\Shell.
+ * Cake\Console\Command.
  */
 trait MailerAwareTrait
 {
@@ -32,21 +32,17 @@ trait MailerAwareTrait
      * Returns a mailer instance.
      *
      * @param string $name Mailer's name.
-     * @param \Cake\Mailer\Email|null $email Email instance.
+     * @param array|string|null $config Array of configs, or profile name string.
      * @return \Cake\Mailer\Mailer
      * @throws \Cake\Mailer\Exception\MissingMailerException if undefined mailer class.
      */
-    protected function getMailer(string $name, ?Email $email = null): Mailer
+    protected function getMailer(string $name, $config = null): Mailer
     {
-        if ($email === null) {
-            $email = new Email();
-        }
-
         $className = App::className($name, 'Mailer', 'Mailer');
         if ($className === null) {
             throw new MissingMailerException(compact('name'));
         }
 
-        return new $className($email);
+        return new $className($config);
     }
 }

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -939,12 +939,12 @@ class Message implements JsonSerializable, Serializable
      * Get headers as string.
      *
      * @param string[] $include List of headers.
+     * @param string $eol End of line string for concatenating headers.
      * @param \Closure $callback Callback to run each header value through before stringifying.
-     * @param string $eol End of line string.
      * @return string
      * @see Message::getHeaders()
      */
-    public function getHeadersString(array $include = [], ?Closure $callback = null, string $eol = "\r\n"): string
+    public function getHeadersString(array $include = [], string $eol = "\r\n", ?Closure $callback = null): string
     {
         $headers = $this->getHeaders($include);
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -22,6 +22,7 @@ use Cake\Http\Client\FormDataPart;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Cake\Utility\Text;
+use Closure;
 use InvalidArgumentException;
 use JsonSerializable;
 use Serializable;
@@ -854,8 +855,8 @@ class Message implements JsonSerializable, Serializable
      * - `bcc`
      * - `subject`
      *
-     * @param array $include List of headers.
-     * @return array
+     * @param string[] $include List of headers.
+     * @return string[]
      */
     public function getHeaders(array $include = []): array
     {
@@ -932,6 +933,40 @@ class Message implements JsonSerializable, Serializable
         $headers['Content-Transfer-Encoding'] = $this->getContentTransferEncoding();
 
         return $headers;
+    }
+
+    /**
+     * Get headers as string.
+     *
+     * @param string[] $include List of headers.
+     * @param \Closure $callback Callback to run each header value through before stringifying.
+     * @param string $eol End of line string.
+     * @return string
+     * @see Message::getHeaders()
+     */
+    public function getHeadersString(array $include = [], ?Closure $callback = null, string $eol = "\r\n"): string
+    {
+        $headers = $this->getHeaders($include);
+
+        if ($callback) {
+            $headers = array_map($callback, $headers);
+        }
+
+        $out = '';
+        foreach ($headers as $key => $value) {
+            if (empty($value) && $value !== '0') {
+                continue;
+            }
+
+            foreach ((array)$value as $val) {
+                $out .= $key . ': ' . $val . $eol;
+            }
+        }
+        if (!empty($out)) {
+            $out = substr($out, 0, -1 * strlen($eol));
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1236,6 +1236,21 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
+     * Get generated body as string.
+     *
+     * @param string $eol End of line string for imploding.
+     * @return string
+     * @see Message::getBody()
+     */
+    public function getBodyString(string $eol = "\r\n"): string
+    {
+        /** @var array $lines */
+        $lines = $this->getBody();
+
+        return implode($eol, $lines);
+    }
+
+    /**
      * Create unique boundary identifier
      *
      * @return void

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -946,27 +946,24 @@ class Message implements JsonSerializable, Serializable
      */
     public function getHeadersString(array $include = [], string $eol = "\r\n", ?Closure $callback = null): string
     {
-        $headers = $this->getHeaders($include);
+        $lines = $this->getHeaders($include);
 
         if ($callback) {
-            $headers = array_map($callback, $headers);
+            $lines = array_map($callback, $lines);
         }
 
-        $out = '';
-        foreach ($headers as $key => $value) {
+        $headers = [];
+        foreach ($lines as $key => $value) {
             if (empty($value) && $value !== '0') {
                 continue;
             }
 
             foreach ((array)$value as $val) {
-                $out .= $key . ': ' . $val . $eol;
+                $headers[] = $key . ': ' . $val;
             }
         }
-        if (!empty($out)) {
-            $out = substr($out, 0, -1 * strlen($eol));
-        }
 
-        return $out;
+        return implode($eol, $headers);
     }
 
     /**

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1214,20 +1214,12 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
-     * Get generated message body.
+     * Get generated message body as array.
      *
-     * @param string|null $type Use MESSAGE_* constants or null to return the full message as array
-     * @return string|array String if type is given, array if type is null
+     * @return array
      */
-    public function getBody(?string $type = null)
+    public function getBody()
     {
-        switch ($type) {
-            case static::MESSAGE_HTML:
-                return $this->htmlMessage;
-            case static::MESSAGE_TEXT:
-                return $this->textMessage;
-        }
-
         if (empty($this->message)) {
             $this->message = $this->generateMessage();
         }
@@ -1244,7 +1236,6 @@ class Message implements JsonSerializable, Serializable
      */
     public function getBodyString(string $eol = "\r\n"): string
     {
-        /** @var array $lines */
         $lines = $this->getBody();
 
         return implode($eol, $lines);
@@ -1533,6 +1524,26 @@ class Message implements JsonSerializable, Serializable
         $this->setBody([static::MESSAGE_HTML => $content]);
 
         return $this;
+    }
+
+    /**
+     * Get text body of message.
+     *
+     * @return string
+     */
+    public function getBodyText()
+    {
+        return $this->textMessage;
+    }
+
+    /**
+     * Get HTML body of message.
+     *
+     * @return string
+     */
+    public function getBodyHtml()
+    {
+        return $this->htmlMessage;
     }
 
     /**

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1201,18 +1201,6 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
-     * Get generated message body.
-     *
-     * @param string|null $type Use MESSAGE_* constants or null to return the full message as array
-     * @return string|array String if type is given, array if type is null
-     * @internal This method is just for backwards compatibility. Use getBody() instead.
-     */
-    public function message(?string $type = null)
-    {
-        return $this->getBody();
-    }
-
-    /**
      * Create unique boundary identifier
      *
      * @return void

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer;
 
-use Cake\View\ViewBuilder;
+use Cake\View\View;
 use Cake\View\ViewVarsTrait;
 
 /**
@@ -35,12 +35,10 @@ class Renderer
 
     /**
      * Constructor
-     *
-     * @param \Cake\View\ViewBuilder|null $viewBuilder View builder instance.
      */
-    public function __construct(?ViewBuilder $viewBuilder = null)
+    public function __construct()
     {
-        $this->_viewBuilder = $viewBuilder;
+        $this->reset();
     }
 
     /**
@@ -87,5 +85,21 @@ class Renderer
         }
 
         return $rendered;
+    }
+
+    public function reset()
+    {
+        $this->viewBuilder()
+            ->setClassName(View::class)
+            ->setLayout('default')
+            ->setHelpers(['Html'], false)
+            ->setVars([], false);
+    }
+
+    public function __clone()
+    {
+        if ($this->_viewBuilder !== null) {
+            $this->_viewBuilder = clone $this->_viewBuilder;
+        }
     }
 }

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -87,6 +87,11 @@ class Renderer
         return $rendered;
     }
 
+    /**
+     * Reset view builder to defaults.
+     *
+     * @return $this
+     */
     public function reset()
     {
         $this->viewBuilder()
@@ -94,6 +99,8 @@ class Renderer
             ->setLayout('default')
             ->setHelpers(['Html'], false)
             ->setVars([], false);
+
+        return $this;
     }
 
     public function __clone()

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -94,11 +94,12 @@ class Renderer
      */
     public function reset()
     {
+        $this->_viewBuilder = null;
+
         $this->viewBuilder()
             ->setClassName(View::class)
             ->setLayout('default')
-            ->setHelpers(['Html'], false)
-            ->setVars([], false);
+            ->setHelpers(['Html'], false);
 
         return $this;
     }

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -104,6 +104,11 @@ class Renderer
         return $this;
     }
 
+    /**
+     * Clone ViewBuilder instance when renderer is cloned.
+     *
+     * @return void
+     */
     public function __clone()
     {
         if ($this->_viewBuilder !== null) {

--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -32,10 +32,9 @@ class DebugTransport extends AbstractTransport
      */
     public function send(Message $message): array
     {
-        $headers = $message->getHeaders(
+        $headers = $message->getHeadersString(
             ['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject']
         );
-        $headers = $this->_headersToString($headers);
         $message = implode("\r\n", (array)$message->getBody());
 
         return ['headers' => $headers, 'message' => $message];

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -49,10 +49,10 @@ class MailTransport extends AbstractTransport
                 'cc',
                 'bcc',
             ],
+            $eol,
             function ($val) {
                 return str_replace(["\r", "\n"], '', $val);
-            },
-            $eol
+            }
         );
 
         $subject = str_replace(["\r", "\n"], '', $message->getSubject());

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -38,22 +38,23 @@ class MailTransport extends AbstractTransport
         if (isset($this->_config['eol'])) {
             $eol = $this->_config['eol'];
         }
-        $headers = $message->getHeaders([
-            'from',
-            'sender',
-            'replyTo',
-            'readReceipt',
-            'returnPath',
-            'to',
-            'cc',
-            'bcc',
-        ]);
-        $to = $headers['To'];
-        unset($headers['To']);
-        foreach ($headers as $key => $header) {
-            $headers[$key] = str_replace(["\r", "\n"], '', $header);
-        }
-        $headers = $this->_headersToString($headers, $eol);
+        $to = $message->getHeaders(['to'])['To'];
+        $headers = $message->getHeadersString(
+            [
+                'from',
+                'sender',
+                'replyTo',
+                'readReceipt',
+                'returnPath',
+                'cc',
+                'bcc',
+            ],
+            function ($val) {
+                return str_replace(["\r", "\n"], '', $val);
+            },
+            $eol
+        );
+
         $subject = str_replace(["\r", "\n"], '', $message->getSubject());
         $to = str_replace(["\r", "\n"], '', $to);
 

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -58,7 +58,7 @@ class MailTransport extends AbstractTransport
         $subject = str_replace(["\r", "\n"], '', $message->getSubject());
         $to = str_replace(["\r", "\n"], '', $to);
 
-        $message = implode($eol, (array)$message->getBody());
+        $message = $message->getBodyString($eol);
 
         $params = $this->_config['additionalParameters'] ?? '';
         $this->_mail($to, $subject, $message, $headers, $params);

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -408,7 +408,16 @@ class SmtpTransport extends AbstractTransport
     {
         $this->_smtpSend('DATA', '354');
 
-        $headers = $this->_headersToString($this->_prepareMessageHeaders($message));
+        $headers = $message->getHeadersString([
+            'from',
+            'sender',
+            'replyTo',
+            'readReceipt',
+            'to',
+            'cc',
+            'subject',
+            'returnPath'
+        ]);
         $message = $this->_prepareMessage($message);
 
         $this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -404,7 +404,7 @@ class SmtpTransport extends AbstractTransport
             'to',
             'cc',
             'subject',
-            'returnPath'
+            'returnPath',
         ]);
         $message = $this->_prepareMessage($message);
 

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -347,17 +347,6 @@ class SmtpTransport extends AbstractTransport
     }
 
     /**
-     * Prepares the message headers.
-     *
-     * @param \Cake\Mailer\Message $message Message instance
-     * @return array
-     */
-    protected function _prepareMessageHeaders(Message $message): array
-    {
-        return $message->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject', 'returnPath']);
-    }
-
-    /**
      * Prepares the message body.
      *
      * @param \Cake\Mailer\Message $message Message instance
@@ -365,7 +354,6 @@ class SmtpTransport extends AbstractTransport
      */
     protected function _prepareMessage(Message $message): string
     {
-        /** @var array $lines */
         $lines = $message->getBody();
         $messages = [];
         foreach ($lines as $line) {

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -26,7 +26,7 @@ class MailContains extends MailConstraintBase
     /**
      * Mail type to check contents of
      *
-     * @var string
+     * @var string|null
      */
     protected $type;
 
@@ -40,7 +40,8 @@ class MailContains extends MailConstraintBase
     {
         $messages = $this->getMessages();
         foreach ($messages as $message) {
-            $message = implode("\r\n", (array)$message->getBody($this->type));
+            $method = 'getBody' . ($this->type ? ucfirst($this->type) : 'String');
+            $message = $message->$method();
 
             $other = preg_quote($other, '/');
             if (preg_match("/$other/", $message) > 0) {

--- a/src/TestSuite/Constraint/Email/MailContainsHtml.php
+++ b/src/TestSuite/Constraint/Email/MailContainsHtml.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Constraint\Email;
 
-use Cake\Mailer\Email;
+use Cake\Mailer\Message;
 
 /**
  * MailContainsHtml
@@ -28,7 +28,7 @@ class MailContainsHtml extends MailContains
     /**
      * @var string
      */
-    protected $type = Email::MESSAGE_HTML;
+    protected $type = Message::MESSAGE_HTML;
 
     /**
      * Assertion message string

--- a/src/TestSuite/Constraint/Email/MailContainsHtml.php
+++ b/src/TestSuite/Constraint/Email/MailContainsHtml.php
@@ -26,7 +26,7 @@ use Cake\Mailer\Message;
 class MailContainsHtml extends MailContains
 {
     /**
-     * @var string
+     * @inheritDoc
      */
     protected $type = Message::MESSAGE_HTML;
 

--- a/src/TestSuite/Constraint/Email/MailContainsText.php
+++ b/src/TestSuite/Constraint/Email/MailContainsText.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Constraint\Email;
 
-use Cake\Mailer\Email;
+use Cake\Mailer\Message;
 
 /**
  * MailContainsText
@@ -28,7 +28,7 @@ class MailContainsText extends MailContains
     /**
      * @var string
      */
-    protected $type = Email::MESSAGE_TEXT;
+    protected $type = Message::MESSAGE_TEXT;
 
     /**
      * Assertion message string

--- a/src/TestSuite/Constraint/Email/MailContainsText.php
+++ b/src/TestSuite/Constraint/Email/MailContainsText.php
@@ -26,7 +26,7 @@ use Cake\Mailer\Message;
 class MailContainsText extends MailContains
 {
     /**
-     * @var string
+     * @inheritDoc
      */
     protected $type = Message::MESSAGE_TEXT;
 

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2037,7 +2037,7 @@ class EmailTest extends TestCase
 
         $template = $this->Email->viewBuilder()->getTemplate();
         $layout = $this->Email->viewBuilder()->getLayout();
-        $this->assertSame('', $template);
+        $this->assertNull($template);
         $this->assertEquals($configs['layout'], $layout);
     }
 

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Mailer;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Mailer\Email;
+use Cake\Mailer\Mailer;
 use Cake\Mailer\Message;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
@@ -75,6 +76,7 @@ class EmailTest extends TestCase
     {
         parent::tearDown();
         Log::drop('email');
+        Email::drop('default');
         Email::drop('test');
         TransportFactory::drop('debug');
         TransportFactory::drop('badClassName');
@@ -2715,6 +2717,20 @@ XML;
         $this->assertStringContainsString('test', $result['viewConfig']['_vars']['exception']);
         unset($result['viewConfig']['_vars']['exception']);
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * testStaticMethodProxy
+     *
+     * @return void
+     */
+    public function testStaticMethodProxy()
+    {
+        Email::setConfig('proxy_test', ['yay']);
+        $this->assertEquals(['yay'], Mailer::getConfig('proxy_test'));
+
+        Email::drop('proxy_test');
+        $this->assertSame([], Mailer::configured());
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -35,8 +35,14 @@ class MailerAwareTraitTest extends TestCase
     {
         $originalAppNamespace = Configure::read('App.namespace');
         static::setAppNamespace();
+
         $stub = new Stub();
         $this->assertInstanceOf(TestMailer::class, $stub->getMailer('Test'));
+
+        $stub = new Stub();
+        $mailer = $stub->getMailer('Test', ['from' => 'admad@cakephp.org']);
+        $this->assertSame(['admad@cakephp.org' => 'admad@cakephp.org'], $mailer->getFrom());
+
         static::setAppNamespace($originalAppNamespace);
     }
 

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -131,6 +131,22 @@ class MailerTest extends TestCase
     }
 
     /**
+     * testMessage function
+     *
+     * @return void
+     */
+    public function testMessage()
+    {
+        $message = $this->mailer->getMessage();
+        $this->assertInstanceOf(Message::class, $message);
+
+        $newMessage = new Message();
+        $this->mailer->setMessage($newMessage);
+        $this->assertSame($newMessage, $this->mailer->getMessage());
+        $this->assertNotSame($message, $newMessage);
+    }
+
+    /**
      * Test reading/writing configuration profiles.
      *
      * @return void

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -515,7 +515,7 @@ class MailerTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Transport was not defined. You must set on using setTransport() or set `transport` option in profile.'
+            'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.'
         );
         $this->mailer->setTo('cake@cakephp.org');
         $this->mailer->setFrom('cake@cakephp.org');

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -412,7 +412,7 @@ class MailerTest extends TestCase
 
     public function testSet()
     {
-        $result = (new Mailer())->set('key', 'value');
+        $result = (new Mailer())->setViewVars('key', 'value');
         $this->assertInstanceOf(Mailer::class, $result);
         $this->assertSame(['key' => 'value'], $result->getRenderer()->viewBuilder()->getVars());
     }
@@ -956,7 +956,7 @@ class MailerTest extends TestCase
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['empty']);
         $this->mailer->viewBuilder()->setTemplate('custom', 'default');
-        $this->mailer->set(['value' => 12345]);
+        $this->mailer->setViewVars(['value' => 12345]);
         $result = $this->mailer->send();
 
         $this->assertStringContainsString('Here is your value: 12345', $result['message']);
@@ -976,7 +976,7 @@ class MailerTest extends TestCase
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['empty']);
         $this->mailer->viewBuilder()->setTemplate('japanese', 'default');
-        $this->mailer->set(['value' => '日本語の差し込み123']);
+        $this->mailer->setViewVars(['value' => '日本語の差し込み123']);
         $this->mailer->setCharset('ISO-2022-JP');
         $result = $this->mailer->send();
 
@@ -1002,7 +1002,7 @@ class MailerTest extends TestCase
             ->setTemplate('custom_helper')
             ->setLayout('default')
             ->setHelpers(['Time'], false);
-        $this->mailer->set(['time' => $timestamp]);
+        $this->mailer->setViewVars(['time' => $timestamp]);
 
         $result = $this->mailer->send();
         $dateTime = new \DateTime();
@@ -1088,7 +1088,7 @@ class MailerTest extends TestCase
 
         $this->assertStringContainsString('Into TestPlugin. (themed)', $result['message']);
 
-        $this->mailer->set(['value' => 12345]);
+        $this->mailer->setViewVars(['value' => 12345]);
         $this->mailer->viewBuilder()
             ->setTemplate('custom')
             ->setLayout('TestPlugin.plug_default');
@@ -1129,7 +1129,7 @@ class MailerTest extends TestCase
         $this->mailer->setSubject('My title');
         $this->mailer->viewBuilder()->setTemplate('custom', 'default');
         $this->mailer->setProfile([]);
-        $this->mailer->set(['value' => 12345]);
+        $this->mailer->setViewVars(['value' => 12345]);
         $this->mailer->setEmailFormat('both');
         $this->mailer->send();
 

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -488,9 +488,8 @@ class MailerTest extends TestCase
         $this->mailer->setTo(['you@cakephp.org' => 'You']);
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['empty']);
-        $this->mailer->setBodyText("Here is my body, with multi lines.\nThis is the second line.\r\n\r\nAnd the last.");
 
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver("Here is my body, with multi lines.\nThis is the second line.\r\n\r\nAnd the last.");
         $expected = ['headers', 'message'];
         $this->assertEquals($expected, array_keys($result));
         $expected = "Here is my body, with multi lines.\r\nThis is the second line.\r\n\r\nAnd the last.\r\n\r\n";
@@ -500,8 +499,7 @@ class MailerTest extends TestCase
         $this->assertStringContainsString('Message-ID: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);
 
-        $this->mailer->setBodyText('Other body');
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Other body');
         $expected = "Other body\r\n\r\n";
         $this->assertSame($expected, $result['message']);
         $this->assertStringContainsString('Message-ID: ', $result['headers']);
@@ -538,8 +536,7 @@ class MailerTest extends TestCase
         $this->mailer->setSubject('My title');
         $this->mailer->setEmailFormat('text');
         $this->mailer->setAttachments([CAKE . 'basics.php']);
-        $this->mailer->setBodyText('Hello');
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -576,8 +573,7 @@ class MailerTest extends TestCase
                 'data' => $data,
                 'mimetype' => 'image/gif',
         ]]);
-        $this->mailer->setBodyText('Hello');
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -610,8 +606,7 @@ class MailerTest extends TestCase
         $this->mailer->setSubject('My title');
         $this->mailer->setEmailFormat('both');
         $this->mailer->setAttachments([CORE_PATH . 'VERSION.txt']);
-        $this->mailer->setBody(['text' => 'Hello', 'html' => 'Hello']);
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -662,8 +657,7 @@ class MailerTest extends TestCase
                 'contentId' => 'abc123',
             ],
         ]);
-        $this->mailer->setBody(['text' => 'Hello', 'html' => 'Hello']);
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -720,8 +714,7 @@ class MailerTest extends TestCase
                 'contentId' => 'abc123',
             ],
         ]);
-        $this->mailer->setBody(['text' => 'Hello', 'html' => 'Hello']);
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -765,8 +758,7 @@ class MailerTest extends TestCase
                 'contentDisposition' => false,
             ],
         ]);
-        $this->mailer->setBodyText('Hello');
-        $result = $this->mailer->send();
+        $result = $this->mailer->deliver('Hello');
 
         $boundary = $this->mailer->boundary;
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
@@ -1392,8 +1384,7 @@ class MailerTest extends TestCase
         $this->mailer->setFrom('cake@cakephp.org');
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['log' => ['scope' => 'email']]);
-        $this->mailer->setBodyText($message);
-        $this->mailer->send();
+        $this->mailer->deliver($message);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -23,7 +23,6 @@ use Cake\Mailer\Transport\DebugTransport;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
 use RuntimeException;
-use TestApp\Mailer\TestMailer;
 
 class MailerTest extends TestCase
 {
@@ -270,16 +269,6 @@ class MailerTest extends TestCase
         $em = new Mailer('default');
 
         $this->assertSame($mock, $em->getTransport());
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetName()
-    {
-        $result = (new TestMailer())->getName();
-        $expected = 'Test';
-        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -1230,10 +1230,10 @@ class MailerTest extends TestCase
         $this->mailer->send();
 
         $expected = '<p>This email was sent using the <a href="https://cakephp.org">CakePHP Framework</a></p>';
-        $this->assertStringContainsString($expected, $this->mailer->getBody(Message::MESSAGE_HTML));
+        $this->assertStringContainsString($expected, $this->mailer->getBodyHtml());
 
         $expected = 'This email was sent using the CakePHP Framework, https://cakephp.org.';
-        $this->assertStringContainsString($expected, $this->mailer->getBody(Message::MESSAGE_TEXT));
+        $this->assertStringContainsString($expected, $this->mailer->getBodyText());
 
         $message = $this->mailer->getBody();
         $this->assertContains('Content-Type: text/plain; charset=UTF-8', $message);

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Mailer;
 
+use Cake\Core\Configure;
 use Cake\Mailer\Message;
+use Cake\Mailer\Transport\DebugTransport;
 use Cake\TestSuite\TestCase;
 use TestApp\Mailer\TestMessage;
 
@@ -34,7 +36,7 @@ class MessageTest extends TestCase
     {
         parent::setUp();
 
-        $this->message = new Message();
+        $this->message = new TestMessage();
     }
 
     /**
@@ -104,6 +106,135 @@ class MessageTest extends TestCase
             '',
         ];
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * testWrapLongLine()
+     *
+     * @return void
+     */
+    public function testWrapLongLine()
+    {
+        $transort = new DebugTransport();
+
+        $message = '<a href="http://cakephp.org">' . str_repeat('x', Message::LINE_LENGTH_MUST) . '</a>';
+
+        $this->message->setFrom('cake@cakephp.org');
+        $this->message->setTo('cake@cakephp.org');
+        $this->message->setSubject('Wordwrap Test');
+        $this->message->setBodyText($message);
+
+        $result = $transort->send($this->message);
+
+        $expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('x', Message::LINE_LENGTH_MUST - 26) . "\r\n" .
+            str_repeat('x', 26) . "\r\n</a>\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+
+        $str1 = 'a ';
+        $str2 = ' b';
+        $length = strlen($str1) + strlen($str2);
+        $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length - 1) . $str2;
+
+        $this->message->setBodyText($message);
+
+        $result = $transort->send($this->message);
+        $expected = "{$message}\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+
+        $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length) . $str2;
+
+        $this->message->setBodyText($message);
+
+        $result = $transort->send($this->message);
+        $expected = "{$message}\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+
+        $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . $str2;
+
+        $this->message->setBodyText($message);
+
+        $result = $transort->send($this->message);
+        $expected = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . sprintf("\r\n%s\r\n\r\n", trim($str2));
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+    }
+
+    /**
+     * testWrapWithTagsAcrossLines()
+     *
+     * @return void
+     */
+    public function testWrapWithTagsAcrossLines()
+    {
+        $str = <<<HTML
+<table>
+<th align="right" valign="top"
+        style="font-weight: bold">The tag is across multiple lines</th>
+</table>
+HTML;
+        $message = $str . str_repeat('x', Message::LINE_LENGTH_MUST + 1);
+
+        $this->message->setFrom('cake@cakephp.org');
+        $this->message->setTo('cake@cakephp.org');
+        $this->message->setSubject('Wordwrap Test');
+        $this->message->setBodyText($message);
+
+        $result = (new DebugTransport())->send($this->message);
+
+        $message = str_replace("\r\n", "\n", substr($message, 0, -9));
+        $message = str_replace("\n", "\r\n", $message);
+        $expected = "{$message}\r\nxxxxxxxxx\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+    }
+
+    /**
+     * CakeEmailTest::testWrapIncludeLessThanSign()
+     *
+     * @return void
+     */
+    public function testWrapIncludeLessThanSign()
+    {
+        $str = 'foo<bar';
+        $length = strlen($str);
+        $message = $str . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1);
+
+        $this->message->setFrom('cake@cakephp.org');
+        $this->message->setTo('cake@cakephp.org');
+        $this->message->setSubject('Wordwrap Test');
+        $this->message->setBodyText($message);
+
+        $result = (new DebugTransport())->send($this->message);
+        $message = substr($message, 0, -1);
+        $expected = "{$message}\r\nx\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
+        $this->assertLineLengths($result['message']);
+    }
+
+    /**
+     * CakeEmailTest::testWrapForJapaneseEncoding()
+     *
+     * @return void
+     */
+    public function testWrapForJapaneseEncoding()
+    {
+        $this->skipIf(!function_exists('mb_convert_encoding'));
+
+        $message = mb_convert_encoding('受け付けました', 'iso-2022-jp', 'UTF-8');
+
+        $this->message->setFrom('cake@cakephp.org');
+        $this->message->setTo('cake@cakephp.org');
+        $this->message->setSubject('Wordwrap Test');
+        $this->message->setCharset('iso-2022-jp');
+        $this->message->setHeaderCharset('iso-2022-jp');
+        $this->message->setBodyText($message);
+
+        $result = (new DebugTransport())->send($this->message);
+        $expected = "{$message}\r\n\r\n";
+        $this->assertEquals($expected, $result['message']);
     }
 
     /**
@@ -205,5 +336,996 @@ class MessageTest extends TestCase
             'Content-Transfer-Encoding: 8bit',
         ];
         $this->assertSame(implode("\r\n", $expected), $this->message->getHeadersString());
+    }
+
+    /**
+     * testFrom method
+     *
+     * @return void
+     */
+    public function testFrom()
+    {
+        $this->assertSame([], $this->message->getFrom());
+
+        $this->message->setFrom('cake@cakephp.org');
+        $expected = ['cake@cakephp.org' => 'cake@cakephp.org'];
+        $this->assertSame($expected, $this->message->getFrom());
+
+        $this->message->setFrom(['cake@cakephp.org']);
+        $this->assertSame($expected, $this->message->getFrom());
+
+        $this->message->setFrom('cake@cakephp.org', 'CakePHP');
+        $expected = ['cake@cakephp.org' => 'CakePHP'];
+        $this->assertSame($expected, $this->message->getFrom());
+
+        $result = $this->message->setFrom(['cake@cakephp.org' => 'CakePHP']);
+        $this->assertSame($expected, $this->message->getFrom());
+        $this->assertSame($this->message, $result);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $result = $this->message->setFrom(['cake@cakephp.org' => 'CakePHP', 'fail@cakephp.org' => 'From can only be one address']);
+    }
+
+    /**
+     * Test that from addresses using colons work.
+     *
+     * @return void
+     */
+    public function testFromWithColonsAndQuotes()
+    {
+        $address = [
+            'info@example.com' => '70:20:00 " Forum',
+        ];
+        $this->message->setFrom($address);
+        $this->assertEquals($address, $this->message->getFrom());
+
+        $result = $this->message->getHeadersString(['from']);
+        $this->assertStringContainsString('From: "70:20:00 \" Forum" <info@example.com>', $result);
+    }
+
+    /**
+     * testSender method
+     *
+     * @return void
+     */
+    public function testSender()
+    {
+        $this->message->reset();
+        $this->assertSame([], $this->message->getSender());
+
+        $this->message->setSender('cake@cakephp.org', 'Name');
+        $expected = ['cake@cakephp.org' => 'Name'];
+        $this->assertSame($expected, $this->message->getSender());
+
+        $headers = $this->message->getHeaders(['from' => true, 'sender' => true]);
+        $this->assertFalse($headers['From']);
+        $this->assertSame('Name <cake@cakephp.org>', $headers['Sender']);
+
+        $this->message->setFrom('cake@cakephp.org', 'CakePHP');
+        $headers = $this->message->getHeaders(['from' => true, 'sender' => true]);
+        $this->assertSame('CakePHP <cake@cakephp.org>', $headers['From']);
+        $this->assertSame('', $headers['Sender']);
+    }
+
+    /**
+     * testTo method
+     *
+     * @return void
+     */
+    public function testTo()
+    {
+        $this->assertSame([], $this->message->getTo());
+
+        $result = $this->message->setTo('cake@cakephp.org');
+        $expected = ['cake@cakephp.org' => 'cake@cakephp.org'];
+        $this->assertSame($expected, $this->message->getTo());
+        $this->assertSame($this->message, $result);
+
+        $this->message->setTo('cake@cakephp.org', 'CakePHP');
+        $expected = ['cake@cakephp.org' => 'CakePHP'];
+        $this->assertSame($expected, $this->message->getTo());
+
+        $list = [
+            'root@localhost' => 'root',
+            'bjørn@hammeröath.com' => 'Bjorn',
+            'cake.php@cakephp.org' => 'Cake PHP',
+            'cake-php@googlegroups.com' => 'Cake Groups',
+            'root@cakephp.org',
+        ];
+        $this->message->setTo($list);
+        $expected = [
+            'root@localhost' => 'root',
+            'bjørn@hammeröath.com' => 'Bjorn',
+            'cake.php@cakephp.org' => 'Cake PHP',
+            'cake-php@googlegroups.com' => 'Cake Groups',
+            'root@cakephp.org' => 'root@cakephp.org',
+        ];
+        $this->assertSame($expected, $this->message->getTo());
+
+        $this->message->addTo('jrbasso@cakephp.org');
+        $this->message->addTo('mark_story@cakephp.org', 'Mark Story');
+        $this->message->addTo('foobar@ætdcadsl.dk');
+        $result = $this->message->addTo(['phpnut@cakephp.org' => 'PhpNut', 'jose_zap@cakephp.org']);
+        $expected = [
+            'root@localhost' => 'root',
+            'bjørn@hammeröath.com' => 'Bjorn',
+            'cake.php@cakephp.org' => 'Cake PHP',
+            'cake-php@googlegroups.com' => 'Cake Groups',
+            'root@cakephp.org' => 'root@cakephp.org',
+            'jrbasso@cakephp.org' => 'jrbasso@cakephp.org',
+            'mark_story@cakephp.org' => 'Mark Story',
+            'foobar@ætdcadsl.dk' => 'foobar@ætdcadsl.dk',
+            'phpnut@cakephp.org' => 'PhpNut',
+            'jose_zap@cakephp.org' => 'jose_zap@cakephp.org',
+        ];
+        $this->assertSame($expected, $this->message->getTo());
+        $this->assertSame($this->message, $result);
+    }
+
+    /**
+     * test to address with _ in domain name
+     *
+     * @return void
+     */
+    public function testToUnderscoreDomain()
+    {
+        $result = $this->message->setTo('cake@cake_php.org');
+        $expected = ['cake@cake_php.org' => 'cake@cake_php.org'];
+        $this->assertSame($expected, $this->message->getTo());
+        $this->assertSame($this->message, $result);
+    }
+
+    /**
+     * Data provider function for testBuildInvalidData
+     *
+     * @return array
+     */
+    public static function invalidEmails()
+    {
+        return [
+            [''],
+            ['string'],
+            ['<tag>'],
+            [['ok@cakephp.org', '1.0', '', 'string']],
+        ];
+    }
+
+    /**
+     * testBuildInvalidData
+     *
+     * @dataProvider invalidEmails
+     * @return void
+     */
+    public function testInvalidEmail($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->setTo($value);
+    }
+
+    /**
+     * testBuildInvalidData
+     *
+     * @dataProvider invalidEmails
+     * @return void
+     */
+    public function testInvalidEmailAdd($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->addTo($value);
+    }
+
+    /**
+     * test emailPattern method
+     *
+     * @return void
+     */
+    public function testEmailPattern()
+    {
+        $regex = '/.+@.+\..+/i';
+        $this->assertSame($regex, $this->message->setEmailPattern($regex)->getEmailPattern());
+    }
+
+    /**
+     * Tests that it is possible to set email regex configuration to a CakeEmail object
+     *
+     * @return void
+     */
+    public function testConfigEmailPattern()
+    {
+        $regex = '/.+@.+\..+/i';
+        $email = new Message(['emailPattern' => $regex]);
+        $this->assertSame($regex, $email->getEmailPattern());
+    }
+
+    /**
+     * Tests that it is possible set custom email validation
+     *
+     * @return void
+     */
+    public function testCustomEmailValidation()
+    {
+        $regex = '/^[\.a-z0-9!#$%&\'*+\/=?^_`{|}~-]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]{2,6}$/i';
+
+        $this->message->setEmailPattern($regex)->setTo('pass.@example.com');
+        $this->assertSame([
+            'pass.@example.com' => 'pass.@example.com',
+        ], $this->message->getTo());
+
+        $this->message->addTo('pass..old.docomo@example.com');
+        $this->assertSame([
+            'pass.@example.com' => 'pass.@example.com',
+            'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+        ], $this->message->getTo());
+
+        $this->message->reset();
+        $emails = [
+            'pass.@example.com',
+            'pass..old.docomo@example.com',
+        ];
+        $additionalEmails = [
+            '.extend.@example.com',
+            '.docomo@example.com',
+        ];
+        $this->message->setEmailPattern($regex)->setTo($emails);
+        $this->assertSame([
+            'pass.@example.com' => 'pass.@example.com',
+            'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+        ], $this->message->getTo());
+
+        $this->message->addTo($additionalEmails);
+        $this->assertSame([
+            'pass.@example.com' => 'pass.@example.com',
+            'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+            '.extend.@example.com' => '.extend.@example.com',
+            '.docomo@example.com' => '.docomo@example.com',
+        ], $this->message->getTo());
+    }
+
+    /**
+     * Tests that it is possible to unset the email pattern and make use of filter_var() instead.
+     *
+     * @return void
+     *
+     */
+    public function testUnsetEmailPattern()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
+        $email = new Message();
+        $this->assertSame(Message::EMAIL_PATTERN, $email->getEmailPattern());
+
+        $email->setEmailPattern(null);
+        $this->assertNull($email->getEmailPattern());
+
+        $email->setTo('pass@example.com');
+        $email->setTo('fail.@example.com');
+    }
+
+    /**
+     * Tests that passing an empty string throws an InvalidArgumentException.
+     *
+     * @return void
+     *
+     */
+    public function testEmptyTo()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The email set for "to" is empty.');
+        $email = new Message();
+        $email->setTo('');
+    }
+
+    /**
+     * testFormatAddress method
+     *
+     * @return void
+     */
+    public function testFormatAddress()
+    {
+        $result = $this->message->fmtAddress(['cake@cakephp.org' => 'cake@cakephp.org']);
+        $expected = ['cake@cakephp.org'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress([
+            'cake@cakephp.org' => 'cake@cakephp.org',
+            'php@cakephp.org' => 'php@cakephp.org',
+        ]);
+        $expected = ['cake@cakephp.org', 'php@cakephp.org'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress([
+            'cake@cakephp.org' => 'CakePHP',
+            'php@cakephp.org' => 'Cake',
+        ]);
+        $expected = ['CakePHP <cake@cakephp.org>', 'Cake <php@cakephp.org>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['me@example.com' => 'Last, First']);
+        $expected = ['"Last, First" <me@example.com>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['me@example.com' => '"Last" First']);
+        $expected = ['"\"Last\" First" <me@example.com>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['me@example.com' => 'Last First']);
+        $expected = ['Last First <me@example.com>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['cake@cakephp.org' => 'ÄÖÜTest']);
+        $expected = ['=?UTF-8?B?w4TDlsOcVGVzdA==?= <cake@cakephp.org>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['cake@cakephp.org' => '日本語Test']);
+        $expected = ['=?UTF-8?B?5pel5pys6KqeVGVzdA==?= <cake@cakephp.org>'];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * testFormatAddressJapanese
+     *
+     * @return void
+     */
+    public function testFormatAddressJapanese()
+    {
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $result = $this->message->fmtAddress(['cake@cakephp.org' => '日本語Test']);
+        $expected = ['=?ISO-2022-JP?B?GyRCRnxLXDhsGyhCVGVzdA==?= <cake@cakephp.org>'];
+        $this->assertSame($expected, $result);
+
+        $result = $this->message->fmtAddress(['cake@cakephp.org' => '寿限無寿限無五劫の擦り切れ海砂利水魚の水行末雲来末風来末食う寝る処に住む処やぶら小路の藪柑子パイポパイポパイポのシューリンガンシューリンガンのグーリンダイグーリンダイのポンポコピーのポンポコナーの長久命の長助']);
+        $expected = ["=?ISO-2022-JP?B?GyRCPHc4Qkw1PHc4Qkw1OF45ZSROOyQkakBaJGwzJDo9TXg/ZTV7GyhC?=\r\n" .
+            " =?ISO-2022-JP?B?GyRCJE4/ZTlUS3YxQE1oS3ZJd01oS3Y/KSQmPzIkaz1oJEs9OyRgGyhC?=\r\n" .
+            " =?ISO-2022-JP?B?GyRCPWgkZCRWJGk+Lk8pJE5pLjQ7O1IlUSUkJV0lUSUkJV0lUSUkGyhC?=\r\n" .
+            " =?ISO-2022-JP?B?GyRCJV0kTiU3JWUhPCVqJXMlLCVzJTclZSE8JWolcyUsJXMkTiUwGyhC?=\r\n" .
+            " =?ISO-2022-JP?B?GyRCITwlaiVzJUAlJCUwITwlaiVzJUAlJCROJV0lcyVdJTMlVCE8GyhC?=\r\n" .
+            ' =?ISO-2022-JP?B?GyRCJE4lXSVzJV0lMyVKITwkTkQ5NVdMPyRORDk9dRsoQg==?= <cake@cakephp.org>'];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * testAddresses method
+     *
+     * @return void
+     */
+    public function testAddresses()
+    {
+        $this->message->reset();
+        $this->message->setFrom('cake@cakephp.org', 'CakePHP');
+        $this->message->setReplyTo('replyto@cakephp.org', 'ReplyTo CakePHP');
+        $this->message->setReadReceipt('readreceipt@cakephp.org', 'ReadReceipt CakePHP');
+        $this->message->setReturnPath('returnpath@cakephp.org', 'ReturnPath CakePHP');
+        $this->message->setTo('to@cakephp.org', 'To, CakePHP');
+        $this->message->setCc('cc@cakephp.org', 'Cc CakePHP');
+        $this->message->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
+        $this->message->addTo('to2@cakephp.org', 'To2 CakePHP');
+        $this->message->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
+        $this->message->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
+
+        $this->assertSame($this->message->getFrom(), ['cake@cakephp.org' => 'CakePHP']);
+        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP']);
+        $this->assertSame($this->message->getReadReceipt(), ['readreceipt@cakephp.org' => 'ReadReceipt CakePHP']);
+        $this->assertSame($this->message->getReturnPath(), ['returnpath@cakephp.org' => 'ReturnPath CakePHP']);
+        $this->assertSame($this->message->getTo(), ['to@cakephp.org' => 'To, CakePHP', 'to2@cakephp.org' => 'To2 CakePHP']);
+        $this->assertSame($this->message->getCc(), ['cc@cakephp.org' => 'Cc CakePHP', 'cc2@cakephp.org' => 'Cc2 CakePHP']);
+        $this->assertSame($this->message->getBcc(), ['bcc@cakephp.org' => 'Bcc CakePHP', 'bcc2@cakephp.org' => 'Bcc2 CakePHP']);
+
+        $headers = $this->message->getHeaders(array_fill_keys(['from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'], true));
+        $this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
+        $this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
+        $this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
+        $this->assertSame($headers['To'], '"To, CakePHP" <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');
+        $this->assertSame($headers['Cc'], 'Cc CakePHP <cc@cakephp.org>, Cc2 CakePHP <cc2@cakephp.org>');
+        $this->assertSame($headers['Bcc'], 'Bcc CakePHP <bcc@cakephp.org>, Bcc2 CakePHP <bcc2@cakephp.org>');
+    }
+
+    /**
+     * test reset addresses method
+     *
+     * @return void
+     */
+    public function testResetAddresses()
+    {
+        $this->message->reset();
+        $this->message
+            ->setFrom('cake@cakephp.org', 'CakePHP')
+            ->setReplyTo('replyto@cakephp.org', 'ReplyTo CakePHP')
+            ->setReadReceipt('readreceipt@cakephp.org', 'ReadReceipt CakePHP')
+            ->setReturnPath('returnpath@cakephp.org', 'ReturnPath CakePHP')
+            ->setTo('to@cakephp.org', 'To, CakePHP')
+            ->setCc('cc@cakephp.org', 'Cc CakePHP')
+            ->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
+
+        $this->assertNotEmpty($this->message->getFrom());
+        $this->assertNotEmpty($this->message->getReplyTo());
+        $this->assertNotEmpty($this->message->getReadReceipt());
+        $this->assertNotEmpty($this->message->getReturnPath());
+        $this->assertNotEmpty($this->message->getTo());
+        $this->assertNotEmpty($this->message->getCc());
+        $this->assertNotEmpty($this->message->getBcc());
+
+        $this->message
+            ->setFrom([])
+            ->setReplyTo([])
+            ->setReadReceipt([])
+            ->setReturnPath([])
+            ->setTo([])
+            ->setCc([])
+            ->setBcc([]);
+
+        $this->assertEmpty($this->message->getFrom());
+        $this->assertEmpty($this->message->getReplyTo());
+        $this->assertEmpty($this->message->getReadReceipt());
+        $this->assertEmpty($this->message->getReturnPath());
+        $this->assertEmpty($this->message->getTo());
+        $this->assertEmpty($this->message->getCc());
+        $this->assertEmpty($this->message->getBcc());
+    }
+
+    /**
+     * testMessageId method
+     *
+     * @return void
+     */
+    public function testMessageId()
+    {
+        $this->message->setMessageId(true);
+        $result = $this->message->getHeaders();
+        $this->assertArrayHasKey('Message-ID', $result);
+
+        $this->message->setMessageId(false);
+        $result = $this->message->getHeaders();
+        $this->assertArrayNotHasKey('Message-ID', $result);
+
+        $result = $this->message->setMessageId('<my-email@localhost>');
+        $this->assertSame($this->message, $result);
+        $result = $this->message->getHeaders();
+        $this->assertSame('<my-email@localhost>', $result['Message-ID']);
+
+        $result = $this->message->getMessageId();
+        $this->assertSame('<my-email@localhost>', $result);
+    }
+
+    public function testAutoMessageIdIsIdempotent()
+    {
+        $headers = $this->message->getHeaders();
+        $this->assertArrayHasKey('Message-ID', $headers);
+
+        $regeneratedHeaders = $this->message->getHeaders();
+        $this->assertSame($headers['Message-ID'], $regeneratedHeaders['Message-ID']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPriority()
+    {
+        $this->message->setPriority(4);
+
+        $this->assertSame(4, $this->message->getPriority());
+
+        $result = $this->message->getHeaders();
+        $this->assertArrayHasKey('X-Priority', $result);
+    }
+
+    /**
+     * testMessageIdInvalid method
+     *
+     * @return void
+     */
+    public function testMessageIdInvalid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->setMessageId('my-email@localhost');
+    }
+
+    /**
+     * testDomain method
+     *
+     * @return void
+     */
+    public function testDomain()
+    {
+        $result = $this->message->getDomain();
+        $expected = env('HTTP_HOST') ? env('HTTP_HOST') : php_uname('n');
+        $this->assertSame($expected, $result);
+
+        $this->message->setDomain('example.org');
+        $result = $this->message->getDomain();
+        $expected = 'example.org';
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * testMessageIdWithDomain method
+     *
+     * @return void
+     */
+    public function testMessageIdWithDomain()
+    {
+        $this->message->setDomain('example.org');
+        $result = $this->message->getHeaders();
+        $expected = '@example.org>';
+        $this->assertTextContains($expected, $result['Message-ID']);
+
+        $_SERVER['HTTP_HOST'] = 'example.org';
+        $result = $this->message->getHeaders();
+        $this->assertTextContains('example.org', $result['Message-ID']);
+
+        $_SERVER['HTTP_HOST'] = 'example.org:81';
+        $result = $this->message->getHeaders();
+        $this->assertTextNotContains(':81', $result['Message-ID']);
+    }
+
+    /**
+     * testSubject method
+     *
+     * @return void
+     */
+    public function testSubject()
+    {
+        $this->message->setSubject('You have a new message.');
+        $this->assertSame('You have a new message.', $this->message->getSubject());
+
+        $this->message->setSubject('You have a new message, I think.');
+        $this->assertSame($this->message->getSubject(), 'You have a new message, I think.');
+        $this->message->setSubject('1');
+        $this->assertSame('1', $this->message->getSubject());
+
+        $input = 'هذه رسالة بعنوان طويل مرسل للمستلم';
+        $this->message->setSubject($input);
+        $expected = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
+        $this->assertSame($expected, $this->message->getSubject());
+        $this->assertSame($input, $this->message->getOriginalSubject());
+    }
+
+    /**
+     * testSubjectJapanese
+     *
+     * @return void
+     */
+    public function testSubjectJapanese()
+    {
+        mb_internal_encoding('UTF-8');
+
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $this->message->setSubject('日本語のSubjectにも対応するよ');
+        $expected = '=?ISO-2022-JP?B?GyRCRnxLXDhsJE4bKEJTdWJqZWN0GyRCJEskYkJQMX4kOSRrJGgbKEI=?=';
+        $this->assertSame($expected, $this->message->getSubject());
+
+        $this->message->setSubject('長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？');
+        $expected = "=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n" .
+            " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n" .
+            ' =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=';
+        $this->assertSame($expected, $this->message->getSubject());
+    }
+
+    /**
+     * testAttachments method
+     *
+     * @return void
+     */
+    public function testSetAttachments()
+    {
+        $this->message->setAttachments([CAKE . 'basics.php']);
+        $expected = [
+            'basics.php' => [
+                'file' => CAKE . 'basics.php',
+                'mimetype' => 'text/x-php',
+            ],
+        ];
+        $this->assertSame($expected, $this->message->getAttachments());
+
+        $this->message->setAttachments([]);
+        $this->assertSame([], $this->message->getAttachments());
+
+        $this->message->setAttachments([
+            ['file' => CAKE . 'basics.php', 'mimetype' => 'text/plain'],
+        ]);
+        $this->message->addAttachments([CORE_PATH . 'config' . DS . 'bootstrap.php']);
+        $this->message->addAttachments([CORE_PATH . 'config' . DS . 'bootstrap.php']);
+        $this->message->addAttachments([
+            'other.txt' => CORE_PATH . 'config' . DS . 'bootstrap.php',
+            'license' => CORE_PATH . 'LICENSE',
+        ]);
+        $expected = [
+            'basics.php' => ['file' => CAKE . 'basics.php', 'mimetype' => 'text/plain'],
+            'bootstrap.php' => ['file' => CORE_PATH . 'config' . DS . 'bootstrap.php', 'mimetype' => 'text/x-php'],
+            'other.txt' => ['file' => CORE_PATH . 'config' . DS . 'bootstrap.php', 'mimetype' => 'text/x-php'],
+            'license' => ['file' => CORE_PATH . 'LICENSE', 'mimetype' => 'text/plain'],
+        ];
+        $this->assertSame($expected, $this->message->getAttachments());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->setAttachments([['nofile' => CAKE . 'basics.php', 'mimetype' => 'text/plain']]);
+    }
+
+    /**
+     * Test send() with no template and data string attachment and no mimetype
+     *
+     * @return void
+     */
+    public function testSetAttachmentDataNoMimetype()
+    {
+        $this->message->setAttachments(['cake.icon.gif' => [
+            'data' => 'test',
+        ]]);
+        $result = $this->message->getAttachments();
+        $expected = [
+            'cake.icon.gif' => [
+                'data' => base64_encode('test') . "\r\n",
+                'mimetype' => 'application/octet-stream',
+            ],
+        ];
+        $this->assertSame($expected, $this->message->getAttachments());
+    }
+
+    /**
+     * testReset method
+     *
+     * @return void
+     */
+    public function testReset()
+    {
+        $this->message->setTo('cake@cakephp.org');
+        $this->message->setEmailPattern('/.+@.+\..+/i');
+        $this->assertSame(['cake@cakephp.org' => 'cake@cakephp.org'], $this->message->getTo());
+
+        $this->message->reset();
+        $this->assertSame([], $this->message->getTo());
+        $this->assertSame(Message::EMAIL_PATTERN, $this->message->getEmailPattern());
+    }
+
+    /**
+     * testReset with charset
+     *
+     * @return void
+     */
+    public function testResetWithCharset()
+    {
+        $this->message->setCharset('ISO-2022-JP');
+        $this->message->reset();
+
+        $this->assertSame('utf-8', $this->message->getCharset());
+        $this->assertSame('utf-8', $this->message->getHeaderCharset());
+    }
+
+    /**
+     * testEmailFormat method
+     *
+     * @return void
+     */
+    public function testEmailFormat()
+    {
+        $result = $this->message->getEmailFormat();
+        $this->assertSame('text', $result);
+
+        $result = $this->message->setEmailFormat('html');
+        $this->assertInstanceOf(Message::class, $result);
+
+        $result = $this->message->getEmailFormat();
+        $this->assertSame('html', $result);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->setEmailFormat('invalid');
+    }
+
+    /**
+     * Tests that it is possible to add charset configuration to a CakeEmail object
+     *
+     * @return void
+     */
+    public function testConfigCharset()
+    {
+        $email = new Message();
+        $this->assertEquals(Configure::read('App.encoding'), $email->getCharset());
+        $this->assertEquals(Configure::read('App.encoding'), $email->getHeaderCharset());
+
+        $email = new Message(['charset' => 'iso-2022-jp', 'headerCharset' => 'iso-2022-jp-ms']);
+        $this->assertSame('iso-2022-jp', $email->getCharset());
+        $this->assertSame('iso-2022-jp-ms', $email->getHeaderCharset());
+
+        $email = new Message(['charset' => 'iso-2022-jp']);
+        $this->assertSame('iso-2022-jp', $email->getCharset());
+        $this->assertSame('iso-2022-jp', $email->getHeaderCharset());
+
+        $email = new Message(['headerCharset' => 'iso-2022-jp-ms']);
+        $this->assertEquals(Configure::read('App.encoding'), $email->getCharset());
+        $this->assertSame('iso-2022-jp-ms', $email->getHeaderCharset());
+    }
+
+    /**
+     * Tests that the body is encoded using the configured charset (Japanese standard encoding)
+     *
+     * @return void
+     */
+    public function testBodyEncodingIso2022Jp()
+    {
+        $message = new Message([
+            'charset' => 'iso-2022-jp',
+            'headerCharset' => 'iso-2022-jp',
+            'transport' => 'debug',
+        ]);
+        $message->setSubject('あれ？もしかしての前と');
+
+        $headers = $message->getHeaders(['subject']);
+        $expected = '?ISO-2022-JP?B?GyRCJCIkbCEpJGIkNyQrJDckRiROQTAkSBsoQg==?=';
+        $this->assertStringContainsString($expected, $headers['Subject']);
+
+        $message->setBodyHtml('①㈱ ってテーブルを作ってやってたらう');
+
+        $result = $message->getHeadersString();
+        $this->assertTextContains('Content-Type: text/plain; charset=ISO-2022-JP', $result);
+        $this->assertTextNotContains('Content-Type: text/plain; charset=ISO-2022-JP-MS', $result); // not charset=iso-2022-jp-ms
+
+        $result = implode('', $message->getBody());
+        $this->assertTextNotContains(mb_convert_encoding('①㈱ ってテーブルを作ってやってたらう', 'ISO-2022-JP-MS'), $result);
+    }
+
+    /**
+     * Tests that the body is encoded using the configured charset (Japanese irregular encoding, but sometime use this)
+     *
+     * @return void
+     */
+    public function testBodyEncodingIso2022JpMs()
+    {
+        $message = new Message([
+            'charset' => 'iso-2022-jp-ms',
+            'headerCharset' => 'iso-2022-jp-ms',
+            'transport' => 'debug',
+        ]);
+        $message->setSubject('あれ？もしかしての前と');
+        $headers = $message->getHeaders(['subject']);
+        $expected = '?ISO-2022-JP?B?GyRCJCIkbCEpJGIkNyQrJDckRiROQTAkSBsoQg==?=';
+        $this->assertStringContainsString($expected, $headers['Subject']);
+
+        $result = $message->setBodyText('①㈱ ってテーブルを作ってやってたらう');
+
+        $result = $message->getHeadersString();
+        $this->assertTextContains('Content-Type: text/plain; charset=ISO-2022-JP', $result);
+        $this->assertTextNotContains('Content-Type: text/plain; charset=iso-2022-jp-ms', $result); // not charset=iso-2022-jp-ms
+
+        $result = implode('', $message->getBody());
+        $this->assertStringContainsString(mb_convert_encoding('①㈱ ってテーブルを作ってやってたらう', 'ISO-2022-JP-MS'), $result);
+    }
+
+    /**
+     * Tests that the body is encoded using the configured charset
+     *
+     * @return void
+     */
+    public function testEncodingMixed()
+    {
+        $message = new Message([
+            'headerCharset' => 'iso-2022-jp-ms',
+            'charset' => 'iso-2022-jp',
+        ]);
+
+        $message->setBodyText('ってテーブルを作ってやってたらう');
+
+        $result = $message->getHeadersString();
+        $this->assertStringContainsString('Content-Type: text/plain; charset=ISO-2022-JP', $result);
+
+        $result = implode('', $message->getBody());
+        $this->assertStringContainsString(mb_convert_encoding('ってテーブルを作ってやってたらう', 'ISO-2022-JP'), $result);
+    }
+
+    /**
+     * Test CakeMessage::_encode function
+     *
+     * @return void
+     */
+    public function testEncode()
+    {
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $result = $this->message->encode('日本語');
+        $expected = '=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=';
+        $this->assertSame($expected, $result);
+
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $result = $this->message->encode('長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？');
+        $expected = "=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n" .
+            " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n" .
+            ' =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=';
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test CakeMessage::_decode function
+     *
+     * @return void
+     */
+    public function testDecode()
+    {
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $result = $this->message->decode('=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=');
+        $expected = '日本語';
+        $this->assertSame($expected, $result);
+
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $result = $this->message->decode("=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n" .
+            " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n" .
+            ' =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=');
+        $expected = '長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？';
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Tests charset setter/getter
+     *
+     * @return void
+     */
+    public function testCharset()
+    {
+        $this->message->setCharset('UTF-8');
+        $this->assertSame($this->message->getCharset(), 'UTF-8');
+
+        $this->message->setCharset('ISO-2022-JP');
+        $this->assertSame($this->message->getCharset(), 'ISO-2022-JP');
+
+        $charset = $this->message->setCharset('Shift_JIS');
+        $this->assertSame('Shift_JIS', $charset->getCharset());
+    }
+
+    /**
+     * Tests headerCharset setter/getter
+     *
+     * @return void
+     */
+    public function testHeaderCharset()
+    {
+        $this->message->setHeaderCharset('UTF-8');
+        $this->assertSame($this->message->getHeaderCharset(), 'UTF-8');
+
+        $this->message->setHeaderCharset('ISO-2022-JP');
+        $this->assertSame($this->message->getHeaderCharset(), 'ISO-2022-JP');
+
+        $charset = $this->message->setHeaderCharset('Shift_JIS');
+        $this->assertSame('Shift_JIS', $charset->getHeaderCharset());
+    }
+
+    /**
+     * Test transferEncoding
+     *
+     * @return void
+     */
+    public function testTransferEncoding()
+    {
+        // Test new transfer encoding
+        $expected = 'quoted-printable';
+        $this->message->setTransferEncoding($expected);
+        $this->assertSame($expected, $this->message->getTransferEncoding());
+        $this->assertSame($expected, $this->message->getContentTransferEncoding());
+
+        // Test default charset/encoding : utf8/8bit
+        $expected = '8bit';
+        $this->message->reset();
+        $this->assertNull($this->message->getTransferEncoding());
+        $this->assertSame($expected, $this->message->getContentTransferEncoding());
+
+        //Test wrong encoding
+        $this->expectException(\InvalidArgumentException::class);
+        $this->message->setTransferEncoding('invalid');
+    }
+
+    /**
+     * Tests for compatible check.
+     *          charset property and       charset() method.
+     *    headerCharset property and headerCharset() method.
+     *
+     * @return void
+     */
+    public function testCharsetsCompatible()
+    {
+        $checkHeaders = [
+            'from' => true,
+            'to' => true,
+            'cc' => true,
+            'subject' => true,
+        ];
+
+        // Header Charset : null (used by default UTF-8)
+        //   Body Charset : ISO-2022-JP
+        $oldStyleEmail = $this->_getEmailByOldStyleCharset('iso-2022-jp', null);
+        $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
+
+        $newStyleEmail = $this->_getEmailByNewStyleCharset('iso-2022-jp', null);
+        $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
+
+        $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
+        $this->assertSame($oldStyleHeaders['To'], $newStyleHeaders['To']);
+        $this->assertSame($oldStyleHeaders['Cc'], $newStyleHeaders['Cc']);
+        $this->assertSame($oldStyleHeaders['Subject'], $newStyleHeaders['Subject']);
+
+        // Header Charset : UTF-8
+        //   Boby Charset : ISO-2022-JP
+        $oldStyleEmail = $this->_getEmailByOldStyleCharset('iso-2022-jp', 'utf-8');
+        $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
+
+        $newStyleEmail = $this->_getEmailByNewStyleCharset('iso-2022-jp', 'utf-8');
+        $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
+
+        $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
+        $this->assertSame($oldStyleHeaders['To'], $newStyleHeaders['To']);
+        $this->assertSame($oldStyleHeaders['Cc'], $newStyleHeaders['Cc']);
+        $this->assertSame($oldStyleHeaders['Subject'], $newStyleHeaders['Subject']);
+
+        // Header Charset : ISO-2022-JP
+        //   Boby Charset : UTF-8
+        $oldStyleEmail = $this->_getEmailByOldStyleCharset('utf-8', 'iso-2022-jp');
+        $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
+
+        $newStyleEmail = $this->_getEmailByNewStyleCharset('utf-8', 'iso-2022-jp');
+        $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
+
+        $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
+        $this->assertSame($oldStyleHeaders['To'], $newStyleHeaders['To']);
+        $this->assertSame($oldStyleHeaders['Cc'], $newStyleHeaders['Cc']);
+        $this->assertSame($oldStyleHeaders['Subject'], $newStyleHeaders['Subject']);
+    }
+
+    /**
+     * @param mixed $charset
+     * @param mixed $headerCharset
+     * @return \Cake\Mailer\Message
+     */
+    protected function _getEmailByOldStyleCharset($charset, $headerCharset)
+    {
+        $message = new Message(['transport' => 'debug']);
+
+        if (!empty($charset)) {
+            $message->setCharset($charset);
+        }
+        if (!empty($headerCharset)) {
+            $message->setHeaderCharset($headerCharset);
+        }
+
+        $message->setFrom('someone@example.com', 'どこかの誰か');
+        $message->setTo('someperson@example.jp', 'どこかのどなたか');
+        $message->setCc('miku@example.net', 'ミク');
+        $message->setSubject('テストメール');
+        $message->setBodyText('テストメールの本文');
+
+        return $message;
+    }
+
+    /**
+     * @param mixed $charset
+     * @param mixed $headerCharset
+     * @return \Cake\Mailer\Message
+     */
+    protected function _getEmailByNewStyleCharset($charset, $headerCharset)
+    {
+        $message = new Message();
+
+        if (!empty($charset)) {
+            $message->setCharset($charset);
+        }
+        if (!empty($headerCharset)) {
+            $message->setHeaderCharset($headerCharset);
+        }
+
+        $message->setFrom('someone@example.com', 'どこかの誰か');
+        $message->setTo('someperson@example.jp', 'どこかのどなたか');
+        $message->setCc('miku@example.net', 'ミク');
+        $message->setSubject('テストメール');
+        $message->setBodyText('テストメールの本文');
+
+        return $message;
+    }
+
+    /**
+     * @param string $message
+     * @return void
+     */
+    protected function assertLineLengths($message)
+    {
+        $lines = explode("\r\n", $message);
+        foreach ($lines as $line) {
+            $this->assertTrue(
+                strlen($line) <= Message::LINE_LENGTH_MUST,
+                'Line length exceeds the max. limit of Message::LINE_LENGTH_MUST'
+            );
+        }
     }
 }

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -16,7 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Mailer\Email;
+use Cake\Mailer\Mailer;
+use Cake\Mailer\Message;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\EmailTrait;
 use Cake\TestSuite\TestCase;
@@ -39,14 +40,14 @@ class EmailTraitTest extends TestCase
     {
         parent::setUp();
 
-        Email::drop('default');
-        Email::drop('alternate');
+        Mailer::drop('default');
+        Mailer::drop('alternate');
 
-        Email::setConfig('default', [
+        Mailer::setConfig('default', [
             'transport' => 'test_tools',
             'from' => 'default@example.com',
         ]);
-        Email::setConfig('alternate', [
+        Mailer::setConfig('alternate', [
             'transport' => 'test_tools',
             'from' => 'alternate@example.com',
         ]);
@@ -64,8 +65,8 @@ class EmailTraitTest extends TestCase
     {
         parent::tearDown();
 
-        Email::drop('default');
-        Email::drop('alternate');
+        Mailer::drop('default');
+        Mailer::drop('alternate');
         TransportFactory::drop('test_tools');
     }
 
@@ -171,10 +172,10 @@ class EmailTraitTest extends TestCase
      */
     public function testAssertUsingRegExpCharacters()
     {
-        (new Email())
+        (new Mailer())
             ->setTo('to3@example.com')
             ->setCc('cc3@example.com')
-            ->send('email with regexp chars $/[]');
+            ->deliver('email with regexp chars $/[]');
 
         $this->assertMailContains('$/[]');
     }
@@ -227,20 +228,20 @@ class EmailTraitTest extends TestCase
      */
     private function sendEmails()
     {
-        (new Email())
+        (new Mailer())
             ->setTo(['to@example.com' => 'Foo Bar'])
             ->addTo('alsoto@example.com')
             ->setCc('cc@example.com')
             ->setBcc(['bcc@example.com' => 'Baz Qux'])
             ->setSubject('Hello world')
             ->setAttachments(['custom_name.php' => CAKE . 'basics.php'])
-            ->setEmailFormat(Email::MESSAGE_TEXT)
-            ->send('text');
+            ->setEmailFormat(Message::MESSAGE_TEXT)
+            ->deliver('text');
 
-        (new Email('alternate'))
+        (new Mailer('alternate'))
             ->setTo('to2@example.com')
             ->setCc('cc2@example.com')
-            ->setEmailFormat(Email::MESSAGE_HTML)
-            ->send('html');
+            ->setEmailFormat(Message::MESSAGE_HTML)
+            ->deliver('html');
     }
 }

--- a/tests/test_app/TestApp/Mailer/TestMailer.php
+++ b/tests/test_app/TestApp/Mailer/TestMailer.php
@@ -23,15 +23,4 @@ use Cake\Mailer\Mailer;
  */
 class TestMailer extends Mailer
 {
-    public function getEmailForAssertion()
-    {
-        return $this->_email;
-    }
-
-    protected function reset(): Mailer
-    {
-        $this->template = $this->viewBuilder()->getTemplate();
-
-        return parent::reset();
-    }
 }

--- a/tests/test_app/TestApp/Mailer/TestMailer.php
+++ b/tests/test_app/TestApp/Mailer/TestMailer.php
@@ -23,4 +23,23 @@ use Cake\Mailer\Mailer;
  */
 class TestMailer extends Mailer
 {
+    protected $messageClass = TestMessage::class;
+
+    public $boundary = null;
+
+    public function deliver(string $content = '')
+    {
+        $result = parent::deliver($content);
+        $this->boundary = $this->message->getBoundary();
+
+        return $result;
+    }
+
+    public function send(?string $action = null, array $args = [], array $headers = []): array
+    {
+        $result = parent::send($action, $args, $headers);
+        $this->boundary = $this->message->getBoundary();
+
+        return $result;
+    }
 }


### PR DESCRIPTION
Refs #13535

### Notable change to `Mailer`:

- It's constructor now takes config array / profile name instead of email instance as argument.
- It's no longer abstract and one can use the new `deliver()` method (non-static unlike `Email::deliver()`) to send email without using a mailer action.

### Todo:
Reverting back would have been more work and would lose the typehinting so I didn't.
- [x] `Email::setConfig()`/`getConfig()` need to be overridden to call `Mailer::setConfig()`/`getConfig()` internally.
- [x] Remove `Mailer::getName()`. I don't think it serves any purpose. `MailerAwareTrait` uses `App::className()` to extrapolate short name to FQCN.
- [x] ~~Since `Email` is deprecated I think it would be best to revert all it's internal changes and make it same as in 3.x.~~ 
This would have been an unnecessary chore and would have to redo all the typehinting work.
- [x] ~~Make `Mailer` implement `JsonSerializable`, `Serializable`. Do people use this feature?~~
Given that the `Message` class and `Renderer`'s `ViewBuilder` are serializable making `Mailer` serializable is not necessary. Earlier when `Email` was made serializable it was a "god" class.
