### PR TITLE
Fix exception to be valid error default code 1 instead of 244.

### DIFF
--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Console\Exception;
 
+use Cake\Console\Command;
 use Cake\Core\Exception\Exception;
 
 /**
@@ -20,7 +21,14 @@ use Cake\Core\Exception\Exception;
  *
  * @see \Cake\Console\Shell::_stop()
  * @see \Cake\Console\Shell::error()
+ * @see \Cake\Console\Command::abort()
  */
 class StopException extends Exception
 {
+    /**
+     * Default exception code
+     *
+     * @var int
+     */
+    protected $_defaultCode = Command::CODE_ERROR;
 }


### PR DESCRIPTION
First part of https://github.com/cakephp/cakephp/issues/13577
```php
$io->error('Project path not found: ' . $args->getArgumentAt(0));
throw new StopException();
```
`echo $?` shows 244 as code instead of default 1 as per CLI standards.