### PR TITLE
Make Controller _viewPath() method public

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -804,7 +804,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @return string
      */
-    protected function _viewPath()
+    public function _viewPath()
     {
         $viewPath = $this->name;
         if ($this->request->getParam('prefix')) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -772,7 +772,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $builder = $this->viewBuilder();
         if (!$builder->getTemplatePath()) {
-            $builder->setTemplatePath($this->_viewPath());
+            $builder->setTemplatePath($this->viewPath());
         }
 
         if ($this->request->getParam('bare')) {
@@ -804,7 +804,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @return string
      */
-    public function _viewPath()
+    public function viewPath()
     {
         $viewPath = $this->name;
         if ($this->request->getParam('prefix')) {


### PR DESCRIPTION
This method can be useful when building components that use view builder.

```
        $this->getController()->disableAutoRender();
        $this->getController()->viewBuilder()->setTemplatePath($this->getController()->_viewPath());
        $this->getController()->viewBuilder()->setTemplate($this->request->getParam('action'));
        $build = $this->getController()->createView();
        $html = $build->render();
```