### PR TITLE
Deprecate setting fixtures as string.

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -98,6 +98,10 @@ class FixtureManager
             return;
         }
         if (!is_array($test->fixtures)) {
+            deprecationWarning(
+                'Setting fixtures as string is deprecated and will be removed in 4.0.' .
+                ' Set TestCase::$fixtures as array instead.'
+            );
             $test->fixtures = array_map('trim', explode(',', $test->fixtures));
         }
         $this->_loadFixtures($test);


### PR DESCRIPTION
It's an untested and unneeded feature.