### PR TITLE
Move route hook into a separate interface

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -21,13 +21,13 @@ use Cake\Command\VersionCommand;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;
-use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use RuntimeException;
@@ -383,11 +383,12 @@ class CommandRunner implements EventDispatcherInterface
      */
     protected function loadRoutes(): void
     {
+        if (!($this->app instanceof RoutingApplicationInterface)) {
+            return;
+        }
         $builder = Router::createRouteBuilder('/');
 
-        if ($this->app instanceof HttpApplicationInterface) {
-            $this->app->routes($builder);
-        }
+        $this->app->routes($builder);
         if ($this->app instanceof PluginApplicationInterface) {
             $this->app->pluginRoutes($builder);
         }

--- a/src/Core/HttpApplicationInterface.php
+++ b/src/Core/HttpApplicationInterface.php
@@ -33,17 +33,6 @@ interface HttpApplicationInterface extends RequestHandlerInterface
      * @return void
      */
     public function bootstrap(): void;
-
-    /**
-     * Define the routes for an application.
-     *
-     * Use the provided RouteBuilder to define an application's routing.
-     *
-     * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
-     * @return void
-     */
-    public function routes(RouteBuilder $routes): void;
-
     /**
      * Define the HTTP middleware layers for an application.
      *

--- a/src/Core/HttpApplicationInterface.php
+++ b/src/Core/HttpApplicationInterface.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use Cake\Http\MiddlewareQueue;
-use Cake\Routing\RouteBuilder;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
@@ -33,6 +32,7 @@ interface HttpApplicationInterface extends RequestHandlerInterface
      * @return void
      */
     public function bootstrap(): void;
+
     /**
      * Define the HTTP middleware layers for an application.
      *

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -27,11 +27,16 @@ use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Base class for application classes.
+ * Base class for full-stack applications
+ *
+ * This class serves as a base class for applications that are using
+ * CakePHP as a full stack framework. If you are only using the Http or Console libraries
+ * you should implement the relevant interfaces directly.
  *
  * The application class is responsible for bootstrapping the application,
  * and ensuring that middleware is attached. It is also invoked as the last piece
@@ -40,7 +45,8 @@ use Psr\Http\Message\ServerRequestInterface;
 abstract class BaseApplication implements
     ConsoleApplicationInterface,
     HttpApplicationInterface,
-    PluginApplicationInterface
+    PluginApplicationInterface,
+    RoutingApplicationInterface
 {
     use EventDispatcherTrait;
 

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -44,7 +44,7 @@ class RoutingMiddleware implements MiddlewareInterface
     /**
      * The application that will have its routing hook invoked.
      *
-     * @var \Cake\Core\RoutingApplicationInterface
+     * @var \Cake\Routing\RoutingApplicationInterface
      */
     protected $app;
 
@@ -59,7 +59,7 @@ class RoutingMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param \Cake\Core\RoutingApplicationInterface $app The application instance that routes are defined on.
+     * @param \Cake\Routing\RoutingApplicationInterface $app The application instance that routes are defined on.
      * @param string|null $cacheConfig The cache config name to use or null to disable routes cache
      */
     public function __construct(RoutingApplicationInterface $app, ?string $cacheConfig = null)

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 namespace Cake\Routing\Middleware;
 
 use Cake\Cache\Cache;
-use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
 use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -44,7 +44,7 @@ class RoutingMiddleware implements MiddlewareInterface
     /**
      * The application that will have its routing hook invoked.
      *
-     * @var \Cake\Core\HttpApplicationInterface
+     * @var \Cake\Core\RoutingApplicationInterface
      */
     protected $app;
 
@@ -59,10 +59,10 @@ class RoutingMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param \Cake\Core\HttpApplicationInterface $app The application instance that routes are defined on.
+     * @param \Cake\Core\RoutingApplicationInterface $app The application instance that routes are defined on.
      * @param string|null $cacheConfig The cache config name to use or null to disable routes cache
      */
-    public function __construct(HttpApplicationInterface $app, ?string $cacheConfig = null)
+    public function __construct(RoutingApplicationInterface $app, ?string $cacheConfig = null)
     {
         $this->app = $app;
         $this->cacheConfig = $cacheConfig;

--- a/src/Routing/RoutingApplicationInterface.php
+++ b/src/Routing/RoutingApplicationInterface.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Routing;
+
+/**
+ * Interface for applications that use routing.
+ */
+interface RoutingApplicationInterface
+{
+    /**
+     * Define the routes for an application.
+     *
+     * Use the provided RouteBuilder to define an application's routing.
+     *
+     * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
+     * @return void
+     */
+    public function routes(RouteBuilder $routes): void;
+}

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 namespace Cake\TestSuite;
 
 use Cake\Core\Configure;
-use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventManager;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -126,7 +126,7 @@ class MiddlewareDispatcher
         }
         $builder = Router::createRouteBuilder('/');
 
-        if ($this->app instanceof HttpApplicationInterface) {
+        if ($this->app instanceof RoutingApplicationInterface) {
             $this->app->routes($builder);
         }
         if ($this->app instanceof PluginApplicationInterface) {


### PR DESCRIPTION
Having the route() hook be on `HttpApplicationInterface` complicates using the Http libraries on their own or with an alternate routing implementation. This change makes that scenario easier with no impact to existing applications.
