### PR TITLE
Removed return type from CollectionTrait::sumOf()

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -316,7 +316,7 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function sumOf($matcher = null): int
+    public function sumOf($matcher = null)
     {
         if ($matcher === null) {
             return array_sum($this->toList());

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1738,9 +1738,16 @@ class CollectionTest extends TestCase
             ['invoice' => ['total' => 200]],
         ];
 
+        $floatItems = [
+            ['invoice' => ['total' => 100.0]],
+            ['invoice' => ['total' => 200.0]],
+        ];
+
         return [
-            'array' => [$items],
-            'iterator' => [$this->yieldItems($items)],
+            'array' => [$items, 300],
+            'iterator' => [$this->yieldItems($items), 300],
+            'floatArray' => [$floatItems, 300.0],
+            'floatIterator' => [$this->yieldItems($floatItems), 300.0],
         ];
     }
 
@@ -1750,9 +1757,9 @@ class CollectionTest extends TestCase
      * @dataProvider sumOfProvider
      * @return void
      */
-    public function testSumOf($items)
+    public function testSumOf($items, $expected)
     {
-        $this->assertEquals(300, (new Collection($items))->sumOf('invoice.total'));
+        $this->assertEquals($expected, (new Collection($items))->sumOf('invoice.total'));
     }
 
     /**
@@ -1761,41 +1768,12 @@ class CollectionTest extends TestCase
      * @dataProvider sumOfProvider
      * @return void
      */
-    public function testSumOfCallable($items)
+    public function testSumOfCallable($items, $expected)
     {
         $sum = (new Collection($items))->sumOf(function ($v) {
-            return $v['invoice']['total'] * 2;
+            return $v['invoice']['total'];
         });
-        $this->assertEquals(600, $sum);
-    }
-
-    /**
-     * Provider for sumOf float tests
-     *
-     * @return array
-     */
-    public function sumOfFloatProvider()
-    {
-        $items = [
-            ['invoice' => ['total' => 100.1]],
-            ['invoice' => ['total' => 200.2]],
-        ];
-
-        return [
-            'array' => [$items],
-            'iterator' => [$this->yieldItems($items)],
-        ];
-    }
-
-    /**
-     * Tests the sumOf method with float result
-     *
-     * @dataProvider sumOfFloatProvider
-     * @return void
-     */
-    public function testSumOfFloat($items)
-    {
-        $this->assertEquals(300.3, (new Collection($items))->sumOf('invoice.total'));
+        $this->assertEquals($expected, $sum);
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1770,6 +1770,35 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Provider for sumOf float tests
+     *
+     * @return array
+     */
+    public function sumOfFloatProvider()
+    {
+        $items = [
+            ['invoice' => ['total' => 100.1]],
+            ['invoice' => ['total' => 200.2]],
+        ];
+
+        return [
+            'array' => [$items],
+            'iterator' => [$this->yieldItems($items)],
+        ];
+    }
+
+    /**
+     * Tests the sumOf method with float result
+     *
+     * @dataProvider sumOfFloatProvider
+     * @return void
+     */
+    public function testSumOfFloat($items)
+    {
+        $this->assertEquals(300.3, (new Collection($items))->sumOf('invoice.total'));
+    }
+
+    /**
      * Tests the stopWhen method with a callable
      *
      * @dataProvider simpleProvider


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/13763

`sumOf()` should allow float and integer results.