### PR TITLE
Remove redundant config.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
     >
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
         <!-- E_ALL & ~E_USER_DEPRECATED (16383)-->
         <!-- E_ALL (32767) -->
         <ini name="error_reporting" value="32767"/>


### PR DESCRIPTION
`apc.enable_cli` can only be set through system php.ini.

https://www.php.net/manual/en/apcu.configuration.php