### PR TITLE
Clear uncleared property in TableLocator::clear method

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -318,6 +318,7 @@ class TableLocator implements LocatorInterface
         $this->_instances = [];
         $this->_config = [];
         $this->_fallbacked = [];
+        $this->_options = [];
     }
 
     /**


### PR DESCRIPTION
As `$this->_config` is reset then it makes sense to reset `$this->_options` too.