### PR TITLE
account for PostgreSQL identifier max length

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -459,7 +459,7 @@ abstract class Driver implements DriverInterface
         // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
         // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
         // to the allowed length of 63.
-        if (PDO::ATTR_DRIVER_NAME === 'pgsql') {
+        if ($this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
             return substr($key, 0, 63);
         }
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -448,21 +448,14 @@ abstract class Driver implements DriverInterface
     }
 
     /**
-     * Truncates an identifier if the database does
+     * Generates a column identifier respecting database constraints
      *
-     * @param string $key Aliased field name
+     * @param string $key Identifier
      *
-     * @return string Aliased field name as returned by Database
+     * @return string Identifier as returned by Database
      */
-    public function sanitizeIdentifier(string $key)
+    public function generateIdentifier(string $key)
     {
-        // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
-        // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
-        // to the allowed length of 63.
-        if ($this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
-            return substr($key, 0, 63);
-        }
-
         return $key;
     }
 }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -446,4 +446,23 @@ abstract class Driver implements DriverInterface
             'connected' => $this->_connection !== null
         ];
     }
+
+    /**
+     * Truncates an identifier if the database does
+     *
+     * @param string $key Aliased field name
+     *
+     * @return string Aliased field name as returned by Database
+     */
+    public function sanitizeIdentifier(string $key)
+    {
+        // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
+        // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
+        // to the allowed length of 63.
+        if (PDO::ATTR_DRIVER_NAME === 'pgsql') {
+            return substr($key, 0, 63);
+        }
+
+        return $key;
+    }
 }

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -199,4 +199,31 @@ trait PDODriverTrait
 
         return $this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
     }
+
+    /**
+     * Creates a map of row keys out of the query select clause that can be
+     * used to hydrate nested result sets more quickly.
+     *
+     * @param \Cake\Database\Query $query The query from where to derive the column map
+     *
+     * @return array
+     */
+    public function calculateColumnMap(Query $query)
+    {
+        $map = [];
+        $defaultAlias = $query->getRepository()->getAlias();
+        foreach ($query->clause('select') as $key => $field) {
+            $key = trim($key, '"`[]');
+
+            if (strpos($key, '__') <= 0) {
+                $map[$defaultAlias][$key] = $key;
+                continue;
+            }
+
+            $parts = explode('__', $key, 2);
+            $map[$parts[0]][$key] = $parts[1];
+        }
+
+        return $map;
+    }
 }

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -201,29 +201,21 @@ trait PDODriverTrait
     }
 
     /**
-     * Creates a map of row keys out of the query select clause that can be
-     * used to hydrate nested result sets more quickly.
+     * Truncates an identifier if the database does
      *
-     * @param \Cake\Database\Query $query The query from where to derive the column map
+     * @param string $key Aliased field name
      *
-     * @return array
+     * @return string Aliased field name as returned by Database
      */
-    public function calculateColumnMap(Query $query)
+    public function sanitizeIdentifier(string $key)
     {
-        $map = [];
-        $defaultAlias = $query->getRepository()->getAlias();
-        foreach ($query->clause('select') as $key => $field) {
-            $key = trim($key, '"`[]');
-
-            if (strpos($key, '__') <= 0) {
-                $map[$defaultAlias][$key] = $key;
-                continue;
-            }
-
-            $parts = explode('__', $key, 2);
-            $map[$parts[0]][$key] = $parts[1];
+        // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
+        // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
+        // to the allowed length of 63.
+        if(PDO::ATTR_DRIVER_NAME === 'pgsql'){
+            return substr($key, 0, 63);
         }
 
-        return $map;
+        return $key;
     }
 }

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -199,23 +199,4 @@ trait PDODriverTrait
 
         return $this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
     }
-
-    /**
-     * Truncates an identifier if the database does
-     *
-     * @param string $key Aliased field name
-     *
-     * @return string Aliased field name as returned by Database
-     */
-    public function sanitizeIdentifier(string $key)
-    {
-        // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
-        // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
-        // to the allowed length of 63.
-        if (PDO::ATTR_DRIVER_NAME === 'pgsql') {
-            return substr($key, 0, 63);
-        }
-
-        return $key;
-    }
 }

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -212,7 +212,7 @@ trait PDODriverTrait
         // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
         // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
         // to the allowed length of 63.
-        if(PDO::ATTR_DRIVER_NAME === 'pgsql'){
+        if (PDO::ATTR_DRIVER_NAME === 'pgsql') {
             return substr($key, 0, 63);
         }
 

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -129,4 +129,15 @@ class Postgres extends Driver
     {
         return true;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generateIdentifier(string $key)
+    {
+        // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
+        // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
+        // to the allowed length of 63.
+        return substr($key, 0, 63);
+    }
 }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -129,29 +129,4 @@ class Postgres extends Driver
     {
         return true;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function calculateColumnMap(Query $query)
-    {
-        $map = [];
-        $defaultAlias = $query->getRepository()->getAlias();
-        foreach ($query->clause('select') as $key => $field) {
-            $key = trim($key, '"`[]');
-
-            if (strpos($key, '__') <= 0) {
-                $map[$defaultAlias][$key] = $key;
-                continue;
-            }
-
-            $parts = explode('__', $key, 2);
-            // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
-            // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
-            // to the allowed length of 63.
-            $map[$parts[0]][substr($key, 0, 63)] = $parts[1];
-        }
-
-        return $map;
-    }
 }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -129,4 +129,29 @@ class Postgres extends Driver
     {
         return true;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function calculateColumnMap(Query $query)
+    {
+        $map = [];
+        $defaultAlias = $query->getRepository()->getAlias();
+        foreach ($query->clause('select') as $key => $field) {
+            $key = trim($key, '"`[]');
+
+            if (strpos($key, '__') <= 0) {
+                $map[$defaultAlias][$key] = $key;
+                continue;
+            }
+
+            $parts = explode('__', $key, 2);
+            // In PostgreSQL, identifiers — table names, column names, constraint names, etc. — are limited to a
+            // maximum length of 63 bytes. Identifiers longer than 63 characters can be used, but they will be truncated
+            // to the allowed length of 63.
+            $map[$parts[0]][substr($key, 0, 63)] = $parts[1];
+        }
+
+        return $map;
+    }
 }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -400,7 +400,18 @@ class ResultSet implements ResultSetInterface
      */
     protected function _calculateColumnMap($query)
     {
-        $map = $this->_driver->calculateColumnMap($query);
+        $map = [];
+        foreach ($query->clause('select') as $key => $aliasedField) {
+            $key = trim($key, '"`[]');
+
+            if (strpos($key, '__') <= 0) {
+                $map[$this->_defaultAlias][$key] = $key;
+                continue;
+            }
+
+            $parts = explode('__', $key, 2);
+            $map[$parts[0]][$this->_driver->sanitizeIdentifier($key)] = $parts[1];
+        }
 
         foreach ($this->_matchingMap as $alias => $assoc) {
             if (!isset($map[$alias])) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -400,18 +400,7 @@ class ResultSet implements ResultSetInterface
      */
     protected function _calculateColumnMap($query)
     {
-        $map = [];
-        foreach ($query->clause('select') as $key => $field) {
-            $key = trim($key, '"`[]');
-
-            if (strpos($key, '__') <= 0) {
-                $map[$this->_defaultAlias][$key] = $key;
-                continue;
-            }
-
-            $parts = explode('__', $key, 2);
-            $map[$parts[0]][$key] = $parts[1];
-        }
+        $map = $this->_driver->calculateColumnMap($query);
 
         foreach ($this->_matchingMap as $alias => $assoc) {
             if (!isset($map[$alias])) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -401,7 +401,7 @@ class ResultSet implements ResultSetInterface
     protected function _calculateColumnMap($query)
     {
         $map = [];
-        foreach ($query->clause('select') as $key => $aliasedField) {
+        foreach ($query->clause('select') as $key => $field) {
             $key = trim($key, '"`[]');
 
             if (strpos($key, '__') <= 0) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -410,7 +410,7 @@ class ResultSet implements ResultSetInterface
             }
 
             $parts = explode('__', $key, 2);
-            $map[$parts[0]][$this->_driver->sanitizeIdentifier($key)] = $parts[1];
+            $map[$parts[0]][$this->_driver->generateIdentifier($key)] = $parts[1];
         }
 
         foreach ($this->_matchingMap as $alias => $assoc) {


### PR DESCRIPTION
Identifiers longer than 63 characters can be used, but they will be truncated to the allowed length of 63.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
