### PR TITLE
Stricter Instance and Static Config traits.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -183,7 +183,7 @@ class Cache
         }
 
         if ($config['className'] instanceof CacheEngine) {
-            $config = $config['className']->config();
+            $config = $config['className']->getAllConfig();
         }
 
         if (!empty($config['groups'])) {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -183,7 +183,7 @@ class Cache
         }
 
         if ($config['className'] instanceof CacheEngine) {
-            $config = $config['className']->getConfig();
+            $config = $config['className']->config();
         }
 
         if (!empty($config['groups'])) {

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -90,7 +90,7 @@ class CacheRegistry extends ObjectRegistry
             );
         }
 
-        $config = $instance->getConfig();
+        $config = $instance->config();
 
         return $instance;
     }

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -90,7 +90,7 @@ class CacheRegistry extends ObjectRegistry
             );
         }
 
-        $config = $instance->config();
+        $config = $instance->getAllConfig();
 
         return $instance;
     }

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -196,7 +196,7 @@ class Component implements EventListenerInterface
         return [
             'components' => $this->components,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->getConfig(),
+            '_config' => $this->config(),
         ];
     }
 }

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -196,7 +196,7 @@ class Component implements EventListenerInterface
         return [
             'components' => $this->components,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->config(),
+            '_config' => $this->getAllConfig(),
         ];
     }
 }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -460,7 +460,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
             'authError' => __d('cake', 'You are not authorized to access that location.'),
         ];
 
-        $config = $this->config();
+        $config = $this->getAllConfig();
         foreach ($config as $key => $value) {
             if ($value !== null) {
                 unset($defaults[$key]);

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -460,7 +460,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
             'authError' => __d('cake', 'You are not authorized to access that location.'),
         ];
 
-        $config = $this->getConfig();
+        $config = $this->config();
         foreach ($config as $key => $value) {
             if ($value !== null) {
                 unset($defaults[$key]);

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -68,7 +68,7 @@ class FlashComponent extends Component
      */
     public function set($message, array $options = []): void
     {
-        $options += (array)$this->getConfig();
+        $options += (array)$this->config();
 
         if ($message instanceof Exception) {
             if (!isset($options['params']['code'])) {

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -68,7 +68,7 @@ class FlashComponent extends Component
      */
     public function set($message, array $options = []): void
     {
-        $options += (array)$this->config();
+        $options += (array)$this->getAllConfig();
 
         if ($message instanceof Exception) {
             if (!isset($options['params']['code'])) {

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -428,6 +428,7 @@ class Configure
      * @param string $cacheConfig The cache configuration to save into. Defaults to 'default'
      * @param array|null $data Either an array of data to store, or leave empty to store all values.
      * @return bool Success
+     * @throws \RuntimeException
      */
     public static function store(string $name, string $cacheConfig = 'default', ?array $data = null): bool
     {
@@ -448,6 +449,7 @@ class Configure
      * @param string $name Name of the stored config file to load.
      * @param string $cacheConfig Name of the Cache configuration to read from.
      * @return bool Success.
+     * @throws \RuntimeException
      */
     public static function restore(string $name, string $cacheConfig = 'default'): bool
     {

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -46,7 +46,7 @@ trait InstanceConfigTrait
      *
      * @return array
      */
-    public function config(): array
+    public function getAllConfig(): array
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -128,14 +128,14 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     {
         $existing = $this->_loaded[$name];
         $msg = sprintf('The "%s" alias has already been loaded.', $name);
-        $hasConfig = method_exists($existing, 'getConfig');
+        $hasConfig = method_exists($existing, 'config');
         if (!$hasConfig) {
             throw new RuntimeException($msg);
         }
         if (empty($config)) {
             return;
         }
-        $existingConfig = $existing->getConfig();
+        $existingConfig = $existing->config();
         unset($config['enabled'], $existingConfig['enabled']);
 
         $failure = null;

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -19,6 +19,7 @@ namespace Cake\Core;
 use BadMethodCallException;
 use InvalidArgumentException;
 use LogicException;
+use RuntimeException;
 
 /**
  * A trait that provides a set of static methods to manage configuration
@@ -112,11 +113,27 @@ trait StaticConfigTrait
      * Reads existing configuration.
      *
      * @param string $key The name of the configuration.
-     * @return mixed Configuration data at the named key or null if the key does not exist.
+     * @return mixed|null Configuration data at the named key or null if the key does not exist.
      */
     public static function getConfig(string $key)
     {
         return static::$_config[$key] ?? null;
+    }
+
+    /**
+     * Reads existing configuration. The value must exist.
+     *
+     * @param string $key The name of the configuration.
+     * @return mixed Configuration data at the named key.
+     * @throws \RuntimeException If value does not exist.
+     */
+    public static function getConfigOrFail(string $key)
+    {
+        if (!isset(static::$_config[$key])) {
+            throw new RuntimeException(sprintf('Expected configuration `%s` not found.', $key));
+        }
+
+        return static::$_config[$key];
     }
 
     /**

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -448,7 +448,7 @@ class Paginator implements PaginatorInterface
             $settings = $settings[$alias];
         }
 
-        $defaults = $this->getConfig();
+        $defaults = $this->config();
         $maxLimit = $settings['maxLimit'] ?? $defaults['maxLimit'];
         $limit = $settings['limit'] ?? $defaults['limit'];
 

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -448,7 +448,7 @@ class Paginator implements PaginatorInterface
             $settings = $settings[$alias];
         }
 
-        $defaults = $this->config();
+        $defaults = $this->getAllConfig();
         $maxLimit = $settings['maxLimit'] ?? $defaults['maxLimit'];
         $limit = $settings['limit'] ?? $defaults['limit'];
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -147,7 +147,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
             /** @var string $className */
             $className = App::className('ErrorHandler', 'Error');
             /** @var \Cake\Error\ErrorHandler $this->errorHandler */
-            $this->errorHandler = new $className($this->config());
+            $this->errorHandler = new $className($this->getAllConfig());
         }
 
         return $this->errorHandler;

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -147,7 +147,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
             /** @var string $className */
             $className = App::className('ErrorHandler', 'Error');
             /** @var \Cake\Error\ErrorHandler $this->errorHandler */
-            $this->errorHandler = new $className($this->getConfig());
+            $this->errorHandler = new $className($this->config());
         }
 
         return $this->errorHandler;

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -278,7 +278,7 @@ class Behavior implements EventListenerInterface
             'Model.beforeRules' => 'beforeRules',
             'Model.afterRules' => 'afterRules',
         ];
-        $config = $this->getConfig();
+        $config = $this->config();
         $priority = $config['priority'] ?? null;
         $events = [];
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -278,7 +278,7 @@ class Behavior implements EventListenerInterface
             'Model.beforeRules' => 'beforeRules',
             'Model.afterRules' => 'afterRules',
         ];
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $priority = $config['priority'] ?? null;
         $events = [];
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -96,7 +96,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function setupAssociations()
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
 
         $this->table->hasMany($config['translationTable'], [
             'className' => $config['translationTable'],
@@ -125,7 +125,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             return;
         }
 
-        $config = $this->config();
+        $config = $this->getAllConfig();
 
         if (isset($options['filterByCurrentLocale'])) {
             $joinType = $options['filterByCurrentLocale'] ? 'INNER' : 'LEFT';

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -96,7 +96,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function setupAssociations()
     {
-        $config = $this->getConfig();
+        $config = $this->config();
 
         $this->table->hasMany($config['translationTable'], [
             'className' => $config['translationTable'],
@@ -125,7 +125,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             return;
         }
 
-        $config = $this->getConfig();
+        $config = $this->config();
 
         if (isset($options['filterByCurrentLocale'])) {
             $joinType = $options['filterByCurrentLocale'] ? 'INNER' : 'LEFT';

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -98,7 +98,7 @@ class TreeBehavior extends Behavior
     public function beforeSave(EventInterface $event, EntityInterface $entity)
     {
         $isNew = $entity->isNew();
-        $config = $this->getConfig();
+        $config = $this->config();
         $parent = $entity->get($config['parent']);
         $primaryKey = $this->_getPrimaryKey();
         $dirty = $entity->isDirty($config['parent']);
@@ -180,7 +180,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setChildrenLevel(EntityInterface $entity): void
     {
-        $config = $this->getConfig();
+        $config = $this->config();
 
         if ($entity->get($config['left']) + 1 === $entity->get($config['right'])) {
             return;
@@ -218,7 +218,7 @@ class TreeBehavior extends Behavior
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity)
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $this->_ensureFields($entity);
         $left = $entity->get($config['left']);
         $right = $entity->get($config['right']);
@@ -252,7 +252,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setParent(EntityInterface $entity, $parent): void
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $parentNode = $this->_getNode($parent);
         $this->_ensureFields($entity);
         $parentLeft = $parentNode->get($config['left']);
@@ -312,7 +312,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setAsRoot(EntityInterface $entity): void
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $edge = $this->_getMax();
         $this->_ensureFields($entity);
         $right = $entity->get($config['right']);
@@ -345,7 +345,7 @@ class TreeBehavior extends Behavior
      */
     protected function _unmarkInternalTree(): void
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $this->_table->updateAll(
             function ($exp) use ($config) {
                 /** @var \Cake\Database\Expression\QueryExpression $exp */
@@ -380,7 +380,7 @@ class TreeBehavior extends Behavior
             throw new InvalidArgumentException("The 'for' key is required for find('path')");
         }
 
-        $config = $this->getConfig();
+        $config = $this->config();
         [$left, $right] = array_map(
             function ($field) {
                 return $this->_table->aliasField($field);
@@ -408,7 +408,7 @@ class TreeBehavior extends Behavior
      */
     public function childCount(EntityInterface $node, bool $direct = false): int
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $parent = $this->_table->aliasField($config['parent']);
 
         if ($direct) {
@@ -440,7 +440,7 @@ class TreeBehavior extends Behavior
      */
     public function findChildren(Query $query, array $options): Query
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $options += ['for' => null, 'direct' => false];
         [$parent, $left, $right] = array_map(
             function ($field) {
@@ -564,7 +564,7 @@ class TreeBehavior extends Behavior
      */
     protected function _removeFromTree(EntityInterface $node)
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $left = $node->get($config['left']);
         $right = $node->get($config['right']);
         $parent = $node->get($config['parent']);
@@ -630,7 +630,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveUp(EntityInterface $node, $number): EntityInterface
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         [$nodeParent, $nodeLeft, $nodeRight] = array_values($node->extract([$parent, $left, $right]));
 
@@ -722,7 +722,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveDown(EntityInterface $node, $number): EntityInterface
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         [$nodeParent, $nodeLeft, $nodeRight] = array_values($node->extract([$parent, $left, $right]));
 
@@ -790,7 +790,7 @@ class TreeBehavior extends Behavior
      */
     protected function _getNode($id): EntityInterface
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $fields = [$parent, $left, $right];
@@ -834,7 +834,7 @@ class TreeBehavior extends Behavior
      */
     protected function _recoverTree(int $counter = 0, $parentId = null, $level = -1): int
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $aliasedPrimaryKey = $this->_table->aliasField($primaryKey);
@@ -960,7 +960,7 @@ class TreeBehavior extends Behavior
      */
     protected function _ensureFields(EntityInterface $entity): void
     {
-        $config = $this->getConfig();
+        $config = $this->config();
         $fields = [$config['left'], $config['right']];
         $values = array_filter($entity->extract($fields));
         if (count($values) === count($fields)) {
@@ -1003,7 +1003,7 @@ class TreeBehavior extends Behavior
         if ($entity instanceof EntityInterface) {
             $id = $entity->get($primaryKey);
         }
-        $config = $this->getConfig();
+        $config = $this->config();
         $entity = $this->_table->find('all')
             ->select([$config['left'], $config['right']])
             ->where([$primaryKey => $id])

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -98,7 +98,7 @@ class TreeBehavior extends Behavior
     public function beforeSave(EventInterface $event, EntityInterface $entity)
     {
         $isNew = $entity->isNew();
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $parent = $entity->get($config['parent']);
         $primaryKey = $this->_getPrimaryKey();
         $dirty = $entity->isDirty($config['parent']);
@@ -180,7 +180,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setChildrenLevel(EntityInterface $entity): void
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
 
         if ($entity->get($config['left']) + 1 === $entity->get($config['right'])) {
             return;
@@ -218,7 +218,7 @@ class TreeBehavior extends Behavior
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity)
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $this->_ensureFields($entity);
         $left = $entity->get($config['left']);
         $right = $entity->get($config['right']);
@@ -252,7 +252,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setParent(EntityInterface $entity, $parent): void
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $parentNode = $this->_getNode($parent);
         $this->_ensureFields($entity);
         $parentLeft = $parentNode->get($config['left']);
@@ -312,7 +312,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setAsRoot(EntityInterface $entity): void
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $edge = $this->_getMax();
         $this->_ensureFields($entity);
         $right = $entity->get($config['right']);
@@ -345,7 +345,7 @@ class TreeBehavior extends Behavior
      */
     protected function _unmarkInternalTree(): void
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $this->_table->updateAll(
             function ($exp) use ($config) {
                 /** @var \Cake\Database\Expression\QueryExpression $exp */
@@ -380,7 +380,7 @@ class TreeBehavior extends Behavior
             throw new InvalidArgumentException("The 'for' key is required for find('path')");
         }
 
-        $config = $this->config();
+        $config = $this->getAllConfig();
         [$left, $right] = array_map(
             function ($field) {
                 return $this->_table->aliasField($field);
@@ -408,7 +408,7 @@ class TreeBehavior extends Behavior
      */
     public function childCount(EntityInterface $node, bool $direct = false): int
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $parent = $this->_table->aliasField($config['parent']);
 
         if ($direct) {
@@ -440,7 +440,7 @@ class TreeBehavior extends Behavior
      */
     public function findChildren(Query $query, array $options): Query
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $options += ['for' => null, 'direct' => false];
         [$parent, $left, $right] = array_map(
             function ($field) {
@@ -564,7 +564,7 @@ class TreeBehavior extends Behavior
      */
     protected function _removeFromTree(EntityInterface $node)
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $left = $node->get($config['left']);
         $right = $node->get($config['right']);
         $parent = $node->get($config['parent']);
@@ -630,7 +630,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveUp(EntityInterface $node, $number): EntityInterface
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         [$nodeParent, $nodeLeft, $nodeRight] = array_values($node->extract([$parent, $left, $right]));
 
@@ -722,7 +722,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveDown(EntityInterface $node, $number): EntityInterface
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         [$nodeParent, $nodeLeft, $nodeRight] = array_values($node->extract([$parent, $left, $right]));
 
@@ -790,7 +790,7 @@ class TreeBehavior extends Behavior
      */
     protected function _getNode($id): EntityInterface
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $fields = [$parent, $left, $right];
@@ -834,7 +834,7 @@ class TreeBehavior extends Behavior
      */
     protected function _recoverTree(int $counter = 0, $parentId = null, $level = -1): int
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $aliasedPrimaryKey = $this->_table->aliasField($primaryKey);
@@ -960,7 +960,7 @@ class TreeBehavior extends Behavior
      */
     protected function _ensureFields(EntityInterface $entity): void
     {
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $fields = [$config['left'], $config['right']];
         $values = array_filter($entity->extract($fields));
         if (count($values) === count($fields)) {
@@ -1003,7 +1003,7 @@ class TreeBehavior extends Behavior
         if ($entity instanceof EntityInterface) {
             $id = $entity->get($primaryKey);
         }
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $entity = $this->_table->find('all')
             ->select([$config['left'], $config['right']])
             ->where([$primaryKey => $id])

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -28,7 +28,7 @@ interface LocatorInterface
      *
      * @return array
      */
-    public function config(): array;
+    public function getAllConfig(): array;
 
     /**
      * Returns configuration for an alias.

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -24,13 +24,19 @@ use Cake\ORM\Table;
 interface LocatorInterface
 {
     /**
-     * Returns configuration for an alias or the full configuration array for
-     * all aliases.
+     * Returns full configuration.
+     *
+     * @return array
+     */
+    public function config(): array;
+
+    /**
+     * Returns configuration for an alias.
      *
      * @param string|null $alias Alias to get config for, null for complete config.
      * @return array The config data.
      */
-    public function getConfig(?string $alias = null): array;
+    public function getConfig(string $alias): array;
 
     /**
      * Stores a list of options to be used when instantiating an object

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -113,12 +113,22 @@ class TableLocator implements LocatorInterface
     }
 
     /**
+     * Returns complete configuration.
+     *
+     * @return array
+     */
+    public function config(): array
+    {
+        return $this->_config;
+    }
+
+    /**
      * Returns configuration for an alias or the full configuration array for all aliases.
      *
-     * @param string|null $alias Alias to get config for, null for complete config.
+     * @param string|null $alias Alias to get config for
      * @return array The config data.
      */
-    public function getConfig(?string $alias = null): array
+    public function getConfig(string $alias): array
     {
         if ($alias === null) {
             return $this->_config;

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -117,7 +117,7 @@ class TableLocator implements LocatorInterface
      *
      * @return array
      */
-    public function config(): array
+    public function getAllConfig(): array
     {
         return $this->_config;
     }

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -135,7 +135,7 @@ class TableHelper extends Helper
             return;
         }
 
-        $config = $this->getConfig();
+        $config = $this->config();
         $widths = $this->_calculateWidths($rows);
 
         $this->_rowSeparator($widths);

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -135,7 +135,7 @@ class TableHelper extends Helper
             return;
         }
 
-        $config = $this->config();
+        $config = $this->getAllConfig();
         $widths = $this->_calculateWidths($rows);
 
         $this->_rowSeparator($widths);

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -215,7 +215,7 @@ class Helper implements EventListenerInterface
         return [
             'helpers' => $this->helpers,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->config(),
+            '_config' => $this->getAllConfig(),
         ];
     }
 }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -215,7 +215,7 @@ class Helper implements EventListenerInterface
         return [
             'helpers' => $this->helpers,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->getConfig(),
+            '_config' => $this->config(),
         ];
     }
 }

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -33,7 +33,7 @@ class StringTemplate
 {
     use InstanceConfigTrait {
         getConfig as get;
-        config as all;
+        getAllConfig as all;
     }
 
     /**

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -33,6 +33,7 @@ class StringTemplate
 {
     use InstanceConfigTrait {
         getConfig as get;
+        config as all;
     }
 
     /**

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -55,7 +55,7 @@ trait StringTemplateTrait
     public function getTemplates(?string $template = null)
     {
         if ($template === null) {
-            return $this->templater()->config();
+            return $this->templater()->getAllConfig();
         }
 
         return $this->templater()->get($template);

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -54,6 +54,10 @@ trait StringTemplateTrait
      */
     public function getTemplates(?string $template = null)
     {
+        if ($template === null) {
+            return $this->templater()->config();
+        }
+
         return $this->templater()->get($template);
     }
 

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -37,6 +37,11 @@ class FormAuthenticateTest extends TestCase
     protected $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
+     * @var \Cake\Auth\FormAuthenticate
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void
@@ -390,8 +395,9 @@ class FormAuthenticateTest extends TestCase
             'hashType' => PASSWORD_BCRYPT,
         ]);
 
+        /** @var \Cake\Auth\AbstractPasswordHasher $passwordHasher */
         $passwordHasher = $this->auth->passwordHasher();
-        $result = $passwordHasher->getConfig();
+        $result = $passwordHasher->config();
         $this->assertEquals(PASSWORD_BCRYPT, $result['hashType']);
 
         $hash = password_hash('mypass', PASSWORD_BCRYPT);

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -397,7 +397,7 @@ class FormAuthenticateTest extends TestCase
 
         /** @var \Cake\Auth\AbstractPasswordHasher $passwordHasher */
         $passwordHasher = $this->auth->passwordHasher();
-        $result = $passwordHasher->config();
+        $result = $passwordHasher->getAllConfig();
         $this->assertEquals(PASSWORD_BCRYPT, $result['hashType']);
 
         $hash = password_hash('mypass', PASSWORD_BCRYPT);

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -399,7 +399,7 @@ class MemcachedEngineTest extends TestCase
         $Memcached = new MemcachedEngine();
         $Memcached->init(['engine' => 'Memcached', 'servers' => $servers]);
 
-        $config = $Memcached->config();
+        $config = $Memcached->getAllConfig();
         $this->assertEquals($config['servers'], $servers);
         Cache::drop('dual_server');
     }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -95,7 +95,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testConfig()
     {
-        $config = Cache::pool('memcached')->getConfig();
+        $config = Cache::pool('memcached')->config();
         unset($config['path']);
         $expecting = [
             'prefix' => 'cake_',
@@ -399,7 +399,7 @@ class MemcachedEngineTest extends TestCase
         $Memcached = new MemcachedEngine();
         $Memcached->init(['engine' => 'Memcached', 'servers' => $servers]);
 
-        $config = $Memcached->getConfig();
+        $config = $Memcached->config();
         $this->assertEquals($config['servers'], $servers);
         Cache::drop('dual_server');
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -91,7 +91,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConfig()
     {
-        $config = Cache::pool('redis')->getConfig();
+        $config = Cache::pool('redis')->config();
         $expecting = [
             'prefix' => 'cake_',
             'duration' => 3600,
@@ -119,7 +119,7 @@ class RedisEngineTest extends TestCase
             'url' => 'redis://localhost:' . $this->port . '?database=1&prefix=redis_',
         ]);
 
-        $config = Cache::pool('redis_dsn')->getConfig();
+        $config = Cache::pool('redis_dsn')->config();
         $expecting = [
             'prefix' => 'redis_',
             'duration' => 3600,
@@ -147,7 +147,7 @@ class RedisEngineTest extends TestCase
     public function testConnect()
     {
         $Redis = new RedisEngine();
-        $this->assertTrue($Redis->init(Cache::pool('redis')->getConfig()));
+        $this->assertTrue($Redis->init(Cache::pool('redis')->config()));
     }
 
     /**

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -189,7 +189,7 @@ class ComponentTest extends TestCase
     {
         $Component = new ConfiguredComponent(new ComponentRegistry(), ['chicken' => 'soup']);
         $this->assertEquals(['chicken' => 'soup'], $Component->configCopy);
-        $this->assertEquals(['chicken' => 'soup'], $Component->config());
+        $this->assertEquals(['chicken' => 'soup'], $Component->getAllConfig());
     }
 
     /**
@@ -232,7 +232,7 @@ class ComponentTest extends TestCase
         $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['Configured' => ['foo' => 'bar']]);
         $this->assertInstanceOf(ConfiguredComponent::class, $Component->Configured, 'class is wrong');
         $this->assertNotSame($Component, $Component->Configured, 'Component instance was reused');
-        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->config());
+        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->getAllConfig());
     }
 
     /**

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -189,7 +189,7 @@ class ComponentTest extends TestCase
     {
         $Component = new ConfiguredComponent(new ComponentRegistry(), ['chicken' => 'soup']);
         $this->assertEquals(['chicken' => 'soup'], $Component->configCopy);
-        $this->assertEquals(['chicken' => 'soup'], $Component->getConfig());
+        $this->assertEquals(['chicken' => 'soup'], $Component->config());
     }
 
     /**
@@ -232,7 +232,7 @@ class ComponentTest extends TestCase
         $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['Configured' => ['foo' => 'bar']]);
         $this->assertInstanceOf(ConfiguredComponent::class, $Component->Configured, 'class is wrong');
         $this->assertNotSame($Component, $Component->Configured, 'Component instance was reused');
-        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->getConfig());
+        $this->assertEquals(['foo' => 'bar', 'enabled' => false], $Component->Configured->config());
     }
 
     /**

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -53,7 +53,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'runtime config should match the defaults if not overridden'
         );
     }
@@ -142,7 +142,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'updates should be merged with existing config'
         );
     }
@@ -174,7 +174,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'zum', 'other' => 'value'],
                 'new' => ['foo' => 'bar'],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'updates should be merged with existing config'
         );
     }
@@ -199,7 +199,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'updates should be merged with existing config'
         );
 
@@ -217,7 +217,7 @@ class InstanceConfigTraitTest extends TestCase
                 'foo' => 'bar',
                 'new' => ['foo' => 'bar'],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'updates should be merged with existing config'
         );
 
@@ -231,9 +231,33 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => ['foo' => 'bar'],
                 'multiple' => 'different',
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'updates should be merged with existing config'
         );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetConfigOrFail()
+    {
+        $this->object->setConfig(['foo' => 'bar']);
+        $this->assertSame(
+            'bar',
+            $this->object->getConfigOrFail('foo'),
+            'should return the same value just set'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetConfigOrFailException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Expected configuration `foo` not found.');
+
+        $this->object->getConfigOrFail('foo');
     }
 
     /**
@@ -251,7 +275,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['new_nested' => true],
                 'new' => 'bar',
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -266,7 +290,7 @@ class InstanceConfigTraitTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Cannot set a.nested.value');
         $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
-        $this->object->getConfig();
+        $this->object->config();
     }
 
     /**
@@ -287,7 +311,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'Merging should not delete untouched array values'
         );
     }
@@ -310,7 +334,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'Should act the same as having passed the equivalent array to the config function'
         );
 
@@ -326,7 +350,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nextra' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'Merging should not delete untouched array values'
         );
     }
@@ -349,7 +373,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'First access should act like any subsequent access'
         );
     }
@@ -370,7 +394,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'If explicitly no-merge, array values should be overwritten'
         );
     }
@@ -397,7 +421,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -418,7 +442,7 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
-            $object->getConfig(),
+            $object->config(),
             'default config should be returned'
         );
 
@@ -448,7 +472,7 @@ class InstanceConfigTraitTest extends TestCase
             [
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'deleted keys should not be present'
         );
     }
@@ -478,7 +502,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'deleted keys should not be present'
         );
 
@@ -492,7 +516,7 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => [],
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'deleted keys should not be present'
         );
     }
@@ -513,7 +537,7 @@ class InstanceConfigTraitTest extends TestCase
             [
                 'some' => 'string',
             ],
-            $this->object->getConfig(),
+            $this->object->config(),
             'deleted keys should not be present'
         );
     }

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -53,7 +53,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'runtime config should match the defaults if not overridden'
         );
     }
@@ -142,7 +142,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -174,7 +174,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'zum', 'other' => 'value'],
                 'new' => ['foo' => 'bar'],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -199,7 +199,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
                 'foo' => 'bar',
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'updates should be merged with existing config'
         );
 
@@ -217,7 +217,7 @@ class InstanceConfigTraitTest extends TestCase
                 'foo' => 'bar',
                 'new' => ['foo' => 'bar'],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'updates should be merged with existing config'
         );
 
@@ -231,7 +231,7 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => ['foo' => 'bar'],
                 'multiple' => 'different',
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'updates should be merged with existing config'
         );
     }
@@ -275,7 +275,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['new_nested' => true],
                 'new' => 'bar',
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -290,7 +290,7 @@ class InstanceConfigTraitTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Cannot set a.nested.value');
         $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
-        $this->object->config();
+        $this->object->getAllConfig();
     }
 
     /**
@@ -311,7 +311,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'Merging should not delete untouched array values'
         );
     }
@@ -334,7 +334,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'Should act the same as having passed the equivalent array to the config function'
         );
 
@@ -350,7 +350,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nextra' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'Merging should not delete untouched array values'
         );
     }
@@ -373,7 +373,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'First access should act like any subsequent access'
         );
     }
@@ -394,7 +394,7 @@ class InstanceConfigTraitTest extends TestCase
                     'nother' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'If explicitly no-merge, array values should be overwritten'
         );
     }
@@ -421,7 +421,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'When merging a scalar property will be overwritten with an array'
         );
     }
@@ -442,7 +442,7 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
-            $object->config(),
+            $object->getAllConfig(),
             'default config should be returned'
         );
 
@@ -472,7 +472,7 @@ class InstanceConfigTraitTest extends TestCase
             [
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'deleted keys should not be present'
         );
     }
@@ -502,7 +502,7 @@ class InstanceConfigTraitTest extends TestCase
                     'other' => 'value',
                 ],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'deleted keys should not be present'
         );
 
@@ -516,7 +516,7 @@ class InstanceConfigTraitTest extends TestCase
                 'some' => 'string',
                 'a' => [],
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'deleted keys should not be present'
         );
     }
@@ -537,7 +537,7 @@ class InstanceConfigTraitTest extends TestCase
             [
                 'some' => 'string',
             ],
-            $this->object->config(),
+            $this->object->getAllConfig(),
             'deleted keys should not be present'
         );
     }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\StaticConfigTrait;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 use TestApp\Config\TestEmailStaticConfig;
 use TestApp\Config\TestLogStaticConfig;
 use TypeError;
@@ -26,6 +27,11 @@ use TypeError;
  */
 class StaticConfigTraitTest extends TestCase
 {
+    /**
+     * @var object
+     */
+    protected $subject;
+
     /**
      * setup method
      *
@@ -69,6 +75,31 @@ class StaticConfigTraitTest extends TestCase
         $this->expectException(TypeError::class);
         $className = get_class($this->subject);
         $className::parseDsn(['url' => 'http://:80']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetConfigOrFail()
+    {
+        $className = get_class($this->subject);
+        $className::setConfig('foo', 'bar');
+
+        $result = $className::getConfigOrFail('foo');
+        $this->assertSame('bar', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetConfigOrFailException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expected configuration `foo` not found.');
+
+        $className = get_class($this->subject);
+        $result = $className::getConfigOrFail('foo');
+        $this->assertSame('bar', $result);
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -41,7 +41,7 @@ class ClientTest extends TestCase
             'host' => 'example.org',
         ];
         $http = new Client($config);
-        $result = $http->getConfig();
+        $result = $http->config();
         foreach ($config as $key => $val) {
             $this->assertEquals($val, $result[$key]);
         }
@@ -51,7 +51,7 @@ class ClientTest extends TestCase
         ]);
         $this->assertSame($result, $http);
 
-        $result = $http->getConfig();
+        $result = $http->config();
         $expected = [
             'scheme' => 'http',
             'host' => 'example.org',

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -41,7 +41,7 @@ class ClientTest extends TestCase
             'host' => 'example.org',
         ];
         $http = new Client($config);
-        $result = $http->config();
+        $result = $http->getAllConfig();
         foreach ($config as $key => $val) {
             $this->assertEquals($val, $result[$key]);
         }
@@ -51,7 +51,7 @@ class ClientTest extends TestCase
         ]);
         $this->assertSame($result, $http);
 
-        $result = $http->config();
+        $result = $http->getAllConfig();
         $expected = [
             'scheme' => 'http',
             'host' => 'example.org',

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -416,12 +416,12 @@ class SmtpTransportTest extends TestCase
             'client' => 'myhost.com',
             'port' => 666,
         ]);
-        $expected = $this->SmtpTransport->getConfig();
+        $expected = $this->SmtpTransport->config();
 
         $this->assertEquals(666, $expected['port']);
 
         $this->SmtpTransport->setConfig([]);
-        $result = $this->SmtpTransport->getConfig();
+        $result = $this->SmtpTransport->config();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -416,12 +416,12 @@ class SmtpTransportTest extends TestCase
             'client' => 'myhost.com',
             'port' => 666,
         ]);
-        $expected = $this->SmtpTransport->config();
+        $expected = $this->SmtpTransport->getAllConfig();
 
         $this->assertEquals(666, $expected['port']);
 
         $this->SmtpTransport->setConfig([]);
-        $result = $this->SmtpTransport->config();
+        $result = $this->SmtpTransport->getAllConfig();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -55,7 +55,7 @@ class SocketTest extends TestCase
     public function testConstruct()
     {
         $this->Socket = new Socket();
-        $config = $this->Socket->getConfig();
+        $config = $this->Socket->config();
         $this->assertSame($config, [
             'persistent' => false,
             'host' => 'localhost',
@@ -67,16 +67,16 @@ class SocketTest extends TestCase
         $this->Socket->reset();
         $this->Socket->__construct(['host' => 'foo-bar']);
         $config['host'] = 'foo-bar';
-        $this->assertSame($this->Socket->getConfig(), $config);
+        $this->assertSame($this->Socket->config(), $config);
 
         $this->Socket = new Socket(['host' => 'www.cakephp.org', 'port' => 23, 'protocol' => 'udp']);
-        $config = $this->Socket->getConfig();
+        $config = $this->Socket->config();
 
         $config['host'] = 'www.cakephp.org';
         $config['port'] = 23;
         $config['protocol'] = 'udp';
 
-        $this->assertSame($this->Socket->getConfig(), $config);
+        $this->assertSame($this->Socket->config(), $config);
     }
 
     /**
@@ -253,7 +253,7 @@ class SocketTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $anotherSocket->getConfig(),
+            $anotherSocket->config(),
             'Reset should cause config to return the defaults defined in _defaultConfig'
         );
     }
@@ -482,10 +482,10 @@ class SocketTest extends TestCase
         $this->assertFalse($result['ssl']['allow_self_signed']);
         $this->assertEquals(5, $result['ssl']['verify_depth']);
         $this->assertSame('smtp.gmail.com', $result['ssl']['CN_match']);
-        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->getConfig());
-        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->getConfig());
-        $this->assertArrayNotHasKey('ssl_verify_host', $socket->getConfig());
-        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->getConfig());
+        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
+        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
     }
 
     /**

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -55,7 +55,7 @@ class SocketTest extends TestCase
     public function testConstruct()
     {
         $this->Socket = new Socket();
-        $config = $this->Socket->config();
+        $config = $this->Socket->getAllConfig();
         $this->assertSame($config, [
             'persistent' => false,
             'host' => 'localhost',
@@ -67,16 +67,16 @@ class SocketTest extends TestCase
         $this->Socket->reset();
         $this->Socket->__construct(['host' => 'foo-bar']);
         $config['host'] = 'foo-bar';
-        $this->assertSame($this->Socket->config(), $config);
+        $this->assertSame($this->Socket->getAllConfig(), $config);
 
         $this->Socket = new Socket(['host' => 'www.cakephp.org', 'port' => 23, 'protocol' => 'udp']);
-        $config = $this->Socket->config();
+        $config = $this->Socket->getAllConfig();
 
         $config['host'] = 'www.cakephp.org';
         $config['port'] = 23;
         $config['protocol'] = 'udp';
 
-        $this->assertSame($this->Socket->config(), $config);
+        $this->assertSame($this->Socket->getAllConfig(), $config);
     }
 
     /**
@@ -253,7 +253,7 @@ class SocketTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $anotherSocket->config(),
+            $anotherSocket->getAllConfig(),
             'Reset should cause config to return the defaults defined in _defaultConfig'
         );
     }
@@ -482,10 +482,10 @@ class SocketTest extends TestCase
         $this->assertFalse($result['ssl']['allow_self_signed']);
         $this->assertEquals(5, $result['ssl']['verify_depth']);
         $this->assertSame('smtp.gmail.com', $result['ssl']['CN_match']);
-        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
-        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
-        $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
-        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->getAllConfig());
+        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->getAllConfig());
+        $this->assertArrayNotHasKey('ssl_verify_host', $socket->getAllConfig());
+        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->getAllConfig());
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -88,7 +88,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -117,7 +117,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -157,7 +157,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -191,7 +191,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
             ['referenceName' => 'Posts']
         );
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -88,7 +88,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->allConfig();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -117,7 +117,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->allConfig();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -157,7 +157,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table->getTable();
         $table->addBehavior('Translate');
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->allConfig();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',
@@ -191,7 +191,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
             ['referenceName' => 'Posts']
         );
 
-        $config = $table->behaviors()->get('Translate')->getStrategy()->config();
+        $config = $table->behaviors()->get('Translate')->getStrategy()->allConfig();
         $wantedKeys = [
             'translationTable',
             'mainTableAlias',

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -88,7 +88,7 @@ class BehaviorRegistryTest extends TestCase
         $config = ['alias' => 'Sluggable', 'replacement' => '-'];
         $result = $this->Behaviors->load('Sluggable', $config);
         $this->assertInstanceOf('TestApp\Model\Behavior\SluggableBehavior', $result);
-        $this->assertEquals($config, $result->getConfig());
+        $this->assertEquals($config, $result->config());
 
         $result = $this->Behaviors->load('TestPlugin.PersisterOne');
         $this->assertInstanceOf('TestPlugin\Model\Behavior\PersisterOneBehavior', $result);

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -38,7 +38,7 @@ class BehaviorTest extends TestCase
         $table = $this->getMockBuilder(Table::class)->getMock();
         $config = ['key' => 'value'];
         $behavior = new TestBehavior($table, $config);
-        $this->assertEquals($config, $behavior->getConfig());
+        $this->assertEquals($config, $behavior->config());
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -38,7 +38,7 @@ class BehaviorTest extends TestCase
         $table = $this->getMockBuilder(Table::class)->getMock();
         $config = ['key' => 'value'];
         $behavior = new TestBehavior($table, $config);
-        $this->assertEquals($config, $behavior->config());
+        $this->assertEquals($config, $behavior->getAllConfig());
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -77,7 +77,7 @@ class TableLocatorTest extends TestCase
         $result = $this->_locator->setConfig('Tests', $data);
         $this->assertSame($this->_locator, $result, 'Returns locator');
 
-        $result = $this->_locator->config();
+        $result = $this->_locator->getAllConfig();
         $expected = ['Tests' => $data];
         $this->assertEquals($expected, $result);
     }
@@ -420,15 +420,15 @@ class TableLocatorTest extends TestCase
     public function testConfigAndBuild()
     {
         $this->_locator->clear();
-        $map = $this->_locator->config();
+        $map = $this->_locator->getAllConfig();
         $this->assertEquals([], $map);
 
         $connection = ConnectionManager::get('test', false);
         $options = ['connection' => $connection];
         $this->_locator->setConfig('users', $options);
-        $map = $this->_locator->config();
+        $map = $this->_locator->getAllConfig();
         $this->assertEquals(['users' => $options], $map);
-        $this->assertEquals($options, $this->_locator->config('users'));
+        $this->assertEquals($options, $this->_locator->getConfig('users'));
 
         $schema = ['id' => ['type' => 'rubbish']];
         $options += ['schema' => $schema];
@@ -443,7 +443,7 @@ class TableLocatorTest extends TestCase
         $this->assertEquals($schema['id']['type'], $table->getSchema()->getColumnType('id'));
 
         $this->_locator->clear();
-        $this->assertEmpty($this->_locator->config());
+        $this->assertEmpty($this->_locator->getAllConfig());
 
         $this->_locator->setConfig('users', $options);
         $table = $this->_locator->get('users', ['className' => MyUsersTable::class]);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -77,7 +77,7 @@ class TableLocatorTest extends TestCase
         $result = $this->_locator->setConfig('Tests', $data);
         $this->assertSame($this->_locator, $result, 'Returns locator');
 
-        $result = $this->_locator->getConfig();
+        $result = $this->_locator->config();
         $expected = ['Tests' => $data];
         $this->assertEquals($expected, $result);
     }
@@ -420,15 +420,15 @@ class TableLocatorTest extends TestCase
     public function testConfigAndBuild()
     {
         $this->_locator->clear();
-        $map = $this->_locator->getConfig();
+        $map = $this->_locator->config();
         $this->assertEquals([], $map);
 
         $connection = ConnectionManager::get('test', false);
         $options = ['connection' => $connection];
         $this->_locator->setConfig('users', $options);
-        $map = $this->_locator->getConfig();
+        $map = $this->_locator->config();
         $this->assertEquals(['users' => $options], $map);
-        $this->assertEquals($options, $this->_locator->getConfig('users'));
+        $this->assertEquals($options, $this->_locator->config('users'));
 
         $schema = ['id' => ['type' => 'rubbish']];
         $options += ['schema' => $schema];
@@ -443,7 +443,7 @@ class TableLocatorTest extends TestCase
         $this->assertEquals($schema['id']['type'], $table->getSchema()->getColumnType('id'));
 
         $this->_locator->clear();
-        $this->assertEmpty($this->_locator->getConfig());
+        $this->assertEmpty($this->_locator->config());
 
         $this->_locator->setConfig('users', $options);
         $table = $this->_locator->get('users', ['className' => MyUsersTable::class]);

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -77,7 +77,7 @@ class HelperTest extends TestCase
             'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'newval'],
             'key3' => 'val3',
         ];
-        $this->assertEquals($expected, $Helper->config());
+        $this->assertEquals($expected, $Helper->getAllConfig());
     }
 
     /**

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -77,7 +77,7 @@ class HelperTest extends TestCase
             'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'newval'],
             'key3' => 'val3',
         ];
-        $this->assertEquals($expected, $Helper->getConfig());
+        $this->assertEquals($expected, $Helper->config());
     }
 
     /**

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -22,6 +22,11 @@ use Cake\View\StringTemplate;
 class StringTemplateTest extends TestCase
 {
     /**
+     * @var \Cake\View\StringTemplate
+     */
+    protected $template;
+
+    /**
      * setUp
      *
      * @return void
@@ -180,7 +185,7 @@ class StringTemplateTest extends TestCase
     {
         $this->template->remove('attribute');
         $this->template->remove('compactAttribute');
-        $this->assertEquals([], $this->template->get());
+        $this->assertEquals([], $this->template->all());
         $this->assertNull($this->template->load('test_templates'));
         $this->assertSame('<a href="{{url}}">{{text}}</a>', $this->template->get('link'));
     }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -867,7 +867,7 @@ class ViewTest extends TestCase
         $View->loadHelper('Html', ['foo' => 'bar']);
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 
-        $config = $View->Html->getConfig();
+        $config = $View->Html->config();
         $this->assertSame('bar', $config['foo']);
     }
 
@@ -906,10 +906,10 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
 
-        $config = $View->Html->getConfig();
+        $config = $View->Html->config();
         $this->assertSame('bar', $config['foo']);
 
-        $config = $View->Form->getConfig();
+        $config = $View->Form->config();
         $this->assertSame('baz', $config['foo']);
     }
 
@@ -934,7 +934,7 @@ class ViewTest extends TestCase
     public function testInitialize()
     {
         $View = new TestView();
-        $config = $View->Html->getConfig();
+        $config = $View->Html->config();
         $this->assertSame('myval', $config['mykey']);
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -867,7 +867,7 @@ class ViewTest extends TestCase
         $View->loadHelper('Html', ['foo' => 'bar']);
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 
-        $config = $View->Html->config();
+        $config = $View->Html->getAllConfig();
         $this->assertSame('bar', $config['foo']);
     }
 
@@ -906,10 +906,10 @@ class ViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
 
-        $config = $View->Html->config();
+        $config = $View->Html->getAllConfig();
         $this->assertSame('bar', $config['foo']);
 
-        $config = $View->Form->config();
+        $config = $View->Form->getAllConfig();
         $this->assertSame('baz', $config['foo']);
     }
 
@@ -934,7 +934,7 @@ class ViewTest extends TestCase
     public function testInitialize()
     {
         $View = new TestView();
-        $config = $View->Html->config();
+        $config = $View->Html->getAllConfig();
         $this->assertSame('myval', $config['mykey']);
     }
 

--- a/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
+++ b/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
@@ -28,11 +28,11 @@ class ReadOnlyTestInstanceConfig
      * Example of how to prevent modifying config at run time
      *
      * @throws \Exception
-     * @param mixed $key
+     * @param string|array $key
      * @param mixed $value
      * @return void
      */
-    protected function _configWrite($key, $value = null)
+    protected function _configWrite($key, $value = null): void
     {
         throw new Exception('This Instance is readonly');
     }

--- a/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
+++ b/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
@@ -30,7 +30,7 @@ class EventListenerTestHelper extends Helper
      */
     public function beforeRender(EventInterface $event, $viewFile)
     {
-        $this->config('options.foo', 'bar');
+        $this->getAllConfig('options.foo', 'bar');
     }
 
     /**


### PR DESCRIPTION
Concrete issue:
```php
$roles = Configure::read($this->getConfig('rolesKey'));
```
But since the config value for this table was returning null in one instance, suddenly, the whole config array was returned instead of just the subset of the right key (which would be roles array).
With a bit more strict API access, these things are less easy to happen and easier to prevent by design.

### orFail
Adding orFail methods prevents null returns where you don't expect those under normal circumstances.
In the above example:
```php
$roles = Configure::read($this->getConfigOrFail('rolesTable'));
```

### get...() with non nullable key
- config() returns the whole array if needed, similar like the wrappers in other places
- set and get explicitly work on specific keys then.

This way you can typehint the key as string, and no accidental null read returns the whole config, as currently getConfig() would do with accidental null input.

Those changes should be rector auto-fixable.
