### PR TITLE
Fix partial empty option for dateTime

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2524,10 +2524,8 @@ class FormHelper extends Helper
                 $options[$type] = [];
             }
 
-            // Pass empty options to each type.
-            if (!empty($options['empty']) &&
-                is_array($options[$type])
-            ) {
+            // Pass boolean/scalar empty options to each type.
+            if (is_array($options[$type]) && isset($options['empty']) && !is_array($options['empty'])) {
                 $options[$type]['empty'] = $options['empty'];
             }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6272,8 +6272,6 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testDatetimeEmpty method
-     *
      * Test empty defaulting to true for datetime.
      *
      * @return void
@@ -6326,6 +6324,73 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
         $this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+    }
+
+    /**
+     * Presence check for array form empty options
+     *
+     * @return void
+     */
+    public function testDateTimeEmptyAsArrayPresence()
+    {
+        $result = $this->Form->dateTime('Contact.date', [
+            'empty' => [
+                'day' => 'DAY',
+                'month' => 'MONTH',
+                'year' => 'YEAR',
+                'hour' => 'HOUR',
+                'minute' => 'MINUTE',
+                'meridian' => false
+            ],
+            'default' => true
+        ]);
+
+        $this->assertRegExp('/<option value="">DAY<\/option>/', $result);
+        $this->assertRegExp('/<option value="">MONTH<\/option>/', $result);
+        $this->assertRegExp('/<option value="">YEAR<\/option>/', $result);
+        $this->assertRegExp('/<option value="">HOUR<\/option>/', $result);
+        $this->assertRegExp('/<option value="">MINUTE<\/option>/', $result);
+        $this->assertNotRegExp('/<option value=""><\/option>/', $result);
+
+    }
+
+    /**
+     * Test datetime with array empty value, ensuring
+     * empty options aren't duplicated.
+     *
+     * @return void
+     */
+    public function testDatetimeEmptyArrayForm()
+    {
+        extract($this->dateRegex);
+
+        $result = $this->Form->dateTime('Contact.date', [
+            'minYear' => '2017',
+            'maxYear' => '2019',
+            'empty' => [
+                'year' => 'pick year',
+                'month' => 'pick month',
+            ],
+            'hour' => false,
+            'minute' => false,
+            'second' => false,
+            'meridian' => false,
+        ]);
+        $expected = [
+            ['select' => ['name' => 'Contact[date][year]']],
+            ['option' => ['value' => '', 'selected' => 'selected']], 'pick year', '/option',
+            '*/select',
+
+            ['select' => ['name' => 'Contact[date][month]']],
+            ['option' => ['value' => '', 'selected' => 'selected']], 'pick month', '/option',
+            $monthsRegex,
+            '*/select',
+
+            ['select' => ['name' => 'Contact[date][day]']],
+            $daysRegex,
+            '*/select',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -6455,42 +6520,6 @@ class FormHelperTest extends TestCase
 
         $this->assertRegExp('/<option value="">-<\/option>/', $result);
         $this->assertNotRegExp('/<option value="0" selected="selected">0<\/option>/', $result);
-    }
-
-    /**
-     * testDateTimeEmptyAsArray method
-     *
-     * @return void
-     */
-    public function testDateTimeEmptyAsArray()
-    {
-        $result = $this->Form->dateTime('Contact.date', [
-            'empty' => [
-                'day' => 'DAY',
-                'month' => 'MONTH',
-                'year' => 'YEAR',
-                'hour' => 'HOUR',
-                'minute' => 'MINUTE',
-                'meridian' => false
-            ],
-            'default' => true
-        ]);
-
-        $this->assertRegExp('/<option value="">DAY<\/option>/', $result);
-        $this->assertRegExp('/<option value="">MONTH<\/option>/', $result);
-        $this->assertRegExp('/<option value="">YEAR<\/option>/', $result);
-        $this->assertRegExp('/<option value="">HOUR<\/option>/', $result);
-        $this->assertRegExp('/<option value="">MINUTE<\/option>/', $result);
-        $this->assertNotRegExp('/<option value=""><\/option>/', $result);
-
-        $result = $this->Form->dateTime('Contact.date', [
-            'empty' => ['day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR'],
-            'default' => true
-        ]);
-
-        $this->assertRegExp('/<option value="">DAY<\/option>/', $result);
-        $this->assertRegExp('/<option value="">MONTH<\/option>/', $result);
-        $this->assertRegExp('/<option value="">YEAR<\/option>/', $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6351,7 +6351,6 @@ class FormHelperTest extends TestCase
         $this->assertRegExp('/<option value="">HOUR<\/option>/', $result);
         $this->assertRegExp('/<option value="">MINUTE<\/option>/', $result);
         $this->assertNotRegExp('/<option value=""><\/option>/', $result);
-
     }
 
     /**


### PR DESCRIPTION
When the `empty` option is partially defined for the dateTime method, only the specified components should have an empty value set.

Fixes #13765
