### PR TITLE
Solving headers already sent bug on sessions whit phpunit.phar

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -170,7 +170,9 @@ class CakeTestSuiteDispatcher {
 			} elseif (is_file($vendor . DS . 'phpunit.phar')) {
 				$backup = $GLOBALS['_SERVER']['SCRIPT_NAME'];
 				$GLOBALS['_SERVER']['SCRIPT_NAME'] = '-';
+				ob_start();
 				$included = include_once $vendor . DS . 'phpunit.phar';
+				ob_end_clean();
 				$GLOBALS['_SERVER']['SCRIPT_NAME'] = $backup;
 				return $included;
 			}


### PR DESCRIPTION
CakePHP sessions tests fail when using composer.phar and it's has shebang. Even using --stderr, it seems that this is ignored. We could use travis to run the tests with composer.phar too, but I don't know how to configure it.
* Note: yes it is a legacy project with more than 250 models that I still could not migrate to 3.x