### PR TITLE
4.x csrfmiddleware

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -47,7 +47,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 class CsrfProtectionMiddleware implements MiddlewareInterface
 {
     /**
-     * Default config for the CSRF handling.
+     * Config for the CSRF handling.
      *
      *  - `cookieName` The name of the cookie to send.
      *  - `expiry` A strotime compatible value of how long the CSRF token should last.
@@ -59,20 +59,13 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected $_config = [
         'cookieName' => 'csrfToken',
         'expiry' => 0,
         'secure' => false,
         'httpOnly' => false,
         'field' => '_csrfToken',
     ];
-
-    /**
-     * Configuration
-     *
-     * @var array
-     */
-    protected $_config = [];
 
     /**
      * Callback for deciding whether or not to skip the token check for particular request.
@@ -86,11 +79,11 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param array $config Config options. See $_defaultConfig for valid keys.
+     * @param array $config Config options. See $_config for valid keys.
      */
     public function __construct(array $config = [])
     {
-        $this->_config = $config + $this->_defaultConfig;
+        $this->_config = $config + $this->_config;
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -321,6 +321,9 @@ class CsrfProtectionMiddlewareTest extends TestCase
     public function testSkippingTokenCheckUsingWhitelistCallback()
     {
         $request = new ServerRequest([
+            'post' => [
+                '_csrfToken' => 'foo',
+            ],
             'environment' => [
                 'REQUEST_METHOD' => 'POST',
             ],
@@ -333,7 +336,14 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
             return true;
         });
-        $response = $middleware->process($request, $this->_getRequestHandler());
+
+        $handler = new TestRequestHandler(function ($request) {
+            $this->assertEmpty($request->getParsedBody());
+
+            return new Response();
+        });
+
+        $response = $middleware->process($request, $handler);
         $this->assertInstanceOf(Response::class, $response);
     }
 }


### PR DESCRIPTION
- Some minor optimization
- Ensured CSRF token is always cleared from POST data (so that unsetting it isn't necessary in SecurityComponent)
- Changed the request attribute from `csrfToken` to `_csrfToken` for naming consistency and in line with our convention of prefixing special keys / attributes with underscore.
- Removed the `$_defaultConfig` property and set defaults in `$_config` itself. The middleware doesn't use `InstanceConfigTrait` so two properties were unnecessary.