### PR TITLE
Added sqlserver support to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,16 +77,10 @@ before_install:
       fi
 
   - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test;"; fi
-  - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test2;"; fi
-  - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test3;"; fi
 
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
-  - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi
-  - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test3;'; fi
 
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
-  - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi
-  - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
   - |
       if [[ ${TRAVIS_PHP_VERSION} != "5.6" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: php
 
 php:
-  - 7.0
-  - 5.6
-  - 7.2
   - 7.3
+  - 5.6
+  - 7.0
+  - 7.2
   - '7.4snapshot'
 
 dist: xenial
 
 env:
   matrix:
+    - DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
     - DB=sqlite db_dsn='sqlite:///:memory:'
     - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
     - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
@@ -42,9 +43,6 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.2
-      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
-
     - php: 5.6
       env: PREFER_LOWEST=1
 
@@ -53,6 +51,19 @@ matrix:
 
     - php: 7.1
       env: CODECOVERAGE=1 DEFAULT=0
+
+  exclude:
+    - php: 5.6
+      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
+
+    - php: 7.0
+      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
+
+    - php: 7.2
+      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
+
+    - php: 7.4snapshot
+      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
 
   allow_failures:
     - php: '7.4snapshot'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.3
   - '7.4snapshot'
 
-dist: trusty
+dist: xenial
 
 env:
   matrix:
@@ -22,11 +22,16 @@ env:
 services:
   - memcached
   - redis-server
-  - postgresql
   - mysql
 
 addons:
   postgresql: "9.4"
+  apt:
+    sources:
+      - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/mssql-server-2017 xenial main'
+        key_url: https://packages.microsoft.com/keys/microsoft.asc
+      - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main'
+        key_url: https://packages.microsoft.com/keys/microsoft.asc
 
 cache:
   directories:
@@ -37,6 +42,9 @@ matrix:
   fast_finish: true
 
   include:
+    - php: 7.2
+      env: DB=sqlserver db_dsn='sqlserver://SA:Strong!Passw0rd@localhost/cakephp_test?timezone=UTC'
+
     - php: 5.6
       env: PREFER_LOWEST=1
 
@@ -56,6 +64,22 @@ before_install:
         phpenv config-rm xdebug.ini
       fi
 
+  - pecl channel-update pecl.php.net
+  - if [[ $CODECOVERAGE == 1 ]]; then pecl install pcov; fi
+
+  - |
+      if [ $DB = 'sqlserver' ]; then
+        sudo apt-get install -y mssql-server
+        sudo MSSQL_SA_PASSWORD="Strong!Passw0rd" MSSQL_PID=Express /opt/mssql/bin/mssql-conf -n setup accept-eula
+        sudo ACCEPT_EULA=Y apt-get install -y mssql-tools msodbcsql17 unixodbc-dev
+        pecl install sqlsrv
+        pecl install pdo_sqlsrv
+      fi
+
+  - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test;"; fi
+  - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test2;"; fi
+  - if [ $DB = 'sqlserver' ]; then /opt/mssql-tools/bin/sqlcmd -b -S localhost -U SA -P "Strong!Passw0rd" -Q "CREATE DATABASE cakephp_test3;"; fi
+
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test3;'; fi
@@ -64,8 +88,6 @@ before_install:
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi
   - if [ $DB = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi
 
-  - pecl channel-update pecl.php.net
-  - if [[ $CODECOVERAGE == 1 ]]; then pecl install pcov; fi
   - |
       if [[ ${TRAVIS_PHP_VERSION} != "5.6" ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;


### PR DESCRIPTION
I made this change to allow testing against the full suite of databases for future contributions such as fractional seconds support.

This has two key changes:

- Move to xenial distribution (the current default for travis)
- Added sqlserver db support

The xenial distribution was required for sqlserver packages.  This bump makes sense to do anyway. 
 The hidden change that happens here is mysql for xenial is 5.7 by default.  I can work on adding mysql 5.6 back to xenial, but it is non-trivial in the way sqlserver is.

We can install sqlserver pdo for versions >= 7.1.  I enabled just for 7.3 as it does take a little bit of time.
