### PR TITLE
4.x controller response

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -492,11 +492,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface, Co
      * Dispatches the controller action. Checks that the action
      * exists and isn't private.
      *
-     * @return \Psr\Http\Message\ResponseInterface The resulting response.
+     * @return void
      * @throws \Cake\Controller\Exception\MissingActionException If controller action is not found.
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
      */
-    public function invokeAction(): ?ResponseInterface
+    public function invokeAction(): void
     {
         $request = $this->request;
 
@@ -526,8 +526,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface, Co
         if ($result) {
             $this->response = $result;
         }
-
-        return $this->response;
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -545,14 +545,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface, Co
     }
 
     /**
-     * Perform the startup process for this controller.
-     * Fire the Components and Controller callbacks in the correct order.
-     *
-     * - Initializes components, which fires their `initialize` callback
-     * - Calls the controller `beforeFilter`.
-     * - triggers Component `startup` methods.
-     *
-     * @return \Psr\Http\Message\ResponseInterface|null
+     * @inheritDoc
      */
     public function startupProcess(): ?ResponseInterface
     {
@@ -569,22 +562,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface, Co
     }
 
     /**
-     * Perform the various shutdown processes for this controller.
-     * Fire the Components and Controller callbacks in the correct order.
-     *
-     * - triggers the component `shutdown` callback.
-     * - calls the Controller's `afterFilter` method.
-     *
-     * @return \Psr\Http\Message\ResponseInterface|null
+     * @inheritDoc
      */
-    public function shutdownProcess(): ?ResponseInterface
+    public function shutdownProcess(): ResponseInterface
     {
         $event = $this->dispatchEvent('Controller.shutdown');
         if ($event->getResult() instanceof ResponseInterface) {
             return $event->getResult();
         }
 
-        return null;
+        return $this->response;
     }
 
     /**

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -58,26 +58,6 @@ class ActionDispatcher
             Router::setRequest($request);
         }
 
-        $controller = $this->factory->create($request, $response);
-
-        return $this->_invoke($controller);
-    }
-
-    /**
-     * Invoke a controller's action and wrapping methods.
-     *
-     * @param \Cake\Http\ControllerInterface $controller The controller to invoke.
-     * @return \Psr\Http\Message\ResponseInterface The response
-     */
-    protected function _invoke(ControllerInterface $controller): ResponseInterface
-    {
-        $result = $controller->startupProcess();
-        if ($result) {
-            return $result;
-        }
-
-        $controller->invokeAction();
-
-        return $controller->shutdownProcess();
+        return $this->factory->create($request, $response)->invokeAction();
     }
 }

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -72,17 +72,12 @@ class ActionDispatcher
     protected function _invoke(ControllerInterface $controller): ResponseInterface
     {
         $result = $controller->startupProcess();
-        if ($result instanceof ResponseInterface) {
+        if ($result) {
             return $result;
         }
 
         $controller->invokeAction();
 
-        $result = $controller->shutdownProcess();
-        if ($result instanceof ResponseInterface) {
-            return $result;
-        }
-
-        return $controller->getResponse();
+        return $controller->shutdownProcess();
     }
 }

--- a/src/Http/ControllerInterface.php
+++ b/src/Http/ControllerInterface.php
@@ -25,37 +25,11 @@ use Psr\Http\Message\ResponseInterface;
 interface ControllerInterface
 {
     /**
-     * Perform the startup process for this controller.
-     *
-     * Fire the Components and Controller callbacks in the correct order.
-     *
-     * - Initializes components, which fires their `initialize` callback
-     * - Calls the controller `beforeFilter`.
-     * - triggers Component `startup` methods.
-     *
-     * @return \Psr\Http\Message\ResponseInterface|null
-     */
-    public function startupProcess(): ?ResponseInterface;
-
-    /**
-     * Perform the various shutdown processes for this controller.
-     *
-     * Fire the Components and Controller callbacks in the correct order and
-     * return the final response instance.
-     *
-     * - triggers the component `shutdown` callback.
-     * - calls the Controller's `afterFilter` method.
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function shutdownProcess(): ResponseInterface;
-
-    /**
      * Dispatches the controller action. Checks that the action exists and isn't private.
      *
-     * @return void
+     * @return \Psr\Http\Message\ResponseInterface
      * @throws \Cake\Controller\Exception\MissingActionException If controller action is not found.
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
      */
-    public function invokeAction(): void;
+    public function invokeAction(): ResponseInterface;
 }

--- a/src/Http/ControllerInterface.php
+++ b/src/Http/ControllerInterface.php
@@ -26,6 +26,7 @@ interface ControllerInterface
 {
     /**
      * Perform the startup process for this controller.
+     *
      * Fire the Components and Controller callbacks in the correct order.
      *
      * - Initializes components, which fires their `initialize` callback
@@ -38,14 +39,16 @@ interface ControllerInterface
 
     /**
      * Perform the various shutdown processes for this controller.
-     * Fire the Components and Controller callbacks in the correct order.
+     *
+     * Fire the Components and Controller callbacks in the correct order and
+     * return the final response instance.
      *
      * - triggers the component `shutdown` callback.
      * - calls the Controller's `afterFilter` method.
      *
-     * @return \Psr\Http\Message\ResponseInterface|null
+     * @return \Psr\Http\Message\ResponseInterface
      */
-    public function shutdownProcess(): ?ResponseInterface;
+    public function shutdownProcess(): ResponseInterface;
 
     /**
      * Dispatches the controller action. Checks that the action exists and isn't private.
@@ -55,11 +58,4 @@ interface ControllerInterface
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
      */
     public function invokeAction(): void;
-
-    /**
-     * Gets the response instance.
-     *
-     * @return \Cake\Http\Response
-     */
-    public function getResponse(): Response;
 }

--- a/src/Http/ControllerInterface.php
+++ b/src/Http/ControllerInterface.php
@@ -48,14 +48,13 @@ interface ControllerInterface
     public function shutdownProcess(): ?ResponseInterface;
 
     /**
-     * Dispatches the controller action. Checks that the action
-     * exists and isn't private.
+     * Dispatches the controller action. Checks that the action exists and isn't private.
      *
-     * @return \Psr\Http\Message\ResponseInterface The resulting response.
+     * @return void
      * @throws \Cake\Controller\Exception\MissingActionException If controller action is not found.
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
      */
-    public function invokeAction(): ?ResponseInterface;
+    public function invokeAction(): void;
 
     /**
      * Gets the response instance.

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -731,9 +731,8 @@ class ControllerTest extends TestCase
         $response = new Response();
 
         $Controller = new TestController($url, $response);
-        $result = $Controller->invokeAction();
+        $Controller->invokeAction();
 
-        $this->assertSame('I am from the controller.', (string)$result);
         $this->assertSame('I am from the controller.', (string)$Controller->getResponse());
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -731,8 +731,9 @@ class ControllerTest extends TestCase
         $response = new Response();
 
         $Controller = new TestController($url, $response);
-        $Controller->invokeAction();
+        $result = $Controller->invokeAction();
 
+        $this->assertSame('I am from the controller.', (string)$result);
         $this->assertSame('I am from the controller.', (string)$Controller->getResponse());
     }
 

--- a/tests/test_app/TestApp/Controller/CakesController.php
+++ b/tests/test_app/TestApp/Controller/CakesController.php
@@ -16,7 +16,7 @@ class CakesController extends Controller
      *
      * @var string
      */
-    public $modelClass = 'Posts';
+    protected $modelClass = 'Posts';
 
     /**
      * index method
@@ -52,7 +52,7 @@ class CakesController extends Controller
     /**
      * Startup process
      *
-     * \Psr\Http\Message\ResponseInterface|null
+     * @return \Psr\Http\Message\ResponseInterface|null
      */
     public function startupProcess(): ?ResponseInterface
     {
@@ -67,15 +67,16 @@ class CakesController extends Controller
     /**
      * Shutdown process
      *
-     * \Psr\Http\Message\ResponseInterface|null
+     * @return \Psr\Http\Message\ResponseInterface
      */
-    public function shutdownProcess(): ?ResponseInterface
+    public function shutdownProcess(): ResponseInterface
     {
-        parent::shutdownProcess();
+        $response = parent::shutdownProcess();
+
         if ($this->request->getParam('stop') === 'shutdown') {
-            return $this->response->withStringBody('shutdown stop');
+            $response = $response->withStringBody('shutdown stop');
         }
 
-        return null;
+        return $response;
     }
 }

--- a/tests/test_app/TestApp/Controller/CakesController.php
+++ b/tests/test_app/TestApp/Controller/CakesController.php
@@ -67,16 +67,15 @@ class CakesController extends Controller
     /**
      * Shutdown process
      *
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Psr\Http\Message\ResponseInterface|null
      */
-    public function shutdownProcess(): ResponseInterface
+    public function shutdownProcess(): ?ResponseInterface
     {
-        $response = parent::shutdownProcess();
-
+        parent::shutdownProcess();
         if ($this->request->getParam('stop') === 'shutdown') {
-            $response = $response->withStringBody('shutdown stop');
+            return $this->response->withStringBody('shutdown stop');
         }
 
-        return $response;
+        return null;
     }
 }

--- a/tests/test_app/TestApp/Controller/TestController.php
+++ b/tests/test_app/TestApp/Controller/TestController.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace TestApp\Controller;
 
-use Cake\Event\EventInterface;
-
 /**
  * TestController class
  */
@@ -23,16 +21,6 @@ class TestController extends ControllerTestAppController
      * @var string
      */
     public $modelClass = 'Comments';
-
-    /**
-     * beforeFilter handler
-     *
-     * @param \Cake\Event\EventInterface $event
-     * @return \Cake\Http\Response|null
-     */
-    public function beforeFilter(EventInterface $event): ?Response
-    {
-    }
 
     /**
      * index method


### PR DESCRIPTION
- Change return type of `ControllerInterface::invokeAction()` to void as it's return value is never used by `ActionDispatcher`.
-  Remove `ControllerInterface::getResponse()`.
    
    Having a method with return type `Response` while other interface methods
   have return type `ResponseInterface` looked fugly. As a consequence
 `shutdownProcess()` now always returns a response as it's the last step in
  in controller action invocation. 