### PR TITLE
4.x - Cookie defaults

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,6 +193,11 @@ parameters:
 			path: src/Http/Client/Auth/Digest.php
 
 		-
+			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Cookie/Cookie.php
+
+		-
 			message: "#^Method Cake\\\\Http\\\\Middleware\\\\CspMiddleware\\:\\:process\\(\\) should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns Psr\\\\Http\\\\Message\\\\MessageInterface\\.$#"
 			count: 1
 			path: src/Http/Middleware/CspMiddleware.php

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -197,8 +197,14 @@ class Cookie implements CookieInterface
      */
     public static function setDefaults(array $options): void
     {
+        if (isset($options['expires'])) {
+            $options['expires'] = static::dateTimeInstance($options['expires']);
+        }
+        if (isset($options['samesite'])) {
+            static::validateSameSiteValue($options['samesite']);
+        }
+
         static::$defaults = $options + static::$defaults;
-        static::$defaults['expires'] = static::dateTimeInstance(static::$defaults['expires']);
     }
 
     /**
@@ -242,6 +248,13 @@ class Cookie implements CookieInterface
         if ($expires instanceof DateTimeInterface) {
             /** @psalm-suppress UndefinedInterfaceMethod */
             return $expires->setTimezone(new DateTimeZone('GMT'));
+        }
+
+        if (!is_string($expires) && !is_int($expires)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid type `%s` for expires.',
+                getTypeName($expires)
+            ));
         }
 
         if (!is_numeric($expires)) {
@@ -642,11 +655,11 @@ class Cookie implements CookieInterface
      * @return void
      * @throws \InvalidArgumentException
      */
-    protected function validateSameSiteValue(string $sameSite)
+    protected static function validateSameSiteValue(string $sameSite)
     {
         if (!in_array($sameSite, CookieInterface::SAMESITE_VALUES, true)) {
             throw new InvalidArgumentException(
-                'Samesite value must be either of: ' . implode(',', CookieInterface::SAMESITE_VALUES)
+                'Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES)
             );
         }
     }

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -252,7 +252,7 @@ class Cookie implements CookieInterface
 
         if (!is_string($expires) && !is_int($expires)) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid type `%s` for expires.',
+                'Invalid type `%s` for expires. Expected an string, integer or DateTime object.',
                 getTypeName($expires)
             ));
         }

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -117,6 +117,7 @@ class Cookie implements CookieInterface
      * Default attributes for a cookie.
      *
      * @var array
+     * @see \Cake\Cookie\Cookie::setDefaults()
      */
     protected static $defaults = [
         'expires' => null,
@@ -179,6 +180,16 @@ class Cookie implements CookieInterface
     /**
      * Set default options for the cookies.
      *
+     * Valid option keys are:
+     *
+     * - `expires`: Can be a UNIX timestamp or `strtotime()` compatible string or `DateTimeInterface` instance or `null`.
+     * - `path`: A path string. Defauts to `'/'`.
+     * - `domain`: Domain name string. Defaults to `''`.
+     * - `httponly`: Boolean. Defaults to `false`.
+     * - `secure`: Boolean. Defaults to `false`.
+     * - `samesite`: Can be one of `CookieInterface::SAMESITE_LAX`, `CookieInterface::SAMESITE_STRICT`,
+     *    `CookieInterface::SAMESITE_NONE` or `null`. Defaults to `null`.
+     *
      * @param array $options Default options.
      * @return void
      */
@@ -192,10 +203,9 @@ class Cookie implements CookieInterface
      *
      * @param string $name Cookie name
      * @param string|array $value Value of the cookie
-     * @param array $options Cookies options. Can contain one of following keys:
-     *  expires, path, domain, secure, httponly and samesite.
-     *  (Keys must be lowercase).
+     * @param array $options Cookies options.
      * @return static
+     * @see \Cake\Cookie\Cookie::setDefaults()
      */
     public static function create(string $name, $value, array $options = [])
     {
@@ -232,6 +242,7 @@ class Cookie implements CookieInterface
      * @param string $cookie Cookie header string.
      * @param array $defaults Default attributes.
      * @return static
+     * @see \Cake\Cookie\Cookie::setDefaults()
      */
     public static function createFromHeaderString(string $cookie, array $defaults = [])
     {

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -44,7 +44,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Constructor
      *
-     * @param array $cookies Array of cookie objects
+     * @param \Cake\Http\Cookie\CookieInterface[] $cookies Array of cookie objects
      */
     public function __construct(array $cookies = [])
     {
@@ -185,7 +185,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Checks if only valid cookie objects are in the array
      *
-     * @param array $cookies Array of cookie objects
+     * @param \Cake\Http\Cookie\CookieInterface[] $cookies Array of cookie objects
      * @return void
      * @throws \InvalidArgumentException
      */

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -233,7 +233,7 @@ class ResponseEmitter implements EmitterInterface
     protected function setCookie($cookie): bool
     {
         if (is_string($cookie)) {
-            $cookie = Cookie::createFromHeaderString($cookie);
+            $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
         }
 
         if (PHP_VERSION_ID >= 70300) {

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -18,6 +18,7 @@ use Cake\Chronos\Chronos;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
 use Cake\TestSuite\TestCase;
+use DateTimeInterface;
 
 /**
  * HTTP cookies test.
@@ -513,12 +514,14 @@ class CookieTest extends TestCase
 
     public function testDefaults()
     {
-        Cookie::setDefaults(['path' => '/cakephp']);
+        Cookie::setDefaults(['path' => '/cakephp', 'expires' => time()]);
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertSame('/cakephp', $cookie->getPath());
+        $this->assertInstanceOf(DateTimeInterface::class, $cookie->getExpiry());
 
-        Cookie::setDefaults(['path' => '/']);
+        Cookie::setDefaults(['path' => '/', 'expires' => null]);
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertSame('/', $cookie->getPath());
+        $this->assertNull($cookie->getExpiry());
     }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -510,4 +510,15 @@ class CookieTest extends TestCase
         // https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1
         $this->assertNull($result->getSameSite());
     }
+
+    public function testDefaults()
+    {
+        Cookie::setDefaults(['path' => '/cakephp']);
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $this->assertSame('/cakephp', $cookie->getPath());
+
+        Cookie::setDefaults(['path' => '/']);
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $this->assertSame('/', $cookie->getPath());
+    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -188,7 +188,7 @@ class CookieTest extends TestCase
     public function testWithSameSiteException()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(',', CookieInterface::SAMESITE_VALUES));
+        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
 
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $cookie->withSameSite('invalid');
@@ -523,5 +523,23 @@ class CookieTest extends TestCase
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertSame('/', $cookie->getPath());
         $this->assertNull($cookie->getExpiry());
+    }
+
+    public function testInvalidExpiresForDefaults()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type `array` for expire');
+
+        Cookie::setDefaults(['expires' => ['ompalompa']]);
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+    }
+
+    public function testInvalidSameSiteForDefaults()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
+
+        Cookie::setDefaults(['samesite' => 'ompalompa']);
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
     }
 }

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -54,7 +54,7 @@ class ResponseEmitterTest extends TestCase
             ->method('setCookie')
             ->will($this->returnCallback(function ($cookie) {
                 if (is_string($cookie)) {
-                    $cookie = Cookie::createFromHeaderString($cookie);
+                    $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
                 }
 
                 $GLOBALS['mockedCookies'][] = ['name' => $cookie->getName(), 'value' => $cookie->getValue()]


### PR DESCRIPTION
Currently it was a bit tedious having to specify common non default options/attributes when creating cookies.

For e.g. if your app is under a subfolder of webserver's document root a sensible default is to have the path for all cookies set to `/subfolder` instead of `/` (that's what `CookieComponent` did). But in 4.x you would have to specify the subfolder path each time when creating a new cookie.

So I have added a new static method `Cookie::setDefaults()` to avoid having to repeatedly pass common options.