### PR TITLE
WIP - PHP 7.4

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -239,7 +239,7 @@ class ConsoleOutput
             }
         }
 
-        return "\033[" . implode($styleInfo, ';') . 'm' . $matches['text'] . "\033[0m";
+        return "\033[" . implode(';', $styleInfo) . 'm' . $matches['text'] . "\033[0m";
     }
 
     /**

--- a/src/Shell/CompletionShell.php
+++ b/src/Shell/CompletionShell.php
@@ -168,7 +168,7 @@ class CompletionShell extends Shell
     protected function _output($options = [])
     {
         if ($options) {
-            return $this->out(implode($options, ' '));
+            return $this->out(implode(' ', $options));
         }
     }
 }

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -50,8 +50,8 @@ trait SecureFieldTokenTrait
         ksort($locked, SORT_STRING);
         $fields += $locked;
 
-        $locked = implode(array_keys($locked), '|');
-        $unlocked = implode($unlockedFields, '|');
+        $locked = implode('|', array_keys($locked));
+        $unlocked = implode('|', $unlockedFields);
         $hashParts = [
             $url,
             serialize($fields),

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1636,14 +1636,14 @@ class ViewTest extends TestCase
     /**
      * Test setting a block's content to an object without __toString magic method
      *
-     * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
      * @return void
      */
     public function testBlockSetObjectWithoutToString()
     {
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->checkException(
+            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+        );
+
         $objectWithToString = new TestObjectWithoutToString();
         $this->View->assign('testWithObjectWithoutToString', $objectWithToString);
     }
@@ -1693,14 +1693,14 @@ class ViewTest extends TestCase
     /**
      * Test appending an object without __toString magic method to a block with append.
      *
-     * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error     Exception by PHPUnit.
-     *
      * @return void
      */
     public function testBlockAppendObjectWithoutToString()
     {
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->checkException(
+            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+        );
+
         $object = new TestObjectWithoutToString();
         $this->View->assign('testBlock', 'Block ');
         $this->View->append('testBlock', $object);
@@ -1726,14 +1726,14 @@ class ViewTest extends TestCase
     /**
      * Test prepending an object without __toString magic method to a block with prepend.
      *
-     * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
      * @return void
      */
     public function testBlockPrependObjectWithoutToString()
     {
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->checkException(
+            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+        );
+
         $object = new TestObjectWithoutToString();
         $this->View->assign('test', 'Block ');
         $this->View->prepend('test', $object);
@@ -2197,5 +2197,15 @@ TEXT;
             $this->assertEquals('mypath', $View->templatePath());
             $this->assertEquals('mypath', $View->templatePath);
         });
+    }
+
+    protected function checkException($message)
+    {
+        if (version_compare(PHP_VERSION, '7.4', '>=')) {
+            $this->expectException(\Error::class);
+        } else {
+            $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        }
+        $this->expectExceptionMessage($message);
     }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1641,7 +1641,7 @@ class ViewTest extends TestCase
     public function testBlockSetObjectWithoutToString()
     {
         $this->checkException(
-            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
         );
 
         $objectWithToString = new TestObjectWithoutToString();
@@ -1698,7 +1698,7 @@ class ViewTest extends TestCase
     public function testBlockAppendObjectWithoutToString()
     {
         $this->checkException(
-            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
         );
 
         $object = new TestObjectWithoutToString();
@@ -1731,7 +1731,7 @@ class ViewTest extends TestCase
     public function testBlockPrependObjectWithoutToString()
     {
         $this->checkException(
-            'Object of class Cake\Test\TestCase\View\TestObjectWithoutToString could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
         );
 
         $object = new TestObjectWithoutToString();


### PR DESCRIPTION
We need to figure out how to deal with the `Function ReflectionType::__toString() is deprecated` error generated in phpunit's mock generator class. I tried using `syfony/phpunit-bridge` but [didn't work](https://travis-ci.org/ADmad/cakephp/jobs/577837769).