### PR TITLE
Fix invalid argument types in SqlserverSchema

### DIFF
--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -119,6 +119,14 @@ class Collection implements CollectionInterface
      * @param \Cake\Database\Schema\TableSchema $schema The table schema instance.
      * @return void
      * @throws \Cake\Database\Exception on query failure.
+     * @uses \Cake\Database\Schema\BaseSchema::describeColumnSql
+     * @uses \Cake\Database\Schema\BaseSchema::describeIndexSql
+     * @uses \Cake\Database\Schema\BaseSchema::describeForeignKeySql
+     * @uses \Cake\Database\Schema\BaseSchema::describeOptionsSql
+     * @uses \Cake\Database\Schema\BaseSchema::convertColumnDescription
+     * @uses \Cake\Database\Schema\BaseSchema::convertIndexDescription
+     * @uses \Cake\Database\Schema\BaseSchema::convertForeignKeyDescription
+     * @uses \Cake\Database\Schema\BaseSchema::convertOptionsDescription
      */
     protected function _reflect(string $stage, string $name, array $config, TableSchema $schema): void
     {

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -86,9 +86,6 @@ class SqlserverSchema extends BaseSchema
         ?int $scale = null
     ): array {
         $col = strtolower($col);
-        $length = $length !== null ? (int)$length : $length;
-        $precision = $precision !== null ? (int)$precision : $precision;
-        $scale = $scale !== null ? (int)$scale : $scale;
 
         if (in_array($col, ['date', 'time'])) {
             return ['type' => $col, 'length' => null];
@@ -167,9 +164,9 @@ class SqlserverSchema extends BaseSchema
     {
         $field = $this->_convertColumn(
             $row['type'],
-            $row['char_length'],
-            $row['precision'],
-            $row['scale']
+            $row['char_length'] != null ? (int)$row['char_length'] : null,
+            $row['precision'] != null ? (int)$row['precision'] : null,
+            $row['scale'] != null ? (int)$row['scale'] : null
         );
         if (!empty($row['default'])) {
             $row['default'] = trim($row['default'], '()');


### PR DESCRIPTION
Fix bad merge b55efaa.

Also add `@uses` for BaseSchema methods as IDE can't find usages for dynamically built method names.

