### PR TITLE
Add deprecations for 4.x API changes.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -194,6 +194,10 @@ class ConsoleIo
      */
     public function info($message = null, $newlines = 1, $level = self::NORMAL)
     {
+        if ($message === null) {
+            deprecationWarning('ConsoleIo::info() in 4.x will not allow null anymore.');
+        }
+
         $messageType = 'info';
         $message = $this->wrapMessageWithType($messageType, $message);
 
@@ -210,6 +214,10 @@ class ConsoleIo
      */
     public function warning($message = null, $newlines = 1)
     {
+        if ($message === null) {
+            deprecationWarning('ConsoleIo::warning() in 4.x will not allow null anymore.');
+        }
+
         $messageType = 'warning';
         $message = $this->wrapMessageWithType($messageType, $message);
 
@@ -226,6 +234,10 @@ class ConsoleIo
      */
     public function error($message = null, $newlines = 1)
     {
+        if ($message === null) {
+            deprecationWarning('ConsoleIo::error() in 4.x will not allow null anymore.');
+        }
+
         $messageType = 'error';
         $message = $this->wrapMessageWithType($messageType, $message);
 
@@ -243,6 +255,10 @@ class ConsoleIo
      */
     public function success($message = null, $newlines = 1, $level = self::NORMAL)
     {
+        if ($message === null) {
+            deprecationWarning('ConsoleIo::success() in 4.x will not allow null anymore.');
+        }
+
         $messageType = 'success';
         $message = $this->wrapMessageWithType($messageType, $message);
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -717,6 +717,8 @@ class Shell
      */
     public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
+
+
         return $this->_io->out($message, $newlines, $level);
     }
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -717,8 +717,6 @@ class Shell
      */
     public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-
-
         return $this->_io->out($message, $newlines, $level);
     }
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -277,7 +277,11 @@ class HtmlHelper extends Helper
         $out = null;
 
         if (isset($options['link'])) {
-            $options['link'] = $this->Url->assetUrl($options['link']);
+            if (is_array($options['link'])) {
+                $options['link'] = $this->Url->build($options['link']);
+            } else {
+                $options['link'] = $this->Url->assetUrl($options['link']);
+            }
             if (isset($options['rel']) && $options['rel'] === 'icon') {
                 $out = $this->formatTemplate('metalink', [
                     'url' => $options['link'],
@@ -850,14 +854,18 @@ class HtmlHelper extends Helper
      * - `fullBase` If true the src attribute will get a full address for the image file.
      * - `plugin` False value will prevent parsing path as a plugin
      *
-     * @param string|array $path Path to the image file, relative to the app/webroot/img/ directory.
+     * @param string|array $path Path to the image file, relative to the webroot/img/ directory.
      * @param array $options Array of HTML attributes. See above for special options.
      * @return string completed img tag
      * @link https://book.cakephp.org/3.0/en/views/helpers/html.html#linking-to-images
      */
     public function image($path, array $options = [])
     {
-        $path = $this->Url->image($path, $options);
+        if (is_string($path)) {
+            $path = $this->Url->image($path, $options);
+        } else {
+            $path = $this->Url->build($path, $options);
+        }
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
         if (!isset($options['alt'])) {

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -80,10 +80,6 @@ class UrlHelper extends Helper
      */
     public function image($path, array $options = [])
     {
-        if (is_array($path)) {
-            deprecationWarning('UrlHelper::image() in 4.x will not allow array of paths anymore. Use string here.');
-        }
-
         $pathPrefix = Configure::read('App.imageBaseUrl');
 
         return $this->assetUrl($path, $options + compact('pathPrefix'));
@@ -109,10 +105,6 @@ class UrlHelper extends Helper
      */
     public function css($path, array $options = [])
     {
-        if (is_array($path)) {
-            deprecationWarning('UrlHelper::css() in 4.x will not allow array of paths anymore. Use string here.');
-        }
-
         $pathPrefix = Configure::read('App.cssBaseUrl');
         $ext = '.css';
 
@@ -139,10 +131,6 @@ class UrlHelper extends Helper
      */
     public function script($path, array $options = [])
     {
-        if (is_array($path)) {
-            deprecationWarning('UrlHelper::script() in 4.x will not allow array of paths anymore. Use string here.');
-        }
-
         $pathPrefix = Configure::read('App.jsBaseUrl');
         $ext = '.js';
 
@@ -174,8 +162,6 @@ class UrlHelper extends Helper
     public function assetUrl($path, array $options = [])
     {
         if (is_array($path)) {
-            deprecationWarning('UrlHelper::assetUrl() in 4.x will not allow array of paths anymore. Use string here.');
-
             return $this->build($path, !empty($options['fullBase']));
         }
         // data URIs only require HTML escaping
@@ -250,11 +236,15 @@ class UrlHelper extends Helper
      */
     public function assetTimestamp($path, $timestamp = null)
     {
+        if (strpos($path, '?') !== false) {
+            return $path;
+        }
+
         if ($timestamp === null) {
             $timestamp = Configure::read('Asset.timestamp');
         }
         $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));
-        if ($timestampEnabled && strpos($path, '?') === false) {
+        if ($timestampEnabled) {
             $filepath = preg_replace(
                 '/^' . preg_quote($this->_View->getRequest()->getAttribute('webroot'), '/') . '/',
                 '',

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -80,6 +80,10 @@ class UrlHelper extends Helper
      */
     public function image($path, array $options = [])
     {
+        if (is_array($path)) {
+            deprecationWarning('UrlHelper::image() in 4.x will not allow array of paths anymore. Use string here.');
+        }
+
         $pathPrefix = Configure::read('App.imageBaseUrl');
 
         return $this->assetUrl($path, $options + compact('pathPrefix'));
@@ -105,6 +109,10 @@ class UrlHelper extends Helper
      */
     public function css($path, array $options = [])
     {
+        if (is_array($path)) {
+            deprecationWarning('UrlHelper::css() in 4.x will not allow array of paths anymore. Use string here.');
+        }
+
         $pathPrefix = Configure::read('App.cssBaseUrl');
         $ext = '.css';
 
@@ -131,6 +139,10 @@ class UrlHelper extends Helper
      */
     public function script($path, array $options = [])
     {
+        if (is_array($path)) {
+            deprecationWarning('UrlHelper::script() in 4.x will not allow array of paths anymore. Use string here.');
+        }
+
         $pathPrefix = Configure::read('App.jsBaseUrl');
         $ext = '.js';
 
@@ -162,6 +174,8 @@ class UrlHelper extends Helper
     public function assetUrl($path, array $options = [])
     {
         if (is_array($path)) {
+            deprecationWarning('UrlHelper::assetUrl() in 4.x will not allow array of paths anymore. Use string here.');
+
             return $this->build($path, !empty($options['fullBase']));
         }
         // data URIs only require HTML escaping

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -373,6 +373,15 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->image('//google.com/"><script>alert(1)</script>');
         $expected = ['img' => ['src' => '//google.com/&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', 'alt' => '']];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Html->image([
+            'controller' => 'images',
+            'action' => 'display',
+            'test',
+            '?' => ['one' => 'two', 'three' => 'four'],
+        ]);
+        $expected = ['img' => ['src' => '/images/display/test?one=two&amp;three=four', 'alt' => '']];
+        $this->assertHtml($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/13630 and other 4.x changes that are hard to spot in 3.x and will crash hard on upgrade.
Best to allow people to get up to date here inside 3.x to make the upgrade path easier (as in the diff between them smaller).