### PR TITLE
4.x url helper

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -663,14 +663,18 @@ class HtmlHelper extends Helper
      * - `fullBase` If true the src attribute will get a full address for the image file.
      * - `plugin` False value will prevent parsing path as a plugin
      *
-     * @param string $path Path to the image file, relative to the app/webroot/img/ directory.
+     * @param string|array $path Path to the image file, relative to the webroot/img/ directory.
      * @param array $options Array of HTML attributes. See above for special options.
      * @return string completed img tag
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-images
      */
-    public function image(string $path, array $options = []): string
+    public function image($path, array $options = []): string
     {
-        $path = $this->Url->image($path, $options);
+        if (is_string($path)) {
+            $path = $this->Url->image($path, $options);
+        } else {
+            $path = $this->Url->build($path, $options);
+        }
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
         if (!isset($options['alt'])) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -219,7 +219,11 @@ class HtmlHelper extends Helper
         $out = '';
 
         if (isset($options['link'])) {
-            $options['link'] = $this->Url->assetUrl($options['link']);
+            if (is_array($options['link'])) {
+                $options['link'] = $this->Url->build($options['link']);
+            } else {
+                $options['link'] = $this->Url->assetUrl($options['link']);
+            }
             if (isset($options['rel']) && $options['rel'] === 'icon') {
                 $out = $this->formatTemplate('metalink', [
                     'url' => $options['link'],
@@ -659,12 +663,12 @@ class HtmlHelper extends Helper
      * - `fullBase` If true the src attribute will get a full address for the image file.
      * - `plugin` False value will prevent parsing path as a plugin
      *
-     * @param string|array $path Path to the image file, relative to the app/webroot/img/ directory.
+     * @param string $path Path to the image file, relative to the app/webroot/img/ directory.
      * @param array $options Array of HTML attributes. See above for special options.
      * @return string completed img tag
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-images
      */
-    public function image($path, array $options = []): string
+    public function image(string $path, array $options = []): string
     {
         $path = $this->Url->image($path, $options);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -65,7 +65,7 @@ class UrlHelper extends Helper
      * Depending on options passed provides full URL with domain name. Also calls
      * `Helper::assetTimestamp()` to add timestamp to local files.
      *
-     * @param string|array $path Path string or URL array
+     * @param string $path Path string.
      * @param array $options Options array. Possible keys:
      *   `fullBase` Return full URL with domain name
      *   `pathPrefix` Path prefix for relative URLs
@@ -76,7 +76,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function image($path, array $options = []): string
+    public function image(string $path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.imageBaseUrl');
 
@@ -89,7 +89,7 @@ class UrlHelper extends Helper
      * Depending on options passed provides full URL with domain name. Also calls
      * `Helper::assetTimestamp()` to add timestamp to local files.
      *
-     * @param string|array $path Path string or URL array
+     * @param string $path Path string.
      * @param array $options Options array. Possible keys:
      *   `fullBase` Return full URL with domain name
      *   `pathPrefix` Path prefix for relative URLs
@@ -101,7 +101,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function css($path, array $options = []): string
+    public function css(string $path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.cssBaseUrl');
         $ext = '.css';
@@ -115,7 +115,7 @@ class UrlHelper extends Helper
      * Depending on options passed provides full URL with domain name. Also calls
      * `Helper::assetTimestamp()` to add timestamp to local files.
      *
-     * @param string|array $path Path string or URL array
+     * @param string $path Path string.
      * @param array $options Options array. Possible keys:
      *   `fullBase` Return full URL with domain name
      *   `pathPrefix` Path prefix for relative URLs
@@ -127,7 +127,7 @@ class UrlHelper extends Helper
      *        enable timestamping regardless of debug value.
      * @return string Generated URL
      */
-    public function script($path, array $options = []): string
+    public function script(string $path, array $options = []): string
     {
         $pathPrefix = Configure::read('App.jsBaseUrl');
         $ext = '.js';
@@ -153,15 +153,12 @@ class UrlHelper extends Helper
      *    Set to true to apply timestamps when debug is true. Set to 'force' to always
      *    enable timestamping regardless of debug value.
      *
-     * @param string|array $path Path string or URL array
+     * @param string $path Path string or URL array
      * @param array $options Options array.
      * @return string Generated URL
      */
-    public function assetUrl($path, array $options = []): string
+    public function assetUrl(string $path, array $options = []): string
     {
-        if (is_array($path)) {
-            return $this->build($path, $options);
-        }
         // data URIs only require HTML escaping
         if (preg_match('/^data:[a-z]+\/[a-z]+;/', $path)) {
             return h($path);

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -231,11 +231,15 @@ class UrlHelper extends Helper
      */
     public function assetTimestamp(string $path, $timestamp = null): string
     {
+        if (strpos($path, '?') !== false) {
+            return $path;
+        }
+
         if ($timestamp === null) {
             $timestamp = Configure::read('Asset.timestamp');
         }
         $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));
-        if ($timestampEnabled && strpos($path, '?') === false) {
+        if ($timestampEnabled) {
             $filepath = preg_replace(
                 '/^' . preg_quote($this->_View->getRequest()->getAttribute('webroot'), '/') . '/',
                 '',

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -371,10 +371,6 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => '//google.com/logo.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->image(['controller' => 'test', 'action' => 'view', 1, '_ext' => 'gif']);
-        $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
-        $this->assertHtml($expected, $result);
-
         $result = $this->Html->image('/test/view/1.gif');
         $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
@@ -426,15 +422,6 @@ class HtmlHelperTest extends TestCase
     {
         $result = $this->Html->image('test.gif?one=two&three=four');
         $expected = ['img' => ['src' => 'img/test.gif?one=two&amp;three=four', 'alt' => '']];
-        $this->assertHtml($expected, $result);
-
-        $result = $this->Html->image([
-            'controller' => 'images',
-            'action' => 'display',
-            'test',
-            '?' => ['one' => 'two', 'three' => 'four'],
-        ]);
-        $expected = ['img' => ['src' => '/images/display/test?one=two&amp;three=four', 'alt' => '']];
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -371,6 +371,10 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => '//google.com/logo.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
+        $result = $this->Html->image(['controller' => 'test', 'action' => 'view', 1, '_ext' => 'gif']);
+        $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
+        $this->assertHtml($expected, $result);
+
         $result = $this->Html->image('/test/view/1.gif');
         $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
@@ -385,6 +389,15 @@ class HtmlHelperTest extends TestCase
 
         $result = $this->Html->image('//google.com/"><script>alert(1)</script>');
         $expected = ['img' => ['src' => '//google.com/&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', 'alt' => '']];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->image([
+            'controller' => 'images',
+            'action' => 'display',
+            'test',
+            '?' => ['one' => 'two', 'three' => 'four'],
+        ]);
+        $expected = ['img' => ['src' => '/images/display/test?one=two&amp;three=four', 'alt' => '']];
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -199,17 +199,8 @@ class UrlHelperTest extends TestCase
      */
     public function testAssetUrl()
     {
-        Router::connect('/:controller/:action/*');
-
         $this->Helper->webroot = '';
-        $result = $this->Helper->assetUrl(
-            [
-                'controller' => 'js',
-                'action' => 'post',
-                '_ext' => 'js',
-            ],
-            ['fullBase' => true]
-        );
+        $result = $this->Helper->assetUrl('js/post.js', ['fullBase' => true]);
         $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg', ['pathPrefix' => 'img/']);
@@ -366,15 +357,9 @@ class UrlHelperTest extends TestCase
      */
     public function testScript()
     {
-        Router::connect('/:controller/:action/*');
-
         $this->Helper->webroot = '';
         $result = $this->Helper->script(
-            [
-                'controller' => 'js',
-                'action' => 'post',
-                '_ext' => 'js',
-            ],
+            'post.js',
             ['fullBase' => true]
         );
         $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);


### PR DESCRIPTION
`UrlHelper::assetUrl()/image()/script()/css()` now only take path as string. This allows having a cleaner API without multiple argument types.

I don't see a reason why these methods should take an array argument. Anyone dynamically generating assets through controllers can just use `UrlHelper::build()`.