### PR TITLE
Fix double column reflection

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -90,7 +90,7 @@ class MysqlSchema extends BaseSchema
 
         $col = strtolower($matches[1]);
         $length = $precision = null;
-        if (isset($matches[2])) {
+        if (isset($matches[2]) && strlen($matches[2])) {
             $length = $matches[2];
             if (strpos($matches[2], ',') !== false) {
                 list($length, $precision) = explode(',', $length);
@@ -123,7 +123,7 @@ class MysqlSchema extends BaseSchema
             return ['type' => TableSchema::TYPE_UUID, 'length' => null];
         }
         if ($col === 'char') {
-            return ['type' => TableSchema::TYPE_STRING, 'fixed' => true, 'length' => $length];
+            return ['type' => TableSchema::TYPE_STRING, 'length' => $length, 'fixed' => true];
         }
         if (strpos($col, 'char') !== false) {
             return ['type' => TableSchema::TYPE_STRING, 'length' => $length];

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -80,9 +80,9 @@ class SqlserverSchema extends BaseSchema
     protected function _convertColumn($col, $length = null, $precision = null, $scale = null)
     {
         $col = strtolower($col);
-        $length = (int)$length;
-        $precision = (int)$precision;
-        $scale = (int)$scale;
+        $length = $length !== null ? (int)$length : $length;
+        $precision = $precision !== null ? (int)$precision : $precision;
+        $scale = $scale !== null ? (int)$scale : $scale;
 
         if (in_array($col, ['date', 'time'])) {
             return ['type' => $col, 'length' => null];

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -109,11 +109,11 @@ class MysqlSchemaTest extends TestCase
             ],
             [
                 'VARCHAR(255)',
-                ['type' => 'string', 'length' => 255]
+                ['type' => 'string', 'length' => 255, 'collate' => 'utf8_general_ci']
             ],
             [
                 'CHAR(25)',
-                ['type' => 'string', 'length' => 25, 'fixed' => true]
+                ['type' => 'string', 'length' => 25, 'fixed' => true, 'collate' => 'utf8_general_ci']
             ],
             [
                 'CHAR(36)',
@@ -129,19 +129,19 @@ class MysqlSchemaTest extends TestCase
             ],
             [
                 'TEXT',
-                ['type' => 'text', 'length' => null]
+                ['type' => 'text', 'length' => null, 'collate' => 'utf8_general_ci']
             ],
             [
                 'TINYTEXT',
-                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'collate' => 'utf8_general_ci']
             ],
             [
                 'MEDIUMTEXT',
-                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'collate' => 'utf8_general_ci']
             ],
             [
                 'LONGTEXT',
-                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'collate' => 'utf8_general_ci']
             ],
             [
                 'TINYBLOB',
@@ -221,19 +221,18 @@ class MysqlSchemaTest extends TestCase
         $expected += [
             'null' => true,
             'default' => 'Default value',
-            'collate' => 'utf8_general_ci',
             'comment' => 'Comment section',
         ];
-
         $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')->getMock();
         $dialect = new MysqlSchema($driver);
 
-        $table = $this->getMockBuilder(TableSchema::class)
-            ->setConstructorArgs(['table'])
-            ->getMock();
-        $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
-
+        $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field);
+
+        $actual = array_intersect_key($table->getColumn('field'), $expected);
+        ksort($expected);
+        ksort($actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -154,35 +154,35 @@ SQL;
             // String
             [
                 ['type' => 'VARCHAR'],
-                ['type' => 'string', 'length' => null]
+                ['type' => 'string', 'length' => null, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'VARCHAR(10)'],
-                ['type' => 'string', 'length' => 10]
+                ['type' => 'string', 'length' => 10, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHARACTER VARYING'],
-                ['type' => 'string', 'length' => null]
+                ['type' => 'string', 'length' => null, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHARACTER VARYING(10)'],
-                ['type' => 'string', 'length' => 10]
+                ['type' => 'string', 'length' => 10, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHARACTER VARYING(255)', 'default' => 'NULL::character varying'],
-                ['type' => 'string', 'length' => 255, 'default' => null]
+                ['type' => 'string', 'length' => 255, 'default' => null, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHAR(10)'],
-                ['type' => 'string', 'fixed' => true, 'length' => 10]
+                ['type' => 'string', 'fixed' => true, 'length' => 10, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHAR(36)'],
-                ['type' => 'string', 'fixed' => true, 'length' => 36]
+                ['type' => 'string', 'fixed' => true, 'length' => 36, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'CHARACTER(10)'],
-                ['type' => 'string', 'fixed' => true, 'length' => 10]
+                ['type' => 'string', 'fixed' => true, 'length' => 10, 'collate' => 'ja_JP.utf8']
             ],
             [
                 ['type' => 'MONEY'],
@@ -200,7 +200,7 @@ SQL;
             // Text
             [
                 ['type' => 'TEXT'],
-                ['type' => 'text', 'length' => null]
+                ['type' => 'text', 'length' => null, 'collate' => 'ja_JP.utf8']
             ],
             // Blob
             [
@@ -250,18 +250,18 @@ SQL;
             'null' => true,
             'default' => 'Default value',
             'comment' => 'Comment section',
-            'collate' => 'ja_JP.utf8',
         ];
 
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')->getMock();
         $dialect = new PostgresSchema($driver);
 
-        $table = $this->getMockBuilder(TableSchema::class)
-            ->setConstructorArgs(['table'])
-            ->getMock();
-        $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
-
+        $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field);
+
+        $actual = array_intersect_key($table->getColumn('field'), $expected);
+        ksort($expected);
+        ksort($actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -168,17 +168,19 @@ class SqliteSchemaTest extends TestCase
         $expected += [
             'null' => true,
             'default' => 'Default value',
+            'comment' => null,
         ];
 
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchema($driver);
 
-        $table = $this->getMockBuilder(TableSchema::class)
-            ->setConstructorArgs(['table'])
-            ->getMock();
-        $table->expects($this->at(1))->method('addColumn')->with('field', $expected);
-
+        $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field);
+
+        $actual = array_intersect_key($table->getColumn('field'), $expected);
+        ksort($expected);
+        ksort($actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -184,14 +184,14 @@ SQL;
                 null,
                 null,
                 null,
-                ['type' => 'string', 'length' => 255]
+                ['type' => 'string', 'length' => 255, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'VARCHAR',
                 10,
                 null,
                 null,
-                ['type' => 'string', 'length' => 10]
+                ['type' => 'string', 'length' => 10, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'NVARCHAR',
@@ -199,14 +199,14 @@ SQL;
                 null,
                 null,
                 // Sqlserver returns double lengths for unicode columns
-                ['type' => 'string', 'length' => 25]
+                ['type' => 'string', 'length' => 25, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'CHAR',
                 10,
                 null,
                 null,
-                ['type' => 'string', 'fixed' => true, 'length' => 10]
+                ['type' => 'string', 'fixed' => true, 'length' => 10, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'NCHAR',
@@ -214,7 +214,7 @@ SQL;
                 null,
                 null,
                 // SQLServer returns double length for unicode columns.
-                ['type' => 'string', 'fixed' => true, 'length' => 5]
+                ['type' => 'string', 'fixed' => true, 'length' => 5, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'UNIQUEIDENTIFIER',
@@ -228,7 +228,7 @@ SQL;
                 null,
                 null,
                 null,
-                ['type' => 'text', 'length' => null]
+                ['type' => 'text', 'length' => null, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'REAL',
@@ -242,7 +242,7 @@ SQL;
                 -1,
                 null,
                 null,
-                ['type' => 'text', 'length' => null]
+                ['type' => 'text', 'length' => null, 'collate' => 'Japanese_Unicode_CI_AI']
             ],
             [
                 'IMAGE',
@@ -289,18 +289,18 @@ SQL;
         $expected += [
             'null' => true,
             'default' => 'Default value',
-            'collate' => 'Japanese_Unicode_CI_AI',
         ];
 
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')->getMock();
         $dialect = new SqlserverSchema($driver);
 
-        $table = $this->getMockBuilder('Cake\Database\Schema\TableSchema')
-            ->setConstructorArgs(['table'])
-            ->getMock();
-        $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
-
+        $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field);
+
+        $actual = array_intersect_key($table->getColumn('field'), $expected);
+        ksort($expected);
+        ksort($actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
Fix `double unsigned` from having its length and precision incorrectly set to 0 when null is more accurate. I've refactored the tests for all the drivers as assertEquals() was masking this problem previously.

Fixes #13697