### PR TITLE
New Feature: Allow overriding of button title

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1823,6 +1823,9 @@ class FormHelper extends AppHelper {
  */
 	public function button($title, $options = array()) {
 		$options += array('type' => 'submit', 'escape' => false, 'secure' => false);
+		if (isset($options['title'])) {
+			$title = $options['title'];
+		}
 		if ($options['escape']) {
 			$title = h($title);
 		}


### PR DESCRIPTION
This is a non-breaking feature that allows the button title to be passed via the options array. This can be useful when using FormHelper::inputs as it allows adding buttons into the same fieldset as other inputs. For example:

$fields = [];
$fields[] = [ 'name' => '', 'type' => 'button', 'label' => false, 'title' => 'Select All' ];
$fields[] = [ 'name' => 'data[Products][]', 'type' => 'checkbox', 'label' => 'Product 1', 'value' => 1 ];
$fields[] = [ 'name' => 'data[Products][]', 'type' => 'checkbox', 'label' => 'Product 2', 'value' => 2 ];
etc.

echo $this->Form->inputs( $fields, null, [
	'fieldset' => 'products',
	'legend' => 'Product Access'
] );