### PR TITLE
Avoid potentially parsing URL multiple times.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -230,13 +230,14 @@ class Router
     {
         static::$_request = $request;
 
+        static::$_requestContext['_base'] = $request->getAttribute('base');
+        static::$_requestContext['params'] = $request->getAttribute('params', []);
+
         $uri = $request->getUri();
-        static::$_requestContext = [
+        static::$_requestContext += [
             '_scheme' => $uri->getScheme(),
             '_host' => $uri->getHost(),
             '_port' => $uri->getPort(),
-            '_base' => $request->getAttribute('base'),
-            'params' => $request->getAttribute('params', []),
         ];
     }
 
@@ -477,7 +478,7 @@ class Router
             // If a full URL is requested with a scheme the host should default
             // to App.fullBaseUrl to avoid corrupt URLs
             if ($full && isset($url['_scheme']) && !isset($url['_host'])) {
-                $url['_host'] = parse_url(static::fullBaseUrl(), PHP_URL_HOST);
+                $url['_host'] = $context['_host'];
             }
             $context['params'] = $params;
 
@@ -567,6 +568,13 @@ class Router
         } else {
             static::$_fullBaseUrl = Configure::read('App.fullBaseUrl');
         }
+
+        $parts = parse_url(static::$_fullBaseUrl);
+        static::$_requestContext = [
+            '_scheme' => $parts['scheme'],
+            '_host' => $parts['host'],
+            '_port' => $parts['port'] ?? null,
+        ] + static::$_requestContext;
 
         return static::$_fullBaseUrl;
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -566,7 +566,25 @@ class Router
             static::$_fullBaseUrl = $base;
             Configure::write('App.fullBaseUrl', $base);
         } else {
-            static::$_fullBaseUrl = Configure::read('App.fullBaseUrl');
+            $base = (string)Configure::read('App.fullBaseUrl');
+
+            // If App.fullBaseUrl is empty but context is set from request through setRequest()
+            if (!$base && !empty(static::$_requestContext['_host'])) {
+                $base = sprintf(
+                    '%s://%s',
+                    static::$_requestContext['_scheme'],
+                    static::$_requestContext['_host']
+                );
+                if (!empty(static::$_requestContext['_port'])) {
+                    $base .= ':' . static::$_requestContext['_port'];
+                }
+
+                Configure::write('App.fullBaseUrl', $base);
+
+                return static::$_fullBaseUrl = $base;
+            }
+
+            static::$_fullBaseUrl = $base;
         }
 
         $parts = parse_url(static::$_fullBaseUrl);

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -763,7 +763,7 @@ class AuthComponentTest extends TestCase
             'webroot' => 'webroot',
             'base' => false,
             'baseUrl' => '/cake/index.php',
-            'fullBaseUrl' => '',
+            'fullBaseUrl' => 'http://localhost',
         ]);
 
         $this->Auth->getController()->getRequest()->getSession()->delete('Auth');

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1884,6 +1884,7 @@ class RouterTest extends TestCase
      */
     public function testGenerationWithSslOption()
     {
+        Router::fullBaseUrl('http://app.test');
         Router::connect('/:controller/:action/*');
         $request = new ServerRequest([
             'url' => '/images/index',
@@ -1897,52 +1898,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertSame('https://localhost/images/index', $result);
+        $this->assertSame('https://app.test/images/index', $result);
 
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertSame('http://localhost/images/index', $result);
-    }
-
-    /**
-     * Test that the _ssl + _full options work together.
-     *
-     * @return void
-     */
-    public function testGenerationWithSslAndFullOption()
-    {
-        Configure::write('App.fullBaseUrl', 'http://app.localhost');
-        Router::connect('/:controller/:action/*');
-
-        $request = new ServerRequest([
-            'environment' => ['HTTP_HOST' => 'localhost'],
-        ]);
-        Router::setRequest($request);
-
-        $result = Router::url([
-            'controller' => 'images',
-            'action' => 'index',
-            '_ssl' => true,
-            '_full' => true,
-        ]);
-        $this->assertSame('https://app.localhost/images/index', $result);
-
-        $result = Router::url([
-            'controller' => 'images',
-            'action' => 'index',
-            '_ssl' => false,
-            '_full' => true,
-        ]);
-        $this->assertSame('http://app.localhost/images/index', $result);
-
-        $result = Router::url([
-            'controller' => 'images',
-            'action' => 'index',
-            '_full' => false,
-            '_ssl' => false,
-        ]);
-        $this->assertSame('http://localhost/images/index', $result);
+        $this->assertSame('http://app.test/images/index', $result);
     }
 
     /**
@@ -1955,7 +1916,7 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
         $request = new ServerRequest([
             'url' => '/images/index',
-            'environment' => ['HTTP_HOST' => 'localhost', 'HTTPS' => 'on'],
+            'environment' => ['HTTP_HOST' => 'app.test', 'HTTPS' => 'on'],
             'params' => [
                 'plugin' => null,
                 'controller' => 'images',
@@ -1967,12 +1928,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertSame('http://localhost/images/index', $result);
+        $this->assertSame('http://app.test/images/index', $result);
 
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertSame('https://localhost/images/index', $result);
+        $this->assertSame('https://app.test/images/index', $result);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -155,6 +155,24 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Test that full base URL can be generated from request context too if
+     * App.fullBaseUrl is not set.
+     *
+     * @return void
+     */
+    public function testFullBaseURLFromRequest()
+    {
+        Configure::write('App.fullBaseUrl', false);
+        $server = [
+            'HTTP_HOST' => 'cake.local',
+        ];
+
+        $request = ServerRequestFactory::fromGlobals($server);
+        Router::setRequest($request);
+        $this->assertSame('http://cake.local', Router::fullBaseUrl());
+    }
+
+    /**
      * testRouteDefaultParams method
      *
      * @return void


### PR DESCRIPTION
In order for this optimization to work `Router::fullBaseUrl()` needs to be called initially during app bootup so that the request context in populated.

This would require replacing the `Configure::write('App.fullBaseUrl', ...)` in app's `config/boostrap.php` with call to `Router::fullBaseUrl()` instead. So this is something those upgrading from 3.x would need to care of.