### PR TITLE
Use Closure instead of callable for various methods of Routing package.

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -406,7 +406,7 @@ class RouteCollection
      * scope or any child scopes that share the same RouteCollection.
      *
      * @param string $name The name of the middleware. Used when applying middleware to a scope.
-     * @param callable|string $middleware The middleware callable or class name to register.
+     * @param string|\Closure|\Psr\Http\Server\MiddlewareInterface $middleware The middleware Closure or class name to register.
      * @return $this
      * @throws \RuntimeException
      */

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -21,9 +21,7 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Utility\Inflector;
 use Closure;
-use Exception;
 use ReflectionFunction;
-use ReflectionMethod;
 use RuntimeException;
 use Throwable;
 
@@ -342,22 +340,11 @@ class Router
     protected static function _applyUrlFilters(array $url): array
     {
         $request = static::getRequest();
-        $e = null;
         foreach (static::$_urlFilters as $filter) {
             try {
                 $url = $filter($url, $request);
-            } catch (Exception $e) {
-                // fall through
             } catch (Throwable $e) {
-                // fall through
-            }
-            if ($e !== null) {
-                if (is_array($filter)) {
-                    $ref = new ReflectionMethod($filter[0], $filter[1]);
-                } else {
-                    /** @psalm-suppress InvalidArgument */
-                    $ref = new ReflectionFunction($filter);
-                }
+                $ref = new ReflectionFunction($filter);
                 $message = sprintf(
                     'URL filter defined in %s on line %s could not be applied. The filter failed with: %s',
                     $ref->getFileName(),

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Utility\Inflector;
+use Closure;
 use Exception;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -145,7 +146,7 @@ class Router
      * The stack of URL filters to apply against routing URLs before passing the
      * parameters to the route collection.
      *
-     * @var callable[]
+     * @var \Closure[]
      */
     protected static $_urlFilters = [];
 
@@ -322,10 +323,10 @@ class Router
      * });
      * ```
      *
-     * @param callable $function The function to add
+     * @param \Closure $function The function to add
      * @return void
      */
-    public static function addUrlFilter(callable $function): void
+    public static function addUrlFilter(Closure $function): void
     {
         static::$_urlFilters[] = $function;
     }
@@ -781,13 +782,13 @@ class Router
      *
      * @param string $path The path prefix for the scope. This path will be prepended
      *   to all routes connected in the scoped collection.
-     * @param array|callable $params An array of routing defaults to add to each connected route.
-     *   If you have no parameters, this argument can be a callable.
-     * @param callable|null $callback The callback to invoke with the scoped collection.
-     * @throws \InvalidArgumentException When an invalid callable is provided.
+     * @param array|\Closure $params An array of routing defaults to add to each connected route.
+     *   If you have no parameters, this argument can be a Closure.
+     * @param \Closure|null $callback The callback to invoke with the scoped collection.
+     * @throws \InvalidArgumentException When an invalid callback is provided.
      * @return void
      */
-    public static function scope(string $path, $params = [], $callback = null): void
+    public static function scope(string $path, $params = [], ?Closure $callback = null): void
     {
         $options = [];
         if (is_array($params)) {
@@ -816,15 +817,15 @@ class Router
      * to the `Controller\Admin\Api\` namespace.
      *
      * @param string $name The prefix name to use.
-     * @param array|callable $params An array of routing defaults to add to each connected route.
-     *   If you have no parameters, this argument can be a callable.
-     * @param callable|null $callback The callback to invoke that builds the prefixed routes.
+     * @param array|\Closure $params An array of routing defaults to add to each connected route.
+     *   If you have no parameters, this argument can be a Closure.
+     * @param \Closure|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
      */
-    public static function prefix(string $name, $params = [], ?callable $callback = null): void
+    public static function prefix(string $name, $params = [], ?Closure $callback = null): void
     {
         if ($callback === null) {
-            /** @var callable $callback */
+            /** @var \Closure $callback */
             $callback = $params;
             $params = [];
         }
@@ -850,16 +851,15 @@ class Router
      * prepended, and have a matching plugin routing key set.
      *
      * @param string $name The plugin name to build routes for
-     * @param array|callable $options Either the options to use, or a callback
-     * @param callable|null $callback The callback to invoke that builds the plugin routes.
+     * @param array|\Closure $options Either the options to use, or a callback
+     * @param \Closure|null $callback The callback to invoke that builds the plugin routes.
      *   Only required when $options is defined
      * @return void
      * @psalm-suppress PossiblyInvalidArrayAccess
      */
-    public static function plugin(string $name, $options = [], ?callable $callback = null): void
+    public static function plugin(string $name, $options = [], ?Closure $callback = null): void
     {
-        if ($callback === null) {
-            /** @var callable $callback */
+        if (!is_array($options)) {
             $callback = $options;
             $options = [];
         }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1158,7 +1158,9 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter([$this, 'badFilter']);
+        Router::addUrlFilter(function () {
+            return $this->badFilter();
+        });
         Router::url(['controller' => 'posts', 'action' => 'index', 'lang' => 'en']);
     }
 


### PR DESCRIPTION
I don't think anyone would be using invokable classes for connecting routes. For various router/routerbuilder methods we allow passing callback for 2nd params/options argument which is an array so using Closures only for callback are better for type checks.