### PR TITLE
Add missing Email `@deprecated` tags

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1335,13 +1335,13 @@ class Email implements JsonSerializable, Serializable
 
         if ($template === false) {
             return [
-                'template' => $this->getTemplate(),
-                'layout' => $this->getLayout()
+                'template' => $this->viewBuilder()->getTemplate(),
+                'layout' => $this->viewBuilder()->getLayout()
             ];
         }
-        $this->setTemplate($template);
+        $this->viewBuilder()->setTemplate($template);
         if ($layout !== false) {
-            $this->setLayout($layout);
+            $this->viewBuilder()->setLayout($layout);
         }
 
         return $this;
@@ -1477,10 +1477,12 @@ class Email implements JsonSerializable, Serializable
         );
 
         if ($theme === null) {
-            return $this->getTheme();
+            return $this->viewBuilder()->getTheme();
         }
 
-        return $this->setTheme($theme);
+        $this->viewBuilder()->setTheme($theme);
+
+        return $this;
     }
 
     /**
@@ -1530,10 +1532,12 @@ class Email implements JsonSerializable, Serializable
         );
 
         if ($helpers === null) {
-            return $this->getHelpers();
+            return $this->viewBuilder()->getHelpers();
         }
 
-        return $this->setHelpers((array)$helpers);
+        $this->viewBuilder()->setHelpers((array)$helpers);
+
+        return $this;
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1256,6 +1256,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @param string|null $template Template name or null to not use.
      * @return $this
+     * @deprecated 3.7.0 Use $email->viewBuilder()->setTemplate() instead.
      */
     public function setTemplate($template)
     {
@@ -1272,6 +1273,7 @@ class Email implements JsonSerializable, Serializable
      * Gets template.
      *
      * @return string
+     * @deprecated 3.7.0 Use $email->viewBuilder()->getTemplate() instead.
      */
     public function getTemplate()
     {


### PR DESCRIPTION
Missing `@deprecated` tags on `Email::setTemplate()/getTemplate()`.

Also `template()`/`theme()/helpers()` will now emit 1 warning without subwarnings