### PR TITLE
Fix memory leak in unit tests - improve clean up in tearDown method

### DIFF
--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -70,7 +70,7 @@ trait LocatorAwareTrait
      */
     public function getTableLocator()
     {
-        if (!$this->_tableLocator) {
+        if (!isset($this->_tableLocator)) {
             $this->_tableLocator = TableRegistry::getTableLocator();
         }
 

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -70,7 +70,7 @@ trait LocatorAwareTrait
      */
     public function getTableLocator()
     {
-        if (!isset($this->_tableLocator)) {
+        if ($this->_tableLocator === null) {
             $this->_tableLocator = TableRegistry::getTableLocator();
         }
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -161,6 +161,7 @@ abstract class TestCase extends BaseTestCase
             Configure::write($this->_configure);
         }
         $this->getTableLocator()->clear();
+        unset($this->_configure, $this->_pathRestore, $this->_tableLocator);
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -161,7 +161,8 @@ abstract class TestCase extends BaseTestCase
             Configure::write($this->_configure);
         }
         $this->getTableLocator()->clear();
-        unset($this->_configure, $this->_pathRestore, $this->_tableLocator);
+        $this->_configure = $this->_pathRestore = [];
+        $this->_tableLocator = null;
     }
 
     /**


### PR DESCRIPTION
There is a similar clean up in 2.x - https://github.com/cakephp/cakephp/blob/2.x/lib/Cake/TestSuite/CakeTestCase.php#L168