### PR TITLE
Aligned Time::__debugInfo() with Chronos::__debugInfo()

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -453,9 +453,9 @@ trait DateFormatTrait
     public function __debugInfo()
     {
         return [
-            'time' => $this->format('Y-m-d\TH:i:s.uP'),
+            'time' => $this->format('Y-m-d H:i:s.uP'),
             'timezone' => $this->getTimezone()->getName(),
-            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->format('Y-m-d\TH:i:s.uP') : false
+            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->format('Y-m-d H:i:s.uP') : false
         ];
     }
 }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -789,9 +789,9 @@ class TimeTest extends TestCase
     {
         $time = new $class('2014-04-20 10:10:10');
         $expected = [
-            'time' => '2014-04-20T10:10:10.000000+00:00',
+            'time' => '2014-04-20 10:10:10.000000+00:00',
             'timezone' => 'UTC',
-            'fixedNowTime' => $class::getTestNow()->format('Y-m-d\TH:i:s.uP')
+            'fixedNowTime' => $class::getTestNow()->format('Y-m-d H:i:s.uP')
         ];
         $this->assertEquals($expected, $time->__debugInfo());
     }


### PR DESCRIPTION
This is very minor, but I see no reason why Time and Chronos shouldn't have the same __debugInfo() format.

The only remaining difference is Time includes the timezone offset in the `time` string while Chronos does not.

Chronos:

```
$properties['time'] = $this->format('Y-m-d H:i:s.u');
```
