### PR TITLE
Fix BelongsToMany::find() applying joins

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1036,11 +1036,11 @@ class BelongsToMany extends Association
             ->where($this->targetConditions())
             ->addDefaultTypes($this->getTarget());
 
-        if (!($this->junctionConditions() || $this->getFinder())) {
-            return $query;
+        if ($this->junctionConditions()) {
+            return $this->_appendJunctionJoin($query);
         }
 
-        return $this->_appendJunctionJoin($query);
+        return $query;
     }
 
     /**
@@ -1159,6 +1159,7 @@ class BelongsToMany extends Association
                 $existing = $this->find()
                     ->select($keys)
                     ->where(array_combine($prefixedForeignKey, $primaryValue));
+                $existing = $this->_appendJunctionJoin($existing);
 
                 $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
                 $inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities, $options);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -304,7 +304,7 @@ class BelongsToManyTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
-        $assoc = $tags->belongsToMany('Articles', [
+        $tags->belongsToMany('Articles', [
             'sourceTable' => $tags,
             'targetTable' => $articles,
             'finder' => 'published',
@@ -607,7 +607,7 @@ class BelongsToManyTest extends TestCase
 
         $joint->expects($this->once())
             ->method('save')
-            ->will($this->returnCallback(function (EntityInterface $e, $opts) {
+            ->will($this->returnCallback(function (EntityInterface $e) {
                 $this->assertSame('Plugin.ArticlesTags', $e->getSource());
 
                 return $e;
@@ -765,7 +765,7 @@ class BelongsToManyTest extends TestCase
         $this->assertFalse($entity->isDirty('tags'), 'Property should be cleaned');
 
         $new = $articles->get(1, ['contain' => 'Tags']);
-        $this->assertSame([], $entity->tags, 'Should not be data in db');
+        $this->assertSame([], $new->tags, 'Should not be data in db');
     }
 
     /**
@@ -1276,6 +1276,26 @@ class BelongsToManyTest extends TestCase
 
         $this->assertNotEmpty($result->tags[0]->two, 'Should have computed field');
         $this->assertNotEmpty($result->tags[0]->name, 'Should have standard field');
+    }
+
+    /**
+     * Test that association proxy find() works with no join records
+     *
+     * @return void
+     */
+    public function testAssociationProxyFindNoJoinRecords()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'through' => 'ArticlesTags',
+        ]);
+        $table->Tags->junction()->deleteAll('1=1');
+
+        $query = $table->Tags->find();
+        $result = $query->toArray();
+        $this->assertCount(3, $result);
     }
 
     /**


### PR DESCRIPTION
The association find proxy method should only apply joins if the association has junction conditions. If a custom finder is used then that finder method should apply the required joins.

Fixes #13712