### PR TITLE
4.x merge fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 services:
   - memcached

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -231,13 +231,8 @@ class ConsoleIo
      *
      * @param string|string[] $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-<<<<<<< HEAD
      * @return int The number of bytes returned from writing to stderr.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::err
-=======
-     * @return int|bool The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/3/en/console-and-shells.html#ConsoleIo::err
->>>>>>> origin/3.next
      */
     public function error($message, int $newlines = 1): int
     {
@@ -253,14 +248,9 @@ class ConsoleIo
      * @param string|string[] $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
-<<<<<<< HEAD
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#ConsoleIo::out
-=======
-     * @return int|bool The number of bytes returned from writing to stdout.
      * @see https://book.cakephp.org/3/en/console-and-shells.html#ConsoleIo::out
->>>>>>> origin/3.next
      */
     public function success($message, int $newlines = 1, int $level = self::NORMAL): ?int
     {

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -112,8 +112,8 @@ trait InstanceConfigTrait
      * ```
      *
      * @param string|null $key The key to get or null for the whole config.
-     * @param mixed|null $default The return value when the key does not exist.
-     * @return mixed|null Configuration data at the named key or null if the key does not exist.
+     * @param mixed $default The return value when the key does not exist.
+     * @return mixed Configuration data at the named key or null if the key does not exist.
      */
     public function getConfig(?string $key = null, $default = null)
     {


### PR DESCRIPTION
Fixed left-over merge conflicts and merge errors.

- getConfig() has different hints in the backport.  Set to original 4.x hints.
- travis config merge missed setting distribution to xenial

@ADmad @markstory 