### PR TITLE
Security: randomToken and shortHash

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -388,4 +388,18 @@ class Security
 
         return static::$_salt = (string)$salt;
     }
+
+    /**
+     * Creates a secure random sensitive case token.
+     *
+     * @param int $length String length. Default 12.
+     * @return string
+     */
+    public static function randomToken($length = 12)
+    {
+        $random = base64_encode(static::randomBytes($length * 4));
+        $clean = preg_replace('/[^A-Za-z0-9]/', '', $random);
+
+        return substr($clean, random_int(1, $length * 2), $length);
+    }
 }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -405,7 +405,8 @@ class Security
 
     /**
      * Generate a 12 chars short hash (like git signature).
-     * @param  mixed $input Data to hash. Can be string or array
+     *
+     * @param  mixed $input Data to hash. Can be string or array.
      * @return string
      */
     public static function shortHash($input)

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -402,4 +402,18 @@ class Security
 
         return substr($clean, random_int(1, $length * 2), $length);
     }
+
+    /**
+     * Generate a 12 chars short hash (like git signature).
+     * @param  mixed $input Data to hash. Can be string or array
+     * @return string
+     */
+    public static function shortHash($input)
+    {
+        if (is_array($input)) {
+            $input = serialize($input);
+        }
+
+        return substr(static::hash($input, null, true), 0, 12);
+    }
 }

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -407,4 +407,40 @@ class SecurityTest extends TestCase
 
         $this->assertRegExp('/^[A-Za-z0-9]+$/', $value, 'should return a ASCII string');
     }
+
+    /**
+     * testShortHas method
+     *
+     * @return void
+     */
+    public function testShortHash()
+    {
+        $_hashType = Security::$hashType;
+        $_salt = Security::getSalt();
+
+        Security::setSalt('testShortHash');
+
+        // sha256
+        Security::setHash('sha256');
+
+        $result = Security::shortHash('someKey');
+        $this->assertSame(12, strlen($result));
+        $this->assertSame($result, '77d167ded549');
+
+        $result = Security::shortHash(['key' => 'value']);
+        $this->assertSame($result, 'c172fadcc0b3');
+
+        // md5
+        Security::setHash('md5');
+
+        $result = Security::shortHash('someKey');
+        $this->assertSame(12, strlen($result));
+        $this->assertSame($result, '766863df4538');
+
+        $result = Security::shortHash(['key' => 'value']);
+        $this->assertSame($result, 'a72367494f61');
+
+        Security::setHash($_hashType);
+        Security::setSalt($_salt);
+    }
 }

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -391,4 +391,20 @@ class SecurityTest extends TestCase
         $this->assertTrue(Security::constantEquals($snowman, $snowman));
         $this->assertFalse(Security::constantEquals(str_repeat($snowman, 3), $snowman));
     }
+
+    /**
+     * Test the randomString method.
+     *
+     * @return void
+     */
+    public function testRandomToken()
+    {
+        $value = Security::randomToken(7);
+        $this->assertSame(7, strlen($value));
+
+        $value = Security::randomToken();
+        $this->assertSame(12, strlen($value));
+
+        $this->assertRegExp('/^[A-Za-z0-9]+$/', $value, 'should return a ASCII string');
+    }
 }

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -409,7 +409,7 @@ class SecurityTest extends TestCase
     }
 
     /**
-     * testShortHas method
+     * Test the shortHash method.
      *
      * @return void
      */


### PR DESCRIPTION
I often use this methods in my projects, so, i propose them if you think they are cool ;)

**randomToken** : generate a random sensitive case token. It's not hexadecimal but full alphanumeric.
**shortHash** : return a short version of `hash` (like git commit). Really useful to assign uniq id for a string or array.
maybe `shortHash` could be included in `Security::hash` with a new `$length` param.