### PR TITLE
Fix incorrect cookies being used on redirects

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -418,7 +418,6 @@ class Client
             $handleRedirect = $response->isRedirect() && $redirects-- > 0;
             if ($handleRedirect) {
                 $url = $request->getUri();
-                $request = $this->_cookies->addToRequest($request, []);
 
                 $location = $response->getHeaderLine('Location');
                 $locationUrl = $this->buildUrl($location, [], [
@@ -427,8 +426,8 @@ class Client
                     'scheme' => $url->getScheme(),
                     'protocolRelative' => true
                 ]);
-
                 $request = $request->withUri(new Uri($locationUrl));
+                $request = $this->_cookies->addToRequest($request, []);
             }
         } while ($handleRedirect);
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -845,4 +845,52 @@ class ClientTest extends TestCase
         $this->assertTrue($cookies->has('redirect1'));
         $this->assertTrue($cookies->has('redirect2'));
     }
+
+    /**
+     * test redirect across sub domains
+     *
+     * @return void
+     */
+    public function testRedirectDifferentSubDomains()
+    {
+        $adapter = $this->getMockBuilder(Client\Adapter\Stream::class)
+            ->setMethods(['send'])
+            ->getMock();
+
+        $url = 'http://auth.example.org';
+
+        $redirect = new Response([
+            'HTTP/1.0 301',
+            'Location: http://backstage.example.org',
+        ]);
+        $adapter->expects($this->at(0))
+            ->method('send')
+            ->willReturn([$redirect]);
+
+        $response = new Response([
+            'HTTP/1.0 200'
+        ]);
+        $adapter->expects($this->at(1))
+            ->method('send')
+            ->with($this->callback(function ($request) {
+                $this->assertSame('http://backstage.example.org', (string)$request->getUri());
+                $this->assertSame('session=backend', $request->getHeaderLine('Cookie'));
+
+                return true;
+            }))
+            ->willReturn([$response]);
+
+        $client = new Client([
+            'adapter' => $adapter
+        ]);
+        $client->addCookie(new Cookie('session', 'backend', null, '/', 'backstage.example.org'));
+        $client->addCookie(new Cookie('session', 'authz', null, '/', 'auth.example.org'));
+
+        $result = $client->send(new Request($url), [
+            'redirect' => 10
+        ]);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame($response, $result);
+    }
 }


### PR DESCRIPTION
When handling redirects cookies should be fetched after the new location has been set as the redirect could switch domains.

Fixes #13543

