### PR TITLE
4.0 - Http fixes for standalone usage

### DIFF
--- a/src/Http/MiddlewareApplication.php
+++ b/src/Http/MiddlewareApplication.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Cake\Core\HttpApplicationInterface;
+use Cake\Routing\RouteBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Base class for standalone HTTP applications
+ *
+ * Provides a base class to inherit from for applications using
+ * only the http package. This class defines a fallback handler
+ * that renders a simple 404 response.
+ *
+ * You can overload the `handle` method to provide your own logic
+ * to run when no middleware generates a response.
+ */
+abstract class MiddlewareApplication implements HttpApplicationInterface {
+    /**
+     * @inheritDoc
+     */
+    abstract public function bootstrap(): void;
+
+    /**
+     * @inheritDoc
+     */
+    abstract public function middleware(MiddlewareQueue $middleware): MiddlewareQueue;
+
+    /**
+     * Generate a 404 response as no middleware handled the request.
+     *
+     * @param \Cake\Http\ServerRequest $request The request
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function handle(
+        ServerRequestInterface $request
+    ): ResponseInterface {
+        return new Response(['body' => 'Not found', 'status' => 404]);
+    }
+}

--- a/src/Http/MiddlewareApplication.php
+++ b/src/Http/MiddlewareApplication.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Core\HttpApplicationInterface;
-use Cake\Routing\RouteBuilder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -31,7 +30,8 @@ use Psr\Http\Message\ServerRequestInterface;
  * You can overload the `handle` method to provide your own logic
  * to run when no middleware generates a response.
  */
-abstract class MiddlewareApplication implements HttpApplicationInterface {
+abstract class MiddlewareApplication implements HttpApplicationInterface
+{
     /**
      * @inheritDoc
      */

--- a/src/Http/README.md
+++ b/src/Http/README.md
@@ -74,6 +74,8 @@ requests. In your application's webroot, you can add an `index.php` and process
 requests:
 
 ```php
+<?php
+// in webroot/index.php
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use App\Application;
@@ -84,6 +86,12 @@ $server = new Server(new Application());
 
 // Run the request/response through the application and emit the response.
 $server->emit($server->run());
+```
+
+You can then run your application using PHP's built in webserver:
+
+```bash
+php -S localhost:8765 -t ./webroot ./webroot/index.php
 ```
 
 For more information on middleware, [consult the

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -135,7 +135,7 @@ class Session
      */
     protected static function _defaultConfig(string $name)
     {
-        $tmp = defined('TMP') ? TMP : sys_get_temp_dir();
+        $tmp = defined('TMP') ? TMP : sys_get_temp_dir() . DIRECTORY_SEPARATOR;
         $defaults = [
             'php' => [
                 'ini' => [

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -135,6 +135,7 @@ class Session
      */
     protected static function _defaultConfig(string $name)
     {
+        $tmp = defined('TMP') ? TMP : sys_get_temp_dir();
         $defaults = [
             'php' => [
                 'ini' => [
@@ -146,7 +147,7 @@ class Session
                     'session.use_trans_sid' => 0,
                     'session.serialize_handler' => 'php',
                     'session.use_cookies' => 1,
-                    'session.save_path' => TMP . 'sessions',
+                    'session.save_path' => $tmp . 'sessions',
                     'session.save_handler' => 'files',
                 ],
             ],

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -27,8 +27,11 @@
         "cakephp/core": "^4.0",
         "cakephp/event": "^4.0",
         "cakephp/utility": "^4.0",
+        "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "zendframework/zend-diactoros": "^2.1"
+        "psr/http-server-middleware": "^1.0",
+        "zendframework/zend-diactoros": "^2.1",
+        "zendframework/zend-httphandlerrunner": "^1.0"
     },
     "suggest": {
         "cakephp/cache": "To use cache session storage",

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Core\Configure;
+use Cake\Http\MiddlewareApplication;
+use Cake\Http\MiddlewareQueue;
+use Cake\Http\ServerRequestFactory;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * MiddlewareApplication test.
+ */
+class MiddlewareApplicationTest extends TestCase
+{
+    /**
+     * Setup
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        static::setAppNamespace();
+    }
+
+    /**
+     * Integration test for a simple controller.
+     *
+     * @return void
+     */
+    public function testHandle()
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/cakes']);
+        $request = $request->withAttribute('params', [
+            'controller' => 'Cakes',
+            'action' => 'index',
+            'plugin' => null,
+            'pass' => [],
+        ]);
+
+        $app = $this->getMockForAbstractClass(MiddlewareApplication::class);
+        $result = $app->handle($request);
+        $this->assertInstanceOf(ResponseInterface::class, $result);
+        $this->assertSame('Not found', '' . $result->getBody());
+        $this->assertSame(404, $result->getStatusCode());
+    }
+}

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.5.0
+ * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Http;

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Core\Configure;
 use Cake\Http\MiddlewareApplication;
-use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ResponseInterface;


### PR DESCRIPTION
A few fixes for using cakephp/http on its own. I've added a new `MiddlewareApplication` that can function like `BaseApplication` does for full stack applications.