### PR TITLE
Promote cleaner names of QueryExpression::and()/or() without _

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -839,8 +839,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      * $query
      *   ->where(['title !=' => 'Hello World'])
      *   ->where(function ($exp, $query) {
-     *     $or = $exp->or_(['id' => 1]);
-     *     $and = $exp->and_(['id >' => 2, 'id <' => 10]);
+     *     $or = $exp->or(['id' => 1]);
+     *     $and = $exp->and(['id >' => 2, 'id <' => 10]);
      *    return $or->add($and);
      *   });
      * ```
@@ -1025,7 +1025,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *   ->where(['title' => 'Foo'])
      *   ->andWhere(function ($exp, $query) {
      *     return $exp
-     *       ->or_(['author_id' => 1])
+     *       ->or(['author_id' => 1])
      *       ->add(['author_id' => 2]);
      *   });
      * ```
@@ -1088,7 +1088,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *   ->where(['title' => 'Foo'])
      *   ->orWhere(function ($exp, $query) {
      *     return $exp
-     *       ->or_(['author_id' => 1])
+     *       ->or(['author_id' => 1])
      *       ->add(['author_id' => 2]);
      *   });
      * ```

--- a/src/Database/README.md
+++ b/src/Database/README.md
@@ -270,7 +270,7 @@ Combining expressions is also possible:
 
 ```php
 $query->where(function ($exp) {
-        $orConditions = $exp->or_(['author_id' => 2])
+        $orConditions = $exp->or(['author_id' => 2])
             ->eq('author_id', 5);
         return $exp
             ->not($orConditions)

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -346,8 +346,8 @@ interface QueryInterface
      *  $query
      *  ->where(['title !=' => 'Hello World'])
      *  ->where(function ($exp, $query) {
-     *      $or = $exp->or_(['id' => 1]);
-     *      $and = $exp->and_(['id >' => 2, 'id <' => 10]);
+     *      $or = $exp->or(['id' => 1]);
+     *      $and = $exp->and(['id >' => 2, 'id <' => 10]);
      *  return $or->add($and);
      *  });
      * ```

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -17,6 +17,7 @@ namespace Cake\ORM\Association;
 use Cake\Core\App;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\QueryInterface;
 use Cake\ORM\Association;
@@ -518,7 +519,7 @@ class BelongsToMany extends Association
         $subquery = $this->_appendJunctionJoin($subquery, $conditions);
 
         $query
-            ->andWhere(function ($exp) use ($subquery, $conds) {
+            ->andWhere(function (QueryExpression $exp) use ($subquery, $conds) {
                 $identifiers = [];
                 foreach (array_keys($conds) as $field) {
                     $identifiers[] = new IdentifierExpression($field);
@@ -527,7 +528,7 @@ class BelongsToMany extends Association
                 $nullExp = clone $exp;
 
                 return $exp
-                    ->or_([
+                    ->or([
                         $exp->notIn($identifiers, $subquery),
                         $nullExp->and(array_map([$nullExp, 'isNull'], array_keys($conds))),
                     ]);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -418,7 +418,7 @@ class Marshaller
             $query = $target->find();
             $query->andWhere(function ($exp) use ($conditions) {
                 /** @var \Cake\Database\Expression\QueryExpression $exp */
-                return $exp->or_($conditions);
+                return $exp->or($conditions);
             });
 
             $keyFields = array_keys($primaryKey);

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -234,8 +234,8 @@ class QueryExpressionTest extends TestCase
     public function testEmptyOr()
     {
         $expr = new QueryExpression();
-        $expr = $expr->or_([]);
-        $expr = $expr->or_([]);
+        $expr = $expr->or([]);
+        $expr = $expr->or([]);
         $this->assertCount(0, $expr);
 
         $expr = new QueryExpression(['OR' => []]);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1664,7 +1664,7 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $and = $exp->and_(['id' => 2, 'id >' => 1]);
+                $and = $exp->and(['id' => 2, 'id >' => 1]);
 
                 return $exp->add($and);
             })
@@ -1678,7 +1678,7 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $and = $exp->and_(['id' => 2, 'id <' => 2]);
+                $and = $exp->and(['id' => 2, 'id <' => 2]);
 
                 return $exp->add($and);
             })
@@ -1691,7 +1691,7 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $and = $exp->and_(function ($and) {
+                $and = $exp->and(function ($and) {
                     return $and->eq('id', 1)->gt('id', 0);
                 });
 
@@ -1707,8 +1707,8 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $or = $exp->or_(['id' => 1]);
-                $and = $exp->and_(['id >' => 2, 'id <' => 4]);
+                $or = $exp->or(['id' => 1]);
+                $and = $exp->and(['id >' => 2, 'id <' => 4]);
 
                 return $or->add($and);
             })
@@ -1723,7 +1723,7 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $or = $exp->or_(function ($or) {
+                $or = $exp->or(function ($or) {
                     return $or->eq('id', 1)->eq('id', 2);
                 });
 
@@ -1751,7 +1751,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(function ($exp) {
                 return $exp->not(
-                    $exp->and_(['id' => 2, 'created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
                 );
             })
             ->execute();
@@ -1766,7 +1766,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(function ($exp) {
                 return $exp->not(
-                    $exp->and_(['id' => 2, 'created' => new \DateTime('2012-12-21 12:00')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new \DateTime('2012-12-21 12:00')], ['created' => 'datetime'])
                 );
             })
             ->execute();


### PR DESCRIPTION
Ref https://github.com/cakephp/cakephp/pull/13783, https://github.com/cakephp/docs/pull/6258

I'm not sure if to mark `and_()`/`or_()` with `@deprecated 3.9.0` as methods are still called via `__call`.
 Depending on this, the target branch should be `master` or `3.next`. In 4.x methods are now marked `@deprecated 4.0.0 Use and() instead.`.