### PR TITLE
Replace callable with Closure in DB and ORM layer.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -28,6 +28,7 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
 use Cake\Utility\Text;
+use Closure;
 use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
@@ -191,7 +192,7 @@ class Shell
         $this->_io = $io ?: new ConsoleIo();
         $this->_tableLocator = $locator;
 
-        $this->modelFactory('Table', [$this->getTableLocator(), 'get']);
+        $this->modelFactory('Table', Closure::fromCallable([$this->getTableLocator(), 'get']));
         $this->Tasks = new TaskRegistry($this);
 
         $this->_mergeVars(

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -29,6 +29,7 @@ use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Routing\Router;
 use Cake\View\ViewVarsTrait;
+use Closure;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
 use ReflectionException;
@@ -199,7 +200,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $this->setEventManager($eventManager);
         }
 
-        $this->modelFactory('Table', [$this->getTableLocator(), 'get']);
+        $this->modelFactory('Table', Closure::fromCallable([$this->getTableLocator(), 'get']));
         $plugin = $this->request->getParam('plugin');
         $modelClass = ($plugin ? $plugin . '.' : '') . $this->name;
         $this->_setModelClass($modelClass);

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -32,6 +32,7 @@ use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\CollectionInterface as SchemaCollectionInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Log\Log;
+use Closure;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
@@ -682,7 +683,7 @@ class Connection implements ConnectionInterface
      * });
      * ```
      */
-    public function transactional(callable $callback)
+    public function transactional(Closure $callback)
     {
         $this->begin();
 
@@ -730,7 +731,7 @@ class Connection implements ConnectionInterface
      * });
      * ```
      */
-    public function disableConstraints(callable $callback)
+    public function disableConstraints(Closure $callback)
     {
         return $this->getDisconnectRetry()->run(function () use ($callback) {
             $this->disableForeignKeys();

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -19,6 +19,7 @@ namespace Cake\Database;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Statement\PDOStatement;
+use Closure;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -263,7 +264,7 @@ abstract class Driver implements DriverInterface
     /**
      * @inheritDoc
      */
-    abstract public function queryTranslator(string $type): callable;
+    abstract public function queryTranslator(string $type): Closure;
 
     /**
      * @inheritDoc

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Database\Schema\BaseSchema;
+use Closure;
 
 /**
  * Interface for database driver.
@@ -158,15 +159,15 @@ interface DriverInterface
     public function supportsQuoting(): bool;
 
     /**
-     * Returns a callable function that will be used to transform a passed Query object.
+     * Returns a closure that will be used to transform a passed Query object.
      * This function, in turn, will return an instance of a Query object that has been
      * transformed to accommodate any specificities of the SQL dialect in use.
      *
      * @param string $type The type of query to be transformed
      * (select, insert, update, delete).
-     * @return callable
+     * @return \Closure
      */
-    public function queryTranslator(string $type): callable;
+    public function queryTranslator(string $type): Closure;
 
     /**
      * Get the schema dialect.

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * An expression object that represents a SQL BETWEEN snippet
@@ -103,7 +104,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         foreach ([$this->_field, $this->_from, $this->_to] as $part) {
             if ($part instanceof ExpressionInterface) {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * This class represents a SQL Case statement
@@ -233,7 +234,7 @@ class CaseExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
-    public function traverse(callable $visitor)
+    public function traverse(Closure $visitor)
     {
         foreach (['_conditions', '_values'] as $part) {
             foreach ($this->{$part} as $c) {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -20,6 +20,7 @@ use Cake\Database\Exception as DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * A Comparison is a type of query expression that represents an operation
@@ -168,7 +169,7 @@ class Comparison implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         if ($this->_field instanceof ExpressionInterface) {
             $callable($this->_field);

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * Represents a single identifier name in the database.
@@ -82,10 +83,10 @@ class IdentifierExpression implements ExpressionInterface
      * This method is a no-op, this is a leaf type of expression,
      * hence there is nothing to traverse
      *
-     * @param callable $callable The callable to traverse with.
+     * @param \Closure $callable The callable to traverse with.
      * @return $this
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         return $this;
     }

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * An expression object for complex ORDER BY clauses
@@ -62,7 +63,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
-    public function traverse(callable $visitor)
+    public function traverse(Closure $visitor)
     {
         if ($this->_field instanceof ExpressionInterface) {
             $visitor($this->_field);

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -21,6 +21,7 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\TypeMapTrait;
 use Cake\Database\ValueBinder;
+use Closure;
 use Countable;
 use InvalidArgumentException;
 
@@ -29,8 +30,8 @@ use InvalidArgumentException;
  * expressions that can be compiled by converting this object to string
  * and will contain a correctly parenthesized and nested expression.
  *
- * @method $this and(callable|string|array|\Cake\Database\ExpressionInterface $conditions)
- * @method $this or(callable|string|array|\Cake\Database\ExpressionInterface $conditions)
+ * @method $this and(\Closure|string|array|\Cake\Database\ExpressionInterface $conditions)
+ * @method $this or(\Closure|string|array|\Cake\Database\ExpressionInterface $conditions)
  */
 class QueryExpression implements ExpressionInterface, Countable
 {
@@ -415,19 +416,17 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *
-     * @param callable|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with AND
+     * @param \Closure|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with AND
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      */
     public function and_($conditions, $types = [])
     {
-        if ($this->isCallable($conditions)) {
-            /** @var callable $conditions */
+        if ($conditions instanceof Closure) {
             return $conditions(new static([], $this->getTypeMap()->setTypes($types)));
         }
 
-        /** @var string|array|\Cake\Database\ExpressionInterface $conditions */
         return new static($conditions, $this->getTypeMap()->setTypes($types));
     }
 
@@ -435,19 +434,17 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "OR"
      *
-     * @param callable|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with OR
+     * @param \Closure|string|array|\Cake\Database\ExpressionInterface $conditions to be joined with OR
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      */
     public function or_($conditions, $types = [])
     {
-        if ($this->isCallable($conditions)) {
-            /** @var callable $conditions */
+        if ($conditions instanceof Closure) {
             return $conditions(new static([], $this->getTypeMap()->setTypes($types), 'OR'));
         }
 
-        /** @var string|array|\Cake\Database\ExpressionInterface $conditions */
         return new static($conditions, $this->getTypeMap()->setTypes($types), 'OR');
     }
 // phpcs:enable
@@ -540,10 +537,10 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * Callback function receives as only argument an instance of ExpressionInterface
      *
-     * @param callable $callable The callable to apply to all sub-expressions.
+     * @param \Closure $callable The callable to apply to all sub-expressions.
      * @return $this
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         foreach ($this->_conditions as $c) {
             if ($c instanceof ExpressionInterface) {
@@ -567,10 +564,10 @@ class QueryExpression implements ExpressionInterface, Countable
      * passed by reference, this will enable you to change the key under which the
      * modified part is stored.
      *
-     * @param callable $callable The callable to apply to each part.
+     * @param \Closure $callable The callable to apply to each part.
      * @return $this
      */
-    public function iterateParts(callable $callable)
+    public function iterateParts(Closure $callable)
     {
         $parts = [];
         foreach ($this->_conditions as $k => $c) {
@@ -599,29 +596,6 @@ class QueryExpression implements ExpressionInterface, Countable
             return call_user_func_array([$this, $method . '_'], $args);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $method));
-    }
-
-    /**
-     * Check whether or not a callable is acceptable.
-     *
-     * We don't accept ['class', 'method'] style callbacks,
-     * as they often contain user input and arrays of strings
-     * are easy to sneak in.
-     *
-     * @param callable|string|array|\Cake\Database\ExpressionInterface $c The callable to check.
-     * @return bool Valid callable.
-     */
-    public function isCallable($c): bool
-    {
-        if (is_string($c)) {
-            return false;
-        }
-        /** @psalm-suppress RedundantCondition */
-        if (is_object($c) && is_callable($c)) {
-            return true;
-        }
-
-        return is_array($c) && isset($c[0]) && is_object($c[0]) && is_callable($c);
     }
 
     /**
@@ -660,7 +634,7 @@ class QueryExpression implements ExpressionInterface, Countable
         foreach ($conditions as $k => $c) {
             $numericKey = is_numeric($k);
 
-            if ($this->isCallable($c)) {
+            if ($c instanceof Closure) {
                 /** @var \Cake\Database\Expression\QueryExpression $expr */
                 $expr = new static([], $typeMap);
                 $c = $c($expr, $this);

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * This expression represents SQL fragments that are used for comparing one tuple
@@ -146,10 +147,10 @@ class TupleComparison extends Comparison
      *
      * Callback function receives as its only argument an instance of an ExpressionInterface
      *
-     * @param callable $callable The callable to apply to sub-expressions
+     * @param \Closure $callable The callable to apply to sub-expressions
      * @return $this
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         /** @var string[] $fields */
         $fields = $this->getField();
@@ -183,10 +184,10 @@ class TupleComparison extends Comparison
      * it is an ExpressionInterface
      *
      * @param mixed $value The value to traverse
-     * @param callable $callable The callable to use when traversing
+     * @param \Closure $callable The callable to use when traversing
      * @return void
      */
-    protected function _traverseValue($value, $callable): void
+    protected function _traverseValue($value, Closure $callable): void
     {
         if ($value instanceof ExpressionInterface) {
             $callable($value);

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * An expression object that represents an expression with only a single operand.
@@ -94,7 +95,7 @@ class UnaryExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
-    public function traverse(callable $callable)
+    public function traverse(Closure $callable)
     {
         if ($this->_value instanceof ExpressionInterface) {
             $callable($this->_value);

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -23,6 +23,7 @@ use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\TypeMap;
 use Cake\Database\TypeMapTrait;
 use Cake\Database\ValueBinder;
+use Closure;
 
 /**
  * An expression object to contain values being inserted.
@@ -261,10 +262,10 @@ class ValuesExpression implements ExpressionInterface
      * This method will also traverse any queries that are to be used in the INSERT
      * values.
      *
-     * @param callable $visitor The visitor to traverse the expression with.
+     * @param \Closure $visitor The visitor to traverse the expression with.
      * @return $this
      */
-    public function traverse(callable $visitor)
+    public function traverse(Closure $visitor)
     {
         if ($this->_query) {
             return $this;

--- a/src/Database/ExpressionInterface.php
+++ b/src/Database/ExpressionInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Closure;
+
 /**
  * An interface used by Expression objects.
  */
@@ -35,8 +37,8 @@ interface ExpressionInterface
      * passing as first parameter the instance of the expression currently
      * being iterated.
      *
-     * @param callable $visitor The callable to apply to all nodes.
+     * @param \Closure $visitor The callable to apply to all nodes.
      * @return $this
      */
-    public function traverse(callable $visitor);
+    public function traverse(Closure $visitor);
 }

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -19,6 +19,7 @@ namespace Cake\Database;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
+use Closure;
 
 /**
  * Contains all the logic related to quoting identifiers in a Query object
@@ -64,7 +65,7 @@ class IdentifierQuoter
             $this->_quoteParts($query);
         }
 
-        $query->traverseExpressions([$this, 'quoteExpression']);
+        $query->traverseExpressions(Closure::fromCallable([$this, 'quoteExpression']));
         $query->setValueBinder($binder);
 
         return $query;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -22,6 +22,7 @@ use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Statement\CallbackStatement;
+use Closure;
 use InvalidArgumentException;
 use IteratorAggregate;
 use RuntimeException;
@@ -125,7 +126,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * statement upon retrieval. Each one of the callback function will receive
      * the row array as first argument.
      *
-     * @var callable[]
+     * @var \Closure[]
      */
     protected $_resultDecorators = [];
 
@@ -312,10 +313,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      * });
      * ```
      *
-     * @param callable $visitor A function or callable to be executed for each part
+     * @param \Closure $visitor A function or callable to be executed for each part
      * @return $this
      */
-    public function traverse(callable $visitor)
+    public function traverse(Closure $visitor)
     {
         $parts = array_keys($this->_parts);
         foreach ($parts as $name) {
@@ -345,11 +346,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      * }, ['select', 'from']);
      * ```
      *
-     * @param callable $visitor A function or callable to be executed for each part
+     * @param \Closure $visitor A function or callable to be executed for each part
      * @param string[] $parts The list of query parts to traverse
      * @return $this
      */
-    public function traverseParts(callable $visitor, array $parts)
+    public function traverseParts(Closure $visitor, array $parts)
     {
         foreach ($parts as $name) {
             $visitor($this->_parts[$name], $name);
@@ -389,13 +390,13 @@ class Query implements ExpressionInterface, IteratorAggregate
      * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
      * from the table.
      *
-     * @param array|\Cake\Database\ExpressionInterface|string|callable $fields fields to be added to the list.
+     * @param array|\Cake\Database\ExpressionInterface|string|\Closure $fields fields to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
     public function select($fields = [], bool $overwrite = false)
     {
-        if (!is_string($fields) && is_callable($fields)) {
+        if ($fields instanceof Closure) {
             $fields = $fields($this);
         }
 
@@ -642,7 +643,7 @@ class Query implements ExpressionInterface, IteratorAggregate
                 $t = ['table' => $t, 'conditions' => $this->newExpr()];
             }
 
-            if (!is_string($t['conditions']) && is_callable($t['conditions'])) {
+            if ($t['conditions'] instanceof Closure) {
                 $t['conditions'] = $t['conditions']($this->newExpr(), $this);
             }
 
@@ -911,7 +912,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If you use string conditions make sure that your values are correctly quoted.
      * The safest thing you can do is to never use string conditions.
      *
-     * @param string|array|\Cake\Database\ExpressionInterface|callable|null $conditions The conditions to filter on.
+     * @param string|array|\Cake\Database\ExpressionInterface|\Closure|null $conditions The conditions to filter on.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Type
@@ -1080,7 +1081,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * `WHERE (title = 'Foo') AND (author_id = 1 OR author_id = 2)`
      *
-     * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The conditions to add with AND.
+     * @param string|array|\Cake\Database\ExpressionInterface|\Closure $conditions The conditions to add with AND.
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\Type
@@ -1148,7 +1149,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If you need to set complex expressions as order conditions, you
      * should use `orderAsc()` or `orderDesc()`.
      *
-     * @param array|\Cake\Database\ExpressionInterface|callable|string $fields fields to be added to the list
+     * @param array|\Cake\Database\ExpressionInterface|\Closure|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
      */
@@ -1280,7 +1281,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Having fields are not suitable for use with user supplied data as they are
      * not sanitized by the query builder.
      *
-     * @param string|array|\Cake\Database\ExpressionInterface|callable|null $conditions The having conditions.
+     * @param string|array|\Cake\Database\ExpressionInterface|\Closure|null $conditions The having conditions.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Query::where()
@@ -1305,7 +1306,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Having fields are not suitable for use with user supplied data as they are
      * not sanitized by the query builder.
      *
-     * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The AND conditions for HAVING.
+     * @param string|array|\Cake\Database\ExpressionInterface|\Closure $conditions The AND conditions for HAVING.
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::andWhere()
      * @return $this
@@ -1634,7 +1635,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * });
      * ```
      *
-     * @param string|array|callable|\Cake\Database\Expression\QueryExpression $key The column name or array of keys
+     * @param string|array|\Closure|\Cake\Database\Expression\QueryExpression $key The column name or array of keys
      *    + values to set. This can also be a QueryExpression containing a SQL fragment.
      *    It can also be a callable, that is required to return an expression object.
      * @param mixed $value The value to update $key to. Can be null if $key is an
@@ -1649,9 +1650,8 @@ class Query implements ExpressionInterface, IteratorAggregate
             $this->_parts['set'] = $this->newExpr()->setConjunction(',');
         }
 
-        if ($this->_parts['set']->isCallable($key)) {
+        if ($key instanceof Closure) {
             $exp = $this->newExpr()->setConjunction(',');
-            /** @psalm-suppress PossiblyInvalidFunctionCall */
             $this->_parts['set']->add($key($exp));
 
             return $this;
@@ -1667,7 +1667,6 @@ class Query implements ExpressionInterface, IteratorAggregate
         if (is_string($types) && is_string($key)) {
             $types = [$key => $types];
         }
-        /** @psalm-suppress PossiblyInvalidArgument */
         $this->_parts['set']->eq($key, $value, $types);
 
         return $this;
@@ -1862,11 +1861,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      * });
      * ```
      *
-     * @param callable|null $callback The callback to invoke when results are fetched.
+     * @param \Closure|null $callback The callback to invoke when results are fetched.
      * @param bool $overwrite Whether or not this should append or replace all existing decorators.
      * @return $this
      */
-    public function decorateResults(?callable $callback, bool $overwrite = false)
+    public function decorateResults(?Closure $callback, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_resultDecorators = [];
@@ -1887,11 +1886,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * Callback will receive as first parameter the currently visited expression.
      *
-     * @param callable $callback the function to be executed for each ExpressionInterface
+     * @param \Closure $callback the function to be executed for each ExpressionInterface
      *   found inside this query.
      * @return $this
      */
-    public function traverseExpressions(callable $callback)
+    public function traverseExpressions(Closure $callback)
     {
         $visitor = function ($expression) use (&$visitor, $callback) {
             if (is_array($expression)) {
@@ -2105,7 +2104,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Helper function used to build conditions by composing QueryExpression objects.
      *
      * @param string $part Name of the query part to append the new part to
-     * @param string|null|array|\Cake\Database\ExpressionInterface|callable $append Expression or builder function
+     * @param string|null|array|\Cake\Database\ExpressionInterface|\Closure $append Expression or builder function
      *   to append.
      * @param string $conjunction type of conjunction to be used to operate part
      * @param array $types associative array of type names used to bind values to query
@@ -2120,8 +2119,7 @@ class Query implements ExpressionInterface, IteratorAggregate
             return;
         }
 
-        if ($expression->isCallable($append)) {
-            /** @psalm-suppress PossiblyInvalidFunctionCall */
+        if ($append instanceof Closure) {
             $append = $append($this->newExpr(), $this);
         }
 

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -18,6 +18,7 @@ namespace Cake\Database;
 
 use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\IdentifierExpression;
+use Closure;
 use RuntimeException;
 
 /**
@@ -89,9 +90,9 @@ trait SqlDialectTrait
      *
      * @param string $type the type of query to be transformed
      * (select, insert, update, delete)
-     * @return callable
+     * @return \Closure
      */
-    public function queryTranslator(string $type): callable
+    public function queryTranslator(string $type): Closure
     {
         return function ($query) use ($type) {
             if ($this->isAutoQuotingEnabled()) {

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use Closure;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -77,24 +78,24 @@ interface ConnectionInterface extends LoggerAwareInterface
      *
      * The callback will receive the connection instance as its first argument.
      *
-     * @param callable $transaction The callback to execute within a transaction.
+     * @param \Closure $transaction The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.
      */
-    public function transactional(callable $transaction);
+    public function transactional(Closure $transaction);
 
     /**
      * Run an operation with constraints disabled.
      *
      * Constraints should be re-enabled after the callback succeeds/fails.
      *
-     * @param callable $operation The callback to execute within a transaction.
+     * @param \Closure $operation The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.
      */
-    public function disableConstraints(callable $operation);
+    public function disableConstraints(Closure $operation);
 
     /**
      * Enable/disable query logging

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -19,6 +19,7 @@ namespace Cake\Datasource;
 use Cake\Core\App;
 use Cake\Core\ObjectRegistry;
 use Cake\Datasource\Exception\MissingDatasourceException;
+use Closure;
 
 /**
  * A registry object for connection instances.
@@ -68,14 +69,14 @@ class ConnectionRegistry extends ObjectRegistry
      * If a callable is passed as first argument, The returned value of this
      * function will be the result of the callable.
      *
-     * @param string|\Cake\Datasource\ConnectionInterface|callable $class The classname or object to make.
+     * @param string|\Cake\Datasource\ConnectionInterface|\Closure $class The classname or object to make.
      * @param string $alias The alias of the object.
      * @param array $settings An array of settings to use for the datasource.
      * @return \Cake\Datasource\ConnectionInterface A connection with the correct settings.
      */
     protected function _create($class, string $alias, array $settings)
     {
-        if (is_callable($class)) {
+        if ($class instanceof Closure) {
             return $class($alias);
         }
 

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\ORM\TableRegistry;
+use Closure;
 use InvalidArgumentException;
 
 /**
@@ -27,7 +28,7 @@ class FactoryLocator
     /**
      * A list of model factory functions.
      *
-     * @var callable[]
+     * @var \Closure[]
      */
     protected static $_modelFactories = [];
 
@@ -35,10 +36,10 @@ class FactoryLocator
      * Register a callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable $factory The factory function used to create instances.
+     * @param \Closure $factory The factory function used to create instances.
      * @return void
      */
-    public static function add(string $type, callable $factory): void
+    public static function add(string $type, Closure $factory): void
     {
         static::$_modelFactories[$type] = $factory;
     }
@@ -59,12 +60,12 @@ class FactoryLocator
      *
      * @param string $type The repository type to get the factory for.
      * @throws \InvalidArgumentException If the specified repository type has no factory.
-     * @return callable The factory for the repository type.
+     * @return \Closure The factory for the repository type.
      */
-    public static function get(string $type): callable
+    public static function get(string $type): Closure
     {
         if (!isset(static::$_modelFactories['Table'])) {
-            static::$_modelFactories['Table'] = [TableRegistry::getTableLocator(), 'get'];
+            static::$_modelFactories['Table'] = Closure::fromCallable([TableRegistry::getTableLocator(), 'get']);
         }
 
         if (!isset(static::$_modelFactories[$type])) {

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
+use Closure;
 use UnexpectedValueException;
 
 /**
@@ -137,10 +138,10 @@ trait ModelAwareTrait
      * Override a existing callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable $factory The factory function used to create instances.
+     * @param \Closure $factory The factory function used to create instances.
      * @return void
      */
-    public function modelFactory(string $type, callable $factory): void
+    public function modelFactory(string $type, Closure $factory): void
     {
         $this->_modelFactories[$type] = $factory;
     }

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -18,6 +18,7 @@ namespace Cake\Datasource;
 
 use Cake\Cache\Cache;
 use Cake\Cache\CacheEngine;
+use Closure;
 use RuntimeException;
 use Traversable;
 
@@ -34,7 +35,7 @@ class QueryCacher
     /**
      * The key or function to generate a key.
      *
-     * @var string|callable
+     * @var string|\Closure
      */
     protected $_key;
 
@@ -54,8 +55,8 @@ class QueryCacher
      */
     public function __construct($key, $config)
     {
-        if (!is_string($key) && !is_callable($key)) {
-            throw new RuntimeException('Cache keys must be strings or callables.');
+        if (!is_string($key) && !$key instanceof Closure) {
+            throw new RuntimeException('Cache keys must be strings or Closures.');
         }
         $this->_key = $key;
 

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -391,7 +391,7 @@ interface QueryInterface
      * If you use string conditions make sure that your values are correctly quoted.
      * The safest thing you can do is to never use string conditions.
      *
-     * @param string|array|callable|null $conditions The conditions to filter on.
+     * @param string|array|\Closure|null $conditions The conditions to filter on.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @return $this

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -19,6 +19,7 @@ namespace Cake\Datasource;
 use BadMethodCallException;
 use Cake\Collection\Iterator\MapReduce;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Closure;
 use InvalidArgumentException;
 use Traversable;
 
@@ -57,7 +58,7 @@ trait QueryTrait
      * List of formatter classes or callbacks that will post-process the
      * results when fetched
      *
-     * @var callable[]
+     * @var \Closure[]
      */
     protected $_formatters = [];
 
@@ -319,13 +320,13 @@ trait QueryTrait
      * If the third argument is set to true, it will erase previous map reducers
      * and replace it with the arguments passed.
      *
-     * @param callable|null $mapper The mapper callable.
-     * @param callable|null $reducer The reducing function.
+     * @param \Closure|null $mapper The mapper callable.
+     * @param \Closure|null $reducer The reducing function.
      * @param bool $overwrite Set to true to overwrite existing map + reduce functions.
      * @return $this
      * @see \Cake\Collection\Iterator\MapReduce for details on how to use emit data to the map reducer.
      */
-    public function mapReduce(?callable $mapper = null, ?callable $reducer = null, bool $overwrite = false)
+    public function mapReduce(?Closure $mapper = null, ?Closure $reducer = null, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_mapReduce = [];
@@ -383,12 +384,12 @@ trait QueryTrait
      * });
      * ```
      *
-     * @param callable|null $formatter The formatting callable.
+     * @param \Closure|null $formatter The formatting callable.
      * @param int|true $mode Whether or not to overwrite, append or prepend the formatter.
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function formatResults(?callable $formatter = null, $mode = 0)
+    public function formatResults(?Closure $formatter = null, $mode = 0)
     {
         if ($mode === self::OVERWRITE) {
             $this->_formatters = [];
@@ -415,7 +416,7 @@ trait QueryTrait
     /**
      * Returns the list of previously registered format routines.
      *
-     * @return callable[]
+     * @return \Closure[]
      */
     public function getResultFormatters(): array
     {

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -106,7 +106,7 @@ interface RepositoryInterface
      * This method will *not* trigger beforeSave/afterSave events. If you need those
      * first load a collection of records and update them.
      *
-     * @param string|array|callable|\Cake\Database\Expression\QueryExpression $fields A hash of field => new value.
+     * @param string|array|\Closure|\Cake\Database\Expression\QueryExpression $fields A hash of field => new value.
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Count Returns the affected rows.

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -121,7 +121,7 @@ abstract class Association
      * A list of conditions to be always included when fetching records from
      * the target association
      *
-     * @var array|callable
+     * @var array|\Closure
      */
     protected $_conditions = [];
 
@@ -421,7 +421,7 @@ abstract class Association
      * Sets a list of conditions to be always included when fetching records from
      * the target association.
      *
-     * @param array|callable $conditions list of conditions to be used
+     * @param array|\Closure $conditions list of conditions to be used
      * @see \Cake\Database\Query::where() for examples on the format of the array
      * @return \Cake\ORM\Association
      */
@@ -437,7 +437,7 @@ abstract class Association
      * the target association.
      *
      * @see \Cake\Database\Query::where() for examples on the format of the array
-     * @return array|callable
+     * @return array|\Closure
      */
     public function getConditions()
     {
@@ -855,7 +855,7 @@ abstract class Association
      * Proxies the operation to the target table's exists method after
      * appending the default conditions for this association
      *
-     * @param array|callable|\Cake\Database\ExpressionInterface $conditions The conditions to use
+     * @param array|\Closure|\Cake\Database\ExpressionInterface $conditions The conditions to use
      * for checking if any record matches.
      * @see \Cake\ORM\Table::exists()
      * @return bool

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -50,7 +50,7 @@ class SelectWithPivotLoader extends SelectLoader
     /**
      * Custom conditions for the junction association
      *
-     * @var string|array|\Cake\Database\ExpressionInterface|callable|null
+     * @var string|array|\Cake\Database\ExpressionInterface|\Closure|null
      */
     protected $junctionConditions;
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -25,6 +25,7 @@ use Cake\ORM\PropertyMarshalInterface;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
+use Closure;
 
 /**
  * This behavior provides a way to translate dynamic data by keeping translations
@@ -295,7 +296,10 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
                 return $query;
             }])
-            ->formatResults([$this->getStrategy(), 'groupTranslations'], $query::PREPEND);
+            ->formatResults(
+                Closure::fromCallable([$this->getStrategy(), 'groupTranslations']),
+                $query::PREPEND
+            );
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -27,6 +27,7 @@ use Cake\Database\ValueBinder;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
 use Cake\Datasource\ResultSetInterface;
+use Closure;
 use InvalidArgumentException;
 use JsonSerializable;
 use RuntimeException;
@@ -210,7 +211,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * all the fields in the schema of the table or the association will be added to
      * the select clause.
      *
-     * @param array|\Cake\Database\ExpressionInterface|callable|string|\Cake\ORM\Table|\Cake\ORM\Association $fields Fields
+     * @param array|\Cake\Database\ExpressionInterface|\Closure|string|\Cake\ORM\Table|\Cake\ORM\Association $fields Fields
      * to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
@@ -422,7 +423,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * previous list will be emptied.
      *
      * @param array|string $associations List of table aliases to be queried.
-     * @param callable|bool $override The query builder for the association, or
+     * @param \Closure|bool $override The query builder for the association, or
      *   if associations is an array, a bool on whether to override previous list
      *   with the one passed
      * defaults to merging previous list with the new one.
@@ -436,7 +437,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         $queryBuilder = null;
-        if (is_callable($override)) {
+        if ($override instanceof Closure) {
             $queryBuilder = $override;
         }
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -28,6 +28,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Exception\MissingCellTemplateException;
 use Cake\View\Exception\MissingTemplateException;
+use Closure;
 use Error;
 use Exception;
 use ReflectionException;
@@ -123,7 +124,7 @@ abstract class Cell implements EventDispatcherInterface
         }
         $this->request = $request;
         $this->response = $response;
-        $this->modelFactory('Table', [$this->getTableLocator(), 'get']);
+        $this->modelFactory('Table', Closure::fromCallable([$this->getTableLocator(), 'get']));
 
         $this->_validCellOptions = array_merge(['action', 'args'], $this->_validCellOptions);
         foreach ($this->_validCellOptions as $var) {


### PR DESCRIPTION
Refs #13598 

Barring couple of places where invokable classes can be used as argument, I have replaced all `callable`s with `Closure` in the `Database` and `ORM` packages :slightly_smiling_face:.

Edit: As stated below some of the changes might not be desirable. The reason I changed all possible  is so that they are highlighted in the diff and we can identify which ones should be changed to Closure and which retained as callable.