### PR TITLE
Fix loading ShellHelpers from plugins

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -806,12 +806,12 @@ class Shell extends CakeObject {
 			return $this->_helpers[$name];
 		}
 		list($plugin, $helperClassName) = pluginSplit($name, true);
-		$helperClassName = Inflector::camelize($name) . "ShellHelper";
-		App::uses($helperClassName, $plugin . "Console/Helper");
-		if (!class_exists($helperClassName)) {
+		$helperClassNameShellHelper = Inflector::camelize($helperClassName) . "ShellHelper";
+		App::uses($helperClassNameShellHelper, $plugin . "Console/Helper");
+		if (!class_exists($helperClassNameShellHelper)) {
 			throw new RuntimeException("Class " . $helperClassName . " not found");
 		}
-		$helper = new $helperClassName($this->stdout);
+		$helper = new $helperClassNameShellHelper($this->stdout);
 		$this->_helpers[$name] = $helper;
 		return $helper;
 	}


### PR DESCRIPTION
Previously the Shell::helper() function would call a `class_exists` on a variable that contained the `Plugin.ClassName` notation which will always result be false, e.g. `class_exists('YourPlugin.TestShellHelper')` will always be false. Loading ShellHelpers from a plugin will never work because of this. (This notation is described in the ShellHelper 2.x documentation).
After the pluginSplit and the loading of the actual ShellHelper class file (through `App::uses`), the `class_exists` should be called on the real class name, not on `Plugin.ClassName`.

Through this fix, plugins with an ExampleShellHelper in placed in MyPlugin/Console/Helper/ExampleShellHelper.php can be called in Shells by `$this->helper('MyPlugin.ExampleShellHelper')` and plugins within your app can still be loaded through the regular `$this->helper('MyShellHelper')`.
