### PR TITLE
Fix route name generation when using braced placeholders.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -369,7 +369,10 @@ class Route
         ];
         foreach ($keys as $key => $glue) {
             $value = null;
-            if (strpos($this->template, ':' . $key) !== false) {
+            if (
+                strpos($this->template, ':' . $key) !== false
+                || strpos($this->template, '{' . $key . '}') !== false
+            ) {
                 $value = '_' . $key;
             } elseif (isset($this->defaults[$key])) {
                 $value = $this->defaults[$key];

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -970,8 +970,8 @@ class RouteBuilder
     public function fallbacks(?string $routeClass = null)
     {
         $routeClass = $routeClass ?: $this->_routeClass;
-        $this->connect('/:controller', ['action' => 'index'], compact('routeClass'));
-        $this->connect('/:controller/:action/*', [], compact('routeClass'));
+        $this->connect('/{controller}', ['action' => 'index'], compact('routeClass'));
+        $this->connect('/{controller}/{action}/*', [], compact('routeClass'));
 
         return $this;
     }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1520,6 +1520,9 @@ class RouteTest extends TestCase
         $route = new Route('/:controller/:action');
         $this->assertSame('_controller:_action', $route->getName());
 
+        $route = new Route('/{controller}/{action}');
+        $this->assertSame('_controller:_action', $route->getName());
+
         $route = new Route('/articles/:action', ['controller' => 'posts']);
         $this->assertSame('posts:_action', $route->getName());
 

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -869,8 +869,8 @@ class RouteBuilderTest extends TestCase
         $routes->fallbacks();
 
         $all = $this->collection->routes();
-        $this->assertSame('/api/:controller', $all[0]->template);
-        $this->assertSame('/api/:controller/:action/*', $all[1]->template);
+        $this->assertSame('/api/{controller}', $all[0]->template);
+        $this->assertSame('/api/{controller}/{action}/*', $all[1]->template);
         $this->assertInstanceOf(Route::class, $all[0]);
     }
 
@@ -885,8 +885,8 @@ class RouteBuilderTest extends TestCase
         $routes->fallbacks('InflectedRoute');
 
         $all = $this->collection->routes();
-        $this->assertSame('/api/:controller', $all[0]->template);
-        $this->assertSame('/api/:controller/:action/*', $all[1]->template);
+        $this->assertSame('/api/{controller}', $all[0]->template);
+        $this->assertSame('/api/{controller}/{action}/*', $all[1]->template);
         $this->assertInstanceOf(InflectedRoute::class, $all[0]);
     }
 

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -593,7 +593,7 @@ class RouteCollectionTest extends TestCase
         ];
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/:action/*', ['controller' => 'Users']);
-        $routes->connect('/admin/:controller', ['prefix' => 'admin', 'action' => 'index']);
+        $routes->connect('/admin/{controller}', ['prefix' => 'admin', 'action' => 'index']);
 
         $url = [
             'plugin' => null,

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1349,7 +1349,7 @@ class RouterTest extends TestCase
             'pass' => ['home'],
             'controller' => 'Pages',
             'action' => 'display',
-            '_matchedRoute' => '/:controller/:action/*',
+            '_matchedRoute' => '/{controller}/{action}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1750,7 +1750,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             '_ext' => 'rss',
             'pass' => [],
-            '_matchedRoute' => '/:controller',
+            '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1761,7 +1761,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'pass' => ['1'],
             '_ext' => 'rss',
-            '_matchedRoute' => '/:controller/:action/*',
+            '_matchedRoute' => '/{controller}/{action}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1780,7 +1780,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             '_ext' => 'xml',
             'pass' => [],
-            '_matchedRoute' => '/:controller',
+            '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1791,7 +1791,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '?' => ['hello' => 'goodbye'],
-            '_matchedRoute' => '/:controller',
+            '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -124,6 +124,7 @@ class HtmlHelperTest extends TestCase
      */
     public function testLink()
     {
+        Router::reload();
         Router::connect('/:controller/:action/*');
 
         $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', ''));


### PR DESCRIPTION
Earlier reverse routing failed when using placeholder like {controller} or {action}
in URL template since automatic route names are generated based on such special keys
and are used by RouteCollection for matching.

This probably need to be backported to 3.x too. I made the patch for 4.x as that's what I was working on when I discovered the bug and was unsure if it affected 3.x too.