### PR TITLE
Format dev error messages

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -930,6 +930,29 @@ TEXT;
     }
 
     /**
+     * Format an exception message to be HTML formatted.
+     *
+     * Does the following formatting operations:
+     *
+     * - HTML escape the message.
+     * - Convert `bool` into `<code>bool</code>`
+     * - Convert newlines into `<br />`
+     *
+     * @param string $message The string message to format.
+     * @return string Formatted message.
+     */
+    public static function formatHtmlMessage(string $message): string
+    {
+        $message = h($message);
+        $message = preg_replace_callback('/`([^`]+)`/', function ($matches) {
+            return '<code>' . $matches[1] . '</code>';
+        }, $message);
+        $message = nl2br($message);
+
+        return $message;
+    }
+
+    /**
      * Verifies that the application's salt and cipher seed value has been changed from the default value.
      *
      * @return void

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -944,9 +944,7 @@ TEXT;
     public static function formatHtmlMessage(string $message): string
     {
         $message = h($message);
-        $message = preg_replace_callback('/`([^`]+)`/', function ($matches) {
-            return '<code>' . $matches[1] . '</code>';
-        }, $message);
+        $message = preg_replace('/`([^`]+)`/', '<code>$1</code>', $message);
         $message = nl2br($message);
 
         return $message;

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -20,7 +20,7 @@ use Cake\Error\Debugger;
     <?= $this->Html->charset() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>
-        Error: <?= Debugger::formatHtmlMessage($this->fetch('title')) ?>
+        Error: <?= h($this->fetch('title')) ?>
     </title>
     <?= $this->Html->meta('icon') ?>
     <style>
@@ -245,7 +245,7 @@ use Cake\Error\Debugger;
 <body>
     <header>
         <h1 class="header-title" data-content="&#128203">
-            <?= h($this->fetch('title')) ?>
+            <?= Debugger::formatHtmlMessage($this->fetch('title')) ?>
         </h1>
         <span class="header-type"><?= get_class($error) ?></span>
     </header>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+use Cake\Error\Debugger;
 ?>
 <!DOCTYPE html>
 <html>
@@ -19,7 +20,7 @@
     <?= $this->Html->charset() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>
-        Error: <?= h($this->fetch('title')) ?>
+        Error: <?= Debugger::formatHtmlMessage($this->fetch('title')) ?>
     </title>
     <?= $this->Html->meta('icon') ?>
     <style>

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -831,17 +831,17 @@ EXPECTED;
      *
      * @return void
      */
-    public function formatHtmlMessage()
+    public function testFormatHtmlMessage()
     {
         $output = Debugger::formatHtmlMessage('Some `code` to `replace`');
         $this->assertSame('Some <code>code</code> to <code>replace</code>', $output);
 
-        $output = Debugger::formatHtmlMessage('Some `co\nde` to `replace`\nmore');
-        $this->assertSame('Some <code>co<br>de</code> to <code>replace</code><br>more', $output);
+        $output = Debugger::formatHtmlMessage("Some `co\nde` to `replace`\nmore");
+        $this->assertSame("Some <code>co<br />\nde</code> to <code>replace</code><br />\nmore", $output);
 
-        $output = Debugger::formatHtmlMessage('Some `code` to <script>alert("test")</script>\nmore');
+        $output = Debugger::formatHtmlMessage("Some `code` to <script>alert(\"test\")</script>\nmore");
         $this->assertSame(
-            'Some <code>co<br>de</code> to &lt;script&gt;alert(&quot;test&quot;&lt;/script&gt;<br>more',
+            "Some <code>code</code> to &lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;<br />\nmore",
             $output
         );
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -825,4 +825,24 @@ EXPECTED;
         $expected = sprintf($expected, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 9);
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * test formatHtmlMessage
+     *
+     * @return void
+     */
+    public function formatHtmlMessage()
+    {
+        $output = Debugger::formatHtmlMessage('Some `code` to `replace`');
+        $this->assertSame('Some <code>code</code> to <code>replace</code>', $output);
+
+        $output = Debugger::formatHtmlMessage('Some `co\nde` to `replace`\nmore');
+        $this->assertSame('Some <code>co<br>de</code> to <code>replace</code><br>more', $output);
+
+        $output = Debugger::formatHtmlMessage('Some `code` to <script>alert("test")</script>\nmore');
+        $this->assertSame(
+            'Some <code>co<br>de</code> to &lt;script&gt;alert(&quot;test&quot;&lt;/script&gt;<br>more',
+            $output
+        );
+    }
 }


### PR DESCRIPTION
Apply a few simple HTML formatting transforms to error messages. This should help make error pages easier to understand and gives us more options when writing verbose error messages.
