### PR TITLE
4.x mysql charset

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -81,9 +81,6 @@ class Mysql extends Driver
         if (!empty($config['timezone'])) {
             $config['init'][] = sprintf("SET time_zone = '%s'", $config['timezone']);
         }
-        if (!empty($config['encoding'])) {
-            $config['init'][] = sprintf('SET NAMES %s', $config['encoding']);
-        }
 
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
@@ -103,7 +100,7 @@ class Mysql extends Driver
             // phpcs:ignore Generic.Files.LineLength
             $dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']};charset={$config['encoding']}";
         } else {
-            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']};charset={$config['encoding']}";
         }
 
         $this->_connect($dsn, $config);

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -97,10 +97,13 @@ class Mysql extends Driver
         }
 
         if (empty($config['unix_socket'])) {
-            // phpcs:ignore Generic.Files.LineLength
-            $dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']};charset={$config['encoding']}";
+            $dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']}";
         } else {
-            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']};charset={$config['encoding']}";
+            $dsn = "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+        }
+
+        if (!empty($config['encoding'])) {
+            $dsn .= ";charset={$config['encoding']}";
         }
 
         $this->_connect($dsn, $config);

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -58,7 +58,7 @@ class MysqlTest extends TestCase
             'flags' => [],
             'encoding' => 'utf8mb4',
             'timezone' => null,
-            'init' => ['SET NAMES utf8mb4'],
+            'init' => []
         ];
 
         $expected['flags'] += [
@@ -108,7 +108,6 @@ class MysqlTest extends TestCase
         $dsn = 'mysql:host=foo;port=3440;dbname=bar;charset=some-encoding';
         $expected = $config;
         $expected['init'][] = "SET time_zone = 'Antarctica'";
-        $expected['init'][] = 'SET NAMES some-encoding';
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => false,
             PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
@@ -121,8 +120,7 @@ class MysqlTest extends TestCase
         $connection->expects($this->at(0))->method('exec')->with('Execute this');
         $connection->expects($this->at(1))->method('exec')->with('this too');
         $connection->expects($this->at(2))->method('exec')->with("SET time_zone = 'Antarctica'");
-        $connection->expects($this->at(3))->method('exec')->with('SET NAMES some-encoding');
-        $connection->expects($this->exactly(4))->method('exec');
+        $connection->expects($this->exactly(3))->method('exec');
 
         $driver->expects($this->once())->method('_connect')
             ->with($dsn, $expected);

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -58,7 +58,7 @@ class MysqlTest extends TestCase
             'flags' => [],
             'encoding' => 'utf8mb4',
             'timezone' => null,
-            'init' => []
+            'init' => [],
         ];
 
         $expected['flags'] += [
@@ -93,8 +93,8 @@ class MysqlTest extends TestCase
             'username' => 'user',
             'password' => 'pass',
             'port' => 3440,
-            'flags' => [1 => true, 2 => false],
-            'encoding' => 'some-encoding',
+            'flags' => [PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'],
+            'encoding' => null,
             'timezone' => 'Antarctica',
             'init' => [
                 'Execute this',
@@ -105,10 +105,11 @@ class MysqlTest extends TestCase
             ->setMethods(['_connect', 'getConnection'])
             ->setConstructorArgs([$config])
             ->getMock();
-        $dsn = 'mysql:host=foo;port=3440;dbname=bar;charset=some-encoding';
+        $dsn = 'mysql:host=foo;port=3440;dbname=bar';
         $expected = $config;
         $expected['init'][] = "SET time_zone = 'Antarctica'";
         $expected['flags'] += [
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
             PDO::ATTR_PERSISTENT => false,
             PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,


### PR DESCRIPTION
Refs #13057

Given the concerns raised by @chinpei215 it's safer to make this change in 4.x. I have tweaked the patch to allow using `SET NAMES ...` to set the charset if specifying charset in connection DSN is not feasible for someone. We can document this in skeleton app's config file.