### PR TITLE
Fix Sqlserver reflection of VARBINARY(MAX)

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -138,6 +138,10 @@ class SqlserverSchema extends BaseSchema
         }
 
         if ($col === 'image' || strpos($col, 'binary') !== false) {
+            // -1 is the value for MAX which we treat as a 'long' binary
+            if ($length == -1) {
+                $length = TableSchema::LENGTH_LONG;
+            }
             return ['type' => TableSchema::TYPE_BINARY, 'length' => $length];
         }
 

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -142,6 +142,7 @@ class SqlserverSchema extends BaseSchema
             if ($length == -1) {
                 $length = TableSchema::LENGTH_LONG;
             }
+
             return ['type' => TableSchema::TYPE_BINARY, 'length' => $length];
         }
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -265,6 +265,13 @@ SQL;
                 null,
                 ['type' => 'binary', 'length' => 30]
             ],
+            [
+                'VARBINARY',
+                -1,
+                null,
+                null,
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG]
+            ],
         ];
     }
 


### PR DESCRIPTION
Use LENGTH_LONG for this column type so that we can generate the same column definition when creating DDL.

Fixes #13714
