### PR TITLE
Encode Content-Disposition header fields

### DIFF
--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -13,6 +13,9 @@
  */
 namespace Cake\Http\Client;
 
+use Cake\Utility\Inflector;
+use Cake\Utility\Text;
+
 /**
  * Contains the data and behavior for a single
  * part in a Multipart FormData request body.
@@ -74,17 +77,26 @@ class FormDataPart
     protected $_contentId;
 
     /**
+     * The charset attribute for the Content-Disposition header fields
+     *
+     * @var string|null
+     */
+    protected $_charset;
+
+    /**
      * Constructor
      *
      * @param string $name The name of the data.
      * @param string $value The value of the data.
      * @param string $disposition The type of disposition to use, defaults to form-data.
+     * @param string|null $charset The charset of the data.
      */
-    public function __construct($name, $value, $disposition = 'form-data')
+    public function __construct($name, $value, $disposition = 'form-data', $charset = null)
     {
         $this->_name = $name;
         $this->_value = $value;
         $this->_disposition = $disposition;
+        $this->_charset = $charset;
     }
 
     /**
@@ -198,10 +210,10 @@ class FormDataPart
         if ($this->_disposition) {
             $out .= 'Content-Disposition: ' . $this->_disposition;
             if ($this->_name) {
-                $out .= '; name="' . $this->_name . '"';
+                $out .= '; ' . $this->_headerParameterToString('name', $this->_name);
             }
             if ($this->_filename) {
-                $out .= '; filename="' . $this->_filename . '"';
+                $out .= '; ' . $this->_headerParameterToString('filename', $this->_filename);
             }
             $out .= "\r\n";
         }
@@ -218,6 +230,27 @@ class FormDataPart
         $out .= (string)$this->_value;
 
         return $out;
+    }
+
+    /**
+     * Get the string for the header parameter.
+     *
+     * If the value contains non-ASCII letters an additional header indicating
+     * the charset encoding will be set.
+     *
+     * @param string $name The name of the header parameter
+     * @param string $value The value of the header parameter
+     * @return string
+     */
+    protected function _headerParameterToString($name, $value)
+    {
+        $transliterated = Text::transliterate(str_replace('"', '', $value));
+        $return = sprintf('%s="%s"', $name, $transliterated);
+        if ($this->_charset !== null && $value !== $transliterated) {
+            $return .= sprintf("; %s*=%s''%s", $name, strtolower($this->_charset), rawurlencode($value));
+        }
+
+        return $return;
     }
 }
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2521,7 +2521,7 @@ class Email implements JsonSerializable, Serializable
                 !isset($fileInfo['contentDisposition']) ||
                 $fileInfo['contentDisposition']
             );
-            $part = new FormDataPart(false, $data, false);
+            $part = new FormDataPart('', $data, '', $this->getHeaderCharset());
 
             if ($hasDisposition) {
                 $part->disposition('attachment');
@@ -2571,7 +2571,7 @@ class Email implements JsonSerializable, Serializable
             $data = isset($fileInfo['data']) ? $fileInfo['data'] : $this->_readFile($fileInfo['file']);
 
             $msg[] = '--' . $boundary;
-            $part = new FormDataPart(false, $data, 'inline');
+            $part = new FormDataPart('', $data, 'inline', $this->getHeaderCharset());
             $part->type($fileInfo['mimetype']);
             $part->transferEncoding('base64');
             $part->contentId($fileInfo['contentId']);


### PR DESCRIPTION
Set character encoding for Content-Disposition header parameters in line with RFC 2231 for email and RFC 8187 for HTTP.

This PR fixes #13854

I have not adapted any test cases yet, because I wanted to wait for feedback on my changes first.
