### PR TITLE
Throw exception from Event::getSubject() when subject is null.

### DIFF
--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event\Decorator;
 
+use Cake\Core\Exception\Exception;
 use Cake\Event\EventInterface;
 use RuntimeException;
 
@@ -58,8 +59,9 @@ class SubjectFilterDecorator extends AbstractDecorator
             $this->_options['allowedSubject'] = [$this->_options['allowedSubject']];
         }
 
-        $subject = $event->getSubject();
-        if ($subject === null) {
+        try {
+            $subject = $event->getSubject();
+        } catch (Exception $e) {
             return false;
         }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -16,8 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use Cake\Core\Exception\Exception;
+
 /**
  * Class Event
+ *
+ * @template TSubject
  */
 class Event implements EventInterface
 {
@@ -32,6 +36,7 @@ class Event implements EventInterface
      * The object this event applies to (usually the same object that generates the event)
      *
      * @var object|null
+     * @psalm-var TSubject|null
      */
     protected $_subject;
 
@@ -73,6 +78,7 @@ class Event implements EventInterface
      *   (usually the object that is generating the event).
      * @param array|\ArrayAccess|null $data any value you wish to be transported
      *   with this event to it can be read by listeners.
+     * @psalm-param TSubject|null $subject
      */
     public function __construct(string $name, $subject = null, $data = null)
     {
@@ -94,10 +100,16 @@ class Event implements EventInterface
     /**
      * Returns the subject of this event
      *
-     * @return object|null
+     * @return object
+     * @psalm-return TSubject
+     * @psalm-suppress LessSpecificImplementedReturnType
      */
     public function getSubject()
     {
+        if ($this->_subject === null) {
+            throw new Exception('No subject set for this event');
+        }
+
         return $this->_subject;
     }
 

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -33,7 +33,7 @@ interface EventInterface
     /**
      * Returns the subject of this event.
      *
-     * @return object|null
+     * @return object
      */
     public function getSubject();
 

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -471,9 +471,12 @@ class EventManager implements EventManagerInterface
             $count = count($this->_eventList);
             for ($i = 0; $i < $count; $i++) {
                 $event = $this->_eventList[$i];
-                $subject = $event->getSubject();
-                $properties['_dispatchedEvents'][] = $event->getName() . ' with ' .
-                    (is_object($subject) ? 'subject ' . get_class($subject) : 'no subject');
+                try {
+                    $subject = $event->getSubject();
+                    $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . get_class($subject);
+                } catch (Exception $e) {
+                    $properties['_dispatchedEvents'][] = $event->getName() . ' with no subject';
+                }
             }
         } else {
             $properties['_dispatchedEvents'] = null;

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Event;
 
 use ArrayObject;
+use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
 
@@ -52,6 +53,9 @@ class EventTest extends TestCase
     {
         $event = new Event('fake.event', $this);
         $this->assertSame($this, $event->getSubject());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No subject set for this event');
 
         $event = new Event('fake.event');
         $this->assertNull($event->getSubject());


### PR DESCRIPTION
This avoids static analyzers from complaining about possibly null value when using return value of the method.