### PR TITLE
Fix undefined property $_tableLocator

### DIFF
--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -70,7 +70,7 @@ trait LocatorAwareTrait
      */
     public function getTableLocator()
     {
-        if ($this->_tableLocator === null) {
+        if (!isset($this->_tableLocator)) {
             $this->_tableLocator = TableRegistry::getTableLocator();
         }
 


### PR DESCRIPTION
The problem with `$this->_tableLocator === null` and `!$this->_tableLocator` is that it results in: 
```
Undefined property: MyTest::$_tableLocator

.../Vendor/cakephp/orm/Locator/LocatorAwareTrait.php:73
.../src/TestSuite/MyTestCase.php:59
```