### PR TITLE
Set value for Limit if parameter found

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1264,10 +1264,11 @@ class PaginatorHelper extends Helper
             ];
         }
 
+        $query = $this->_View->getRequest()->getQueryParams();
         $out .= $this->Form->control('limit', $options + [
                 'type' => 'select',
                 'label' => __('View'),
-                'value' => $default,
+                'value' => !empty($query['limit'])?$query['limit']:$default,
                 'options' => $limits,
                 'onChange' => 'this.form.submit()'
             ]);


### PR DESCRIPTION
There was an issue with selecting a limit value if any default value was set. Updated 'value' options if has 'limit' query.

`echo $this->Paginator->limitControl([25 => 25, 50 => 50],50); `

<img width="529" alt="Screen Shot 2019-10-09 at 12 12 47" src="https://user-images.githubusercontent.com/4234756/66448994-76267c00-ea8e-11e9-8aa0-4b5c983a08d0.png">
