### PR TITLE
4.x routing

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -980,7 +980,7 @@ class RouteBuilder
      * scope or any child scopes that share the same RouteCollection.
      *
      * @param string $name The name of the middleware. Used when applying middleware to a scope.
-     * @param callable|string $middleware The middleware callable or class name to register.
+     * @param string|\Closure|\Psr\Http\Server\MiddlewareInterface $middleware The middleware to register.
      * @return $this
      * @see \Cake\Routing\RouteCollection
      */

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -931,7 +931,10 @@ class RouteBuilder
             $params = [];
         }
         if (!is_callable($callback)) {
-            throw new InvalidArgumentException('Need a callable function/object to connect routes.');
+            throw new InvalidArgumentException(sprintf(
+                'Need a valid callable to connect routes. Got `%s` instead.',
+                getTypeName($callback)
+            ));
         }
 
         if ($this->_path !== '/') {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -351,7 +351,7 @@ class RouteBuilder
      */
     public function resources(string $name, $options = [], $callback = null)
     {
-        if (is_callable($options)) {
+        if (!is_array($options)) {
             $callback = $options;
             $options = [];
         }
@@ -422,7 +422,7 @@ class RouteBuilder
             $this->connect($url, $params, $routeOptions);
         }
 
-        if (is_callable($callback)) {
+        if ($callback !== null) {
             $idName = Inflector::singularize(Inflector::underscore($name)) . '_id';
             $path = '/' . $options['path'] . '/:' . $idName;
             $this->scope($path, [], $callback);
@@ -856,12 +856,9 @@ class RouteBuilder
      * @throws \InvalidArgumentException If a valid callback is not passed
      * @psalm-suppress PossiblyInvalidArrayAccess
      */
-    public function prefix(string $name, $params = [], ?callable $callback = null)
+    public function prefix(string $name, $params = [], $callback = null)
     {
-        if ($callback === null) {
-            if (!is_callable($params)) {
-                throw new InvalidArgumentException('A valid callback is expected');
-            }
+        if (!is_array($params)) {
             $callback = $params;
             $params = [];
         }
@@ -899,12 +896,9 @@ class RouteBuilder
      *   Only required when $options is defined.
      * @return $this
      */
-    public function plugin(string $name, $options = [], ?callable $callback = null)
+    public function plugin(string $name, $options = [], $callback = null)
     {
-        if ($callback === null) {
-            if (!is_callable($options)) {
-                throw new InvalidArgumentException('A valid callback is expected');
-            }
+        if (!is_array($options)) {
             $callback = $options;
             $options = [];
         }
@@ -932,13 +926,12 @@ class RouteBuilder
      */
     public function scope(string $path, $params, $callback = null)
     {
-        if (is_callable($params)) {
+        if (!is_array($params)) {
             $callback = $params;
             $params = [];
         }
         if (!is_callable($callback)) {
-            $msg = 'Need a callable function/object to connect routes.';
-            throw new InvalidArgumentException($msg);
+            throw new InvalidArgumentException('Need a callable function/object to connect routes.');
         }
 
         if ($this->_path !== '/') {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -406,7 +406,7 @@ class RouteCollection
      * scope or any child scopes that share the same RouteCollection.
      *
      * @param string $name The name of the middleware. Used when applying middleware to a scope.
-     * @param callable|string $middleware The middleware callable or class name to register.
+     * @param string|\Closure|\Psr\Http\Server\MiddlewareInterface $middleware The middleware to register.
      * @return $this
      * @throws \RuntimeException
      */

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -75,13 +75,6 @@ class RouteCollection
     protected $_middlewareGroups = [];
 
     /**
-     * A map of paths and the list of applicable middleware.
-     *
-     * @var array
-     */
-    protected $_middlewarePaths = [];
-
-    /**
      * Route extensions
      *
      * @var string[]
@@ -475,36 +468,6 @@ class RouteCollection
     public function middlewareExists(string $name): bool
     {
         return $this->hasMiddleware($name) || $this->hasMiddlewareGroup($name);
-    }
-
-    /**
-     * Apply a registered middleware(s) for the provided path
-     *
-     * @param string $path The URL path to register middleware for.
-     * @param string[] $middleware The middleware names to add for the path.
-     * @return $this
-     */
-    public function applyMiddleware(string $path, array $middleware)
-    {
-        foreach ($middleware as $name) {
-            if (!$this->hasMiddleware($name) && !$this->hasMiddlewareGroup($name)) {
-                throw new RuntimeException(sprintf(
-                    "Cannot apply '%s' middleware or middleware group to path '%s'. It has not been registered.",
-                    $name,
-                    $path
-                ));
-            }
-        }
-        // Matches route element pattern in Cake\Routing\Route
-        $path = '#^' . preg_quote($path, '#') . '#';
-        $path = preg_replace('/\\\\:([a-z0-9-_]+(?<![-_]))/i', '[^/]+', $path);
-
-        if (!isset($this->_middlewarePaths[$path])) {
-            $this->_middlewarePaths[$path] = [];
-        }
-        $this->_middlewarePaths[$path] = array_merge($this->_middlewarePaths[$path], $middleware);
-
-        return $this;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -821,10 +821,9 @@ class Router
      * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
      */
-    public static function prefix(string $name, $params = [], ?callable $callback = null): void
+    public static function prefix(string $name, $params = [], $callback = null): void
     {
-        if ($callback === null) {
-            /** @var callable $callback */
+        if (!is_array($params)) {
             $callback = $params;
             $params = [];
         }
@@ -856,10 +855,9 @@ class Router
      * @return void
      * @psalm-suppress PossiblyInvalidArrayAccess
      */
-    public static function plugin(string $name, $options = [], ?callable $callback = null): void
+    public static function plugin(string $name, $options = [], $callback = null): void
     {
-        if ($callback === null) {
-            /** @var callable $callback */
+        if (!is_array($options)) {
             $callback = $options;
             $options = [];
         }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Utility\Inflector;
-use Exception;
 use ReflectionFunction;
 use ReflectionMethod;
 use RuntimeException;
@@ -341,16 +340,10 @@ class Router
     protected static function _applyUrlFilters(array $url): array
     {
         $request = static::getRequest();
-        $e = null;
         foreach (static::$_urlFilters as $filter) {
             try {
                 $url = $filter($url, $request);
-            } catch (Exception $e) {
-                // fall through
             } catch (Throwable $e) {
-                // fall through
-            }
-            if ($e !== null) {
                 if (is_array($filter)) {
                     $ref = new ReflectionMethod($filter[0], $filter[1]);
                 } else {

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -941,6 +941,20 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test that exception is thrown if callback is not a valid callable.
+     *
+     * @return void
+     */
+    public function testScopeException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Need a valid callable to connect routes. Got `string` instead.');
+
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes->scope('/v1', 'fail');
+    }
+
+    /**
      * Test that nested scopes inherit middleware.
      *
      * @return void


### PR DESCRIPTION
Removed multiple checks for callable type. It's now done only once in `RouterBuilder::scope()` which is eventually called by all method related to connecting routes.