### PR TITLE
Add abort() wrapper similar to Shell::abort().

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -251,6 +251,19 @@ class ConsoleIo
     }
 
     /**
+     * @param string $message
+     * @param int $code
+     * @return void
+     * @throws \Cake\Console\Exception\StopException
+     */
+    public function abort($message, $code = Command::CODE_ERROR)
+    {
+        $this->error($message);
+
+        throw new StopException($code);
+    }
+
+    /**
      * Wraps a message with a given message type, e.g. <warning>
      *
      * @param string $messageType The message type, e.g. "warning".

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -251,8 +251,10 @@ class ConsoleIo
     }
 
     /**
-     * @param string $message
-     * @param int $code
+     * Halts the the current process with a StopException.
+     *
+     * @param string $message Error message.
+     * @param int $code Error code.
      * @return void
      * @throws \Cake\Console\Exception\StopException
      */

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -827,7 +827,7 @@ class Shell
 
     /**
      * Displays a formatted error message
-     * and exits the application with status code 1
+     * and exits the application with an error code.
      *
      * @param string $message The error message
      * @param int $exitCode The exit code for the shell task.

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -293,6 +293,22 @@ class ConsoleIoTest extends TestCase
     }
 
     /**
+     * Tests abort() wrapper.
+     *
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionMessage 99
+     * @return void
+     */
+    public function testAbortCustomCode()
+    {
+        $this->err->expects($this->at(0))
+            ->method('write')
+            ->with('<error>Some error</error>', 1);
+
+        $this->io->abort('Some error', 99);
+    }
+
+    /**
      * testNl
      *
      * @return void

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -24,6 +24,10 @@ use Cake\TestSuite\TestCase;
  */
 class ConsoleIoTest extends TestCase
 {
+    /**
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
 
     /**
      * setUp method
@@ -270,6 +274,22 @@ class ConsoleIoTest extends TestCase
         $this->io->err(['Just', 'a', 'test']);
         $this->io->err(['Just', 'a', 'test'], 2);
         $this->io->err();
+    }
+
+    /**
+     * Tests abort() wrapper.
+     *
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionMessage 1
+     * @return void
+     */
+    public function testAbort()
+    {
+        $this->err->expects($this->at(0))
+            ->method('write')
+            ->with('<error>Some error</error>', 1);
+
+        $this->io->abort('Some error');
     }
 
     /**


### PR DESCRIPTION
Resolves the 2nd (enhancement) part of https://github.com/cakephp/cakephp/issues/13577
Convenience wrapper to avoid having to use 2+ lines for simple cases.
