### PR TITLE
Use lowercased type names for paths to non source/class files.

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -178,6 +178,7 @@ class I18nExtractCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
+        $plugin = '';
         if ($args->getOption('exclude')) {
             $this->_exclude = explode(',', (string)$args->getOption('exclude'));
         }
@@ -218,13 +219,20 @@ class I18nExtractCommand extends Command
         if ($args->hasOption('output')) {
             $this->_output = (string)$args->getOption('output');
         } elseif ($args->hasOption('plugin')) {
-            $this->_output = $this->_paths[0] . 'Locale';
+            $this->_output = Plugin::path($plugin)
+                . 'resources' . DIRECTORY_SEPARATOR
+                . 'locales' . DIRECTORY_SEPARATOR;
         } else {
             $message = "What is the path you would like to output?\n[Q]uit";
+            $localePaths = App::path('locales');
+            if (!$localePaths) {
+                /** @psalm-suppress UndefinedConstant */
+                $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales';
+            }
             while (true) {
                 $response = $io->ask(
                     $message,
-                    rtrim($this->_paths[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'Locale'
+                    $localePaths[0]
                 );
                 if (strtoupper($response) === 'Q') {
                     $io->err('Extract Aborted');

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -130,7 +130,7 @@ class I18nExtractCommand extends Command
     protected $_countMarkerError = 0;
 
     /**
-     * Method to interact with the User and get path selections.
+     * Method to interact with the user and get path selections.
      *
      * @param \Cake\Console\ConsoleIo $io The io instance.
      * @return void
@@ -138,14 +138,19 @@ class I18nExtractCommand extends Command
     protected function _getPaths(ConsoleIo $io): void
     {
         /** @psalm-suppress UndefinedConstant */
-        $defaultPath = APP;
+        $defaultPaths = [
+            APP,
+            App::path('templates'),
+            'D', // This is required to break the loop below
+        ];
+        $defaultPathIndex = 0;
         while (true) {
             $currentPaths = count($this->_paths) > 0 ? $this->_paths : ['None'];
             $message = sprintf(
                 "Current paths: %s\nWhat is the path you would like to extract?\n[Q]uit [D]one",
                 implode(', ', $currentPaths)
             );
-            $response = $io->ask($message, $defaultPath);
+            $response = $io->ask($message, $defaultPaths[$defaultPathIndex]);
             if (strtoupper($response) === 'Q') {
                 $io->err('Extract Aborted');
                 $this->abort();
@@ -161,7 +166,7 @@ class I18nExtractCommand extends Command
                 $io->warning('No directories selected. Please choose a directory.');
             } elseif (is_dir($response)) {
                 $this->_paths[] = $response;
-                $defaultPath = 'D';
+                $defaultPathIndex++;
             } else {
                 $io->err('The directory path you supplied was not found. Please try again.');
             }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -208,7 +208,7 @@ class I18nExtractCommand extends Command
         }
 
         if ($args->hasOption('exclude-plugins') && $this->_isExtractingApp()) {
-            $this->_exclude = array_merge($this->_exclude, App::path('Plugin'));
+            $this->_exclude = array_merge($this->_exclude, App::path('plugins'));
         }
 
         if ($this->_extractCore) {

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -21,6 +21,7 @@ use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\App;
+use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use DirectoryIterator;
 
@@ -59,7 +60,7 @@ class I18nInitCommand extends Command
         $paths = App::path('locales');
         if ($args->hasOption('plugin')) {
             $plugin = Inflector::camelize((string)$args->getOption('plugin'));
-            $paths = App::path('locales', $plugin);
+            $paths = [Plugin::path($plugin) . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR];
         }
 
         $response = $io->ask('What folder?', rtrim($paths[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -56,10 +56,10 @@ class I18nInitCommand extends Command
             return static::CODE_ERROR;
         }
 
-        $paths = App::path('Locale');
+        $paths = App::path('locales');
         if ($args->hasOption('plugin')) {
             $plugin = Inflector::camelize((string)$args->getOption('plugin'));
-            $paths = App::path('Locale', $plugin);
+            $paths = App::path('locales', $plugin);
         }
 
         $response = $io->ask('What folder?', rtrim($paths[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -156,22 +156,24 @@ class App
     }
 
     /**
-     * Used to read information stored path
+     * Used to read information stored path.
      *
-     * Usage:
+     * If 1st character of $type argument is lower cased it will return the
+     * value of `App.paths.$type` config.
      *
-     * ```
-     * App::path('Plugin');
-     * ```
-     *
-     * Will return the configured paths for plugins. This is a simpler way to access
-     * the `App.paths.plugins` configure variable.
+     * Example:
      *
      * ```
-     * App::path('Model/Datasource', 'MyPlugin');
+     * App::path('plugins');
      * ```
      *
-     * Will return the path for datasources under the 'MyPlugin' plugin.
+     * Will return the value of `App.paths.plugins` config.
+     *
+     * ```
+     * App::path('Model/Table', 'MyPlugin');
+     * ```
+     *
+     * Will return the path for tables under the 'MyPlugin' plugin.
      *
      * @param string $type type of path
      * @param string|null $plugin name of plugin
@@ -180,24 +182,19 @@ class App
      */
     public static function path(string $type, ?string $plugin = null): array
     {
-        if ($type === 'Plugin') {
-            return (array)Configure::read('App.paths.plugins');
-        }
-        if (empty($plugin) && $type === 'Locale') {
-            return (array)Configure::read('App.paths.locales');
-        }
-        if (empty($plugin) && $type === 'Template') {
-            return (array)Configure::read('App.paths.templates');
-        }
-        if (!empty($plugin)) {
-            if ($type === 'Template') {
-                return [Plugin::templatePath($plugin)];
+        if (empty($plugin)) {
+            if ($type[0] === strtolower($type[0])) {
+                return (array)Configure::read('App.paths.' . $type);
             }
 
-            return [Plugin::classPath($plugin) . $type . DIRECTORY_SEPARATOR];
+            return [APP . $type . DIRECTORY_SEPARATOR];
         }
 
-        return [APP . $type . DIRECTORY_SEPARATOR];
+        if ($type === 'templates') {
+            return [Plugin::templatePath($plugin)];
+        }
+
+        return [Plugin::classPath($plugin) . $type . DIRECTORY_SEPARATOR];
     }
 
     /**
@@ -216,7 +213,7 @@ class App
      */
     public static function core(string $type): array
     {
-        if ($type === 'Template') {
+        if ($type === 'templates') {
             return [CORE_PATH . 'templates' . DIRECTORY_SEPARATOR];
         }
 

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -170,13 +170,14 @@ class App
      * Will return the value of `App.paths.plugins` config.
      *
      * ```
-     * App::path('Model/Table', 'MyPlugin');
+     * App::path('Model/Table');
      * ```
      *
-     * Will return the path for tables under the 'MyPlugin' plugin.
+     * Will return the path for tables `src/Model/Table`.
      *
      * @param string $type type of path
-     * @param string|null $plugin name of plugin
+     * @param string|null $plugin This argument is deprecated.
+     *   Use \Cake\Core\Plugin::classPath()/templatePath() instead for plugin paths.
      * @return array
      * @link https://book.cakephp.org/3.0/en/core-libraries/app.html#finding-paths-to-namespaces
      */
@@ -189,6 +190,11 @@ class App
 
             return [APP . $type . DIRECTORY_SEPARATOR];
         }
+
+        deprecationWarning(
+            'Using App::path() with 2nd argument $plugin is deprecated.'
+            . ' Use \Cake\Core\Plugin::classPath()/templatePath() instead.'
+        );
 
         if ($type === 'templates') {
             return [Plugin::templatePath($plugin)];

--- a/src/Core/ConventionsTrait.php
+++ b/src/Core/ConventionsTrait.php
@@ -140,7 +140,7 @@ trait ConventionsTrait
             return Plugin::path($pluginName);
         }
 
-        return current(App::path('Plugin')) . $pluginName . DIRECTORY_SEPARATOR;
+        return current(App::path('plugins')) . $pluginName . DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -110,7 +110,7 @@ class PluginCollection implements Iterator, Countable
     /**
      * Locate a plugin path by looking at configuration data.
      *
-     * This will use the `plugins` Configure key, and fallback to enumerating `App::path('Plugin')`
+     * This will use the `plugins` Configure key, and fallback to enumerating `App::path('pluginss')`
      *
      * This method is not part of the official public API as plugins with
      * no plugin class are being phased out.
@@ -130,7 +130,7 @@ class PluginCollection implements Iterator, Countable
         }
 
         $pluginPath = str_replace('/', DIRECTORY_SEPARATOR, $name);
-        $paths = App::path('Plugin');
+        $paths = App::path('plugins');
         foreach ($paths as $path) {
             if (is_dir($path . $pluginPath)) {
                 return $path . $pluginPath . DIRECTORY_SEPARATOR;

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -110,7 +110,7 @@ class PluginCollection implements Iterator, Countable
     /**
      * Locate a plugin path by looking at configuration data.
      *
-     * This will use the `plugins` Configure key, and fallback to enumerating `App::path('pluginss')`
+     * This will use the `plugins` Configure key, and fallback to enumerating `App::path('plugins')`
      *
      * This method is not part of the official public API as plugins with
      * no plugin class are being phased out.

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -160,7 +160,7 @@ class MessagesFileLoader
 
         $searchPaths = [];
 
-        $localePaths = App::path('Locale');
+        $localePaths = App::path('locales');
         if (empty($localePaths) && defined('APP')) {
             $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
         }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -302,7 +302,7 @@ class View implements EventDispatcherInterface
      *
      * @var string
      */
-    public const NAME_TEMPLATE = 'Template';
+    public const NAME_TEMPLATE = 'templates';
 
     /**
      * Constant for folder name containing files for overriding plugin templates.

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1524,11 +1524,11 @@ class View implements EventDispatcherInterface
                     . $plugin
                     . DIRECTORY_SEPARATOR;
             }
-            $pluginPaths = array_merge($pluginPaths, App::path(static::NAME_TEMPLATE, $plugin));
+            $pluginPaths[] = Plugin::templatePath($plugin);
         }
 
         if (!empty($this->theme)) {
-            $themePaths = App::path(static::NAME_TEMPLATE, Inflector::camelize($this->theme));
+            $themePaths[] = Plugin::templatePath(Inflector::camelize($this->theme));
 
             if ($plugin) {
                 for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
@@ -1548,7 +1548,7 @@ class View implements EventDispatcherInterface
             $themePaths,
             $pluginPaths,
             $templatePaths,
-            [dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR]
+            App::core('templates')
         );
 
         if ($plugin !== null) {

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -220,16 +220,19 @@ class AppTest extends TestCase
      * test path() with a plugin.
      *
      * @return void
+     * @deprecated
      */
     public function testPathWithPlugins()
     {
-        $basepath = TEST_APP . 'Plugin' . DS;
-        $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
-        $result = App::path('Controller', 'TestPlugin');
-        $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
-        $result = App::path('Controller', 'Company/TestPluginThree');
-        $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
-        $this->assertPathEquals($expected, $result[0]);
+        $this->deprecated(function () {
+            $basepath = TEST_APP . 'Plugin' . DS;
+            $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
+            $result = App::path('Controller', 'TestPlugin');
+            $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
+            $result = App::path('Controller', 'Company/TestPluginThree');
+            $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
+            $this->assertPathEquals($expected, $result[0]);
+        });
     }
 
     /**

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -225,10 +225,8 @@ class AppTest extends TestCase
     {
         $basepath = TEST_APP . 'Plugin' . DS;
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
-
         $result = App::path('Controller', 'TestPlugin');
         $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
-
         $result = App::path('Controller', 'Company/TestPluginThree');
         $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
         $this->assertPathEquals($expected, $result[0]);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -242,7 +242,7 @@ class ViewTest extends TestCase
 
         $View = new TestView(null, null, null, $viewOptions);
         $paths = $View->paths();
-        $expected = array_merge(App::path('Template'), App::core('Template'));
+        $expected = array_merge(App::path('templates'), App::core('templates'));
         $this->assertEquals($expected, $paths);
 
         $paths = $View->paths('TestPlugin');


### PR DESCRIPTION
Refs #13604

I agree with @markstory that `App::path()` doesn't need a `$plugin` argument since `Plugin` class already has methods to get plugin paths. Should I drop the argument?