### PR TITLE
Fix reading of form tampering protection token in FormHelper.

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -486,9 +486,9 @@ class SecurityComponent extends Component
             'unlockedFields' => $this->_config['unlockedFields'],
         ];
 
-        $request->getSession()->write('_Token', $token);
+        $request->getSession()->write('_formToken', $token);
 
-        return $request->withAttribute('securityToken', [
+        return $request->withAttribute('_formToken', [
             'unlockedFields' => $token['unlockedFields'],
         ]);
     }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -489,7 +489,7 @@ class SecurityComponent extends Component
             'unlockedFields' => $this->_config['unlockedFields'],
         ];
 
-        return $request->withAttribute('_formToken', [
+        return $request->withAttribute('formToken', [
             'unlockedFields' => $token['unlockedFields'],
         ]);
     }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -315,7 +315,7 @@ class SecurityComponent extends Component
         if (strpos($token, ':')) {
             [$token, $locked] = explode(':', $token, 2);
         }
-        unset($check['_Token'], $check['_csrfToken']);
+        unset($check['_Token']);
 
         $locked = explode('|', $locked);
         $unlocked = explode('|', $unlocked);

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -177,11 +177,11 @@ class SecurityComponent extends Component
         if ($exception !== null) {
             if (!Configure::read('debug')) {
                 $exception->setReason($exception->getMessage());
-                $exception->setMessage(self::DEFAULT_EXCEPTION_MESSAGE);
+                $exception->setMessage(static::DEFAULT_EXCEPTION_MESSAGE);
             }
             throw $exception;
         }
-        throw new BadRequestException(self::DEFAULT_EXCEPTION_MESSAGE);
+        throw new BadRequestException(static::DEFAULT_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -230,7 +230,7 @@ class SecurityComponent extends Component
             return;
         }
 
-        $msg = self::DEFAULT_EXCEPTION_MESSAGE;
+        $msg = static::DEFAULT_EXCEPTION_MESSAGE;
         if (Configure::read('debug')) {
             $msg = $this->_debugPostTokenNotMatching($controller, $hashParts);
         }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -489,8 +489,6 @@ class SecurityComponent extends Component
             'unlockedFields' => $this->_config['unlockedFields'],
         ];
 
-        $request->getSession()->write('_formToken', $token);
-
         return $request->withAttribute('_formToken', [
             'unlockedFields' => $token['unlockedFields'],
         ]);

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -338,7 +338,10 @@ class SecurityComponent extends Component
         }
 
         $unlockedFields = array_unique(
-            array_merge((array)$this->getConfig('disabledFields'), (array)$this->_config['unlockedFields'], $unlocked)
+            array_merge(
+                (array)$this->_config['unlockedFields'],
+                $unlocked
+            )
         );
 
         /** @var (string|int)[] $fieldList */

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -528,7 +528,7 @@ class FormHelper extends Helper
     {
         $request = $this->_View->getRequest();
 
-        $formToken = $request->getAttribute('_formToken');
+        $formToken = $request->getAttribute('formToken');
         if (!empty($formToken['unlockedFields'])) {
             foreach ($formToken['unlockedFields'] as $unlocked) {
                 $this->_unlockedFields[] = $unlocked;
@@ -562,7 +562,7 @@ class FormHelper extends Helper
     {
         $out = '';
 
-        if ($this->requestType !== 'get' && $this->_View->getRequest()->getAttribute('_formToken')) {
+        if ($this->requestType !== 'get' && $this->_View->getRequest()->getAttribute('formToken')) {
             $out .= $this->secure($this->fields, $secureAttributes);
             $this->fields = [];
             $this->_unlockedFields = [];
@@ -595,7 +595,7 @@ class FormHelper extends Helper
      */
     public function secure(array $fields = [], array $secureAttributes = []): string
     {
-        if (!$this->_View->getRequest()->getAttribute('_formToken')) {
+        if (!$this->_View->getRequest()->getAttribute('formToken')) {
             return '';
         }
         $debugSecurity = Configure::read('debug');
@@ -2293,7 +2293,7 @@ class FormHelper extends Helper
     protected function _initInputField(string $field, array $options = []): array
     {
         if (!isset($options['secure'])) {
-            $options['secure'] = (bool)$this->_View->getRequest()->getAttribute('_formToken');
+            $options['secure'] = (bool)$this->_View->getRequest()->getAttribute('formToken');
         }
         $context = $this->_getContext();
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -528,8 +528,9 @@ class FormHelper extends Helper
     {
         $request = $this->_View->getRequest();
 
-        if ($request->getParam('_Token.unlockedFields')) {
-            foreach ((array)$request->getParam('_Token.unlockedFields') as $unlocked) {
+        $formToken = $request->getAttribute('_formToken');
+        if (!empty($formToken['unlockedFields'])) {
+            foreach ($formToken['unlockedFields'] as $unlocked) {
                 $this->_unlockedFields[] = $unlocked;
             }
         }
@@ -561,7 +562,7 @@ class FormHelper extends Helper
     {
         $out = '';
 
-        if ($this->requestType !== 'get' && $this->_View->getRequest()->getParam('_Token')) {
+        if ($this->requestType !== 'get' && $this->_View->getRequest()->getAttribute('_formToken')) {
             $out .= $this->secure($this->fields, $secureAttributes);
             $this->fields = [];
             $this->_unlockedFields = [];
@@ -594,7 +595,7 @@ class FormHelper extends Helper
      */
     public function secure(array $fields = [], array $secureAttributes = []): string
     {
-        if (!$this->_View->getRequest()->getParam('_Token')) {
+        if (!$this->_View->getRequest()->getAttribute('_formToken')) {
             return '';
         }
         $debugSecurity = Configure::read('debug');
@@ -2292,7 +2293,7 @@ class FormHelper extends Helper
     protected function _initInputField(string $field, array $options = []): array
     {
         if (!isset($options['secure'])) {
-            $options['secure'] = (bool)$this->_View->getRequest()->getParam('_Token');
+            $options['secure'] = (bool)$this->_View->getRequest()->getAttribute('_formToken');
         }
         $context = $this->_getContext();
 

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -790,32 +790,6 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * testValidatePostWithDisabledFields method
-     *
-     * @return void
-     * @triggers Controller.startup $this->Controller
-     */
-    public function testValidatePostWithDisabledFields(): void
-    {
-        $event = new Event('Controller.startup', $this->Controller);
-        $this->Security->setConfig('disabledFields', ['Model.username', 'Model.password']);
-        $this->Security->startup($event);
-        $fields = '0313460e1136e1227044399fe10a6edc0cbca279%3AModel.hidden';
-        $unlocked = '';
-        $debug = 'not used';
-
-        $this->Controller->setRequest($this->Controller->getRequest()->withParsedBody([
-            'Model' => [
-                'username' => '', 'password' => '', 'hidden' => '0',
-            ],
-            '_Token' => compact('fields', 'unlocked', 'debug'),
-        ]));
-
-        $result = $this->validatePost();
-        $this->assertNull($result);
-    }
-
-    /**
      * testValidatePostDisabledFieldsInData method
      *
      * Test validating post data with posted unlocked fields.
@@ -1166,44 +1140,6 @@ class SecurityComponentTest extends TestCase
         ]));
         $result = $this->validatePost('SecurityException', 'Bad Request');
         $this->assertFalse($result);
-    }
-
-    /**
-     * testFormDisabledFields method
-     *
-     * @return void
-     * @triggers Controller.startup $this->Controller
-     */
-    public function testFormDisabledFields(): void
-    {
-        $event = new Event('Controller.startup', $this->Controller);
-
-        $this->Security->startup($event);
-        $fields = '4eaf5c6b93d5140c24171d5fdce16ed5b904f288%3An%3A0%3A%7B%7D';
-        $unlocked = '';
-        $debug = urlencode(json_encode([
-            '/articles/index',
-            [],
-            [],
-        ]));
-
-        $this->Controller->setRequest($this->Controller->getRequest()->withParsedBody([
-            'MyModel' => ['name' => 'some data'],
-            '_Token' => compact('fields', 'unlocked', 'debug'),
-        ]));
-        $result = $this->validatePost('SecurityException', 'Unexpected field \'MyModel.name\' in POST data');
-        $this->assertFalse($result);
-
-        $this->Security->startup($event);
-        $this->Security->setConfig('disabledFields', ['MyModel.name']);
-
-        $this->Controller->setRequest($this->Controller->getRequest()->withParsedBody([
-            'MyModel' => ['name' => 'some data'],
-            '_Token' => compact('fields', 'unlocked', 'debug'),
-        ]));
-
-        $result = $this->validatePost();
-        $this->assertNull($result);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -213,7 +213,7 @@ class SecurityComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
         $this->Controller->Security->startup($event);
-        $this->assertTrue($this->Controller->getRequest()->getSession()->check('_Token'));
+        $this->assertTrue($this->Controller->getRequest()->getSession()->check('_formToken'));
     }
 
     /**
@@ -1311,7 +1311,7 @@ class SecurityComponentTest extends TestCase
 
         $this->Security->blackHole($this->Controller, 'auth');
         $this->assertTrue(
-            $this->Controller->getRequest()->getSession()->check('_Token'),
+            $this->Controller->getRequest()->getSession()->check('_formToken'),
             '_Token was deleted by blackHole %s'
         );
     }
@@ -1328,7 +1328,7 @@ class SecurityComponentTest extends TestCase
         $request = $this->Controller->getRequest();
         $request = $this->Security->generateToken($request);
 
-        $securityToken = $request->getAttribute('securityToken');
+        $securityToken = $request->getAttribute('_formToken');
         $this->assertNotEmpty($securityToken);
         $this->assertSame([], $securityToken['unlockedFields']);
     }

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -204,19 +204,6 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * testStartup method
-     *
-     * @return void
-     * @triggers Controller.startup $this->Controller
-     */
-    public function testStartup(): void
-    {
-        $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
-        $this->assertTrue($this->Controller->getRequest()->getSession()->check('_formToken'));
-    }
-
-    /**
      * testRequireSecureFail method
      *
      * @return void
@@ -356,7 +343,6 @@ class SecurityComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
-        $this->Controller->getRequest()->getSession()->delete('_Token');
         $unlocked = '';
         $debug = urlencode(json_encode([
             '/articles/index',
@@ -385,7 +371,6 @@ class SecurityComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
-        $this->Controller->getRequest()->getSession()->delete('_Token');
 
         $fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3AModel.valid';
 
@@ -1228,27 +1213,6 @@ class SecurityComponentTest extends TestCase
             'SecurityException',
             'URL mismatch in POST data (expected \'another-url\' but found \'/posts/edit/1\')'
         ));
-    }
-
-    /**
-     * testBlackHoleNotDeletingSessionInformation method
-     *
-     * Test that blackhole doesn't delete the _Token session key so repeat data submissions
-     * stay blackholed.
-     *
-     * @return void
-     * @triggers Controller.startup $this->Controller
-     */
-    public function testBlackHoleNotDeletingSessionInformation(): void
-    {
-        $event = new Event('Controller.startup', $this->Controller);
-        $this->Security->startup($event);
-
-        $this->Security->blackHole($this->Controller, 'auth');
-        $this->assertTrue(
-            $this->Controller->getRequest()->getSession()->check('_formToken'),
-            '_Token was deleted by blackHole %s'
-        );
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -488,7 +488,6 @@ class SecurityComponentTest extends TestCase
         $debug = 'not used';
 
         $this->Controller->setRequest($this->Controller->getRequest()->withParsedBody([
-            '_csrfToken' => 'abc123',
             'Model' => ['multi_field' => ['1', '3']],
             '_Token' => compact('fields', 'unlocked', 'debug'),
         ]));

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -1227,7 +1227,7 @@ class SecurityComponentTest extends TestCase
         $request = $this->Controller->getRequest();
         $request = $this->Security->generateToken($request);
 
-        $securityToken = $request->getAttribute('_formToken');
+        $securityToken = $request->getAttribute('formToken');
         $this->assertNotEmpty($securityToken);
         $this->assertSame([], $securityToken['unlockedFields']);
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1097,7 +1097,7 @@ class FormHelperTest extends TestCase
      */
     public function testValidateHashNoModel()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'foo'));
 
         $fields = ['anything'];
         $result = $this->Form->secure($fields);
@@ -1113,7 +1113,7 @@ class FormHelperTest extends TestCase
      */
     public function testNoCheckboxLocking()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'foo'));
         $this->assertSame([], $this->Form->fields);
 
         $this->Form->checkbox('check', ['value' => '1']);
@@ -1131,7 +1131,7 @@ class FormHelperTest extends TestCase
     {
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1179,7 +1179,7 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1366,7 +1366,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'foo'));
 
         $fields = [
             'Model.0.password', 'Model.0.username', 'Model.0.hidden' => 'value',
@@ -1417,7 +1417,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleSubmitButtons()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->text('Address.title');
@@ -1496,7 +1496,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitNestedNamed()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->submit('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1511,7 +1511,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageNoName()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->create();
         $result = $this->Form->submit('save.png');
@@ -1531,7 +1531,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageName()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->create(null);
         $result = $this->Form->submit('save.png', ['name' => 'test']);
@@ -1553,7 +1553,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1632,7 +1632,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityArrayFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->create();
         $this->Form->text('Address.primary.1');
@@ -1651,7 +1651,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlDisabledFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
@@ -1727,12 +1727,12 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getAttribute('_formToken'),
+            $this->View->getRequest()->getAttribute('formToken'),
             ['unlockedFields' => $this->Form->unlockField()]
         );
 
@@ -1805,12 +1805,12 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getAttribute('_formToken'),
+            $this->View->getRequest()->getAttribute('formToken'),
             ['unlockedFields' => $this->Form->unlockField()]
         );
 
@@ -1882,12 +1882,12 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getAttribute('_formToken'),
+            $this->View->getRequest()->getAttribute('formToken'),
             ['unlockedFields' => $this->Form->unlockField()]
         );
 
@@ -1939,12 +1939,12 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getAttribute('_formToken'),
+            $this->View->getRequest()->getAttribute('formToken'),
             ['unlockedFields' => $this->Form->unlockField()]
         );
 
@@ -1997,7 +1997,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecureWithCustomNameAttribute()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom]']);
         $this->assertSame('User.custom', $this->Form->fields[0]);
@@ -2016,7 +2016,7 @@ class FormHelperTest extends TestCase
     public function testFormSecuredControl()
     {
         $this->View->setRequest($this->View->getRequest()
-            ->withAttribute('_formToken', 'stuff')
+            ->withAttribute('formToken', 'stuff')
             ->withAttribute('csrfToken', 'testKey'));
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
@@ -2182,7 +2182,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlCustomName()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->text('text_input', [
@@ -2212,7 +2212,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlDuplicate()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
@@ -2278,7 +2278,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredRadio()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'option1', '2' => 'option2'];
@@ -2309,7 +2309,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabledNotAssoc()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->select('Model.select', [1, 2], ['disabled']);
         $this->Form->checkbox('Model.checkbox', ['disabled']);
@@ -2334,7 +2334,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabled()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $this->Form->checkbox('Model.checkbox', ['disabled' => true]);
         $this->Form->text('Model.text', ['disabled' => true]);
@@ -2362,7 +2362,7 @@ class FormHelperTest extends TestCase
      */
     public function testDisableSecurityUsingForm()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'disabledFields' => [],
         ]));
         $this->Form->create();
@@ -2389,7 +2389,7 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldAddsToList()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => [],
         ]));
         $this->Form->unlockField('Contact.name');
@@ -2408,7 +2408,7 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldRemovingFromFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'unlockedFields' => [],
         ]));
         $this->Form->create($this->article);
@@ -2432,7 +2432,7 @@ class FormHelperTest extends TestCase
      */
     public function testResetUnlockFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', [
             'key' => 'testKey',
             'unlockedFields' => [],
         ]));
@@ -2457,7 +2457,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlIgnoresHost()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'testKey']));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', ['key' => 'testKey']));
 
         $expected = '2548654895b160d724042ed269a2a863fd9d66ee%3A';
         $this->Form->create($this->article, [
@@ -2488,7 +2488,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlHasHtmlAndIdentifier()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
 
         $expected = '0a913f45b887b4d9cc2650ef1edc50183896959c%3A';
         $this->Form->create($this->article, [
@@ -5538,7 +5538,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxSecurity()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5583,7 +5583,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectNoSecureWithNoOptions()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testkey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'testkey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -6021,7 +6021,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecured()
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withAttribute('_formToken', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('formToken', ['unlockedFields' => []])
         );
         $this->Form->dateTime('date');
         $expected = ['date'];
@@ -6043,7 +6043,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecuredDisabled()
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withAttribute('_formToken', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('formToken', ['unlockedFields' => []])
         );
         $this->Form->dateTime('date', ['secure' => false]);
         $expected = [];
@@ -6675,7 +6675,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
-            ->withAttribute('_formToken', ['unlockedFields' => []]));
+            ->withAttribute('formToken', ['unlockedFields' => []]));
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
@@ -6899,7 +6899,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'test']));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', ['key' => 'test']));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -6952,7 +6952,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize([]) . session_id(), Security::getSalt());
         $hash .= '%3A';
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'test']));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', ['key' => 'test']));
 
         $this->Form->create(null, ['url' => ['action' => 'add']]);
         $this->Form->control('title');
@@ -6979,7 +6979,7 @@ class FormHelperTest extends TestCase
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
         $this->View->setRequest($this->View->getRequest()
-            ->withAttribute('_formToken', ['key' => 'test']));
+            ->withAttribute('formToken', ['key' => 'test']));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7038,7 +7038,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
-            ->withAttribute('_formToken', 'val'));
+            ->withAttribute('formToken', 'val'));
 
         $this->Form->create($this->article, ['type' => 'get']);
         $this->Form->end();
@@ -7252,7 +7252,7 @@ class FormHelperTest extends TestCase
      */
     public function testSubmitUnlockedByDefault()
     {
-        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'secured'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('formToken', 'secured'));
         $this->Form->submit('Go go');
         $this->Form->submit('Save', ['name' => 'save']);
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1097,7 +1097,7 @@ class FormHelperTest extends TestCase
      */
     public function testValidateHashNoModel()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
 
         $fields = ['anything'];
         $result = $this->Form->secure($fields);
@@ -1113,7 +1113,7 @@ class FormHelperTest extends TestCase
      */
     public function testNoCheckboxLocking()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
         $this->assertSame([], $this->Form->fields);
 
         $this->Form->checkbox('check', ['value' => '1']);
@@ -1131,7 +1131,7 @@ class FormHelperTest extends TestCase
     {
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1179,7 +1179,7 @@ class FormHelperTest extends TestCase
         Configure::write('debug', false);
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $result = $this->Form->secure($fields);
 
         $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
@@ -1366,7 +1366,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'foo'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'foo'));
 
         $fields = [
             'Model.0.password', 'Model.0.username', 'Model.0.hidden' => 'value',
@@ -1417,7 +1417,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleSubmitButtons()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->text('Address.title');
@@ -1496,7 +1496,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitNestedNamed()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->create($this->article);
         $this->Form->submit('Test', ['type' => 'submit', 'name' => 'Address[button]']);
@@ -1511,7 +1511,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageNoName()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->create();
         $result = $this->Form->submit('save.png');
@@ -1531,7 +1531,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuritySubmitImageName()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->create(null);
         $result = $this->Form->submit('save.png', ['name' => 'test']);
@@ -1553,7 +1553,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
@@ -1632,7 +1632,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityArrayFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->create();
         $this->Form->text('Address.primary.1');
@@ -1651,7 +1651,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityMultipleControlDisabledFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
@@ -1727,11 +1727,14 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
-        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals(
+            $this->View->getRequest()->getAttribute('_formToken'),
+            ['unlockedFields' => $this->Form->unlockField()]
+        );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1802,11 +1805,14 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
-        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals(
+            $this->View->getRequest()->getAttribute('_formToken'),
+            ['unlockedFields' => $this->Form->unlockField()]
+        );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1876,11 +1882,14 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
-        $this->assertEquals($this->View->getRequest()->getParam('_Token.unlockedFields'), $this->Form->unlockField());
+        $this->assertEquals(
+            $this->View->getRequest()->getAttribute('_formToken'),
+            ['unlockedFields' => $this->Form->unlockField()]
+        );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
         $this->Form->text('Addresses.title');
@@ -1930,13 +1939,13 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => ['first_name', 'address'],
         ]));
         $this->Form->create();
         $this->assertEquals(
-            $this->View->getRequest()->getParam('_Token.unlockedFields'),
-            $this->Form->unlockField()
+            $this->View->getRequest()->getAttribute('_formToken'),
+            ['unlockedFields' => $this->Form->unlockField()]
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -1988,7 +1997,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecureWithCustomNameAttribute()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->text('UserForm.published', ['name' => 'User[custom]']);
         $this->assertSame('User.custom', $this->Form->fields[0]);
@@ -2007,7 +2016,7 @@ class FormHelperTest extends TestCase
     public function testFormSecuredControl()
     {
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('_Token', 'stuff')
+            ->withAttribute('_formToken', 'stuff')
             ->withAttribute('csrfToken', 'testKey'));
         $this->article['schema'] = [
             'ratio' => ['type' => 'decimal', 'length' => 5, 'precision' => 6],
@@ -2173,7 +2182,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlCustomName()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->text('text_input', [
@@ -2203,7 +2212,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredControlDuplicate()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->control('text_val', [
@@ -2269,7 +2278,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredRadio()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->assertEquals([], $this->Form->fields);
         $options = ['1' => 'option1', '2' => 'option2'];
@@ -2300,7 +2309,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabledNotAssoc()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->select('Model.select', [1, 2], ['disabled']);
         $this->Form->checkbox('Model.checkbox', ['disabled']);
@@ -2325,7 +2334,7 @@ class FormHelperTest extends TestCase
      */
     public function testFormSecuredAndDisabled()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $this->Form->checkbox('Model.checkbox', ['disabled' => true]);
         $this->Form->text('Model.text', ['disabled' => true]);
@@ -2353,7 +2362,7 @@ class FormHelperTest extends TestCase
      */
     public function testDisableSecurityUsingForm()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'disabledFields' => [],
         ]));
         $this->Form->create();
@@ -2380,7 +2389,7 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldAddsToList()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => [],
         ]));
         $this->Form->unlockField('Contact.name');
@@ -2399,7 +2408,7 @@ class FormHelperTest extends TestCase
      */
     public function testUnlockFieldRemovingFromFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'unlockedFields' => [],
         ]));
         $this->Form->create($this->article);
@@ -2423,7 +2432,7 @@ class FormHelperTest extends TestCase
      */
     public function testResetUnlockFields()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', [
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', [
             'key' => 'testKey',
             'unlockedFields' => [],
         ]));
@@ -2448,7 +2457,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlIgnoresHost()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', ['key' => 'testKey']));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'testKey']));
 
         $expected = '2548654895b160d724042ed269a2a863fd9d66ee%3A';
         $this->Form->create($this->article, [
@@ -2479,7 +2488,7 @@ class FormHelperTest extends TestCase
      */
     public function testSecuredFormUrlHasHtmlAndIdentifier()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
 
         $expected = '0a913f45b887b4d9cc2650ef1edc50183896959c%3A';
         $this->Form->create($this->article, [
@@ -5529,7 +5538,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectMultipleCheckboxSecurity()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testKey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testKey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -5574,7 +5583,7 @@ class FormHelperTest extends TestCase
      */
     public function testSelectNoSecureWithNoOptions()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'testkey'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'testkey'));
         $this->assertEquals([], $this->Form->fields);
 
         $this->Form->select(
@@ -6012,7 +6021,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecured()
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withParam('_Token', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('_formToken', ['unlockedFields' => []])
         );
         $this->Form->dateTime('date');
         $expected = ['date'];
@@ -6034,7 +6043,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecuredDisabled()
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withParam('_Token', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('_formToken', ['unlockedFields' => []])
         );
         $this->Form->dateTime('date', ['secure' => false]);
         $expected = [];
@@ -6666,7 +6675,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
-            ->withParam('_Token.unlockedFields', []));
+            ->withAttribute('_formToken', ['unlockedFields' => []]));
 
         $result = $this->Form->postButton('Delete', '/posts/delete/1');
         $tokenDebug = urlencode(json_encode([
@@ -6890,7 +6899,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token.key', 'test'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'test']));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -6943,7 +6952,7 @@ class FormHelperTest extends TestCase
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize([]) . session_id(), Security::getSalt());
         $hash .= '%3A';
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token.key', 'test'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', ['key' => 'test']));
 
         $this->Form->create(null, ['url' => ['action' => 'add']]);
         $this->Form->control('title');
@@ -6970,7 +6979,7 @@ class FormHelperTest extends TestCase
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('_Token.key', 'test'));
+            ->withAttribute('_formToken', ['key' => 'test']));
 
         $result = $this->Form->postLink(
             'Delete',
@@ -7029,7 +7038,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
-            ->withParam('_Token', 'val'));
+            ->withAttribute('_formToken', 'val'));
 
         $this->Form->create($this->article, ['type' => 'get']);
         $this->Form->end();
@@ -7243,7 +7252,7 @@ class FormHelperTest extends TestCase
      */
     public function testSubmitUnlockedByDefault()
     {
-        $this->View->setRequest($this->View->getRequest()->withParam('_Token', 'secured'));
+        $this->View->setRequest($this->View->getRequest()->withAttribute('_formToken', 'secured'));
         $this->Form->submit('Go go');
         $this->Form->submit('Save', ['name' => 'save']);
 


### PR DESCRIPTION
Updating the FormHelper was missed when the token was moved from
request param to request attribute. Refs #13669.