### PR TITLE
4.x body parser

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -172,6 +172,17 @@ class RequestHandlerComponent extends Component
         if (!$this->ext && $isAjax) {
             $this->ext = 'ajax';
         }
+
+        if (
+            !$request->is(['get', 'head', 'options'])
+            && $request->getParsedBody() === []
+            && !empty($request->input())
+        ) {
+            deprecationWarning(
+                'Request\'s input data parsing feature has been removed from RequestHandler. '
+                . 'Use the BodyParserMiddleware in your Application class instead.'
+            );
+        }
     }
 
     /**

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -26,10 +26,7 @@ use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
-use Cake\Utility\Exception\XmlException;
 use Cake\Utility\Inflector;
-use Cake\Utility\Xml;
-use RuntimeException;
 
 /**
  * Request object handling for alternative HTTP requests.
@@ -67,15 +64,12 @@ class RequestHandlerComponent extends Component
      * - `checkHttpCache` - Whether to check for HTTP cache. Default `true`.
      * - `viewClassMap` - Mapping between type and view classes. If undefined
      *   json, xml, and ajax will be mapped. Defining any types will omit the defaults.
-     * - `inputTypeMap` - A mapping between types and deserializers for request bodies.
-     *   If undefined json & xml will be mapped. Defining any types will omit the defaults.
      *
      * @var array
      */
     protected $_defaultConfig = [
         'checkHttpCache' => true,
         'viewClassMap' => [],
-        'inputTypeMap' => [],
     ];
 
     /**
@@ -91,10 +85,6 @@ class RequestHandlerComponent extends Component
                 'json' => 'Json',
                 'xml' => 'Xml',
                 'ajax' => 'Ajax',
-            ],
-            'inputTypeMap' => [
-                'json' => ['json_decode', true],
-                'xml' => [[$this, 'convertXml']],
             ],
         ];
         parent::__construct($registry, $config);
@@ -182,45 +172,6 @@ class RequestHandlerComponent extends Component
         if (!$this->ext && $isAjax) {
             $this->ext = 'ajax';
         }
-
-        if ($request->is(['get', 'head', 'options'])) {
-            return;
-        }
-
-        if ($request->getParsedBody() !== []) {
-            return;
-        }
-
-        foreach ($this->getConfig('inputTypeMap') as $type => $handler) {
-            if (!is_callable($handler[0])) {
-                throw new RuntimeException(sprintf("Invalid callable for '%s' type.", $type));
-            }
-            if ($this->requestedWith($type)) {
-                $input = $request->input(...$handler);
-                $controller->setRequest($request->withParsedBody((array)$input));
-            }
-        }
-    }
-
-    /**
-     * Helper method to parse xml input data, due to lack of anonymous functions
-     * this lives here.
-     *
-     * @param string $xml XML string.
-     * @return array Xml array data
-     */
-    public function convertXml(string $xml): array
-    {
-        try {
-            $xml = Xml::build($xml, ['return' => 'domdocument', 'readFile' => false]);
-            // We might not get child nodes if there are nested inline entities.
-            if ((int)$xml->childNodes->length > 0) {
-                return Xml::toArray($xml);
-            }
-        } catch (XmlException $e) {
-        }
-
-        return [];
     }
 
     /**

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -19,6 +19,7 @@ namespace Cake\Http\Middleware;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Utility\Exception\XmlException;
 use Cake\Utility\Xml;
+use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -37,7 +38,7 @@ class BodyParserMiddleware implements MiddlewareInterface
     /**
      * Registered Parsers
      *
-     * @var callable[]
+     * @var \Closure[]
      */
     protected $parsers = [];
 
@@ -66,13 +67,13 @@ class BodyParserMiddleware implements MiddlewareInterface
         if ($options['json']) {
             $this->addParser(
                 ['application/json', 'text/json'],
-                [$this, 'decodeJson']
+                Closure::fromCallable([$this, 'decodeJson'])
             );
         }
         if ($options['xml']) {
             $this->addParser(
                 ['application/xml', 'text/xml'],
-                [$this, 'decodeXml']
+                Closure::fromCallable([$this, 'decodeXml'])
             );
         }
         if ($options['methods']) {
@@ -119,11 +120,11 @@ class BodyParserMiddleware implements MiddlewareInterface
      * ```
      *
      * @param string[] $types An array of content-type header values to match. eg. application/json
-     * @param callable $parser The parser function. Must return an array of data to be inserted
+     * @param \Closure $parser The parser function. Must return an array of data to be inserted
      *   into the request.
      * @return $this
      */
-    public function addParser(array $types, callable $parser)
+    public function addParser(array $types, Closure $parser)
     {
         foreach ($types as $type) {
             $type = strtolower($type);
@@ -136,7 +137,7 @@ class BodyParserMiddleware implements MiddlewareInterface
     /**
      * Get the current parsers
      *
-     * @return callable[]
+     * @return \Closure[]
      */
     public function getParsers(): array
     {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -324,6 +324,25 @@ class RequestHandlerComponentTest extends TestCase
     }
 
     /**
+     * Test that startup() throws deprecation warning if input data is available and request data is not populated.
+     *
+     * @return void
+     */
+    public function testInitializeInputDataWarning()
+    {
+        $request = new ServerRequest([
+            'input' => json_encode(['foo' => 'bar']),
+        ]);
+        $this->Controller->setRequest($request->withMethod('POST'));
+
+        $this->deprecated(function () {
+            $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
+        });
+
+        $this->assertEmpty($request->getData());
+    }
+
+    /**
      * testViewClassMap
      *
      * @return void


### PR DESCRIPTION
- Updated `BodyParserMiddleware` to use `Closure`s instead of `callable`s.
- Removed input data parsing feature from `RequestHandlerMiddleware` as that feature is available through `BodyParserMiddleware`.