### PR TITLE
Remove return type on Command::execute()

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -219,9 +219,9 @@ abstract class BaseCommand implements CommandInterface
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int|null|void The exit code or null for success
      */
-    abstract public function execute(Arguments $args, ConsoleIo $io): ?int;
+    abstract public function execute(Arguments $args, ConsoleIo $io);
 
     /**
      * Halt the the current process with a StopException.

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -55,10 +55,9 @@ class Command extends BaseCommand
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int|null|void The exit code or null for success
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
-        return null;
     }
 }


### PR DESCRIPTION
While sometimes useful these typehints cause toil as commands cannot have implicit termination meaning success. By not having this type hint commands don't require an explicit return.

Refs #13603
