### PR TITLE
4.x - MySQL + PostgreSQL - Mapped DATETIME(N) and TIMESTAMP(N)

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -404,8 +404,8 @@ class MysqlSchema extends BaseSchema
             $out .= '(' . $data['length'] . ')';
         }
 
-        $hasLengthAndPrecision = [TableSchema::TYPE_FLOAT, TableSchema::TYPE_DECIMAL];
-        if (in_array($data['type'], $hasLengthAndPrecision, true) && isset($data['length'])) {
+        $lengthAndPrecisionTypes = [TableSchema::TYPE_FLOAT, TableSchema::TYPE_DECIMAL];
+        if (in_array($data['type'], $lengthAndPrecisionTypes, true) && isset($data['length'])) {
             if (isset($data['precision'])) {
                 $out .= '(' . (int)$data['length'] . ',' . (int)$data['precision'] . ')';
             } else {
@@ -413,8 +413,8 @@ class MysqlSchema extends BaseSchema
             }
         }
 
-        $hasPrecision = [TableSchema::TYPE_DATETIME_FRACTIONAL, TableSchema::TYPE_TIMESTAMP_FRACTIONAL];
-        if (in_array($data['type'], $hasPrecision, true) && isset($data['precision'])) {
+        $precisionTypes = [TableSchema::TYPE_DATETIME_FRACTIONAL, TableSchema::TYPE_TIMESTAMP_FRACTIONAL];
+        if (in_array($data['type'], $precisionTypes, true) && isset($data['precision'])) {
             $out .= '(' . (int)$data['precision'] . ')';
         }
 
@@ -462,7 +462,7 @@ class MysqlSchema extends BaseSchema
         }
 
         $timestampTypes = [TableSchema::TYPE_TIMESTAMP, TableSchema::TYPE_TIMESTAMP_FRACTIONAL];
-        if (isset($data['null']) && $data['null'] === true && in_array($data['type'], $timestampTypes)) {
+        if (isset($data['null']) && $data['null'] === true && in_array($data['type'], $timestampTypes, true)) {
             $out .= ' NULL';
             unset($data['default']);
         }

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -381,6 +381,7 @@ class PostgresSchema extends BaseSchema
             TableSchema::TYPE_DATE => ' DATE',
             TableSchema::TYPE_TIME => ' TIME',
             TableSchema::TYPE_DATETIME => ' TIMESTAMP',
+            TableSchema::TYPE_DATATIME_FRACTIONAL => ' TIMESTAMP',
             TableSchema::TYPE_TIMESTAMP => ' TIMESTAMP',
             TableSchema::TYPE_TIMESTAMP_FRACTIONAL => ' TIMESTAMP',
             TableSchema::TYPE_UUID => ' UUID',
@@ -432,6 +433,8 @@ class PostgresSchema extends BaseSchema
 
         $hasPrecision = [
             TableSchema::TYPE_FLOAT,
+            TableSchema::TYPE_DATETIME,
+            TableSchema::TYPE_DATETIME_FRACTIONAL,
             TableSchema::TYPE_TIMESTAMP,
             TableSchema::TYPE_TIMESTAMP_FRACTIONAL,
         ];
@@ -453,9 +456,15 @@ class PostgresSchema extends BaseSchema
             $out .= ' NOT NULL';
         }
 
+        $datetimeTypes = [
+            TableSchema::TYPE_DATETIME,
+            TableSchema::TYPE_DATETIME_FRACTIONAL,
+            TableSchema::TYPE_TIMESTAMP,
+            TableSchema::TYPE_TIMESTAMP_FRACTIONAL,
+        ];
         if (
             isset($data['default']) &&
-            in_array($data['type'], [TableSchema::TYPE_TIMESTAMP, TableSchema::TYPE_DATETIME]) &&
+            in_array($data['type'], $datetimeTypes) &&
             strtolower($data['default']) === 'current_timestamp'
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -381,7 +381,7 @@ class PostgresSchema extends BaseSchema
             TableSchema::TYPE_DATE => ' DATE',
             TableSchema::TYPE_TIME => ' TIME',
             TableSchema::TYPE_DATETIME => ' TIMESTAMP',
-            TableSchema::TYPE_DATATIME_FRACTIONAL => ' TIMESTAMP',
+            TableSchema::TYPE_DATETIME_FRACTIONAL => ' TIMESTAMP',
             TableSchema::TYPE_TIMESTAMP => ' TIMESTAMP',
             TableSchema::TYPE_TIMESTAMP_FRACTIONAL => ' TIMESTAMP',
             TableSchema::TYPE_UUID => ' UUID',

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -52,6 +52,13 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_DATETIME = 'datetime';
 
     /**
+     * Datetime with fractional seconds column type
+     *
+     * @var string
+     */
+    public const TYPE_DATETIME_FRACTIONAL = 'datetimefractional';
+
+    /**
      * Time column type
      *
      * @var string
@@ -64,6 +71,13 @@ interface TableSchemaInterface extends SchemaInterface
      * @var string
      */
     public const TYPE_TIMESTAMP = 'timestamp';
+
+    /**
+     * Timestamp with fractional seconds column type
+     *
+     * @var string
+     */
+    public const TYPE_TIMESTAMP_FRACTIONAL = 'timestampfractional';
 
     /**
      * JSON column type

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -40,6 +40,7 @@ class TypeFactory
         'boolean' => Type\BoolType::class,
         'date' => Type\DateType::class,
         'datetime' => Type\DateTimeType::class,
+        'datetimefractional' => Type\DateTimeFractionalType::class,
         'decimal' => Type\DecimalType::class,
         'float' => Type\FloatType::class,
         'json' => Type\JsonType::class,
@@ -48,6 +49,7 @@ class TypeFactory
         'text' => Type\StringType::class,
         'time' => Type\TimeType::class,
         'timestamp' => Type\DateTimeType::class,
+        'timestampfractional' => Type\DateTimeFractionalType::class,
         'uuid' => Type\UuidType::class,
     ];
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1349,6 +1349,10 @@ class FormHelper extends Helper
             $options += ['empty' => false];
         }
 
+        if ($options['type'] === 'datetime') {
+            $options += ['fieldName' => $fieldName];
+        }
+
         return $options;
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -69,7 +69,9 @@ class FormHelper extends Helper
             'text' => 'textarea',
             'uuid' => 'string',
             'datetime' => 'datetime',
+            'datetimefractional' => 'datetime',
             'timestamp' => 'datetime',
+            'timestampfractional' => 'datetime',
             'date' => 'date',
             'time' => 'time',
             'year' => 'year',
@@ -2195,6 +2197,7 @@ class FormHelper extends Helper
         ];
         $options = $this->_initInputField($fieldName, $options);
         $options['type'] = 'datetime-local';
+        $options['fieldName'] = $fieldName;
 
         return $this->widget('datetime', $options);
     }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -108,7 +108,7 @@ class DateTimeWidget implements WidgetInterface
             'templateVars' => [],
         ];
 
-        if (!isset($this->formatMap($data['type']))) {
+        if (!isset($this->formatMap[$data['type']])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid type "%s" for input tag',
                 $data['type']

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -109,7 +109,7 @@ class DateTimeWidget implements WidgetInterface
 
         if (!isset($this->formatMap[$data['type']])) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid type "%s" for input tag',
+                'Invalid type `%s` for input tag, expected datetime-local, date, time, month or week',
                 $data['type']
             ));
         }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -58,8 +58,7 @@ class DateTimeWidget implements WidgetInterface
      *
      * If not set, defaults to browser default.
      *
-     * @var string[]
-     * @psalm-var array{string|null}
+     * @var array
      */
     protected $defaultStep = [
         'datetime-local' => '1',

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -53,6 +53,14 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'datetime', 'length' => null],
             ],
             [
+                'DATETIME(0)',
+                ['type' => 'datetime', 'length' => null],
+            ],
+            [
+                'DATETIME(6)',
+                ['type' => 'datetimefractional', 'length' => null, 'precision' => 6],
+            ],
+            [
                 'DATE',
                 ['type' => 'date', 'length' => null],
             ],
@@ -63,6 +71,14 @@ class MysqlSchemaTest extends TestCase
             [
                 'TIMESTAMP',
                 ['type' => 'timestamp', 'length' => null],
+            ],
+            [
+                'TIMESTAMP(0)',
+                ['type' => 'timestamp', 'length' => null],
+            ],
+            [
+                'TIMESTAMP(6)',
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
             ],
             [
                 'TINYINT(1)',
@@ -268,6 +284,7 @@ SQL;
                 published BOOLEAN DEFAULT 0,
                 allow_comments TINYINT(1) DEFAULT 0,
                 created DATETIME,
+                created_with_precision DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
                 KEY `author_idx` (`author_id`),
                 UNIQUE KEY `length_idx` (`title`(4)),
                 FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT
@@ -378,6 +395,14 @@ SQL;
                 'default' => null,
                 'length' => null,
                 'precision' => null,
+                'comment' => null,
+            ],
+            'created_with_precision' => [
+                'type' => 'datetimefractional',
+                'null' => true,
+                'default' => 'CURRENT_TIMESTAMP(3)',
+                'length' => null,
+                'precision' => 3,
                 'comment' => null,
             ],
         ];
@@ -739,6 +764,11 @@ SQL;
                 ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 '`open_date` DATETIME NOT NULL DEFAULT \'2016-12-07 23:04:00\'',
             ],
+            [
+                'created_with_precision',
+                ['type' => 'datetimefractional', 'precision' => 3, 'null' => false, 'default' => 'current_timestamp'],
+                '`created_with_precision` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)',
+            ],
             // Date & Time
             [
                 'start_date',
@@ -770,6 +800,11 @@ SQL;
                 'open_date',
                 ['type' => 'timestamp', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 '`open_date` TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\'',
+            ],
+            [
+                'created_with_precision',
+                ['type' => 'timestampfractional', 'precision' => 3, 'null' => false, 'default' => 'current_timestamp'],
+                '`created_with_precision` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -938,7 +938,7 @@ SQL;
             [
                 'current_timestamp_fractional',
                 ['type' => 'timestampfractional', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
-                '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+                '"current_timestamp_fractional" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -878,6 +878,27 @@ SQL;
                 ['type' => 'time'],
                 '"start_time" TIME',
             ],
+            // Datetime
+            [
+                'created',
+                ['type' => 'datetime', 'null' => true],
+                '"created" TIMESTAMP DEFAULT NULL',
+            ],
+            [
+                'created_without_precision',
+                ['type' => 'datetime', 'precision' => 0],
+                '"created_without_precision" TIMESTAMP(0)',
+            ],
+            [
+                'created_without_precision',
+                ['type' => 'datetimefractional', 'precision' => 0],
+                '"created_without_precision" TIMESTAMP(0)',
+            ],
+            [
+                'created_with_precision',
+                ['type' => 'datetimefractional', 'precision' => 3],
+                '"created_with_precision" TIMESTAMP(3)',
+            ],
             // Timestamp
             [
                 'created',
@@ -912,6 +933,11 @@ SQL;
             [
                 'current_timestamp',
                 ['type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
+                '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
+            [
+                'current_timestamp_fractional',
+                ['type' => 'timestampfractional', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
                 '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
             ],
         ];

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -79,6 +79,8 @@ data JSONB,
 average_note DECIMAL(4,2),
 average_income NUMERIC(10,2),
 created TIMESTAMP,
+created_without_precision TIMESTAMP(0),
+created_with_precision TIMESTAMP(3),
 CONSTRAINT "content_idx" UNIQUE ("title", "body"),
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
 )
@@ -98,12 +100,16 @@ SQL;
         return [
             // Timestamp
             [
-                ['type' => 'TIMESTAMP'],
-                ['type' => 'timestamp', 'length' => null],
+                ['type' => 'TIMESTAMP', 'datetime_precision' => 6],
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
             ],
             [
-                ['type' => 'TIMESTAMP WITHOUT TIME ZONE'],
-                ['type' => 'timestamp', 'length' => null],
+                ['type' => 'TIMESTAMP', 'datetime_precision' => 0],
+                ['type' => 'timestamp', 'length' => null, 'precision' => 0],
+            ],
+            [
+                ['type' => 'TIMESTAMP WITHOUT TIME ZONE', 'datetime_precision' => 6],
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
             ],
             // Date & time
             [
@@ -401,11 +407,27 @@ SQL;
                 'comment' => null,
             ],
             'created' => [
+                'type' => 'timestampfractional',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => 6,
+                'comment' => null,
+            ],
+            'created_without_precision' => [
                 'type' => 'timestamp',
                 'null' => true,
                 'default' => null,
                 'length' => null,
-                'precision' => null,
+                'precision' => 0,
+                'comment' => null,
+            ],
+            'created_with_precision' => [
+                'type' => 'timestampfractional',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => 3,
                 'comment' => null,
             ],
         ];
@@ -493,11 +515,11 @@ SQL;
                 'autoIncrement' => null,
             ],
             'created' => [
-                'type' => 'timestamp',
+                'type' => 'timestampfractional',
                 'null' => true,
                 'default' => null,
                 'length' => null,
-                'precision' => null,
+                'precision' => 6,
                 'comment' => null,
             ],
         ];
@@ -845,27 +867,6 @@ SQL;
                 ['type' => 'boolean', 'default' => 1, 'null' => false],
                 '"checked" BOOLEAN NOT NULL DEFAULT TRUE',
             ],
-            // Datetime
-            [
-                'created',
-                ['type' => 'datetime'],
-                '"created" TIMESTAMP',
-            ],
-            [
-                'open_date',
-                ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
-                '"open_date" TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\'',
-            ],
-            [
-                'null_date',
-                ['type' => 'datetime', 'null' => true],
-                '"null_date" TIMESTAMP DEFAULT NULL',
-            ],
-            [
-                'current_timestamp',
-                ['type' => 'datetime', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
-                '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
-            ],
             // Date & Time
             [
                 'start_date',
@@ -882,6 +883,36 @@ SQL;
                 'created',
                 ['type' => 'timestamp', 'null' => true],
                 '"created" TIMESTAMP DEFAULT NULL',
+            ],
+            [
+                'created_without_precision',
+                ['type' => 'timestamp', 'precision' => 0],
+                '"created_without_precision" TIMESTAMP(0)',
+            ],
+            [
+                'created_without_precision',
+                ['type' => 'timestampfractional', 'precision' => 0],
+                '"created_without_precision" TIMESTAMP(0)',
+            ],
+            [
+                'created_with_precision',
+                ['type' => 'timestampfractional', 'precision' => 3],
+                '"created_with_precision" TIMESTAMP(3)',
+            ],
+            [
+                'open_date',
+                ['type' => 'timestampfractional', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '"open_date" TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\'',
+            ],
+            [
+                'null_date',
+                ['type' => 'timestampfractional', 'null' => true],
+                '"null_date" TIMESTAMP DEFAULT NULL',
+            ],
+            [
+                'current_timestamp',
+                ['type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
+                '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
             ],
         ];
     }
@@ -1129,7 +1160,9 @@ SQL;
                 'collate' => 'C',
                 'null' => false,
             ])
-            ->addColumn('created', 'datetime')
+            ->addColumn('created', 'timestamp')
+            ->addColumn('created_without_precision', ['type' => 'timestamp', 'precision' => 0])
+            ->addColumn('created_with_precision', ['type' => 'timestampfractional', 'precision' => 6])
             ->addConstraint('primary', [
                 'type' => 'primary',
                 'columns' => ['id'],
@@ -1147,6 +1180,8 @@ CREATE TABLE "schema_articles" (
 "data" JSONB,
 "hash" CHAR(40) COLLATE "C" NOT NULL,
 "created" TIMESTAMP,
+"created_without_precision" TIMESTAMP(0),
+"created_with_precision" TIMESTAMP(6),
 PRIMARY KEY ("id")
 )
 SQL;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -99,6 +99,28 @@ class TableTest extends TestCase
             'Users__updated' => 'timestamp',
             'updated' => 'timestamp',
         ]);
+
+        $config = $this->connection->config();
+        if (strpos($config['driver'], 'Postgres') !== false) {
+            $this->usersTypeMap = new TypeMap([
+                'Users.id' => 'integer',
+                'id' => 'integer',
+                'Users__id' => 'integer',
+                'Users.username' => 'string',
+                'Users__username' => 'string',
+                'username' => 'string',
+                'Users.password' => 'string',
+                'Users__password' => 'string',
+                'password' => 'string',
+                'Users.created' => 'timestampfractional',
+                'Users__created' => 'timestampfractional',
+                'created' => 'timestampfractional',
+                'Users.updated' => 'timestampfractional',
+                'Users__updated' => 'timestampfractional',
+                'updated' => 'timestampfractional',
+            ]);
+        }
+
         $this->articlesTypeMap = new TypeMap([
             'Articles.id' => 'integer',
             'Articles__id' => 'integer',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7402,6 +7402,7 @@ class FormHelperTest extends TestCase
             'val' => new FrozenTime('2019-09-27 02:52:43'),
         ]);
         $expected = [
+            'div' => ['class' => 'input datetime'],
             'label' => ['for' => 'created'],
             'Created',
             '/label',
@@ -7411,6 +7412,7 @@ class FormHelperTest extends TestCase
                 'value' => '2019-09-27T02:52:43.000',
                 'step' => '0.001',
             ],
+            '/div',
         ];
 
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7398,6 +7398,35 @@ class FormHelperTest extends TestCase
                 'created' => ['type' => 'datetimefractional'],
             ],
         ]);
+        $result = $this->Form->datetime('created', [
+            'val' => new FrozenTime('2019-09-27 02:52:43'),
+        ]);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => 'created',
+                'value' => '2019-09-27T02:52:43.000',
+                'step' => '0.001',
+            ],
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testControlWithFractional method
+     *
+     * Test that control() works with datetimefractional.
+     *
+     * @return void
+     */
+    public function testControlWithFractional()
+    {
+        $this->Form->create([
+            'schema' => [
+                'created' => ['type' => 'datetimefractional'],
+            ],
+        ]);
         $result = $this->Form->control('created', [
             'val' => new FrozenTime('2019-09-27 02:52:43'),
         ]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7402,7 +7402,7 @@ class FormHelperTest extends TestCase
             'val' => new FrozenTime('2019-09-27 02:52:43.123'),
         ]);
         $expected = [
-            'input' => [\
+            'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',
                 'value' => '2019-09-27T02:52:43.123',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7399,13 +7399,13 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $result = $this->Form->datetime('created', [
-            'val' => new FrozenTime('2019-09-27 02:52:43'),
+            'val' => new FrozenTime('2019-09-27 02:52:43.123'),
         ]);
         $expected = [
-            'input' => [
+            'input' => [\
                 'type' => 'datetime-local',
                 'name' => 'created',
-                'value' => '2019-09-27T02:52:43.000',
+                'value' => '2019-09-27T02:52:43.123',
                 'step' => '0.001',
             ],
         ];
@@ -7428,7 +7428,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $result = $this->Form->control('created', [
-            'val' => new FrozenTime('2019-09-27 02:52:43'),
+            'val' => new FrozenTime('2019-09-27 02:52:43.123'),
         ]);
         $expected = [
             'div' => ['class' => 'input datetime'],
@@ -7438,7 +7438,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',
-                'value' => '2019-09-27T02:52:43.000',
+                'value' => '2019-09-27T02:52:43.123',
                 'step' => '0.001',
             ],
             '/div',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7398,10 +7398,13 @@ class FormHelperTest extends TestCase
                 'created' => ['type' => 'datetimefractional'],
             ],
         ]);
-        $result = $this->Form->datetime('created', [
+        $result = $this->Form->control('created', [
             'val' => new FrozenTime('2019-09-27 02:52:43'),
         ]);
         $expected = [
+            'label' => ['for' => 'created'],
+            'Created',
+            '/label',
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7438,6 +7438,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',
+                'id' => 'created',
                 'value' => '2019-09-27T02:52:43.000',
                 'step' => '0.001',
             ],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3437,7 +3437,7 @@ class FormHelperTest extends TestCase
                 'name' => 'prueba',
                 'id' => 'prueba',
                 'type' => 'datetime-local',
-                'value' => '2019-09-27T02:52:43',
+                'value' => '2019-09-27T02:52:43.000',
                 'step' => '1',
             ],
             '/div',
@@ -3470,6 +3470,37 @@ class FormHelperTest extends TestCase
                 'type' => 'datetime-local',
                 'value' => '',
                 'step' => '1',
+            ],
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testControlDatetimeStep method
+     *
+     * Test form->control() with datetime with custom step size.
+     *
+     * @return void
+     */
+    public function testControlDatetimeStep()
+    {
+        $result = $this->Form->control('prueba', [
+            'type' => 'datetime',
+            'value' => new FrozenTime('2019-09-27 02:52:43'),
+            'step' => '0.5',
+        ]);
+        $expected = [
+            'div' => ['class' => 'input datetime'],
+            'label' => ['for' => 'prueba'],
+            'Prueba',
+            '/label',
+            'input' => [
+                'name' => 'prueba',
+                'id' => 'prueba',
+                'type' => 'datetime-local',
+                'value' => '2019-09-27T02:52:43.000',
+                'step' => '0.5',
             ],
             '/div',
         ];
@@ -6034,7 +6065,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'date',
-                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}/',
+                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}\.\d{3}/',
                 'step' => '1',
             ],
         ];
@@ -6108,7 +6139,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'updated',
-                'value' => '2009-06-01T11:15:30',
+                'value' => '2009-06-01T11:15:30.000',
                 'step' => '1',
             ],
         ];
@@ -6121,7 +6152,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'updated',
-                'value' => '2009-06-01T11:15:30',
+                'value' => '2009-06-01T11:15:30.000',
                 'step' => '1',
             ],
         ];
@@ -7345,8 +7376,37 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',
-                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}/',
+                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}\.\d{3}/',
                 'step' => '1',
+            ],
+        ];
+
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * testDateTimeWithFractional method
+     *
+     * Test that datetime() works with datetimefractional.
+     *
+     * @return void
+     */
+    public function testDateTimeWithFractional()
+    {
+        $this->Form->create([
+            'schema' => [
+                'created' => ['type' => 'datetimefractional'],
+            ],
+        ]);
+        $result = $this->Form->datetime('created', [
+            'val' => new FrozenTime('2019-09-27 02:52:43'),
+        ]);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => 'created',
+                'value' => '2019-09-27T02:52:43.000',
+                'step' => '0.001',
             ],
         ];
 

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -104,7 +104,7 @@ class DateTimeWidgetTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => '',
-                'value' => '2014-01-20T12:30:45',
+                'value' => '2014-01-20T12:30:45.000',
                 'step' => '1',
             ],
         ];
@@ -126,7 +126,7 @@ class DateTimeWidgetTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => '',
-                'value' => '2019-02-03T15:30:00',
+                'value' => '2019-02-03T15:30:00.000',
                 'step' => '1',
             ],
         ];

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -160,7 +160,7 @@ class DateTimeWidgetTest extends TestCase
     public function testRenderInvalidTypeException()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid type "foo" for input tag');
+        $this->expectExceptionMessage('Invalid type `foo` for input tag, expected datetime-local, date, time, month or week');
         $result = $this->DateTime->render(['type' => 'foo', 'val' => new \DateTime()], $this->context);
     }
 


### PR DESCRIPTION
This adds proper type mapping for the datetime types with precision now that we have a type that supports them.

**mysql**
``DATETIME`` => ``TYPE_DATETIME``
``DATETIME(0)`` => ``TYPE_DATETIME``
``DATETIME(1-6)`` => ``TYPE_DATETIME_FRACTIONAL``
``TIMESTAMP`` => ``TYPE_TIMESTAMP``
``TIMESTAMP(0)`` => ``TYPE_TIMESTAMP``
``TIMESTAMP(1-6)`` => ``TYPE_TIMESTAMP_FRACTIONAL``

**postgresql**
``TIMESTAMP`` => ``TYPE_TIMESTAMP_FRACTIONAL``
``TIMESTAMP(0)`` => ``TYPE_TIMESTAMP``
``TIMESTAMP(1-6)`` => ``TYPE_TIMESTAMP_FRACTIONAL``

In postgres, ``TIMESTAMP`` without specifying the precision is the same as ``TIMESTAMP(6)``.  This changes the default type to support that as users don't spell out ``TIMESTAMP(6)`` with posgresql.
