### PR TITLE
Add SQLite decimal length/precision

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -273,7 +273,7 @@ REGEXP;
                 $parsed['className'] = $classMap[$parsed['scheme']];
             }
         }
-        
+
         return $parsed;
     }
 

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -273,7 +273,7 @@ REGEXP;
                 $parsed['className'] = $classMap[$parsed['scheme']];
             }
         }
-
+        
         return $parsed;
     }
 

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -61,9 +61,14 @@ class SqliteSchema extends BaseSchema
         }
 
         $col = strtolower($matches[2]);
-        $length = null;
+        $length = $precision = null;
         if (isset($matches[3])) {
-            $length = (int)$matches[3];
+            $length = $matches[3];
+            if (strpos($length, ',') !== false) {
+                [$length, $precision] = explode(',', $length);
+            }
+            $length = (int)$length;
+            $precision = (int)$precision;
         }
 
         if ($col === 'bigint') {
@@ -79,10 +84,10 @@ class SqliteSchema extends BaseSchema
             return ['type' => TableSchema::TYPE_INTEGER, 'length' => $length, 'unsigned' => $unsigned];
         }
         if (strpos($col, 'decimal') !== false) {
-            return ['type' => TableSchema::TYPE_DECIMAL, 'length' => null, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_DECIMAL, 'length' => $length, 'precision' => $precision, 'unsigned' => $unsigned];
         }
         if (in_array($col, ['float', 'real', 'double'])) {
-            return ['type' => TableSchema::TYPE_FLOAT, 'length' => null, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_FLOAT, 'length' => $length, 'precision' => $precision, 'unsigned' => $unsigned];
         }
 
         if (strpos($col, 'boolean') !== false) {

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -126,27 +126,27 @@ class SqliteSchemaTest extends TestCase
             ],
             [
                 'FLOAT',
-                ['type' => 'float', 'length' => null, 'unsigned' => false],
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
             ],
             [
                 'DOUBLE',
-                ['type' => 'float', 'length' => null, 'unsigned' => false],
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
             ],
             [
                 'UNSIGNED DOUBLE',
-                ['type' => 'float', 'length' => null, 'unsigned' => true],
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => true],
             ],
             [
                 'REAL',
-                ['type' => 'float', 'length' => null, 'unsigned' => false],
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
             ],
             [
                 'DECIMAL(11,2)',
-                ['type' => 'decimal', 'length' => null, 'unsigned' => false],
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => false],
             ],
             [
                 'UNSIGNED DECIMAL(11,2)',
-                ['type' => 'decimal', 'length' => null, 'unsigned' => true],
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => true],
             ],
         ];
     }


### PR DESCRIPTION
I  was surprised that decimal/float didnt quite work the same way in SQLite, despite SQLite documentation saying it supports length/precision.

I set up a fixture with
```php
'amount_required' => ['type' => 'decimal','length' => 10, 'precision' => 6, 'null' => false],		'amount_nullable' => ['type' => 'decimal', 'length' => 10, 'precision' => 6, 'null' => true],
```

When running tests the schema for SQLite DB revealed this in cake using `dd($this->Table->getSchema())`:

    'length' => null,
    'precision' => null,

After this fix it now says the same as mysql/postgres schema:

    'length' => 10,
    'precision' => 6,

I am sure though there is more to be done here.


Refs https://github.com/cakephp/cakephp/pull/1281 and https://github.com/cakephp/cakephp/pull/1691