### PR TITLE
#11249: custom selected class

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -161,8 +161,10 @@ class FormHelper extends Helper
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
             // Container for submit buttons.
             'submitContainer' => '<div class="submit">{{content}}</div>',
-            //Confirm javascript template for postLink()
+            // Confirm javascript template for postLink()
             'confirmJs' => '{{confirm}}',
+            // selected class
+            'selectedClass' => 'selected',
         ],
         // set HTML5 validation message to custom required/empty messages
         'autoSetCustomValidity' => false,

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -210,7 +210,8 @@ class MultiCheckboxWidget implements WidgetInterface
             ];
 
             if ($checkbox['checked']) {
-                $labelAttrs = $this->_templates->addClass($labelAttrs, 'selected');
+                $selectedClass = $this->_templates->format('selectedClass', []);
+                $labelAttrs = $this->_templates->addClass($labelAttrs, $selectedClass);
             }
 
             $label = $this->_label->render($labelAttrs, $context);

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -182,7 +182,8 @@ class RadioWidget implements WidgetInterface
         }
 
         if (!is_bool($data['label']) && isset($radio['checked']) && $radio['checked']) {
-            $data['label'] = $this->_templates->addClass($data['label'], 'selected');
+            $selectedClass = $this->_templates->format('selectedClass', []);
+            $data['label'] = $this->_templates->addClass($data['label'], $selectedClass);
         }
 
         $radio['disabled'] = $this->_isDisabled($radio, $data['disabled']);

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -41,6 +41,7 @@ class MultiCheckboxWidgetTest extends TestCase
             'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
             'multicheckboxWrapper' => '<fieldset{{attrs}}>{{content}}</fieldset>',
             'multicheckboxTitle' => '<legend>{{text}}</legend>',
+            'selectedClass' => 'selected',
         ];
         $this->templates = new StringTemplate($templates);
         $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -749,7 +749,7 @@ class MultiCheckboxWidgetTest extends TestCase
             [
                 'div' => ['class' => 'checkbox'],
                 'input' => ['type' => 'checkbox', 'name' => 'field[]', 'value' => '1', 'checked' => 'checked', 'id' => 'field-1'],
-                'label' => ['title' =>'my label', 'for' => 'field-1', 'class' => 'active'],
+                'label' => ['title' => 'my label', 'for' => 'field-1', 'class' => 'active'],
             ],
             'value1',
             '/label',

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -714,4 +714,47 @@ class MultiCheckboxWidgetTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
     }
+
+    /**
+     * testRenderSelectedClass method
+     *
+     * Test that the custom selected class is passed to label
+     * Issue: https://github.com/cakephp/cakephp/issues/11249
+     *
+     * @return void
+     */
+    public function testRenderSelectedClass()
+    {
+        $this->templates->add(['selectedClass' => 'active']);
+
+        $label = new LabelWidget($this->templates);
+        $input = new MultiCheckboxWidget($this->templates, $label);
+        $data = [
+            'name' => 'field',
+            'options' => ['value1', 'value2'],
+            'id' => 'alternative-id',
+            'idPrefix' => 'willBeIgnored',
+        ];
+        $result = $input->render($data, $this->context);
+
+        $data = [
+            'name' => 'field',
+            'options' => [1 => 'value1', 2 => 'value2'],
+            'val' => 1,
+            'label' => ['title' => 'my label'],
+        ];
+        $result = $input->render($data, $this->context);
+
+        $expected = [
+            [
+                'div' => ['class' => 'checkbox'],
+                'input' => ['type' => 'checkbox', 'name' => 'field[]', 'value' => '1', 'checked' => 'checked', 'id' => 'field-1'],
+                'label' => ['title' =>'my label', 'for' => 'field-1', 'class' => 'active'],
+            ],
+            'value1',
+            '/label',
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
 }

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -878,4 +878,37 @@ class RadioWidgetTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
     }
+
+    /**
+     * testRenderSelectedClass method
+     *
+     * Test that the custom selected class is passed to label
+     * Issue: https://github.com/cakephp/cakephp/issues/11249
+     *
+     * @return void
+     */
+    public function testRenderSelectedClass()
+    {
+        $this->templates->add(['selectedClass' => 'active']);
+
+        $label = new NestingLabelWidget($this->templates);
+        $input = new RadioWidget($this->templates, $label);
+        $data = [
+            'name' => 'field',
+            'options' => ['value1' => 'title1'],
+            'val' => 'value1',
+            'label' => ['title' => 'my label'],
+        ];
+        $result = $input->render($data, $this->context);
+
+        $expected = [
+            ['label' => [
+                'title' => 'my label',
+                'class' => 'active',
+                'for' => 'field-value1',
+            ]],
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
 }

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -38,6 +38,7 @@ class RadioWidgetTest extends TestCase
             'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
             'nestingLabel' => '<label{{attrs}}>{{input}}{{text}}</label>',
             'radioWrapper' => '{{label}}',
+            'selectedClass' => 'selected',
         ];
         $this->templates = new StringTemplate($templates);
         $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();


### PR DESCRIPTION
allow custom selected class for radio and checkbox label.

```php
$this->loadHelper('Form', [
    'templates' => [
        'selectedClass' => 'active',
    ],
]);
```

related to #11249

