### PR TITLE
Cleanup "isAjax" from params in Router::reverseArray().

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -851,6 +851,7 @@ class Router
             $params['bare'],
             $params['requested'],
             $params['return'],
+            $params['isAjax'],
             $params['_Token'],
             $params['_csrfToken'],
             $params['_matchedRoute'],

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2794,6 +2794,7 @@ class RouterTest extends TestCase
             'requested' => 1,
             '_Token' => ['key' => 'sekret'],
             '_csrfToken' => 'foo',
+            'isAjax' => true,
         ];
         $result = Router::reverse($params);
         $this->assertEquals('/posts/view/1', $result);


### PR DESCRIPTION
Refs #13661

Earlier I missed that #13661 mentioned `isAjax` too.

This makes me realize that we should stop stuffing keys for security/csrf tokens, ajax etc. in request params. `params` should only contain keys related to routing. Extra info should be set as separate request attributes in 4.x.