### PR TITLE
Fix Number::toPercentage() format

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -112,12 +112,12 @@ class Number
      */
     public static function toPercentage($value, $precision = 2, array $options = [])
     {
-        $options += ['multiply' => false];
-        if ($options['multiply']) {
-            $value *= 100;
+        $options += ['multiply' => false, 'type' => NumberFormatter::PERCENT];
+        if (!$options['multiply']) {
+            $value /= 100;
         }
 
-        return static::precision($value, $precision, $options) . '%';
+        return static::precision($value, $precision, $options);
     }
 
     /**

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -461,7 +461,15 @@ class NumberTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->Number->toPercentage(0.456, 2, ['locale' => 'de-DE', 'multiply' => true]);
-        $expected = '45,60%';
+        $expected = '45,60 %';
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Number->toPercentage(13, 0, ['locale' => 'fi_FI']);
+        $expected = '13 %';
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Number->toPercentage(0.13, 0, ['locale' => 'fi_FI', 'multiply' => true]);
+        $expected = '13 %';
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
Refs #13676 .

Note: I change 

```
        if ($options['multiply']) {
            $value *= 100;
        }
```

to

```
        if (!$options['multiply']) {
            $value /= 100;
        }
```
 because `NumberFormatter::PERCENT` use value `0.13` instead of `13` for `13%`.

For CakePHP, Number::toPercentage(13) => `13%` because it uses `NumberFormatter::DECIMAL` before.