### PR TITLE
 #13681 - Allow null $keyPath on Hash::combine and use numbered array if it is

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -466,12 +466,12 @@ class Hash
         if (is_array($keyPath)) {
             $format = array_shift($keyPath);
             $keys = static::format($data, $keyPath, $format);
-        } elseif (is_null($keyPath)) {
+        } elseif ($keyPath === null) {
             $keys = $keyPath;
         } else {
             $keys = static::extract($data, $keyPath);
         }
-        if (!is_null($keyPath) && empty($keys)) {
+        if ($keyPath !== null && empty($keys)) {
             return [];
         }
 
@@ -504,7 +504,7 @@ class Hash
                     if (!isset($out[$group[$i]])) {
                         $out[$group[$i]] = [];
                     }
-                    if (is_null($keys)) {
+                    if ($keys === null) {
                         $out[$group[$i]][] = $vals[$i];
                     } else {
                         $out[$group[$i]][$keys[$i]] = $vals[$i];

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -518,7 +518,7 @@ class Hash
             return [];
         }
 
-        return array_combine($keys === null ? range(0, count($vals)-1) : $keys, $vals);
+        return array_combine($keys === null ? range(0, count($vals) - 1) : $keys, $vals);
     }
 
     /**

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -483,7 +483,7 @@ class Hash
             $vals = static::extract($data, $valuePath);
         }
         if (empty($vals)) {
-            $vals = array_fill(0, count($keys), null);
+            $vals = array_fill(0, $keys === null ? count($data) : count($keys), null);
         }
 
         if (is_array($keys) && count($keys) !== count($vals)) {
@@ -518,7 +518,7 @@ class Hash
             return [];
         }
 
-        return array_combine($keys, $vals);
+        return array_combine($keys === null ? range(0, count($vals)-1) : $keys, $vals);
     }
 
     /**

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -492,7 +492,6 @@ class Hash
             );
         }
 
-
         if ($groupPath !== null) {
             $group = static::extract($data, $groupPath);
             if (!empty($group)) {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -2309,6 +2309,41 @@ class HashTest extends TestCase
     }
 
     /**
+     * test combine() with null key path.
+     *
+     * @return void
+     */
+    public function testCombineWithNullKeyPath()
+    {
+        $result = Hash::combine([], null, '{n}.User.Data');
+        $this->assertEmpty($result);
+
+        $a = static::userData();
+
+        $result = Hash::combine($a, null);
+        $expected = [0 => null, 1 => null, 2 => null];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.non-existant');
+        $expected = [0 => null, 1 => null, 2 => null];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data');
+        $expected = [
+            0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+            1 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
+            2 => ['user' => 'gwoo', 'name' => 'The Gwoo']];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name');
+        $expected = [
+            0 => 'Mariano Iglesias',
+            1 => 'Larry E. Masters',
+            2 => 'The Gwoo'];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test combine() giving errors on key/value length mismatches.
      *
      * @return void
@@ -2359,6 +2394,18 @@ class HashTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
+        $result = Hash::combine($a, null, '{n}.User.Data', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+            ],
+            2 => [
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
             1 => [
@@ -2367,6 +2414,18 @@ class HashTest extends TestCase
             ],
             2 => [
                 14 => 'Larry E. Masters'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => 'Mariano Iglesias',
+                1 => 'The Gwoo'
+            ],
+            2 => [
+                0 => 'Larry E. Masters'
             ]
         ];
         $this->assertEquals($expected, $result);
@@ -2383,6 +2442,18 @@ class HashTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
+        $result = Hash::combine($a, null, '{n}.User.Data', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+            ],
+            2 => [
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
             1 => [
@@ -2391,6 +2462,18 @@ class HashTest extends TestCase
             ],
             2 => [
                 14 => 'Larry E. Masters'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => 'Mariano Iglesias',
+                1 => 'The Gwoo'
+            ],
+            2 => [
+                0 => 'Larry E. Masters'
             ]
         ];
         $this->assertEquals($expected, $result);
@@ -2418,6 +2501,23 @@ class HashTest extends TestCase
             ],
             2 => [
                 14 => 'phpnut: Larry E. Masters'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine(
+            $a,
+            null,
+            ['%1$s: %2$s', '{n}.User.Data.user', '{n}.User.Data.name'],
+            '{n}.User.group_id'
+        );
+        $expected = [
+            1 => [
+                0 => 'mariano.iglesias: Mariano Iglesias',
+                1 => 'gwoo: The Gwoo'
+            ],
+            2 => [
+                0 => 'phpnut: Larry E. Masters'
             ]
         ];
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
This should solve issue #13681 

It's my first contribution though, so i don't know if it's a perfect one.