### PR TITLE
4.x router cleanup

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -532,7 +532,7 @@ class Router
     public static function routeExists($url = null, bool $full = false): bool
     {
         try {
-            $route = static::url($url, $full);
+            static::url($url, $full);
 
             return true;
         } catch (MissingRouteException $e) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -557,15 +557,18 @@ class Router
      */
     public static function fullBaseUrl(?string $base = null): string
     {
+        if ($base === null && static::$_fullBaseUrl !== null) {
+            return static::$_fullBaseUrl;
+        }
+
         if ($base !== null) {
             static::$_fullBaseUrl = $base;
             Configure::write('App.fullBaseUrl', $base);
-        }
-        if (!static::$_fullBaseUrl) {
+        } else {
             static::$_fullBaseUrl = Configure::read('App.fullBaseUrl');
         }
 
-        return (string)static::$_fullBaseUrl;
+        return static::$_fullBaseUrl;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -231,14 +231,13 @@ class Router
         static::$_request = $request;
 
         $uri = $request->getUri();
-        $context = [
+        static::$_requestContext = [
             '_scheme' => $uri->getScheme(),
             '_host' => $uri->getHost(),
             '_port' => $uri->getPort(),
             '_base' => $request->getAttribute('base'),
-            '_params' => $request->getAttribute('params', []),
+            'params' => $request->getAttribute('params', []),
         ];
-        static::$_requestContext = $context;
     }
 
     /**
@@ -433,8 +432,8 @@ class Router
             'action' => 'index',
             '_ext' => null,
         ];
-        if (!empty($context['_params'])) {
-            $params = $context['_params'];
+        if (!empty($context['params'])) {
+            $params = $context['params'];
         }
 
         $frag = '';

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -40,8 +40,7 @@ class RouterTest extends TestCase
     {
         parent::setUp();
         Configure::write('Routing', ['admin' => null, 'prefixes' => []]);
-        Router::fullBaseUrl('');
-        Configure::write('App.fullBaseUrl', 'http://localhost');
+        Router::reload();
     }
 
     /**
@@ -53,7 +52,6 @@ class RouterTest extends TestCase
     {
         parent::tearDown();
         $this->clearPlugins();
-        Router::reload();
         Router::defaultRouteClass('Cake\Routing\Route\Route');
     }
 


### PR DESCRIPTION
- Fix extra `_params` key being set in `$context` passed to `Route::match()` call on line 484.
-  Optimize `Router::fullBaseUrl()` to return early when called as getter with `Router::$_fullBaseUrl` already set.