### PR TITLE
Empty post body for json will put null value in request->data

### DIFF
--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -220,7 +220,7 @@ class RequestHandlerComponent extends Component {
 
 		foreach ($this->_inputTypeMap as $type => $handler) {
 			if ($this->requestedWith($type)) {
-				$input = call_user_func_array(array($controller->request, 'input'), $handler);
+				$input = (array)call_user_func_array(array($controller->request, 'input'), $handler);
 				$controller->request->data = $input;
 			}
 		}

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -400,6 +400,20 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	}
 
 /**
+ * testStartupCallbackJson method
+ *
+ * @return void
+ */
+	public function testStartupCallbackJson() {
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+		$this->Controller->request = $this->getMock('CakeRequest', array('_readInput'));
+		$this->RequestHandler->startup($this->Controller);
+		$this->assertTrue(is_array($this->Controller->data));
+		$this->assertFalse(is_object($this->Controller->data));
+	}
+
+/**
  * testStartupCallback with charset.
  *
  * @return void


### PR DESCRIPTION
Empty post body for json will put null value in request->data

This will cause the following error when using : request->data('test')

Error: [TypeError] Argument 1 passed to Hash::get() must be of the type array, null given, called in /lib/Cake/Network/CakeRequest.php on line 976
