### PR TITLE
Remove untested and unneeded feature.

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -100,9 +100,7 @@ class FixtureManager
         if (empty($test->fixtures) || !empty($this->_processed[get_class($test)])) {
             return;
         }
-        if (!is_array($test->fixtures)) {
-            $test->fixtures = array_map('trim', explode(',', $test->fixtures));
-        }
+
         $this->_loadFixtures($test);
         $this->_processed[get_class($test)] = true;
     }


### PR DESCRIPTION
`TestCase::$fixtures` is declared as array in `4.x` and there's no real need to
support declaring fixtures list as string.