### PR TITLE
2.x: Fix blackHole parameter

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -397,9 +397,11 @@ class SecurityComponent extends Component {
 				$require = $this->$property;
 				if (in_array($this->_action, $require) || $this->$property === array('*')) {
 					if (!$controller->request->is($method)) {
-						throw new SecurityException(
+						$exception = new SecurityException(
 							sprintf('The request method must be %s', strtoupper($method))
 						);
+						$exception->setType(strtolower($method));
+						throw $exception;
 					}
 				}
 			}
@@ -769,7 +771,7 @@ class SecurityComponent extends Component {
  * it will be removed from the list of valid tokens.
  *
  * @param Controller $controller A controller to check
- * @throws SecurityException
+ * @throws CsrfSecurityException
  * @return bool Valid csrf token.
  */
 	protected function _validateCsrf(Controller $controller) {
@@ -777,15 +779,15 @@ class SecurityComponent extends Component {
 		$requestToken = $controller->request->data('_Token.key');
 
 		if (!$requestToken) {
-			throw new SecurityException('Missing CSRF token');
+			throw new CsrfSecurityException('Missing CSRF token');
 		}
 
 		if (!isset($token['csrfTokens'][$requestToken])) {
-			throw new SecurityException('CSRF token mismatch');
+			throw new CsrfSecurityException('CSRF token mismatch');
 		}
 
 		if ($token['csrfTokens'][$requestToken] < time()) {
-			throw new SecurityException('CSRF token expired');
+			throw new CsrfSecurityException('CSRF token expired');
 		}
 
 		if ($this->csrfUseOnce) {

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -649,6 +649,16 @@ class SecurityException extends BadRequestException {
 	protected $_reason = null;
 
 /**
+ * Setter for type
+ *
+ * @param string $type Exception type
+ * @return void
+ */
+	public function setType($type) {
+		$this->_type = $type;
+	}
+
+/**
  * Getter for type
  *
  * @return string
@@ -685,6 +695,21 @@ class SecurityException extends BadRequestException {
 	public function getReason() {
 		return $this->_reason;
 	}
+
+}
+
+/**
+ * Csrf Security exception - used when SecurityComponent detects csrf issue with the current request
+ *
+ * @package       Cake.Error
+ */
+class CsrfSecurityException extends SecurityException {
+
+/**
+ * Security Exception type
+ * @var string
+ */
+	protected $_type = 'csrf';
 
 }
 


### PR DESCRIPTION
2.x book says the blackhole callback should expect a parameter indicating the type of error bellow.
"auth", "csrf", "get", "post", "put", "delete" and "secure".  
https://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#SecurityComponent::$blackHoleCallback

However, in the current 2.x version, only “auth” or “secure” is set.

This PR fixes the above blackhole callback's parameter bug.