### PR TITLE
Fix exception to be valid error default code 1 instead of 244 - Alternative

### DIFF
--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Console\Exception;
 
+use Cake\Console\Command;
 use Cake\Core\Exception\Exception;
 
 /**
@@ -21,4 +22,10 @@ use Cake\Core\Exception\Exception;
  */
 class ConsoleException extends Exception
 {
+    /**
+     * Default exception code
+     *
+     * @var int
+     */
+    protected $_defaultCode = Command::CODE_ERROR;
 }

--- a/src/Console/Exception/MissingHelperException.php
+++ b/src/Console/Exception/MissingHelperException.php
@@ -12,13 +12,10 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Core\Exception\Exception;
-
 /**
  * Used when a Helper cannot be found.
  */
-class MissingHelperException extends Exception
+class MissingHelperException extends ConsoleException
 {
-
     protected $_messageTemplate = 'Helper class %s could not be found.';
 }

--- a/src/Console/Exception/MissingShellException.php
+++ b/src/Console/Exception/MissingShellException.php
@@ -12,12 +12,10 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Core\Exception\Exception;
-
 /**
  * Used when a shell cannot be found.
  */
-class MissingShellException extends Exception
+class MissingShellException extends ConsoleException
 {
 
     protected $_messageTemplate = 'Shell class for "%s" could not be found. If you are trying to use a plugin shell, that was loaded via $this->addPlugin(), you may need to update bin/cake.php to match https://github.com/cakephp/app/tree/master/bin/cake.php';

--- a/src/Console/Exception/MissingShellMethodException.php
+++ b/src/Console/Exception/MissingShellMethodException.php
@@ -12,12 +12,10 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Core\Exception\Exception;
-
 /**
  * Used when a shell method cannot be found.
  */
-class MissingShellMethodException extends Exception
+class MissingShellMethodException extends ConsoleException
 {
 
     protected $_messageTemplate = "Unknown command %1\$s %2\$s.\nFor usage try `cake %1\$s --help`";

--- a/src/Console/Exception/MissingTaskException.php
+++ b/src/Console/Exception/MissingTaskException.php
@@ -12,13 +12,10 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Core\Exception\Exception;
-
 /**
  * Used when a Task cannot be found.
  */
-class MissingTaskException extends Exception
+class MissingTaskException extends ConsoleException
 {
-
     protected $_messageTemplate = 'Task class %s could not be found.';
 }

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -13,8 +13,6 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Core\Exception\Exception;
-
 /**
  * Exception class for halting errors in console tasks
  *
@@ -22,6 +20,6 @@ use Cake\Core\Exception\Exception;
  * @see \Cake\Console\Shell::error()
  * @see \Cake\Console\Command::abort()
  */
-class StopException extends Exception
+class StopException extends ConsoleException
 {
 }

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Console\Exception;
 
-use Cake\Console\Command;
 use Cake\Core\Exception\Exception;
 
 /**
@@ -25,10 +24,4 @@ use Cake\Core\Exception\Exception;
  */
 class StopException extends Exception
 {
-    /**
-     * Default exception code
-     *
-     * @var int
-     */
-    protected $_defaultCode = Command::CODE_ERROR;
 }

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Console\Exception;
 
+use Cake\Console\Command;
 use Cake\Core\Exception\Exception;
 
 /**
@@ -20,7 +21,14 @@ use Cake\Core\Exception\Exception;
  *
  * @see \Cake\Console\Shell::_stop()
  * @see \Cake\Console\Shell::error()
+ * @see \Cake\Console\Command::abort()
  */
 class StopException extends Exception
 {
+    /**
+     * Default exception code
+     *
+     * @var int
+     */
+    protected $_defaultCode = Command::CODE_ERROR;
 }

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -31,14 +31,15 @@ class ExceptionsTest extends TestCase
      * Tests simple exceptions work.
      *
      * @dataProvider exceptionProvider
-     * @param $class The exception class name
-     * @param $defaultCode The default exception code
+     * @param string $class The exception class name
+     * @param int $defaultCode The default exception code
      * @return void
      */
     public function testSimpleException($class, $defaultCode)
     {
         $previous = new Exception();
 
+        /** @var \Exception $exception */
         $exception = new $class('message', 100, $previous);
         $this->assertSame('message', $exception->getMessage());
         $this->assertSame(100, $exception->getCode());
@@ -124,12 +125,12 @@ class ExceptionsTest extends TestCase
     public function exceptionProvider()
     {
         return [
-            ['Cake\Console\Exception\ConsoleException', 500],
-            ['Cake\Console\Exception\MissingHelperException', 500],
-            ['Cake\Console\Exception\MissingShellException', 500],
-            ['Cake\Console\Exception\MissingShellMethodException', 500],
-            ['Cake\Console\Exception\MissingTaskException', 500],
-            ['Cake\Console\Exception\StopException', 500],
+            ['Cake\Console\Exception\ConsoleException', 1],
+            ['Cake\Console\Exception\MissingHelperException', 1],
+            ['Cake\Console\Exception\MissingShellException', 1],
+            ['Cake\Console\Exception\MissingShellMethodException', 1],
+            ['Cake\Console\Exception\MissingTaskException', 1],
+            ['Cake\Console\Exception\StopException', 1],
             ['Cake\Controller\Exception\AuthSecurityException', 400],
             ['Cake\Controller\Exception\MissingActionException', 404],
             ['Cake\Controller\Exception\MissingComponentException', 500],


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/13578

This fixes all error codes for CLI by extending the base Console exception.