### PR TITLE
Removed dublicate array key

### DIFF
--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -43,7 +43,7 @@ class ViewBuilderTest extends TestCase
         $update = ['test' => 'updated'];
         $builder->setVars($update);
         $this->assertEquals(
-            ['test' => 'val', 'foo' => 'bar', 'test' => 'updated'],
+            ['foo' => 'bar', 'test' => 'updated'],
             $builder->getVars()
         );
 


### PR DESCRIPTION
first value of the key 'test' is overriden and the behaviour doesn't change by this PR
