### PR TITLE
Add deprecation warning for Form::_buildValidator

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -98,6 +98,14 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
         }
 
         $this->getEventManager()->on($this);
+
+        if (method_exists($this, '_buildValidator')) {
+            deprecationWarning(
+                static::class . ' implements `_buildValidator` which is no longer used. ' .
+                'You should implement `buildValidator(Validator $validator, string $name): void` ' .
+                'or `validationDefault(Validator $validator): Validator` instead.'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This method was used in 3.x but is no longer supported. Emit a deprecation warning instead of silently failing.

Fixes cakephp/docs#6075