### PR TITLE
4.x: Remove remaining pieces after requestAction removal

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -102,8 +102,6 @@ class SecurityComponent extends Component
         try {
             $this->_secureRequired($controller);
 
-            $isNotRequestAction = !$request->getParam('requested');
-
             if ($this->_action === $this->_config['blackHoleCallback']) {
                 throw new AuthSecurityException(sprintf(
                     'Action %s is defined as the blackhole callback.',
@@ -113,7 +111,6 @@ class SecurityComponent extends Component
 
             if (!in_array($this->_action, (array)$this->_config['unlockedActions'], true) &&
                 $hasData &&
-                $isNotRequestAction &&
                 $this->_config['validatePost']
             ) {
                 $this->_validatePost($controller);

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -135,7 +135,6 @@ class ServerRequest implements ServerRequestInterface
         'ssl' => ['env' => 'HTTPS', 'options' => [1, 'on']],
         'ajax' => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
         'flash' => ['env' => 'HTTP_USER_AGENT', 'pattern' => '/^(Shockwave|Adobe) Flash/'],
-        'requested' => ['param' => 'requested', 'value' => 1],
         'json' => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
         'xml' => ['accept' => ['application/xml', 'text/xml'], 'param' => '_ext', 'value' => 'xml'],
     ];
@@ -818,7 +817,7 @@ class ServerRequest implements ServerRequestInterface
      * Allows for custom detectors on the request parameters.
      *
      * ```
-     * addDetector('requested', ['param' => 'requested', 'value' => 1]);
+     * addDetector('admin', ['param' => 'prefix', 'value' => 'admin']);
      * ```
      *
      * ### Accept comparison

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -71,7 +71,6 @@ class ActionDispatcherTest extends TestCase
                 'controller' => 'Cakes',
                 'action' => 'index',
                 'pass' => [],
-                'return' => true,
             ],
         ]);
         $res = new Response();

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -2994,35 +2994,6 @@ XML;
     }
 
     /**
-     * Test is('requested') and isRequested()
-     *
-     * @return void
-     */
-    public function testIsRequested()
-    {
-        $request = new ServerRequest([
-            'params' => [
-                'controller' => 'posts',
-                'action' => 'index',
-                'plugin' => null,
-                'requested' => 1,
-            ],
-        ]);
-        $this->assertTrue($request->is('requested'));
-        $this->assertTrue($request->isRequested());
-
-        $request = new ServerRequest([
-            'params' => [
-                'controller' => 'posts',
-                'action' => 'index',
-                'plugin' => null,
-            ],
-        ]);
-        $this->assertFalse($request->is('requested'));
-        $this->assertFalse($request->isRequested());
-    }
-
-    /**
      * Test the cookie() method.
      *
      * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2491,30 +2491,6 @@ class RouterTest extends TestCase
         Router::connect('/:controller', [], ['routeClass' => 'Object']);
     }
 
-    /**
-     * test reversing parameter arrays back into strings.
-     *
-     * Mark the router as initialized so it doesn't auto-load routes
-     *
-     * @return void
-     */
-    public function testReverseToken()
-    {
-        Router::connect('/:controller/:action/*');
-        $params = [
-            'controller' => 'posts',
-            'action' => 'view',
-            'pass' => [1],
-            'url' => [],
-            'autoRender' => 1,
-            'bare' => 1,
-            'return' => 1,
-            'requested' => 1,
-        ];
-        $result = Router::reverse($params);
-        $this->assertSame('/posts/view/1', $result);
-    }
-
     public function testReverseLocalized()
     {
         Router::reload();


### PR DESCRIPTION
Remove remaining 'autoRender',  'bare', 'return', 'requested' used by `requestAction()`.