### PR TITLE
Fix message to be properly used

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -277,6 +277,8 @@ class Command
         try {
             return $command->run($args, $io);
         } catch (StopException $e) {
+            $io->error($e->getMessage());
+            
             return $e->getCode();
         }
     }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -278,7 +278,7 @@ class Command
             return $command->run($args, $io);
         } catch (StopException $e) {
             $io->error($e->getMessage());
-            
+
             return $e->getCode();
         }
     }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -366,6 +366,8 @@ class CommandRunner implements EventDispatcherInterface
         try {
             return $command->run($argv, $io);
         } catch (StopException $e) {
+            $io->error($e->getMessage());
+            
             return $e->getCode();
         }
     }
@@ -384,6 +386,8 @@ class CommandRunner implements EventDispatcherInterface
 
             return $shell->runCommand($argv, true);
         } catch (StopException $e) {
+            $io->error($e->getMessage());
+            
             return $e->getCode();
         }
     }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -367,7 +367,7 @@ class CommandRunner implements EventDispatcherInterface
             return $command->run($argv, $io);
         } catch (StopException $e) {
             $io->error($e->getMessage());
-            
+
             return $e->getCode();
         }
     }
@@ -387,7 +387,7 @@ class CommandRunner implements EventDispatcherInterface
             return $shell->runCommand($argv, true);
         } catch (StopException $e) {
             $io->error($e->getMessage());
-            
+
             return $e->getCode();
         }
     }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -386,8 +386,6 @@ class CommandRunner implements EventDispatcherInterface
 
             return $shell->runCommand($argv, true);
         } catch (StopException $e) {
-            $io->error($e->getMessage());
-
             return $e->getCode();
         }
     }

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -262,7 +262,7 @@ class ConsoleIo
     {
         $this->error($message);
 
-        throw new StopException($code);
+        throw new StopException($message, $code);
     }
 
     /**

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -89,6 +89,7 @@ trait ConsoleIntegrationTestTrait
         try {
             $this->_exitCode = $runner->run($args, $io);
         } catch (StopException $exception) {
+            $io->error($exception->getMessage());
             $this->_exitCode = $exception->getCode();
         }
     }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -354,7 +354,7 @@ class CommandTest extends TestCase
         $command = new Command();
         $result = $command->executeCommand(AbortCommand::class, [], $this->getMockIo($output));
         $this->assertSame(127, $result);
-        $this->assertEquals(['<error>Command aborted</error>'], $output->messages());
+        $this->assertEquals(['<error>Aborted</error>', '<error>Command aborted</error>'], $output->messages());
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -30,6 +30,21 @@ class ConsoleIoTest extends TestCase
     protected $io;
 
     /**
+     * @var \Cake\Console\ConsoleOutput|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $out;
+
+    /**
+     * @var \Cake\Console\ConsoleOutput|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $err;
+
+    /**
+     * @var \Cake\Console\ConsoleInput|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $in;
+
+    /**
      * setUp method
      *
      * @return void
@@ -280,7 +295,7 @@ class ConsoleIoTest extends TestCase
      * Tests abort() wrapper.
      *
      * @expectedException \Cake\Console\Exception\StopException
-     * @expectedExceptionMessage 1
+     * @expectedExceptionMessage Some error
      * @return void
      */
     public function testAbort()
@@ -296,7 +311,7 @@ class ConsoleIoTest extends TestCase
      * Tests abort() wrapper.
      *
      * @expectedException \Cake\Console\Exception\StopException
-     * @expectedExceptionMessage 99
+     * @expectedExceptionMessage Some error
      * @return void
      */
     public function testAbortCustomCode()

--- a/tests/test_app/TestApp/Command/AbortCommand.php
+++ b/tests/test_app/TestApp/Command/AbortCommand.php
@@ -9,7 +9,7 @@ class AbortCommand extends Command
 {
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $io->error('Command aborted');
+        $io->error('Aborted');
         $this->abort(127);
     }
 }


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/13587 

Currently in your code you have to do:
```php
$message = 'Project path not found: ' . $args->getArgumentAt(0);
$io->error($message);
throw new StopException($message);
```

As the message of StopException is not used at all we have to un-dry duplicate it across the error() call as well as the StopException (as documented and already used). But the 2nd intuitively more important message is not used.

That is bad - we should use that in a proper way where we catch the exception and then issue the return with the error code.

Now we would only have to do:
```php
$message = 'Project path not found: ' . $args->getArgumentAt(0);
throw new StopException($message);
```

I wonder if we can do that already in 3.next or if we can only fix this in 4.x.