### PR TITLE
Add HttpsEnforcerMiddleware.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -103,9 +103,6 @@ parameters:
         -
             message: '#Ternary operator condition is always true#'
             path: 'src/TestSuite/IntegrationTestTrait.php'
-        -
-            message: '#Call to an undefined method Psr\\Http\\Message\\ServerRequestInterface::is\(\)#'
-            path: 'src/Http/Middleware/HttpsEnforcerMiddleware.php'
 
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -103,6 +103,9 @@ parameters:
         -
             message: '#Ternary operator condition is always true#'
             path: 'src/TestSuite/IntegrationTestTrait.php'
+        -
+            message: '#Call to an undefined method Psr\\Http\\Message\\ServerRequestInterface::is\(\)#'
+            path: 'src/Http/Middleware/HttpsEnforcerMiddleware.php'
 
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -84,7 +84,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
         }
 
         throw new BadRequestException(
-            'Request to this URL must be made with HTTPS'
+            'Requests to this URL must be made with HTTPS.'
         );
     }
 }

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -68,8 +68,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        /** @psalm-suppress UndefinedInterfaceMethod */
-        if ($request->is('ssl')) {
+        if ($request->getUri()->getScheme() === 'https') {
             return $handler->handle($request);
         }
 

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Middleware;
 
+use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,17 +34,19 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      *
      * ### Options
      *
-     * - `redirect` If set to true (default) redirects GET requests to same URL with https.
-     * - `statusCode` Status code to use in case of redirect, defaults to 301 - Permanent redirect.
-     * - `headers` Array of response headers in case of redirect.
+     * - `redirect` - If set to true (default) redirects GET requests to same URL with https.
+     * - `statusCode` - Status code to use in case of redirect, defaults to 301 - Permanent redirect.
+     * - `headers` - Array of response headers in case of redirect.
+     * - `disableOnDebug` - Whether HTTPS check should be disabled when debug is on. Default `true`.
      *
      * @var array
-     * @psalm-var array{redirect: bool, statusCode: int, headers: array}
+     * @psalm-var array{redirect: bool, statusCode: int, headers: array, disableOnDebug: bool}
      */
     protected $config = [
         'redirect' => true,
         'statusCode' => 301,
         'headers' => [],
+        'disableOnDebug' => true,
     ];
 
     /**
@@ -70,7 +73,11 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if ($request->getUri()->getScheme() === 'https') {
+        if (
+            $request->getUri()->getScheme() === 'https'
+            || ($this->config['disableOnDebug']
+                && Configure::read('debug'))
+        ) {
             return $handler->handle($request);
         }
 

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Middleware;
 
-use Cake\Controller\Exception\SecurityException;
+use Cake\Http\Exception\BadRequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -65,6 +65,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
+     * @throws \Cake\Http\Exception\BadRequestException
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -82,7 +83,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
             );
         }
 
-        throw new SecurityException(
+        throw new BadRequestException(
             'Request to this URL must be made with HTTPS'
         );
     }

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -33,7 +33,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      *
      * ### Options
      *
-     * - `redirect` If set to true (default) redirect to same URL with https.
+     * - `redirect` If set to true (default) redirects GET requests to same URL with https.
      * - `statusCode` Status code to use in case of redirect, defaults to 301 - Permanent redirect.
      * - `headers` Array of response headers in case of redirect.
      *
@@ -60,7 +60,8 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
     /**
      * Check whether request has been made using HTTPS.
      *
-     * Depending on configuration either redirects to same URL with https or throws exception.
+     * Depending on the configuration and request method, either redirects to
+     * same URL with https or throws an exception.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
@@ -73,7 +74,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        if ($this->config['redirect']) {
+        if ($this->config['redirect'] && $request->getMethod() === 'GET') {
             $uri = $request->getUri()->withScheme('https');
 
             return new RedirectResponse(

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware;
+
+use Cake\Controller\Exception\SecurityException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response\RedirectResponse;
+
+/**
+ * Enforces use of HTTPS (SSL) for requests.
+ */
+class HttpsEnforcerMiddleware implements MiddlewareInterface
+{
+    /**
+     * Configuration.
+     *
+     * ### Options
+     *
+     * - `redirect` If set to true (default) redirect to same URL with https.
+     * - `statusCode` Status code to use in case of redirect, defaults to 301 - Permanent redirect.
+     * - `headers` Array of response headers in case of redirect.
+     *
+     * @var array
+     * @psalm-var array{redirect: bool, statusCode: int, headers: array}
+     */
+    protected $config = [
+        'redirect' => true,
+        'statusCode' => 301,
+        'headers' => [],
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param array $config The options to use.
+     * @see self::$config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config + $this->config;
+    }
+
+    /**
+     * Check whether request has been made using HTTPS.
+     *
+     * Depending on configuration either redirects to same URL with https or throws exception.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /** @psalm-suppress UndefinedInterfaceMethod */
+        if ($request->is('ssl')) {
+            return $handler->handle($request);
+        }
+
+        if ($this->config['redirect']) {
+            $uri = $request->getUri()->withScheme('https');
+
+            return new RedirectResponse(
+                $uri,
+                $this->config['statusCode'],
+                $this->config['headers']
+            );
+        }
+
+        throw new SecurityException(
+            'Request to this URL must be made with HTTPS'
+        );
+    }
+}

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Controller\Exception\SecurityException;
+use Cake\Http\Middleware\HttpsEnforcerMiddleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequestFactory;
+use Cake\TestSuite\TestCase;
+use TestApp\Http\TestRequestHandler;
+use Zend\Diactoros\Response\RedirectResponse;
+
+/**
+ * Test for HttpsEnforcerMiddleware
+ */
+class HttpsEnforcerMiddlewareTest extends TestCase
+{
+    public function testForRequestWithHttp()
+    {
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/',
+            'HTTPS' => '1',
+        ]);
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response();
+        });
+
+        $middleware = new HttpsEnforcerMiddleware();
+
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(Response::class, $result);
+    }
+
+    public function testRedirect()
+    {
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/foo',
+        ]);
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response();
+        });
+
+        $middleware = new HttpsEnforcerMiddleware();
+
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertSame(301, $result->getStatusCode());
+        $this->assertEquals(['location' => ['https://localhost/foo']], $result->getHeaders());
+
+        $middleware = new HttpsEnforcerMiddleware([
+            'statusCode' => 302,
+            'headers' => ['X-Foo' => 'bar'],
+        ]);
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertSame(302, $result->getStatusCode());
+        $this->assertEquals(
+            [
+                'location' => ['https://localhost/foo'],
+                'X-Foo' => ['bar'],
+            ],
+            $result->getHeaders()
+        );
+    }
+
+    public function testSecurityException()
+    {
+        $this->expectException(SecurityException::class);
+
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/',
+        ]);
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response();
+        });
+
+        $middleware = new HttpsEnforcerMiddleware(['redirect' => false]);
+        $middleware->process($request, $handler);
+    }
+}

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -30,20 +30,21 @@ use Zend\Diactoros\Uri;
  */
 class HttpsEnforcerMiddlewareTest extends TestCase
 {
-    public function testForRequestWithHttp()
+    public function testForRequestWithHttps()
     {
         $uri = new Uri('https://localhost/foo');
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
         $handler = new TestRequestHandler(function ($req) {
-            return new Response();
+            return new Response(['body' => 'success']);
         });
 
         $middleware = new HttpsEnforcerMiddleware();
 
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('success', (string)$result->getBody());
     }
 
     public function testRedirect()

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -51,7 +51,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
     {
         $uri = new Uri('http://localhost/foo');
         $request = new ServerRequest();
-        $request = $request->withUri($uri);
+        $request = $request->withUri($uri)->withMethod('GET');
 
         $handler = new TestRequestHandler(function ($req) {
             return new Response();
@@ -80,7 +80,12 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         );
     }
 
-    public function testSecurityException()
+    /**
+     * Test that exception is thrown when redirect is disabled.
+     *
+     * @return void
+     */
+    public function testNoRedirectException()
     {
         $this->expectException(BadRequestException::class);
 
@@ -93,6 +98,27 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         });
 
         $middleware = new HttpsEnforcerMiddleware(['redirect' => false]);
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * Test that exception is thrown for non GET request even if redirect is enabled.
+     *
+     * @return void
+     */
+    public function testExceptionForNonGetRequest()
+    {
+        $this->expectException(BadRequestException::class);
+
+        $uri = new Uri('http://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri)->withMethod('POST');
+
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response();
+        });
+
+        $middleware = new HttpsEnforcerMiddleware(['redirect' => true]);
         $middleware->process($request, $handler);
     }
 }

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -19,10 +19,11 @@ namespace Cake\Test\TestCase\Http\Middleware;
 use Cake\Controller\Exception\SecurityException;
 use Cake\Http\Middleware\HttpsEnforcerMiddleware;
 use Cake\Http\Response;
-use Cake\Http\ServerRequestFactory;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use TestApp\Http\TestRequestHandler;
 use Zend\Diactoros\Response\RedirectResponse;
+use Zend\Diactoros\Uri;
 
 /**
  * Test for HttpsEnforcerMiddleware
@@ -31,10 +32,10 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 {
     public function testForRequestWithHttp()
     {
-        $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/',
-            'HTTPS' => '1',
-        ]);
+        $uri = new Uri('https://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
         $handler = new TestRequestHandler(function ($req) {
             return new Response();
         });
@@ -47,9 +48,10 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 
     public function testRedirect()
     {
-        $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/foo',
-        ]);
+        $uri = new Uri('http://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
         $handler = new TestRequestHandler(function ($req) {
             return new Response();
         });
@@ -81,9 +83,10 @@ class HttpsEnforcerMiddlewareTest extends TestCase
     {
         $this->expectException(SecurityException::class);
 
-        $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/',
-        ]);
+        $uri = new Uri('http://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
         $handler = new TestRequestHandler(function ($req) {
             return new Response();
         });

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http\Middleware;
 
-use Cake\Controller\Exception\SecurityException;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Middleware\HttpsEnforcerMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -81,7 +81,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 
     public function testSecurityException()
     {
-        $this->expectException(SecurityException::class);
+        $this->expectException(BadRequestException::class);
 
         $uri = new Uri('http://localhost/foo');
         $request = new ServerRequest();


### PR DESCRIPTION
This will allow deprecating / removing the "requireSecure" feature of SecurityComponent.