### PR TITLE
Include file and line information in error handler middleware

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -230,10 +230,12 @@ class ErrorHandlerMiddleware
     protected function getMessageForException($exception, $isPrevious = false)
     {
         $message = sprintf(
-            '%s[%s] %s',
+            '%s[%s] %s (%s:%s)',
             $isPrevious ? "\nCaused by: " : '',
             get_class($exception),
-            $exception->getMessage()
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
         );
         $debug = Configure::read('debug');
 


### PR DESCRIPTION
This has been bugging me for ages.

Before, it logs a whole bunch of stuff that is basically unhelpful in pinpointing the issue.  The whole stack trace is practically useless:

```
2019-10-05 04:57:10 Error: [ParseError] syntax error, unexpected ']'
#0 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/home/rachman/s...')
#1 [internal function]: Composer\Autoload\ClassLoader->loadClass('App\\Controller\\...')
#2 /home/rachman/sites/myapi.test/src/Controller/Api/NodesController.php(10): spl_autoload_call('App\\Controller\\...')
#3 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(444): include('/home/rachman/s...')
#4 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/home/rachman/s...')
#5 [internal function]: Composer\Autoload\ClassLoader->loadClass('App\\Controller\\...')
#6 [internal function]: spl_autoload_call('App\\Controller\\...')
#7 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Core/App.php(152): class_exists('App\\Controller\\...')
#8 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Core/App.php(64): Cake\Core\App::_classExistsInBase('\\Controller\\Api...', 'App')
#9 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ControllerFactory.php(92): Cake\Core\App::className('Nodes', 'Controller/Api', 'Controller')
#10 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ControllerFactory.php(37): Cake\Http\ControllerFactory->getControllerClass(Object(Cake\Http\ServerRequest))
#11 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ActionDispatcher.php(91): Cake\Http\ControllerFactory->create(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#12 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/BaseApplication.php(235): Cake\Http\ActionDispatcher->dispatch(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#13 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Http\BaseApplication->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#14 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Routing/Middleware/RoutingMiddleware.php(162): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#15 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Routing\Middleware\RoutingMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#16 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Routing/Middleware/AssetMiddleware.php(88): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#17 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Routing\Middleware\AssetMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#18 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Error/Middleware/ErrorHandlerMiddleware.php(96): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#19 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Error\Middleware\ErrorHandlerMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#20 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(51): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#21 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Server.php(98): Cake\Http\Runner->run(Object(Cake\Http\MiddlewareQueue), Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#22 /home/rachman/sites/myapi.test/webroot/index.php(40): Cake\Http\Server->run()
#23 {main}
Request URL: /api/nodes/84
```

After this change:

```
==> logs/error.log <==
2019-10-05 06:20:57 Error: [ParseError] syntax error, unexpected ']' (/home/rachman/sites/myapi.test/src/Controller/Api/AppController.php:123)
#0 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/home/rachman/s...')
#1 [internal function]: Composer\Autoload\ClassLoader->loadClass('App\\Controller\\...')
#2 /home/rachman/sites/myapi.test/src/Controller/Api/NodesController.php(10): spl_autoload_call('App\\Controller\\...')
#3 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(444): include('/home/rachman/s...')
#4 /home/rachman/sites/myapi.test/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/home/rachman/s...')
#5 [internal function]: Composer\Autoload\ClassLoader->loadClass('App\\Controller\\...')
#6 [internal function]: spl_autoload_call('App\\Controller\\...')
#7 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Core/App.php(152): class_exists('App\\Controller\\...')
#8 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Core/App.php(64): Cake\Core\App::_classExistsInBase('\\Controller\\Api...', 'App')
#9 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ControllerFactory.php(92): Cake\Core\App::className('Nodes', 'Controller/Api', 'Controller')
#10 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ControllerFactory.php(37): Cake\Http\ControllerFactory->getControllerClass(Object(Cake\Http\ServerRequest))
#11 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/ActionDispatcher.php(91): Cake\Http\ControllerFactory->create(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#12 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/BaseApplication.php(235): Cake\Http\ActionDispatcher->dispatch(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#13 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Http\BaseApplication->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#14 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Routing/Middleware/RoutingMiddleware.php(162): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#15 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Routing\Middleware\RoutingMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#16 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Routing/Middleware/AssetMiddleware.php(88): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#17 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Routing\Middleware\AssetMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#18 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Error/Middleware/ErrorHandlerMiddleware.php(96): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#19 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(65): Cake\Error\Middleware\ErrorHandlerMiddleware->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response), Object(Cake\Http\Runner))
#20 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Runner.php(51): Cake\Http\Runner->__invoke(Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#21 /home/rachman/sites/myapi.test/vendor/cakephp/cakephp/src/Http/Server.php(98): Cake\Http\Runner->run(Object(Cake\Http\MiddlewareQueue), Object(Cake\Http\ServerRequest), Object(Cake\Http\Response))
#22 /home/rachman/sites/myapi.test/webroot/index.php(40): Cake\Http\Server->run()
#23 {main}
Request URL: /api/nodes/84
```