### PR TITLE
4.x request params cleanup

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -271,9 +271,9 @@ class PaginatorComponent extends Component
     {
         $controller = $this->getController();
         $request = $controller->getRequest();
-        $paging = $this->_paginator->getPagingParams() + (array)$request->getParam('paging', []);
+        $paging = $this->_paginator->getPagingParams() + (array)$request->getAttribute('paging', []);
 
-        $controller->setRequest($request->withParam('paging', $paging));
+        $controller->setRequest($request->withAttribute('paging', $paging));
     }
 
     /**

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -177,7 +177,7 @@ class RequestHandlerComponent extends Component
         }
 
         $isAjax = $request->is('ajax');
-        $controller->setRequest($request->withParam('isAjax', $isAjax));
+        $controller->setRequest($request->withAttribute('isAjax', $isAjax));
 
         if (!$this->ext && $isAjax) {
             $this->ext = 'ajax';

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -505,11 +505,12 @@ class SecurityComponent extends Component
     {
         if ($request->is('requested')) {
             if ($request->getSession()->check('_Token')) {
-                $request = $request->withParam('_Token', $request->getSession()->read('_Token'));
+                $request = $request->withAttribute('securityToken', $request->getSession()->read('_Token'));
             }
 
             return $request;
         }
+
         $token = [
             'allowedControllers' => $this->_config['allowedControllers'],
             'allowedActions' => $this->_config['allowedActions'],
@@ -518,7 +519,7 @@ class SecurityComponent extends Component
 
         $request->getSession()->write('_Token', $token);
 
-        return $request->withParam('_Token', [
+        return $request->withAttribute('securityToken', [
             'unlockedFields' => $token['unlockedFields'],
         ]);
     }

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -112,15 +112,13 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         $cookieData = Hash::get($cookies, $this->_config['cookieName']);
 
         if ($cookieData !== null && strlen($cookieData) > 0) {
-            $params = $request->getAttribute('params');
-            $params['_csrfToken'] = $cookieData;
-            $request = $request->withAttribute('params', $params);
+            $request = $request->withAttribute('csrfToken', $cookieData);
         }
 
         $method = $request->getMethod();
         if ($method === 'GET' && $cookieData === null) {
             $token = $this->_createToken();
-            $request = $this->_addTokenToRequest($token, $request);
+            $request = $request->withAttribute('csrfToken', $token);
             /** @var \Cake\Http\Response $response */
             $response = $handler->handle($request);
 
@@ -177,21 +175,6 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     protected function _createToken(): string
     {
         return hash('sha512', Security::randomBytes(16), false);
-    }
-
-    /**
-     * Add a CSRF token to the request parameters.
-     *
-     * @param string $token The token to add.
-     * @param \Psr\Http\Message\ServerRequestInterface $request The request to augment
-     * @return \Psr\Http\Message\ServerRequestInterface Modified request
-     */
-    protected function _addTokenToRequest(string $token, ServerRequestInterface $request): ServerRequestInterface
-    {
-        $params = $request->getAttribute('params');
-        $params['_csrfToken'] = $token;
-
-        return $request->withAttribute('params', $params);
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -593,7 +593,6 @@ class Router
 
         unset(
             $params['pass'],
-            $params['paging'],
             $params['_matchedRoute'],
             $params['_name']
         );

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -594,7 +594,6 @@ class Router
         unset(
             $params['pass'],
             $params['paging'],
-            $params['_Token'],
             $params['_matchedRoute'],
             $params['_name']
         );

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -531,12 +531,14 @@ class FormHelper extends Helper
                 $this->_unlockedFields[] = $unlocked;
             }
         }
-        if (!$request->getParam('_csrfToken')) {
+
+        $csrfToken = $request->getAttribute('csrfToken');
+        if (!$csrfToken) {
             return '';
         }
 
         return $this->hidden('_csrfToken', [
-            'value' => $request->getParam('_csrfToken'),
+            'value' => $csrfToken,
             'secure' => static::SECURE_SKIP,
             'autocomplete' => 'off',
         ]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -155,7 +155,8 @@ class PaginatorComponentTest extends TestCase
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams(['page' => '1 " onclick="alert(\'xss\');">']));
         $settings = ['limit' => 1, 'maxLimit' => 10];
         $this->Paginator->paginate($this->Post, $settings);
-        $this->assertSame(1, $this->controller->getRequest()->getParam('paging.Posts.page'), 'XSS exploit opened');
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertSame(1, $params['Posts']['page'], 'XSS exploit opened');
     }
 
     /**
@@ -243,8 +244,9 @@ class PaginatorComponentTest extends TestCase
         $table = $this->getTableLocator()->get('PaginatorPosts');
 
         $this->Paginator->paginate($table, $settings);
-        $this->assertArrayHasKey('PaginatorPosts', $this->controller->getRequest()->getParam('paging'));
-        $this->assertArrayNotHasKey(0, $this->controller->getRequest()->getParam('paging'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertArrayHasKey('PaginatorPosts', $params);
+        $this->assertArrayNotHasKey(0, $params);
     }
 
     /**
@@ -270,7 +272,8 @@ class PaginatorComponentTest extends TestCase
             ->will($this->returnValue($query));
 
         $this->Paginator->paginate($table, $settings);
-        $this->assertSame('popular', $this->controller->getRequest()->getParam('paging.PaginatorPosts.finder'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertSame('popular', $params['PaginatorPosts']['finder']);
     }
 
     /**
@@ -365,8 +368,9 @@ class PaginatorComponentTest extends TestCase
             ]);
 
         $this->Paginator->paginate($table, $settings);
-        $this->assertSame('PaginatorPosts.id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sortDefault'));
-        $this->assertSame('DESC', $this->controller->getRequest()->getParam('paging.PaginatorPosts.directionDefault'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertSame('PaginatorPosts.id', $params['PaginatorPosts']['sortDefault']);
+        $this->assertSame('DESC', $params['PaginatorPosts']['directionDefault']);
     }
 
     /**
@@ -680,8 +684,9 @@ class PaginatorComponentTest extends TestCase
             'direction' => 'herp',
         ]));
         $this->Paginator->paginate($table);
-        $this->assertSame('id', $this->controller->getRequest()->getParam('paging.PaginatorPosts.sort'));
-        $this->assertSame('asc', $this->controller->getRequest()->getParam('paging.PaginatorPosts.direction'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertSame('id', $params['PaginatorPosts']['sort']);
+        $this->assertSame('asc', $params['PaginatorPosts']['direction']);
     }
 
     /**
@@ -719,19 +724,20 @@ class PaginatorComponentTest extends TestCase
 
         $this->Paginator->paginate($table);
 
+        $params = $this->controller->getRequest()->getAttribute('paging');
         $this->assertSame(
             0,
-            $this->controller->getRequest()->getParam('paging.PaginatorPosts.count'),
+            $params['PaginatorPosts']['count'],
             'Count should be 0'
         );
         $this->assertSame(
             1,
-            $this->controller->getRequest()->getParam('paging.PaginatorPosts.page'),
+            $params['PaginatorPosts']['page'],
             'Page number should not be 0'
         );
         $this->assertSame(
             1,
-            $this->controller->getRequest()->getParam('paging.PaginatorPosts.pageCount'),
+            $params['PaginatorPosts']['pageCount'],
             'Page count number should not be 0'
         );
     }
@@ -754,9 +760,10 @@ class PaginatorComponentTest extends TestCase
         } catch (NotFoundException $e) {
         }
 
+        $params = $this->controller->getRequest()->getAttribute('paging');
         $this->assertEquals(
             1,
-            $this->controller->getRequest()->getParam('paging.PaginatorPosts.page'),
+            $params['PaginatorPosts']['page'],
             'Page number should not be 0'
         );
 
@@ -785,9 +792,10 @@ class PaginatorComponentTest extends TestCase
         } catch (NotFoundException $e) {
         }
 
+        $params = $this->controller->getRequest()->getAttribute('paging');
         $this->assertEquals(
             3,
-            $this->controller->getRequest()->getParam('paging.PaginatorPosts.pageCount'),
+            $params['PaginatorPosts']['pageCount'],
             'Page count number should not be 0'
         );
 
@@ -1118,15 +1126,17 @@ class PaginatorComponentTest extends TestCase
             'limit' => '1000',
         ]));
         $this->Paginator->paginate($table, $settings);
-        $this->assertEquals(100, $this->controller->getRequest()->getParam('paging.PaginatorPosts.limit'));
-        $this->assertEquals(100, $this->controller->getRequest()->getParam('paging.PaginatorPosts.perPage'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(100, $params['PaginatorPosts']['limit']);
+        $this->assertEquals(100, $params['PaginatorPosts']['perPage']);
 
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'limit' => '10',
         ]));
         $this->Paginator->paginate($table, $settings);
-        $this->assertEquals(10, $this->controller->getRequest()->getParam('paging.PaginatorPosts.limit'));
-        $this->assertEquals(10, $this->controller->getRequest()->getParam('paging.PaginatorPosts.perPage'));
+        $params = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(10, $params['PaginatorPosts']['limit']);
+        $this->assertEquals(10, $params['PaginatorPosts']['perPage']);
     }
 
     /**
@@ -1155,42 +1165,42 @@ class PaginatorComponentTest extends TestCase
         $this->assertCount(4, $result, '4 rows should come back');
         $this->assertEquals(['First Post', 'Second Post', 'Third Post', 'Fourth Post'], $titleExtractor($result));
 
-        $result = $this->controller->getRequest()->getParam('paging.PaginatorPosts');
-        $this->assertEquals(4, $result['current']);
-        $this->assertEquals(4, $result['count']);
+        $result = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(4, $result['PaginatorPosts']['current']);
+        $this->assertEquals(4, $result['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published'];
         $result = $this->Paginator->paginate($table, $settings);
         $this->assertCount(3, $result, '3 rows should come back');
         $this->assertEquals(['First Post', 'Second Post', 'Third Post'], $titleExtractor($result));
 
-        $result = $this->controller->getRequest()->getParam('paging.PaginatorPosts');
-        $this->assertEquals(3, $result['current']);
-        $this->assertEquals(3, $result['count']);
+        $result = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(3, $result['PaginatorPosts']['current']);
+        $this->assertEquals(3, $result['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published', 'limit' => 2, 'page' => 2];
         $result = $this->Paginator->paginate($table, $settings);
         $this->assertCount(1, $result, '1 rows should come back');
         $this->assertEquals(['Third Post'], $titleExtractor($result));
 
-        $result = $this->controller->getRequest()->getParam('paging.PaginatorPosts');
-        $this->assertEquals(1, $result['current']);
-        $this->assertEquals(3, $result['count']);
-        $this->assertEquals(2, $result['pageCount']);
+        $result = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(1, $result['PaginatorPosts']['current']);
+        $this->assertEquals(3, $result['PaginatorPosts']['count']);
+        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
 
         $settings = ['finder' => 'published', 'limit' => 2];
         $result = $this->Paginator->paginate($table, $settings);
         $this->assertCount(2, $result, '2 rows should come back');
         $this->assertEquals(['First Post', 'Second Post'], $titleExtractor($result));
 
-        $result = $this->controller->getRequest()->getParam('paging.PaginatorPosts');
-        $this->assertEquals(2, $result['current']);
-        $this->assertEquals(3, $result['count']);
-        $this->assertEquals(2, $result['pageCount']);
-        $this->assertTrue($result['nextPage']);
-        $this->assertFalse($result['prevPage']);
-        $this->assertEquals(2, $result['perPage']);
-        $this->assertNull($result['limit']);
+        $result = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(2, $result['PaginatorPosts']['current']);
+        $this->assertEquals(3, $result['PaginatorPosts']['count']);
+        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
+        $this->assertTrue($result['PaginatorPosts']['nextPage']);
+        $this->assertFalse($result['PaginatorPosts']['prevPage']);
+        $this->assertEquals(2, $result['PaginatorPosts']['perPage']);
+        $this->assertNull($result['PaginatorPosts']['limit']);
     }
 
     /**
@@ -1219,12 +1229,12 @@ class PaginatorComponentTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
-        $result = $this->controller->getRequest()->getParam('paging.PaginatorPosts');
-        $this->assertEquals(2, $result['current']);
-        $this->assertEquals(3, $result['count']);
-        $this->assertEquals(2, $result['pageCount']);
-        $this->assertTrue($result['nextPage']);
-        $this->assertFalse($result['prevPage']);
+        $result = $this->controller->getRequest()->getAttribute('paging');
+        $this->assertEquals(2, $result['PaginatorPosts']['current']);
+        $this->assertEquals(3, $result['PaginatorPosts']['count']);
+        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
+        $this->assertTrue($result['PaginatorPosts']['nextPage']);
+        $this->assertFalse($result['PaginatorPosts']['prevPage']);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -365,7 +365,7 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Controller->beforeFilter($event);
         $this->RequestHandler->startup($event);
-        $this->assertTrue($this->Controller->getRequest()->getParam('isAjax'));
+        $this->assertTrue($this->Controller->getRequest()->getAttribute('isAjax'));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -1328,8 +1328,9 @@ class SecurityComponentTest extends TestCase
         $request = $this->Controller->getRequest();
         $request = $this->Security->generateToken($request);
 
-        $this->assertNotEmpty($request->getParam('_Token'));
-        $this->assertSame([], $request->getParam('_Token.unlockedFields'));
+        $securityToken = $request->getAttribute('securityToken');
+        $this->assertNotEmpty($securityToken);
+        $this->assertSame([], $securityToken['unlockedFields']);
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -580,7 +580,7 @@ class ControllerTest extends TestCase
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
         $this->assertCount(3, $results);
 
-        $paging = $Controller->getRequest()->getParam('paging');
+        $paging = $Controller->getRequest()->getAttribute('paging');
         $this->assertSame($paging['Posts']['page'], 1);
         $this->assertSame($paging['Posts']['pageCount'], 1);
         $this->assertFalse($paging['Posts']['prevPage']);
@@ -591,7 +591,7 @@ class ControllerTest extends TestCase
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
         $this->assertCount(1, $results);
 
-        $paging = $Controller->getRequest()->getParam('paging');
+        $paging = $Controller->getRequest()->getAttribute('paging');
         $this->assertSame($paging['Posts']['page'], 2);
         $this->assertSame($paging['Posts']['pageCount'], 2);
         $this->assertTrue($paging['Posts']['prevPage']);

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -95,7 +95,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertRegExp('/^[a-f0-9]+$/', $cookie['value'], 'Should look like a hash.');
         $this->assertSame(0, $cookie['expire'], 'session duration.');
         $this->assertSame('/dir/', $cookie['path'], 'session path.');
-        $this->assertEquals($cookie['value'], $updatedRequest->getParam('_csrfToken'));
+        $this->assertEquals($cookie['value'], $updatedRequest->getAttribute('csrfToken'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2510,7 +2510,6 @@ class RouterTest extends TestCase
             'bare' => 1,
             'return' => 1,
             'requested' => 1,
-            '_Token' => ['key' => 'sekret'],
         ];
         $result = Router::reverse($params);
         $this->assertSame('/posts/view/1', $result);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2549,7 +2549,6 @@ class RouterTest extends TestCase
             'action' => 'view',
             'pass' => [1],
             'url' => ['url' => 'eng/posts/view/1'],
-            'paging' => [],
             'models' => [],
         ];
         $result = Router::reverse($params);
@@ -2623,7 +2622,6 @@ class RouterTest extends TestCase
             'action' => 'view',
             'pass' => [123],
             '?' => ['foo' => 'bar', 'baz' => 'quu'],
-            'paging' => [],
         ];
         $actual = Router::reverseToArray($params);
         $expected = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1032,7 +1032,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateWithSecurity()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create($this->article, [
             'url' => '/articles/publish',
@@ -1065,7 +1065,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateEndGetNoSecurity()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
         $article = new Article();
         $result = $this->Form->create($article, [
             'type' => 'get',
@@ -1480,7 +1480,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecurityButtonNestedNamed()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
 
         $this->Form->create();
         $this->Form->button('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -2007,7 +2007,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withParam('_Token', 'stuff')
-            ->withParam('_csrfToken', 'testKey'));
+            ->withAttribute('csrfToken', 'testKey'));
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
             'population' => ['type' => 'decimal', 'length' => 15, 'precision' => 0],
@@ -2248,7 +2248,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredMultipleSelect()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'one', '2' => 'two'];
 
@@ -6572,7 +6572,7 @@ class FormHelperTest extends TestCase
      */
     public function testButtonUnlockedByDefault()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_csrfToken', 'secured'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'secured'));
         $this->Form->button('Save', ['name' => 'save']);
         $this->Form->button('Clear');
 
@@ -6702,7 +6702,7 @@ class FormHelperTest extends TestCase
     public function testSecurePostButton()
     {
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('_csrfToken', 'testkey')
+            ->withAttribute('csrfToken', 'testkey')
             ->withParam('_Token.unlockedFields', []));
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
@@ -7065,7 +7065,7 @@ class FormHelperTest extends TestCase
     public function testPostLinkAfterGetForm()
     {
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('_csrfToken', 'testkey')
+            ->withAttribute('csrfToken', 'testkey')
             ->withParam('_Token', 'val'));
 
         $this->Form->create($this->article, ['type' => 'get']);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -21,6 +21,7 @@ use Cake\Http\ServerRequest;
 use Cake\I18n\I18n;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use Cake\View\Helper\PaginatorHelper;
 use Cake\View\View;
 
@@ -55,20 +56,18 @@ class PaginatorHelperTest extends TestCase
         Configure::write('Config.language', 'eng');
         $request = new ServerRequest([
             'url' => '/',
-            'params' => [
-                'paging' => [
-                    'Article' => [
-                        'page' => 1,
-                        'current' => 9,
-                        'count' => 62,
-                        'prevPage' => false,
-                        'nextPage' => true,
-                        'pageCount' => 7,
-                        'sort' => null,
-                        'direction' => null,
-                        'limit' => null,
-                    ],
-                ],
+        ]);
+        $request = $request->withAttribute('paging', [
+            'Article' => [
+                'page' => 1,
+                'current' => 9,
+                'count' => 62,
+                'prevPage' => false,
+                'nextPage' => true,
+                'pageCount' => 7,
+                'sort' => null,
+                'direction' => null,
+                'limit' => null,
             ],
         ]);
         $this->View = new View($request);
@@ -125,9 +124,9 @@ class PaginatorHelperTest extends TestCase
     public function testHasPrevious()
     {
         $this->assertFalse($this->Paginator->hasPrev());
-        $this->View->setRequest(
-            $this->View->getRequest()->withParam('paging.Article.prevPage', true)
-        );
+        $this->setPagingParams(['Article' => [
+            'prevPage' => true,
+        ]]);
         $this->assertTrue($this->Paginator->hasPrev());
     }
 
@@ -139,9 +138,9 @@ class PaginatorHelperTest extends TestCase
     public function testHasNext()
     {
         $this->assertTrue($this->Paginator->hasNext());
-        $this->View->setRequest(
-            $this->View->getRequest()->withParam('paging.Article.nextPage', false)
-        );
+        $this->setPagingParams(['Article' => [
+            'nextPage' => false,
+        ]]);
         $this->assertFalse($this->Paginator->hasNext());
     }
 
@@ -163,7 +162,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequest($request);
 
         $this->Paginator->options(['url' => ['param']]);
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'current' => 9,
                 'count' => 62,
@@ -214,9 +213,11 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest(
-            $this->View->getRequest()->withParam('paging.Article.sort', 'title')
-        );
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'title',
+            ],
+        ]);
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -225,9 +226,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -236,9 +240,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -247,9 +254,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -258,9 +268,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'ASC']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
@@ -269,9 +282,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'asc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -280,10 +296,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc'));
-
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
             'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
@@ -335,9 +353,12 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'full_name',
+                'direction' => 'asc',
+            ],
+        ]);
 
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
@@ -355,9 +376,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'full_name')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'full_name',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
@@ -428,9 +452,12 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('Article.title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -439,9 +466,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
@@ -450,9 +480,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
@@ -461,9 +494,12 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Account.title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Account.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort('title');
         $expected = [
             'a' => ['href' => '/accounts/index?sort=title&amp;direction=asc'],
@@ -491,7 +527,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequest($request);
 
         $this->Paginator->options(['model' => 'Articles']);
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->setPagingParams([
             'Articles' => [
                 'current' => 9,
                 'count' => 62,
@@ -514,7 +550,7 @@ class PaginatorHelperTest extends TestCase
                 'page' => 1,
                 'scope' => 'tags',
             ],
-        ]));
+        ]);
 
         $result = $this->Paginator->sort('title', 'Title', ['model' => 'Articles']);
         $expected = [
@@ -591,16 +627,23 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortKeyFallbackToParams()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.sort', 'Article.body'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.body',
+            ],
+        ]);
         $result = $this->Paginator->sortKey();
         $this->assertSame('Article.body', $result);
 
         $result = $this->Paginator->sortKey('Article');
         $this->assertSame('Article.body', $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.order', 'DESC'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.body',
+                'order' => 'DESC',
+            ],
+        ]);
         $result = $this->Paginator->sortKey();
         $this->assertSame('Article.body', $result);
 
@@ -619,33 +662,47 @@ class PaginatorHelperTest extends TestCase
         $expected = 'asc';
         $this->assertEquals($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sortDir();
         $this->assertSame('desc', $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sortDir();
         $this->assertSame('asc', $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'desc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'title',
+                'direction' => 'desc',
+            ],
+        ]);
         $result = $this->Paginator->sortDir();
         $this->assertSame('desc', $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'title')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'title',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sortDir();
         $this->assertSame('asc', $result);
 
-        $this->View->setRequest(
-            $this->View->getRequest()->withParam('paging.Article.direction', null)
-        );
+        $this->setPagingParams([
+            'Article' => [
+                'direction' => null,
+            ],
+        ]);
         $result = $this->Paginator->sortDir('Article', ['direction' => 'asc']);
         $this->assertSame('asc', $result);
 
@@ -664,9 +721,12 @@ class PaginatorHelperTest extends TestCase
      */
     public function testSortDirFallbackToParams()
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.body',
+                'direction' => 'asc',
+            ],
+        ]);
 
         $result = $this->Paginator->sortDir();
         $this->assertSame('asc', $result);
@@ -674,9 +734,12 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->sortDir('Article');
         $this->assertSame('asc', $result);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.body')
-            ->withParam('paging.Article.direction', 'DESC'));
+        $this->setPagingParams([
+            'Article' => [
+                'sort' => 'Article.body',
+                'direction' => 'DESC',
+            ],
+        ]);
 
         $result = $this->Paginator->sortDir();
         $this->assertSame('desc', $result);
@@ -705,7 +768,11 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 1));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 1,
+            ],
+        ]);
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
@@ -752,7 +819,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
@@ -789,7 +856,11 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl();
         $this->assertSame('/index', $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 2,
+            ],
+        ]);
         $result = $this->Paginator->generateUrl();
         $this->assertSame('/index?page=2', $result);
 
@@ -797,17 +868,29 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->generateUrl($options);
         $this->assertSame('/index?sort=Article&amp;direction=desc&amp;page=2', $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 3,
+            ],
+        ]);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
         $this->assertSame('/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 3,
+            ],
+        ]);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, [], ['escape' => false]);
         $this->assertSame('/index?sort=Article.name&direction=desc&page=3', $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 3,
+            ],
+        ]);
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options, null, [], ['fullBase' => true]);
         $this->assertSame('http://localhost/index?sort=Article.name&amp;direction=desc&amp;page=3', $result);
@@ -824,10 +907,13 @@ class PaginatorHelperTest extends TestCase
      */
     public function testUrlGenerationResetsToPage1($field, $options, $expected)
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 2)
-            ->withParam('paging.Article.sort', 'name')
-            ->withParam('paging.Article.direction', 'asc'));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 2,
+                'sort' => 'name',
+                'direction' => 'asc',
+            ],
+        ]);
         $result = $this->Paginator->sort($field, null, ['url' => ['?' => $options]]);
         $this->assertSame($expected, $result);
     }
@@ -887,9 +973,12 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 2)
-            ->withParam('paging.Article.prevPage', true));
+        $this->setPagingParams([
+            'Article' => [
+                'page' => 2,
+                'prevPage' => true,
+            ],
+        ]);
         $url = ['prefix' => 'members'];
 
         $result = $this->Paginator->generateUrl([], null, $url);
@@ -957,12 +1046,10 @@ class PaginatorHelperTest extends TestCase
                 'controller' => 'posts',
                 'action' => 'index',
                 'plugin' => null,
-                'paging' => [
-                    'Articles' => ['page' => 2, 'prevPage' => true],
-                ],
             ],
             'webroot' => '/',
         ]);
+        $request = $request->withAttribute('paging', ['Article' => ['page' => 2, 'prevPage' => true]]);
         Router::setRequest($request);
         $this->View->setRequest($request);
 
@@ -1000,10 +1087,13 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.scope', 'article')
-            ->withParam('paging.Article.page', 3)
-            ->withParam('paging.Article.prevPage', true));
+        $this->setPagingParams([
+            'Article' => [
+                'scope' => 'article',
+                'page' => 3,
+                'prevPage' => true,
+            ],
+        ]);
         $this->Paginator->options(['model' => 'Article']);
 
         $result = $this->Paginator->generateUrl([]);
@@ -1062,10 +1152,14 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
+        $this->setPagingParams([
+            'Article' => [
+                'scope' => 'article',
+                'page' => 3,
+                'prevPage' => true,
+            ],
+        ]);
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.scope', 'article')
-            ->withParam('paging.Article.page', 3)
-            ->withParam('paging.Article.prevPage', true)
             ->withQueryParams([
                 'article' => [
                     'puppy' => 'no',
@@ -1104,7 +1198,7 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'title',
         ]];
-        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getAttribute('paging'));
 
         $this->Paginator->options = [];
 
@@ -1113,7 +1207,7 @@ class PaginatorHelperTest extends TestCase
             'sort' => 'title',
         ]];
         $this->Paginator->options($options);
-        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getAttribute('paging'));
 
         $options = ['paging' => ['Article' => [
             'direction' => 'desc',
@@ -1125,7 +1219,7 @@ class PaginatorHelperTest extends TestCase
             'direction' => 'desc',
             'sort' => 'Article.title',
         ]];
-        $this->assertEquals($expected, $this->View->getRequest()->getParam('paging'));
+        $this->assertEquals($expected, $this->View->getRequest()->getAttribute('paging'));
     }
 
     /**
@@ -1143,7 +1237,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
@@ -1202,7 +1296,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
@@ -1235,7 +1329,7 @@ class PaginatorHelperTest extends TestCase
         Router::setRequest($request);
 
         $this->Paginator->options(['model' => 'Articles']);
-        $request = $this->View->getRequest()->withParam('paging', [
+        $request = $this->View->getRequest()->withAttribute('paging', [
             'Articles' => [
                 'page' => 1, 'current' => 3, 'count' => 13,
                 'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
@@ -1261,7 +1355,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrev()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->setPagingParams([
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1270,7 +1364,7 @@ class PaginatorHelperTest extends TestCase
                 'nextPage' => true,
                 'pageCount' => 5,
             ],
-        ]));
+        ], false);
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev disabled'],
@@ -1294,9 +1388,10 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->prev('<< Previous', ['disabledTitle' => false]);
         $this->assertSame('', $result, 'disabled + no text = no link');
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Client.page', 2)
-            ->withParam('paging.Client.prevPage', true));
+        $this->setPagingParams(['Client' => [
+            'page' => 2,
+            'prevPage' => true,
+        ]]);
         $result = $this->Paginator->prev('<< Previous');
         $expected = [
             'li' => ['class' => 'prev'],
@@ -1327,7 +1422,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testPrevWithOptions()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 2, 'current' => 1, 'count' => 13, 'prevPage' => true,
                 'nextPage' => false, 'pageCount' => 2,
@@ -1393,7 +1488,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextDisabled()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 5,
                 'current' => 3,
@@ -1434,7 +1529,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNextAndPrevNonDefaultModel()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1496,7 +1591,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbers()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -1574,7 +1669,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -1598,7 +1693,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 14,
                 'current' => 3,
@@ -1622,7 +1717,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 3,
@@ -1661,7 +1756,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 15,
                 'current' => 3,
@@ -1688,7 +1783,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 10,
                 'current' => 3,
@@ -1716,7 +1811,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 6,
                 'current' => 15,
@@ -1744,7 +1839,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 37,
                 'current' => 15,
@@ -1783,7 +1878,7 @@ class PaginatorHelperTest extends TestCase
         Router::reload();
         Router::connect('/:controller/:action/:page');
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -2025,16 +2120,16 @@ class PaginatorHelperTest extends TestCase
             'ellipsis' => '... ',
         ];
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
-            'Client' => [
-                'page' => 1,
-                'pageCount' => $pageCount,
-            ],
-        ]));
+        $this->setPagingParams(['Client' => [
+            'page' => 1,
+            'pageCount' => $pageCount,
+        ]], false);
 
         $result = [];
         foreach ($pagesToCheck as $page) {
-            $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', $page));
+            $this->setPagingParams(['Client' => [
+                'page' => $page,
+            ]]);
 
             $result[$page] = $this->Paginator->numbers($options);
         }
@@ -2051,7 +2146,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersTemplates()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -2089,7 +2184,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersModulus()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 10,
@@ -2116,7 +2211,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 4895,
                 'current' => 10,
@@ -2139,7 +2234,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
+        $this->setPagingParams(['Client' => [
+            'page' => 3,
+        ]]);
 
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
@@ -2170,7 +2267,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 4893));
+        $this->setPagingParams(['Client' => [
+            'page' => 4893,
+        ]]);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2189,7 +2288,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 58));
+        $this->setPagingParams(['Client' => [
+            'page' => 58,
+        ]]);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2212,7 +2313,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 5));
+        $this->setPagingParams(['Client' => [
+            'page' => 5,
+        ]]);
         $result = $this->Paginator->numbers(['first' => 5, 'modulus' => 4, 'last' => 5]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2231,7 +2334,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
+        $this->setPagingParams(['Client' => [
+            'page' => 3,
+        ]]);
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 2, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2244,7 +2349,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Client.page', 3));
+        $this->setPagingParams(['Client' => [
+            'page' => 3,
+        ]]);
         $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 0, 'last' => 2]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
@@ -2339,7 +2446,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testModulusDisabled()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 2,
@@ -2369,7 +2476,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersWithUrlOptions()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -2393,7 +2500,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 3,
                 'current' => 10,
@@ -2427,7 +2534,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersRouting()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 2,
@@ -2460,7 +2567,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testNumbersNonDefaultModel()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2494,7 +2601,9 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstAndLastTag()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
+        $this->setPagingParams(['Article' => [
+            'page' => 2,
+        ]]);
         $result = $this->Paginator->first('<<');
         $expected = [
             'li' => ['class' => 'first'],
@@ -2544,9 +2653,10 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNoOutput()
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 15)
-            ->withParam('paging.Article.pageCount', 15));
+        $this->setPagingParams(['Article' => [
+            'page' => 15,
+            'pageCount' => 15,
+        ]]);
 
         $result = $this->Paginator->last();
         $expected = '';
@@ -2560,16 +2670,17 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstNonDefaultModel()
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 1)
-            ->withParam('paging.Client', [
+        $this->setPagingParams([
+            'Article' => ['page' => 1],
+            'Client' => [
                 'page' => 3,
                 'current' => 3,
                 'count' => 13,
                 'prevPage' => false,
                 'nextPage' => true,
                 'pageCount' => 5,
-            ]));
+            ],
+        ]);
 
         $result = $this->Paginator->first('first', ['model' => 'Article']);
         $this->assertSame('', $result);
@@ -2606,10 +2717,11 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstFullBaseUrl()
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 3)
-            ->withParam('paging.Article.direction', 'DESC')
-            ->withParam('paging.Article.sort', 'Article.title'));
+        $this->setPagingParams(['Article' => [
+            'page' => 3,
+            'direction' => 'DESC',
+            'sort' => 'Article.title',
+        ]]);
 
         $this->Paginator->options(['url' => ['_full' => true]]);
 
@@ -2633,7 +2745,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testFirstBoundaries()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 3));
+        $this->setPagingParams(['Article' => ['page' => 3]]);
         $result = $this->Paginator->first();
         $expected = [
             'li' => ['class' => 'first'],
@@ -2655,7 +2767,9 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 2));
+        $this->setPagingParams(['Article' => [
+            'page' => 2,
+        ]]);
         $result = $this->Paginator->first(3);
         $this->assertSame('', $result, 'When inside the first links range, no links should be made');
     }
@@ -2716,7 +2830,7 @@ class PaginatorHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 6));
+        $this->setPagingParams(['Article' => ['page' => 6]]);
 
         $result = $this->Paginator->last(2);
         $expected = [
@@ -2740,7 +2854,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastOptions()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 4,
                 'current' => 3,
@@ -2791,16 +2905,17 @@ class PaginatorHelperTest extends TestCase
      */
     public function testLastNonDefaultModel()
     {
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.page', 7)
-            ->withParam('paging.Client', [
+        $this->setPagingParams([
+            'Article' => ['page' => 7],
+            'Client' => [
                 'page' => 3,
                 'current' => 3,
                 'count' => 13,
                 'prevPage' => false,
                 'nextPage' => true,
                 'pageCount' => 5,
-            ]));
+            ],
+        ]);
 
         $result = $this->Paginator->last('last', ['model' => 'Article']);
         $this->assertSame('', $result);
@@ -2823,7 +2938,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounter()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -2866,7 +2981,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testCounterBigNumbers()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
                 'page' => 1523,
                 'current' => 3000,
@@ -2933,10 +3048,15 @@ class PaginatorHelperTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->View->setRequest($this->View->getRequest()
-            ->withParam('paging.Article.sort', 'Article.title')
-            ->withParam('paging.Article.direction', 'asc')
-            ->withParam('paging.Article.page', 1));
+        $params = [
+            'Article' => [
+                'sort' => 'Article.title',
+                'direction' => 'asc',
+                'page' => 1,
+            ],
+        ];
+        $params = Hash::merge($this->View->getRequest()->getAttribute('paging'), $params);
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', $params));
 
         $test = ['url' => [
             'page' => '1',
@@ -2967,7 +3087,8 @@ class PaginatorHelperTest extends TestCase
     public function testCurrent()
     {
         $result = $this->Paginator->current();
-        $this->assertEquals($this->View->getRequest()->getParam('paging.Article.page'), $result);
+        $params = $this->View->getRequest()->getAttribute('paging');
+        $this->assertSame($params['Article']['page'], $result);
 
         $result = $this->Paginator->current('Incorrect');
         $this->assertEquals(1, $result);
@@ -2981,7 +3102,8 @@ class PaginatorHelperTest extends TestCase
     public function testTotal()
     {
         $result = $this->Paginator->total();
-        $this->assertSame($this->View->getRequest()->getParam('paging.Article.pageCount'), $result);
+        $params = $this->View->getRequest()->getAttribute('paging');
+        $this->assertSame($params['Article']['pageCount'], $result);
 
         $result = $this->Paginator->total('Incorrect');
         $this->assertSame(0, $result);
@@ -3011,7 +3133,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithOnePage()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => 1,
                 'current' => 2,
@@ -3033,7 +3155,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testWithZeroPages()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => 0,
                 'current' => 0,
@@ -3110,7 +3232,7 @@ class PaginatorHelperTest extends TestCase
      */
     public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected)
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('paging', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
                 'page' => $page,
                 'prevPage' => $prevPage,
@@ -3232,22 +3354,20 @@ class PaginatorHelperTest extends TestCase
     {
         $request = new ServerRequest([
             'url' => '/',
-            'params' => [
-                'paging' => [
-                    'Article' => [
-                        'page' => 1,
-                        'current' => 9,
-                        'count' => null,
-                        'prevPage' => false,
-                        'nextPage' => true,
-                        'pageCount' => 0,
-                        'start' => 1,
-                        'end' => 9,
-                        'sort' => null,
-                        'direction' => null,
-                        'limit' => null,
-                    ],
-                ],
+        ]);
+        $request = $request->withAttribute('paging', [
+            'Article' => [
+                'page' => 1,
+                'current' => 9,
+                'count' => null,
+                'prevPage' => false,
+                'nextPage' => true,
+                'pageCount' => 0,
+                'start' => 1,
+                'end' => 9,
+                'sort' => null,
+                'direction' => null,
+                'limit' => null,
             ],
         ]);
 
@@ -3275,5 +3395,13 @@ class PaginatorHelperTest extends TestCase
 
         $result = $paginator->total();
         $this->assertSame(0, $result);
+    }
+
+    protected function setPagingParams($params, bool $merge = true)
+    {
+        if ($merge) {
+            $params = Hash::merge($this->View->getRequest()->getAttribute('paging'), $params);
+        }
+        $this->View->setRequest($this->View->getRequest()->withAttribute('paging', $params));
     }
 }


### PR DESCRIPTION
It was just for legacy reasons that various extra data like security token, paging params were stuffed into request params. Request params should be limited to routing relate keys only. The extra data is now set using separate request attributes.