### PR TITLE
Move serialization/unserialization code in helper methods.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -18,16 +18,6 @@
       <code>close</code>
     </PossiblyNullReference>
   </file>
-  <file src="src/Cache/Engine/RedisEngine.php">
-    <InvalidArgument occurrences="1">
-      <code>$value</code>
-    </InvalidArgument>
-    <PossiblyInvalidArgument occurrences="3">
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </PossiblyInvalidArgument>
-  </file>
   <file src="src/Cache/Engine/WincacheEngine.php">
     <NullArgument occurrences="1">
       <code>$success</code>

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -315,7 +315,7 @@ class RedisEngine extends CacheEngine
      *
      * @param mixed $value Value to serialize.
      * @return string
-     * @https://github.com/phpredis/phpredis/issues/81
+     * @link https://github.com/phpredis/phpredis/issues/81
      */
     protected function serialize($value): string
     {

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -140,10 +140,7 @@ class RedisEngine extends CacheEngine
     public function set($key, $value, $ttl = null): bool
     {
         $key = $this->_key($key);
-
-        if (!is_int($value)) {
-            $value = serialize($value);
-        }
+        $value = $this->serialize($value);
 
         $duration = $this->duration($ttl);
         if ($duration === 0) {
@@ -167,11 +164,8 @@ class RedisEngine extends CacheEngine
         if ($value === false) {
             return $default;
         }
-        if (preg_match('/^[-]?\d+$/', $value)) {
-            return (int)$value;
-        }
 
-        return unserialize($value);
+        return $this->unserialize($value);
     }
 
     /**
@@ -269,10 +263,7 @@ class RedisEngine extends CacheEngine
     {
         $duration = $this->_config['duration'];
         $key = $this->_key($key);
-
-        if (!is_int($value)) {
-            $value = serialize($value);
-        }
+        $value = $this->serialize($value);
 
         // setNx() doesn't have an expiry option, so follow up with an expiry
         if ($this->_Redis->setNx($key, $value)) {
@@ -295,7 +286,7 @@ class RedisEngine extends CacheEngine
         foreach ($this->_config['groups'] as $group) {
             $value = $this->_Redis->get($this->_config['prefix'] . $group);
             if (!$value) {
-                $value = 1;
+                $value = $this->serialize(1);
                 $this->_Redis->set($this->_config['prefix'] . $group, $value);
             }
             $result[] = $group . $value;
@@ -314,6 +305,40 @@ class RedisEngine extends CacheEngine
     public function clearGroup(string $group): bool
     {
         return (bool)$this->_Redis->incr($this->_config['prefix'] . $group);
+    }
+
+    /**
+     * Serialize value for saving to Redis.
+     *
+     * This is needed instead of using Redis' in built serialization feature
+     * as it creates problems incrementing/decrementing intially set integer value.
+     *
+     * @param mixed $value Value to serialize.
+     * @return string
+     * @https://github.com/phpredis/phpredis/issues/81
+     */
+    protected function serialize($value): string
+    {
+        if (is_int($value)) {
+            return (string)$value;
+        }
+
+        return serialize($value);
+    }
+
+    /**
+     * Unserialize string value fetched from Redis.
+     *
+     * @param string $value Value to unserialize.
+     * @return mixed
+     */
+    protected function unserialize(string $value)
+    {
+        if (preg_match('/^[-]?\d+$/', $value)) {
+            return (int)$value;
+        }
+
+        return unserialize($value);
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -400,13 +400,13 @@ class RedisEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::read('test_increment', 'redis');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $result = Cache::increment('test_increment', 2, 'redis');
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
 
         $result = Cache::read('test_increment', 'redis');
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -389,6 +389,27 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * testIncrementAfterWrite method
+     *
+     * @return void
+     */
+    public function testIncrementAfterWrite()
+    {
+        Cache::delete('test_increment', 'redis');
+        $result = Cache::write('test_increment', 1, 'redis');
+        $this->assertTrue($result);
+
+        $result = Cache::read('test_increment', 'redis');
+        $this->assertEquals(1, $result);
+
+        $result = Cache::increment('test_increment', 2, 'redis');
+        $this->assertEquals(3, $result);
+
+        $result = Cache::read('test_increment', 'redis');
+        $this->assertEquals(3, $result);
+    }
+
+    /**
      * Test that increment() and decrement() can live forever.
      *
      * @return void


### PR DESCRIPTION
Besides making code cleaner this allows overriding the serialized
format to non PHP specific formats like JSON.