### PR TITLE
Fix missing charset fallback

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -832,7 +832,7 @@ class Email implements JsonSerializable, Serializable
      */
     public function getHeaderCharset()
     {
-        return $this->headerCharset;
+        return $this->headerCharset ? $this->headerCharset : $this->charset;
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2624,6 +2624,20 @@ class EmailTest extends TestCase
     }
 
     /**
+     * Tests headerCharset on reset
+     *
+     * @return void
+     */
+    public function testHeaderCharsetReset()
+    {
+        $email = new Email(['headerCharset' => 'ISO-2022-JP']);
+        $email->reset();
+
+        $this->assertSame('utf-8', $email->getCharset());
+        $this->assertSame('utf-8', $email->getHeaderCharset());
+    }
+
+    /**
      * Test transferEncoding
      *
      * @return void


### PR DESCRIPTION
The header charset should fallback to the email charset if the header charset is undefined.

Fixes #13863