### PR TITLE
Cleanup exceptions to at least use RuntimeException and include previous

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -21,8 +21,8 @@ namespace Cake\Error;
 use Cake\Core\App;
 use Cake\Http\ResponseEmitter;
 use Cake\Routing\Router;
-use Exception;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -149,7 +149,7 @@ class ErrorHandler extends BaseErrorHandler
      * @param \Throwable $exception The exception being rendered.
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The request.
      * @return \Cake\Error\ExceptionRendererInterface The exception renderer.
-     * @throws \Exception When the renderer class cannot be found.
+     * @throws \RuntimeException When the renderer class cannot be found.
      */
     public function getRenderer(
         Throwable $exception,
@@ -160,7 +160,7 @@ class ErrorHandler extends BaseErrorHandler
         if (is_string($renderer)) {
             $class = App::className($renderer, 'Error');
             if (!$class) {
-                throw new Exception(sprintf(
+                throw new RuntimeException(sprintf(
                     "The '%s' renderer class could not be found.",
                     $renderer
                 ));

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -28,8 +28,8 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\Utility\Inflector;
-use Exception;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use RuntimeException;
 
 /**
  * Cake TestCase class
@@ -175,12 +175,12 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      * @see \Cake\TestSuite\TestCase::$autoFixtures
-     * @throws \Exception when no fixture manager is available.
+     * @throws \RuntimeException when no fixture manager is available.
      */
     public function loadFixtures(): void
     {
         if ($this->fixtureManager === null) {
-            throw new Exception('No fixture manager to load the test fixture');
+            throw new RuntimeException('No fixture manager to load the test fixture');
         }
         $args = func_get_args();
         foreach ($args as $class) {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -277,7 +277,7 @@ abstract class Cell implements EventDispatcherInterface
                 $e->getMessage(),
                 $e->getFile(),
                 $e->getLine()
-            ));
+            ), 0, $e);
         }
     }
 

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Config\ReadOnlyTestInstanceConfig;
 use TestApp\Config\TestInstanceConfig;
 
@@ -288,7 +289,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetClobber()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a.nested.value');
         $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
         $this->object->getConfig();

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -27,6 +27,7 @@ use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use TestApp\Error\TestErrorHandler;
 
 /**
@@ -110,7 +111,7 @@ class ErrorHandlerTest extends TestCase
      */
     public function testInvalidRenderer()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
 
         $errorHandler = new ErrorHandler(['exceptionRenderer' => 'TotallyInvalid']);


### PR DESCRIPTION
CakePHP should never throw just the most generic exception here, but instead a bit more precise.
Fixing it to at least Runtime for now, as it is already in other similar places.

Also fixed previous to be included where forgotten and fixed error code to expected int type.