### PR TITLE
Add convert method for convert expression

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -531,7 +531,7 @@ class QueryExpression implements ExpressionInterface, Countable
 
         return $this->eq($wrapIdentifier($left), $wrapIdentifier($right));
     }
-    
+
     /**
      * Adds a new type convertion to the expression object in the form "CAST(field AS type)".
      *
@@ -542,9 +542,9 @@ class QueryExpression implements ExpressionInterface, Countable
     public function convert($field, $type)
     {
         $this->add("CAST($field AS $type)");
+
         return $this;
     }
-
 
     /**
      * Returns the string representation of this object so that it can be used in a

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -531,6 +531,20 @@ class QueryExpression implements ExpressionInterface, Countable
 
         return $this->eq($wrapIdentifier($left), $wrapIdentifier($right));
     }
+    
+    /**
+     * Adds a new type convertion to the expression object in the form "CAST(field AS type)".
+     *
+     * @param string $field Database field to be cast against type
+     * @param string $type target data type to cast field to it
+     * @return $this
+     */
+    public function convert($field, $type)
+    {
+        $this->add("CAST($field AS $type)");
+        return $this;
+    }
+
 
     /**
      * Returns the string representation of this object so that it can be used in a


### PR DESCRIPTION
I just add the convert method as it requested in issue. It just make CAST(expression AS datatype) expression which should works on most DBMS' .

Resolves https://github.com/cakephp/cakephp/issues/13694