### PR TITLE
Add initial support for file upload objects in the request data.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -446,7 +446,9 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      */
     protected function _processFiles($post, $files)
     {
-        if (!is_array($files)) {
+        if (empty($files) ||
+            !is_array($files)
+        ) {
             return $post;
         }
         $fileData = [];

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -244,6 +244,13 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     ];
 
     /**
+     * Whether to merge file uploads as objects (`true`) or arrays (`false`).
+     *
+     * @var bool
+     */
+    private $mergeFilesAsObjects = false;
+
+    /**
      * Wrapper method to create a new request from PHP superglobals.
      *
      * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
@@ -302,6 +309,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
             'base' => '',
             'webroot' => '',
             'input' => null,
+            'mergeFilesAsObjects' => false,
         ];
 
         $this->_setConfig($config);
@@ -363,6 +371,8 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
             $stream = new PhpInputStream();
         }
         $this->stream = $stream;
+
+        $this->mergeFilesAsObjects = $config['mergeFilesAsObjects'];
 
         $config['post'] = $this->_processPost($config['post']);
         $this->data = $this->_processFiles($config['post'], $config['files']);
@@ -457,6 +467,10 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
             ));
         }
         $this->uploadedFiles = $fileData;
+
+        if ($this->mergeFilesAsObjects) {
+            return Hash::merge($post, $fileData);
+        }
 
         // Make a flat map that can be inserted into $post for BC.
         $fileMap = Hash::flatten($fileData);

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -288,6 +288,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * - `input` The data that would come from php://input this is useful for simulating
      *   requests with put, patch or delete data.
      * - `session` An instance of a Session object
+     * - `mergeFilesAsObjects` Whether to merge file uploads as objects (`true`) or arrays (`false`).
      *
      * @param string|array $config An array of request data to create a request with.
      *   The string version of this argument is *deprecated* and will be removed in 4.0.0

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -54,7 +54,7 @@ abstract class ServerRequestFactory extends BaseFactory
             'webroot' => $uri->webroot,
             'base' => $uri->base,
             'session' => $session,
-            'mergeFilesAsObjects' => Configure::read('App.uploadedFilesAsObjects'),
+            'mergeFilesAsObjects' => Configure::read('App.uploadedFilesAsObjects', false),
         ]);
 
         return $request;

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -54,7 +54,7 @@ abstract class ServerRequestFactory extends BaseFactory
             'webroot' => $uri->webroot,
             'base' => $uri->base,
             'session' => $session,
-            'mergeFilesAsObjects' => Configure::read('ServerRequest.mergeFilesAsObjects'),
+            'mergeFilesAsObjects' => Configure::read('App.uploadedFilesAsObjects'),
         ]);
 
         return $request;

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -54,6 +54,7 @@ abstract class ServerRequestFactory extends BaseFactory
             'webroot' => $uri->webroot,
             'base' => $uri->base,
             'session' => $session,
+            'mergeFilesAsObjects' => Configure::read('ServerRequest.mergeFilesAsObjects'),
         ]);
 
         return $request;

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -289,7 +289,7 @@ class ServerRequestFactoryTest extends TestCase
      */
     public function testFromGlobalsWithFilesAsObjectsDefault()
     {
-        $this->assertNull(Configure::read('ServerRequest.mergeFilesAsObjects'));
+        $this->assertNull(Configure::read('App.uploadedFilesAsObjects'));
 
         $files = [
             'file' => [
@@ -321,7 +321,7 @@ class ServerRequestFactoryTest extends TestCase
      */
     public function testFromGlobalsWithFilesAsObjectsDisabled()
     {
-        Configure::write('ServerRequest.mergeFilesAsObjects', false);
+        Configure::write('App.uploadedFilesAsObjects', false);
 
         $files = [
             'file' => [
@@ -353,7 +353,7 @@ class ServerRequestFactoryTest extends TestCase
      */
     public function testFromGlobalsWithFilesAsObjectsEnabled()
     {
-        Configure::write('ServerRequest.mergeFilesAsObjects', true);
+        Configure::write('App.uploadedFilesAsObjects', true);
 
         $files = [
             'file' => [

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -18,6 +18,7 @@ use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
+use Zend\Diactoros\UploadedFile;
 
 /**
  * Test case for the server factory.
@@ -279,5 +280,101 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertEquals('/webroot/', $res->getAttribute('webroot'));
         $this->assertEquals('/index.php', $res->getAttribute('base'));
         $this->assertEquals('/posts/add', $res->getUri()->getPath());
+    }
+
+    /**
+     * Tests the default file upload merging behavior.
+     *
+     * @return void
+     */
+    public function testFromGlobalsWithFilesAsObjectsDefault()
+    {
+        $this->assertNull(Configure::read('ServerRequest.mergeFilesAsObjects'));
+
+        $files = [
+            'file' => [
+                'name' => 'file.txt',
+                'type' => 'text/plain',
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'size' => 1234,
+            ],
+        ];
+        $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
+
+        $expected = [
+            'file' => [
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'name' => 'file.txt',
+                'type' => 'text/plain',
+                'size' => 1234
+            ],
+        ];
+        $this->assertEquals($expected, $request->getData());
+    }
+
+    /**
+     * Tests the "as arrays" file upload merging behavior.
+     *
+     * @return void
+     */
+    public function testFromGlobalsWithFilesAsObjectsDisabled()
+    {
+        Configure::write('ServerRequest.mergeFilesAsObjects', false);
+
+        $files = [
+            'file' => [
+                'name' => 'file.txt',
+                'type' => 'text/plain',
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'size' => 1234,
+            ],
+        ];
+        $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
+
+        $expected = [
+            'file' => [
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'name' => 'file.txt',
+                'type' => 'text/plain',
+                'size' => 1234
+            ],
+        ];
+        $this->assertEquals($expected, $request->getData());
+    }
+
+    /**
+     * Tests the "as objects" file upload merging behavior.
+     *
+     * @return void
+     */
+    public function testFromGlobalsWithFilesAsObjectsEnabled()
+    {
+        Configure::write('ServerRequest.mergeFilesAsObjects', true);
+
+        $files = [
+            'file' => [
+                'name' => 'file.txt',
+                'type' => 'text/plain',
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'size' => 1234,
+            ],
+        ];
+        $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
+
+        $expected = [
+            'file' => new UploadedFile(
+                __FILE__,
+                1234,
+                0,
+                'file.txt',
+                'text/plain'
+            ),
+        ];
+        $this->assertEquals($expected, $request->getData());
     }
 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -589,6 +589,154 @@ class ServerRequestTest extends TestCase
     }
 
     /**
+     * Tests that file uploads are merged into the post data as objects instead of as arrays.
+     *
+     * @return void
+     */
+    public function testFilesAsObjectsInRequestData()
+    {
+        $files = [
+            'flat' => [
+                'name' => 'flat.txt',
+                'type' => 'text/plain',
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'size' => 1,
+            ],
+            'nested' => [
+                'name' => ['file' => 'nested.txt'],
+                'type' => ['file' => 'text/plain'],
+                'tmp_name' => ['file' => __FILE__],
+                'error' => ['file' => 0],
+                'size' => ['file' => 12],
+            ],
+            0 => [
+                'name' => 'numeric.txt',
+                'type' => 'text/plain',
+                'tmp_name' => __FILE__,
+                'error' => 0,
+                'size' => 123,
+            ],
+            1 => [
+                'name' => ['file' => 'numeric-nested.txt'],
+                'type' => ['file' => 'text/plain'],
+                'tmp_name' => ['file' => __FILE__],
+                'error' => ['file' => 0],
+                'size' => ['file' => 1234],
+            ],
+            'deep' => [
+                'name' => [
+                    0 => ['file' => 'deep-1.txt'],
+                    1 => ['file' => 'deep-2.txt'],
+                ],
+                'type' => [
+                    0 => ['file' => 'text/plain'],
+                    1 => ['file' => 'text/plain'],
+                ],
+                'tmp_name' => [
+                    0 => ['file' => __FILE__],
+                    1 => ['file' => __FILE__],
+                ],
+                'error' => [
+                    0 => ['file' => 0],
+                    1 => ['file' => 0],
+                ],
+                'size' => [
+                    0 => ['file' => 12345],
+                    1 => ['file' => 123456],
+                ],
+            ],
+        ];
+
+        $post = [
+            'flat' => ['existing'],
+            'nested' => [
+                'name' => 'nested',
+                'file' => ['existing']
+            ],
+            'deep' => [
+                0 => [
+                    'name' => 'deep 1',
+                    'file' => ['existing']
+                ],
+                1 => [
+                    'name' => 'deep 2',
+                ],
+            ],
+            1 => [
+                'name' => 'numeric nested',
+            ],
+        ];
+
+        $expected = [
+            'flat' => new UploadedFile(
+                __FILE__,
+                1,
+                0,
+                'flat.txt',
+                'text/plain'
+            ),
+            'nested' => [
+                'name' => 'nested',
+                'file' => new UploadedFile(
+                    __FILE__,
+                    12,
+                    0,
+                    'nested.txt',
+                    'text/plain'
+                )
+            ],
+            'deep' => [
+                0 => [
+                    'name' => 'deep 1',
+                    'file' => new UploadedFile(
+                        __FILE__,
+                        12345,
+                        0,
+                        'deep-1.txt',
+                        'text/plain'
+                    )
+                ],
+                1 => [
+                    'name' => 'deep 2',
+                    'file' => new UploadedFile(
+                        __FILE__,
+                        123456,
+                        0,
+                        'deep-2.txt',
+                        'text/plain'
+                    )
+                ],
+            ],
+            0 => new UploadedFile(
+                __FILE__,
+                123,
+                0,
+                'numeric.txt',
+                'text/plain'
+            ),
+            1 => [
+                'name' => 'numeric nested',
+                'file' => new UploadedFile(
+                    __FILE__,
+                    1234,
+                    0,
+                    'numeric-nested.txt',
+                    'text/plain'
+                )
+            ],
+        ];
+
+        $request = new ServerRequest([
+            'files' => $files,
+            'post' => $post,
+            'mergeFilesAsObjects' => true
+        ]);
+
+        $this->assertEquals($expected, $request->getData());
+    }
+
+    /**
      * Test replacing files.
      *
      * @return void

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -589,6 +589,57 @@ class ServerRequestTest extends TestCase
     }
 
     /**
+     * Test passing an invalid data type for the files list.
+     *
+     * @return void
+     */
+    public function testFilesWithInvalidDataType()
+    {
+        $request = new ServerRequest([
+            'files' => 'invalid',
+        ]);
+
+        $this->assertEmpty($request->getData());
+        $this->assertEmpty($request->getUploadedFiles());
+    }
+
+    /**
+     * Test passing an empty files list.
+     *
+     * @return void
+     */
+    public function testFilesWithEmptyList()
+    {
+        $request = new ServerRequest([
+            'files' => [],
+        ]);
+
+        $this->assertEmpty($request->getData());
+        $this->assertEmpty($request->getUploadedFiles());
+    }
+
+    /**
+     * Test passing invalid files list structure.
+     *
+     * @return void
+     */
+    public function testFilesWithInvalidStructure()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value in FILES "{"invalid":["data"]}"');
+
+        new ServerRequest([
+            'files' => [
+                [
+                    'invalid' => [
+                        'data'
+                    ]
+                ]
+            ],
+        ]);
+    }
+
+    /**
      * Tests that file uploads are merged into the post data as objects instead of as arrays.
      *
      * @return void


### PR DESCRIPTION
Uses an opt-in configuration approach in order to keep things backwards compatible.

I couldn't really decide with what names I should go. I've opted for the property "workaround" because changing the signature of `_processFiles()` wouldn't be backwards compatible, and removing the private property later on won't have any side effects on userland code.

refs #13554