### PR TITLE
Fixed microseconds being dropped when creating Time and FrozenTime

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -453,9 +453,9 @@ trait DateFormatTrait
     public function __debugInfo()
     {
         return [
-            'time' => $this->toIso8601String(),
+            'time' => $this->format('Y-m-d\TH:i:s.uP'),
             'timezone' => $this->getTimezone()->getName(),
-            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->toIso8601String() : false
+            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->format('Y-m-d\TH:i:s.uP') : false
         ];
     }
 }

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -111,7 +111,7 @@ class FrozenTime extends Chronos implements JsonSerializable
     {
         if ($time instanceof DateTimeInterface) {
             $tz = $time->getTimezone();
-            $time = $time->format('Y-m-d H:i:s');
+            $time = $time->format('Y-m-d H:i:s.u');
         }
 
         if (is_numeric($time)) {

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -109,7 +109,7 @@ class Time extends MutableDateTime implements JsonSerializable
     {
         if ($time instanceof DateTimeInterface) {
             $tz = $time->getTimezone();
-            $time = $time->format('Y-m-d H:i:s');
+            $time = $time->format('Y-m-d H:i:s.u');
         }
 
         if (is_numeric($time)) {

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\I18n;
 
+use Cake\Chronos\Chronos;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\I18n;
 use Cake\I18n\Time;
@@ -87,14 +88,22 @@ class TimeTest extends TestCase
      */
     public function testConstructFromAnotherInstance($class)
     {
-        $time = '2015-01-22 10:33:44';
+        $time = '2015-01-22 10:33:44.123456';
         $frozen = new FrozenTime($time, 'America/Chicago');
         $subject = new $class($frozen);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s'), 'frozen time construction');
+        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'frozen time construction');
 
         $mut = new Time($time, 'America/Chicago');
         $subject = new $class($mut);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s'), 'mutable time construction');
+        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
+
+        $mut = new Chronos($time, 'America/Chicago');
+        $subject = new $class($mut);
+        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
+
+        $mut = new \DateTime($time, new \DateTimeZone('America/Chicago'));
+        $subject = new $class($mut);
+        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
     }
 
     /**
@@ -780,9 +789,9 @@ class TimeTest extends TestCase
     {
         $time = new $class('2014-04-20 10:10:10');
         $expected = [
-            'time' => '2014-04-20T10:10:10+00:00',
+            'time' => '2014-04-20T10:10:10.000000+00:00',
             'timezone' => 'UTC',
-            'fixedNowTime' => $class::getTestNow()->toIso8601String()
+            'fixedNowTime' => $class::getTestNow()->format('Y-m-d\TH:i:s.uP')
         ];
         $this->assertEquals($expected, $time->__debugInfo());
     }


### PR DESCRIPTION
Fixed microseconds being dropped when creating Time and FrozenTime from DateTimeInterface instances.  Time and FrozenTime convert DateTimeInterface instances to strings before constructing with parent.  

This is backwards compatible as microseconds are never forced anywhere anywhere unless someone is manually parsing debug info.  Users who are formatting with microsecond after a conversion will see actual microseconds instead of 000000 now, but formatting will stay the same.