### PR TITLE
Fix CS - empty values last in docblocks

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -280,7 +280,7 @@ class MemcachedEngine extends CacheEngine
      * Read an option value from the memcached connection.
      *
      * @param string $name The option name to read.
-     * @return string|int|null|bool
+     * @return string|int|bool|null
      */
     public function getOption($name)
     {

--- a/src/Cache/SimpleCacheEngine.php
+++ b/src/Cache/SimpleCacheEngine.php
@@ -100,7 +100,7 @@ class SimpleCacheEngine implements CacheInterface, CacheEngineInterface
      *
      * @param string $key The key of the item to store.
      * @param mixed $value The value of the item to store, must be serializable.
-     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     * @param \DateInterval|int|null $ttl Optional. The TTL value of this item. If no value is sent and
      *   the driver supports TTL then the library may set a default value
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
@@ -176,7 +176,7 @@ class SimpleCacheEngine implements CacheInterface, CacheEngineInterface
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
      * @param iterable $values A list of key => value pairs for a multiple-set operation.
-     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     * @param \DateInterval|int|null $ttl Optional. The TTL value of this item. If no value is sent and
      *   the driver supports TTL then the library may set a default value
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -231,7 +231,7 @@ class Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return null|int The exit code or null for success
+     * @return int|null The exit code or null for success
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -120,7 +120,7 @@ class ConsoleIo
     /**
      * Get/set the current output level.
      *
-     * @param null|int $level The current output level.
+     * @param int|null $level The current output level.
      * @return int The current output level.
      */
     public function level($level = null)
@@ -391,7 +391,7 @@ class ConsoleIo
      * @param string|null $style The style to get or create.
      * @param array|false|null $definition The array definition of the style to change or create a style
      *   or false to remove a style.
-     * @return array|null|true If you are getting styles, the style or null will be returned. If you are creating/modifying
+     * @return array|true|null If you are getting styles, the style or null will be returned. If you are creating/modifying
      *   styles true will be returned.
      * @see \Cake\Console\ConsoleOutput::styles()
      */

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -154,7 +154,7 @@ class CookieComponent extends Component
      * ```
      *
      * @param string $keyname The top level keyname to configure.
-     * @param null|string|array $option Either the option name to set, or an array of options to set,
+     * @param array|string|null $option Either the option name to set, or an array of options to set,
      *   or null to read config options for a given key.
      * @param string|null $value Either the value to set, or empty when $option is an array.
      * @return array|null

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -723,7 +723,7 @@ class RequestHandlerComponent extends Component
      * Maps a content type alias back to its mime-type(s)
      *
      * @param string|array $alias String alias to convert back into a content type. Or an array of aliases to map.
-     * @return string|null|array Null on an undefined alias. String value of the mapped alias type. If an
+     * @return string|array|null Null on an undefined alias. String value of the mapped alias type. If an
      *   alias maps to more than one content type, the first one will be returned. If an array is provided
      *   for $alias, an array of mapped types will be returned.
      */

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -47,7 +47,7 @@ class App
      * @param string $class Class name
      * @param string $type Type of class
      * @param string $suffix Class name suffix
-     * @return false|string False if the class is not found or namespaced class name
+     * @return string|false False if the class is not found or namespaced class name
      */
     public static function className($class, $type = '', $suffix = '')
     {

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -58,7 +58,7 @@ trait PDODriverTrait
      * If first argument is passed, it will set internal connection object or
      * result to the value passed
      *
-     * @param null|\PDO $connection The PDO connection instance.
+     * @param \PDO|null $connection The PDO connection instance.
      * @return \PDO connection object used internally
      */
     public function connection($connection = null)

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2228,7 +2228,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Helper function used to build conditions by composing QueryExpression objects.
      *
      * @param string $part Name of the query part to append the new part to
-     * @param string|null|array|\Cake\Database\ExpressionInterface|callable $append Expression or builder function to append.
+     * @param string|array|\Cake\Database\ExpressionInterface|callable|null $append Expression or builder function to append.
      * @param string $conjunction type of conjunction to be used to operate part
      * @param array $types associative array of type names used to bind values to query
      * @return void

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -69,7 +69,7 @@ class BinaryType extends Type implements TypeInterface
     /**
      * Convert binary into resource handles
      *
-     * @param null|string|resource $value The value to convert.
+     * @param resource|string|null $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return resource|null
      * @throws \Cake\Core\Exception\Exception

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -83,7 +83,7 @@ class BinaryUuidType extends Type implements TypeInterface
     /**
      * Convert binary uuid into resource handles
      *
-     * @param null|string|resource $value The value to convert.
+     * @param resource|string|null $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return resource|string|null
      * @throws \Cake\Core\Exception\Exception

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -85,7 +85,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
     /**
      * Convert float values to PHP integers
      *
-     * @param null|string|resource $value The value to convert.
+     * @param resource|string|null $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return float|null
      * @throws \Cake\Core\Exception\Exception

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -72,7 +72,7 @@ class JsonType extends Type implements TypeInterface, BatchCastingInterface
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
-     * @return string|null|array
+     * @return string|array|null
      */
     public function toPHP($value, Driver $driver)
     {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -90,7 +90,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * If the properties argument is null, the currently hidden properties
      * will be returned. Otherwise the hidden properties will be set.
      *
-     * @param null|array $properties Either an array of properties to hide or null to get properties
+     * @param array|null $properties Either an array of properties to hide or null to get properties
      * @return array|\Cake\Datasource\EntityInterface
      */
     public function hiddenProperties($properties = null);
@@ -101,7 +101,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * If the properties argument is null, the currently virtual properties
      * will be returned. Otherwise the virtual properties will be set.
      *
-     * @param null|array $properties Either an array of properties to treat as virtual or null to get properties
+     * @param array|null $properties Either an array of properties to treat as virtual or null to get properties
      * @return array|\Cake\Datasource\EntityInterface
      */
     public function virtualProperties($properties = null);
@@ -143,7 +143,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      *
      * @deprecated 3.4.0 Use setDirty() and isDirty() instead.
      * @param string|null $property the field to set or check status for
-     * @param null|bool $isDirty true means the property was changed, false means
+     * @param bool|null $isDirty true means the property was changed, false means
      * it was not changed and null will make the function return current state
      * for that property
      * @return bool whether the property was changed or not

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -452,7 +452,7 @@ trait EntityTrait
      * will be returned. Otherwise the hidden properties will be set.
      *
      * @deprecated 3.4.0 Use EntityTrait::setHidden() and EntityTrait::getHidden()
-     * @param null|array $properties Either an array of properties to hide or null to get properties
+     * @param array|null $properties Either an array of properties to hide or null to get properties
      * @return array|$this
      */
     public function hiddenProperties($properties = null)
@@ -507,7 +507,7 @@ trait EntityTrait
      * will be returned. Otherwise the virtual properties will be set.
      *
      * @deprecated 3.4.0 Use EntityTrait::getVirtual() and EntityTrait::setVirtual()
-     * @param null|array $properties Either an array of properties to treat as virtual or null to get properties
+     * @param array|null $properties Either an array of properties to treat as virtual or null to get properties
      * @return array|$this
      */
     public function virtualProperties($properties = null)
@@ -796,7 +796,7 @@ trait EntityTrait
      *
      * @deprecated 3.4.0 Use EntityTrait::setDirty() and EntityTrait::isDirty()
      * @param string|null $property the field to set or check status for
-     * @param null|bool $isDirty true means the property was changed, false means
+     * @param bool|null $isDirty true means the property was changed, false means
      * it was not changed and null will make the function return current state
      * for that property
      * @return bool Whether the property was changed or not

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -178,7 +178,7 @@ trait QueryTrait
      * $query->cache(false);
      * ```
      *
-     * @param false|string|\Closure $key Either the cache key or a function to generate the cache key.
+     * @param \Closure|string|false $key Either the cache key or a function to generate the cache key.
      *   When using a function, this query instance will be supplied as an argument.
      * @param string|\Cake\Cache\CacheEngine $config Either the name of the cache config to use, or
      *   a cache config instance.

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -590,7 +590,7 @@ class File
      * Gets the mime type of the file. Uses the finfo extension if
      * it's available, otherwise falls back to mime_content_type().
      *
-     * @return false|string The mimetype of the file, or false if reading fails.
+     * @return string|false The mimetype of the file, or false if reading fails.
      */
     public function mime()
     {

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -99,7 +99,7 @@ class Schema
      * Get the attributes for a given field.
      *
      * @param string $name The field name.
-     * @return null|array The attributes for a field, or null.
+     * @return array|null The attributes for a field, or null.
      */
     public function field($name)
     {

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -93,7 +93,7 @@ class FormDataPart
      * By passing in `false` you can disable the disposition
      * header from being added.
      *
-     * @param null|string $disposition Use null to get/string to set.
+     * @param string|null $disposition Use null to get/string to set.
      * @return string|null
      */
     public function disposition($disposition = null)
@@ -107,7 +107,7 @@ class FormDataPart
     /**
      * Get/set the contentId for a part.
      *
-     * @param null|string $id The content id.
+     * @param string|null $id The content id.
      * @return string|null
      */
     public function contentId($id = null)
@@ -124,7 +124,7 @@ class FormDataPart
      * Setting the filename to `false` will exclude it from the
      * generated output.
      *
-     * @param null|string $filename Use null to get/string to set.
+     * @param string|null $filename Use null to get/string to set.
      * @return string|null
      */
     public function filename($filename = null)
@@ -138,7 +138,7 @@ class FormDataPart
     /**
      * Get/set the content type.
      *
-     * @param null|string $type Use null to get/string to set.
+     * @param string|null $type Use null to get/string to set.
      * @return string|null
      */
     public function type($type)
@@ -154,7 +154,7 @@ class FormDataPart
      *
      * Useful when content bodies are in encodings like base64.
      *
-     * @param null|string $type The type of encoding the value has.
+     * @param string|null $type The type of encoding the value has.
      * @return string|null
      */
     public function transferEncoding($type)

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -610,7 +610,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Get the response body as XML decoded data.
      *
-     * @return null|\SimpleXMLElement
+     * @return \SimpleXMLElement|null
      */
     public function getXml()
     {
@@ -620,7 +620,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Get the response body as XML decoded data.
      *
-     * @return null|\SimpleXMLElement
+     * @return \SimpleXMLElement|null
      */
     protected function _getXml()
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -762,7 +762,7 @@ class Response implements ResponseInterface
      *
      * Get/Set the Location header value.
      *
-     * @param null|string $url Either null to get the current location, or a string to set one.
+     * @param string|null $url Either null to get the current location, or a string to set one.
      * @return string|null When setting the location null will be returned. When reading the location
      *   a string of the current location header value (if any) will be returned.
      * @deprecated 3.4.0 Mutable responses are deprecated. Use `withLocation()` and `getHeaderLine()`

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -279,7 +279,7 @@ class ResponseEmitter implements EmitterInterface
      * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16
      *
      * @param string $header The Content-Range header to parse.
-     * @return false|array [unit, first, last, length]; returns false if no
+     * @return array|false [unit, first, last, length]; returns false if no
      *     content range or an invalid content range is provided
      */
     protected function parseContentRange($header)

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -55,7 +55,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * In PUT/PATCH/DELETE requests this property will contain the form-urlencoded
      * data.
      *
-     * @var null|array|object
+     * @var array|object|null
      * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getData() instead.
      */
     protected $data = [];

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1624,7 +1624,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name The name or dotted path to the query param or null to read all.
      * @param mixed $default The default value if the named parameter is not set, and $name is not null.
-     * @return null|string|array Query data.
+     * @return array|string|null Query data.
      * @see ServerRequest::getQueryParams()
      */
     public function getQuery($name = null, $default = null)
@@ -1702,7 +1702,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name Dot separated name of the value to read. Or null to read all data.
      * @param mixed $default The default data.
-     * @return null|string|array The value being read.
+     * @return array|string|null The value being read.
      */
     public function getData($name = null, $default = null)
     {
@@ -1782,7 +1782,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Read cookie data from the request's cookie data.
      *
      * @param string $key The key you want to read.
-     * @return null|string Either the cookie value, or null if the value doesn't exist.
+     * @return string|null Either the cookie value, or null if the value doesn't exist.
      * @deprecated 3.4.0 Use getCookie() instead.
      */
     public function cookie($key)
@@ -1804,7 +1804,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string $key The key or dotted path you want to read.
      * @param string $default The default value if the cookie is not set.
-     * @return null|array|string Either the cookie value, or null if the value doesn't exist.
+     * @return string|array|null Either the cookie value, or null if the value doesn't exist.
      */
     public function getCookie($key, $default = null)
     {
@@ -1882,7 +1882,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * post data. For other content types, it may be the deserialized request
      * body.
      *
-     * @return null|array|object The deserialized body parameters, if any.
+     * @return object|array|null The deserialized body parameters, if any.
      *     These will typically be an array or object.
      */
     public function getParsedBody()
@@ -1893,7 +1893,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Update the parsed body and get a new instance.
      *
-     * @param null|array|object $data The deserialized body data. This will
+     * @param object|array|null $data The deserialized body data. This will
      *     typically be in an array or object.
      * @return static
      */
@@ -2237,7 +2237,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Get the uploaded file from a dotted path.
      *
      * @param string $path The dot separated path to the file you want.
-     * @return null|\Psr\Http\Message\UploadedFileInterface
+     * @return \Psr\Http\Message\UploadedFileInterface|null
      */
     public function getUploadedFile($path)
     {

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2093,7 +2093,7 @@ class Email implements JsonSerializable, Serializable
      * Get/Set the configuration profile to use for this instance.
      *
      * @deprecated 3.4.0 Use setProfile()/getProfile() instead.
-     * @param null|string|array $config String with configuration name, or
+     * @param array|string|null $config String with configuration name, or
      *    an array with config or null to return current config.
      * @return string|array|$this
      */

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -248,7 +248,7 @@ class Socket
     /**
      * Get the connection context.
      *
-     * @return null|array Null when there is no connection, an array when there is.
+     * @return array|null Null when there is no connection, an array when there is.
      */
     public function context()
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -138,14 +138,14 @@ class BelongsToMany extends Association
     /**
      * Filtered conditions that reference the target table.
      *
-     * @var null|array
+     * @var array|null
      */
     protected $_targetConditions;
 
     /**
      * Filtered conditions that reference the junction table.
      *
-     * @var null|array
+     * @var array|null
      */
     protected $_junctionConditions;
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -142,7 +142,7 @@ class Route
      * Get/Set the supported extensions for this route.
      *
      * @deprecated 3.3.9 Use getExtensions/setExtensions instead.
-     * @param null|string|array $extensions The extensions to set. Use null to get.
+     * @param array|string|null $extensions The extensions to set. Use null to get.
      * @return array|null The extensions or null.
      */
     public function extensions($extensions = null)

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -191,7 +191,7 @@ class RouteBuilder
      * extensions applied. However, setting extensions does not modify existing routes.
      *
      * @deprecated 3.5.0 Use getExtensions/setExtensions instead.
-     * @param null|string|array $extensions Either the extensions to use or null.
+     * @param array|string|null $extensions Either the extensions to use or null.
      * @return array|null
      */
     public function extensions($extensions = null)

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -369,7 +369,7 @@ class RouteCollection
     /**
      * Get/set the extensions that the route collection could handle.
      *
-     * @param null|string|string[] $extensions Either the list of extensions to set,
+     * @param string[]|string|null $extensions Either the list of extensions to set,
      *   or null to get.
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -184,13 +184,13 @@ trait IntegrationTestTrait
     /**
      * Stored flash messages before render
      *
-     * @var null|array
+     * @var array|null
      */
     protected $_flashMessages;
 
     /**
      *
-     * @var null|string
+     * @var string|null
      */
     protected $_cookieEncryptionKey;
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1259,7 +1259,7 @@ trait IntegrationTestTrait
      * Inspect controller to extract possible causes of the failed assertion
      *
      * @param string $message Original message to use as a base
-     * @return null|string
+     * @return string|null
      */
     protected function extractVerboseMessage($message = null)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -324,7 +324,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @deprecated 3.4.0 Use setProvider()/getProvider() instead.
      * @param string $name The name under which the provider should be set.
-     * @param null|object|string $object Provider object or class name.
+     * @param string|object|null $object Provider object or class name.
      * @return $this|object|string|null
      */
     public function provider($name, $object = null)

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -260,7 +260,7 @@ class ArrayContext implements ContextInterface
      * Get the abstract field type for a given field name.
      *
      * @param string $field A dot separated path to get a schema type for.
-     * @return null|string An abstract data type or null.
+     * @return string|null An abstract data type or null.
      * @see \Cake\Database\Type
      */
     public function type($field)

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -83,7 +83,7 @@ interface ContextInterface
      * Get the abstract field type for a given field name.
      *
      * @param string $field A dot separated path to get a schema type for.
-     * @return null|string An abstract data type or null.
+     * @return string|null An abstract data type or null.
      * @see \Cake\Database\Type
      */
     public function type($field);

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -653,7 +653,7 @@ class EntityContext implements ContextInterface
      * Get the abstract field type for a given field name.
      *
      * @param string $field A dot separated path to get a schema type for.
-     * @return null|string An abstract data type or null.
+     * @return string|null An abstract data type or null.
      * @see \Cake\Database\Type
      */
     public function type($field)

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -45,8 +45,8 @@ class TimeHelper extends Helper
      *
      * Will use the provided timezone, or default output timezone if defined.
      *
-     * @param null|string|\DateTimeZone $timezone The override timezone if applicable.
-     * @return null|string|\DateTimeZone The chosen timezone or null.
+     * @param \DateTimeZone|string|null $timezone The override timezone if applicable.
+     * @return \DateTimeZone|string|null The chosen timezone or null.
      */
     protected function _getTimezone($timezone)
     {

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -59,7 +59,7 @@ trait StringTemplateTrait
      * Gets/sets templates to use.
      *
      * @deprecated 3.4.0 Use setTemplates()/getTemplates() instead.
-     * @param string|null|array $templates null or string allow reading templates. An array
+     * @param string|array|null $templates null or string allow reading templates. An array
      *   allows templates to be added.
      * @return $this|string|array
      */

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -47,21 +47,21 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * The plugin name to use.
      *
-     * @var string|null|false
+     * @var string|false|null
      */
     protected $_plugin;
 
     /**
      * The theme name to use.
      *
-     * @var string|null|false
+     * @var string|false|null
      */
     protected $_theme;
 
     /**
      * The layout name to render.
      *
-     * @var string|null|false
+     * @var string|false|null
      */
     protected $_layout;
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -328,7 +328,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * `False` to remove current plugin name is deprecated as of 3.4.0. Use directly `null` instead.
      *
-     * @param string|null|false $name Plugin name.
+     * @param string|false|null $name Plugin name.
      *   Use null or false to remove the current plugin name.
      * @return $this
      */
@@ -342,7 +342,7 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Gets the plugin name to use.
      *
-     * @return string|null|false
+     * @return string|false|null
      */
     public function getPlugin()
     {
@@ -353,7 +353,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * The plugin name to use
      *
      * @deprecated 3.4.0 Use setPlugin()/getPlugin() instead.
-     * @param string|null|false $name Plugin name. If null returns current plugin.
+     * @param string|false|null $name Plugin name. If null returns current plugin.
      *   Use false to remove the current plugin name.
      * @return string|false|null|$this
      */
@@ -417,7 +417,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * `False` to remove current theme is deprecated as of 3.4.0. Use directly `null` instead.
      *
-     * @param string|null|false $theme Theme name.
+     * @param string|false|null $theme Theme name.
      *   Use null or false to remove the current theme.
      * @return $this
      */
@@ -431,7 +431,7 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Gets the view theme to use.
      *
-     * @return string|null|false
+     * @return string|false|null
      */
     public function getTheme()
     {
@@ -442,7 +442,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * The view theme to use.
      *
      * @deprecated 3.4.0 Use setTheme()/getTheme() instead.
-     * @param string|null|false $theme Theme name. If null returns current theme.
+     * @param string|false|null $theme Theme name. If null returns current theme.
      *   Use false to remove the current theme.
      * @return string|false|null|$this
      */
@@ -504,7 +504,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * The name specified is the filename of the layout in /src/Template/Layout
      * without the .ctp extension.
      *
-     * @param string|null|false $name Layout file name to set.
+     * @param string|false|null $name Layout file name to set.
      * @return $this
      */
     public function setLayout($name)
@@ -517,7 +517,7 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Gets the name of the layout file to render the view inside of.
      *
-     * @return string|null|false
+     * @return string|false|null
      */
     public function getLayout()
     {

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -121,7 +121,7 @@ class RadioWidget implements WidgetInterface
      * Disabled attribute detection.
      *
      * @param array $radio Radio info.
-     * @param array|null|true $disabled The disabled values.
+     * @param array|true|null $disabled The disabled values.
      * @return bool
      */
     protected function _isDisabled($radio, $disabled)
@@ -228,7 +228,7 @@ class RadioWidget implements WidgetInterface
      * input types (multi-checkboxes) will also need labels generated.
      *
      * @param array $radio The input properties.
-     * @param false|string|array $label The properties for a label.
+     * @param array|string|false $label The properties for a label.
      * @param string $input The input widget.
      * @param \Cake\View\Form\ContextInterface $context The form context.
      * @param bool $escape Whether or not to HTML escape the label.


### PR DESCRIPTION
I ran

	'Spryker.Commenting.DocBlockTypeOrder',
	'Spryker.Commenting.DocBlockVariableNullHintLast',
	'Spryker.Commenting.DocBlockVarNotJustNull',

on the master branch.

The actual values should always be first, with the "empty" alternatives, the falsy ones, at the end.
This increases the readability of the types.

I hope this doesnt mess up the merges too much?
We could do the same for 4.x if that helps.