### PR TITLE
Fix docblock/phpstan error. Improve phpstan run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
 
   - if [[ $CODECOVERAGE == 1 ]]; then vendor/bin/pcov clobber; vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
-  - if [[ $CHECKS == 1 ]]; then composer require --dev phpstan/phpstan:^0.11 && vendor/bin/phpstan analyse -c phpstan.neon -l 2 src/; fi
+  - if [[ $CHECKS == 1 ]]; then composer phpstan-setup && composer phpstan; fi
   - if [[ $CHECKS == 1 ]]; then composer cs-check; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,8 @@
         "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
         "test": "phpunit",
-        "test-coverage": "phpunit --coverage-clover=clover.xml"
+        "test-coverage": "phpunit --coverage-clover=clover.xml",
+        "phpstan": "phpstan analyse -c phpstan.neon -l 2 src/",
+        "phpstan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan-shim:^0.11 && mv composer.backup composer.json"
     }
 }

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -133,7 +133,7 @@ class FloatType extends Type implements TypeInterface, BatchCastingInterface
      * Marshals request data into PHP floats.
      *
      * @param mixed $value The value to convert.
-     * @return float|null Converted value.
+     * @return float|string|null Converted value.
      */
     public function marshal($value)
     {

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -44,7 +44,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Socket to SMTP server
      *
-     * @var \Cake\Network\Socket
+     * @var \Cake\Network\Socket|null
      */
     protected $_socket;
 

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -54,13 +54,15 @@ abstract class SerializedView extends View
     /**
      * Load helpers only if serialization is disabled.
      *
-     * @return void
+     * @return $this
      */
     public function loadHelpers()
     {
         if (empty($this->viewVars['_serialize'])) {
             parent::loadHelpers();
         }
+
+        return $this;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1325,7 +1325,9 @@ class View implements EventDispatcherInterface
                 'Use the helper registry through View::helpers() to manage helpers.'
             );
 
-            return $this->helpers = $value;
+            $this->helpers = $value;
+
+            return;
         }
 
         if ($name === 'name') {


### PR DESCRIPTION
some mistakes in doclocks and returns have been fixed
phpstan level 3 is now down from 80 to 76 errors.

it now also is a bit easier to run those commands, it basically backports what we added in 4.x (just without psalm of course).