### PR TITLE
Convert prefix names to be CamelCased

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -103,16 +103,27 @@ class ControllerFactory implements ControllerFactoryInterface
         if ($request->getParam('prefix')) {
             $prefix = $request->getParam('prefix');
 
-            if (strpos($prefix, '/') === false) {
-                $namespace .= '/' . Inflector::camelize($prefix);
-            } else {
-                $prefixes = array_map(
-                    function ($val) {
-                        return Inflector::camelize($val);
-                    },
-                    explode('/', $prefix)
+            $firstChar = substr($prefix, 0, 1);
+            if ($firstChar !== strtoupper($firstChar)) {
+                deprecationWarning(
+                    "The `{$prefix}` prefix did not start with an upper case character. " .
+                    "Routing prefixes should be defined as CamelCase values. " .
+                    "Prefix inflection will be removed in 5.0"
                 );
-                $namespace .= '/' . implode('/', $prefixes);
+
+                if (strpos($prefix, '/') === false) {
+                    $namespace .= '/' . Inflector::camelize($prefix);
+                } else {
+                    $prefixes = array_map(
+                        function ($val) {
+                            return Inflector::camelize($val);
+                        },
+                        explode('/', $prefix)
+                    );
+                    $namespace .= '/' . implode('/', $prefixes);
+                }
+            } else {
+                $namespace .= '/' . $prefix;
             }
         }
         $firstChar = substr($controller, 0, 1);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -843,7 +843,7 @@ class RouteBuilder
             $params = [];
         }
         $path = '/' . Inflector::dasherize($name);
-        $name = Inflector::underscore($name);
+        $name = Inflector::camelize($name);
         if (isset($params['path'])) {
             $path = $params['path'];
             unset($params['path']);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -858,7 +858,7 @@ class Router
         $path = $params['path'] ?? '/' . Inflector::dasherize($name);
         unset($params['path']);
 
-        $params = array_merge($params, ['prefix' => Inflector::underscore($name)]);
+        $params = array_merge($params, ['prefix' => Inflector::camelize($name)]);
         static::scope($path, $params, $callback);
     }
 

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1129,7 +1129,7 @@ class AuthComponentTest extends TestCase
                 'controller' => 'AuthTest',
                 'action' => 'add',
                 'plugin' => null,
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
             ],
             'url' => '/admin/auth_test/add',
             'session' => $this->Auth->session,
@@ -1138,7 +1138,7 @@ class AuthComponentTest extends TestCase
         Router::setRequest($this->Controller->getRequest());
 
         $this->Auth->setConfig('loginAction', [
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'auth_test',
             'action' => 'login',
         ]);
@@ -1146,7 +1146,7 @@ class AuthComponentTest extends TestCase
         $response = $this->Auth->startup($event);
         $redirectHeader = $response->getHeaderLine('Location');
         $expected = Router::url([
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'auth_test',
             'action' => 'login',
             '?' => ['redirect' => '/admin/auth_test/add'],

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -28,7 +28,7 @@ use Cake\TestSuite\TestCase;
 class ControllerFactoryTest extends TestCase
 {
     /**
-     * @var \Cake\Http\ControllerFactory
+     * @var \Cake\Controller\ControllerFactory
      */
     protected $factory;
 
@@ -68,22 +68,24 @@ class ControllerFactoryTest extends TestCase
      *
      * @return void
      */
-    public function testPrefixedAppController()
+    public function testPrefixedAppControllerDeprecated()
     {
-        $request = new ServerRequest([
-            'url' => 'admin/posts/index',
-            'params' => [
-                'prefix' => 'admin',
-                'controller' => 'Posts',
-                'action' => 'index',
-            ],
-        ]);
-        $result = $this->factory->create($request);
-        $this->assertInstanceOf(
-            'TestApp\Controller\Admin\PostsController',
-            $result
-        );
-        $this->assertSame($request, $result->getRequest());
+        $this->deprecated(function() {
+            $request = new ServerRequest([
+                'url' => 'admin/posts/index',
+                'params' => [
+                    'prefix' => 'admin',
+                    'controller' => 'Posts',
+                    'action' => 'index',
+                ],
+            ]);
+            $result = $this->factory->create($request);
+            $this->assertInstanceOf(
+                'TestApp\Controller\Admin\PostsController',
+                $result
+            );
+            $this->assertSame($request, $result->getRequest());
+        });
     }
 
     /**
@@ -96,7 +98,7 @@ class ControllerFactoryTest extends TestCase
         $request = new ServerRequest([
             'url' => 'admin/sub/posts/index',
             'params' => [
-                'prefix' => 'admin/sub',
+                'prefix' => 'Admin/Sub',
                 'controller' => 'Posts',
                 'action' => 'index',
             ],
@@ -165,7 +167,7 @@ class ControllerFactoryTest extends TestCase
         $request = new ServerRequest([
             'url' => 'test_plugin/admin/comments',
             'params' => [
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 'plugin' => 'TestPlugin',
                 'controller' => 'Comments',
                 'action' => 'index',

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -70,7 +70,7 @@ class ControllerFactoryTest extends TestCase
      */
     public function testPrefixedAppControllerDeprecated()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $request = new ServerRequest([
                 'url' => 'admin/posts/index',
                 'params' => [

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -93,7 +93,7 @@ class ExceptionRendererTest extends TestCase
         $request = new ServerRequest();
         $request = $request
             ->withParam('controller', 'Articles')
-            ->withParam('prefix', 'admin');
+            ->withParam('prefix', 'Admin');
 
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception, $request);
 
@@ -123,7 +123,7 @@ class ExceptionRendererTest extends TestCase
         $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
         $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
 
-        $request = $request->withParam('prefix', 'admin');
+        $request = $request->withParam('prefix', 'Admin');
         $exception = new MissingActionException(['controller' => 'Foo', 'action' => 'bar']);
 
         $ExceptionRenderer = new ExceptionRenderer($exception, $request);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -462,7 +462,7 @@ class RouteBuilderTest extends TestCase
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
-            $this->assertEquals(['prefix' => 'admin', 'key' => 'value', 'param' => 'value'], $r->params());
+            $this->assertEquals(['prefix' => 'Admin', 'key' => 'value', 'param' => 'value'], $r->params());
         });
         $this->assertSame($routes, $res);
     }
@@ -479,7 +479,7 @@ class RouteBuilderTest extends TestCase
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
-            $this->assertEquals(['prefix' => 'admin', 'key' => 'value'], $r->params());
+            $this->assertEquals(['prefix' => 'Admin', 'key' => 'value'], $r->params());
         });
         $this->assertSame($routes, $res);
     }
@@ -494,7 +494,7 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
         $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function ($r) {
             $this->assertSame('/admin/api', $r->path());
-            $this->assertEquals(['prefix' => 'admin/api'], $r->params());
+            $this->assertEquals(['prefix' => 'admin/Api'], $r->params());
             $this->assertSame('api:', $r->namePrefix());
         });
         $this->assertSame($routes, $res);
@@ -511,10 +511,10 @@ class RouteBuilderTest extends TestCase
         $res = $routes->prefix('api', function ($r) {
             $r->prefix('v10', ['path' => '/v1.0'], function ($r2) {
                 $this->assertSame('/admin/api/v1.0', $r2->path());
-                $this->assertEquals(['prefix' => 'admin/api/v10'], $r2->params());
+                $this->assertEquals(['prefix' => 'admin/Api/V10'], $r2->params());
                 $r2->prefix('b1', ['path' => '/beta.1'], function ($r3) {
                     $this->assertSame('/admin/api/v1.0/beta.1', $r3->path());
-                    $this->assertEquals(['prefix' => 'admin/api/v10/b1'], $r3->params());
+                    $this->assertEquals(['prefix' => 'admin/Api/V10/B1'], $r3->params());
                 });
             });
         });

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -704,15 +704,15 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
         Router::connect('/reset/*', ['admin' => true, 'controller' => 'users', 'action' => 'reset']);
         Router::connect('/tests', ['controller' => 'tests', 'action' => 'index']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
         Router::extensions('rss', false);
 
         $request = new ServerRequest([
             'params' => [
                 'controller' => 'registrations',
-                'action' => 'admin_index',
+                'action' => 'index',
                 'plugin' => null,
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 '_ext' => 'html',
             ],
             'url' => '/admin/registrations/index',
@@ -724,15 +724,15 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/subscriptions/:action/*', ['controller' => 'subscribe', 'prefix' => 'admin']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/subscriptions/:action/*', ['controller' => 'Subscribe', 'prefix' => 'Admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',
                 'plugin' => null,
-                'controller' => 'subscribe',
-                'prefix' => 'admin',
+                'controller' => 'Subscribe',
+                'prefix' => 'Admin',
             ],
             'webroot' => '/magazine/',
             'base' => '/magazine',
@@ -744,7 +744,7 @@ class RouterTest extends TestCase
         $expected = '/magazine/admin/subscriptions/edit/1';
         $this->assertEquals($expected, $result);
 
-        $result = Router::url(['prefix' => 'admin', 'controller' => 'users', 'action' => 'login']);
+        $result = Router::url(['prefix' => 'Admin', 'controller' => 'users', 'action' => 'login']);
         $expected = '/magazine/admin/users/login';
         $this->assertEquals($expected, $result);
 
@@ -880,7 +880,13 @@ class RouterTest extends TestCase
                 $routes->fallbacks('InflectedRoute');
             });
         });
-        $result = Router::url(['prefix' => 'admin', 'plugin' => 'MyPlugin', 'controller' => 'Forms', 'action' => 'edit', 2]);
+        $result = Router::url([
+            'prefix' => 'Admin',
+            'plugin' => 'MyPlugin',
+            'controller' => 'Forms',
+            'action' => 'edit',
+            2
+        ]);
         $expected = '/admin/my-plugin/forms/edit/2';
         $this->assertEquals($expected, $result);
     }
@@ -898,7 +904,7 @@ class RouterTest extends TestCase
             });
         });
         $result = Router::url([
-            'prefix' => 'admin/backoffice',
+            'prefix' => 'Admin/Backoffice',
             'controller' => 'Dashboards',
             'action' => 'home',
         ]);
@@ -2911,12 +2917,12 @@ class RouterTest extends TestCase
     {
         Router::prefix('admin', function (RouteBuilder $routes) {
             $this->assertSame('/admin', $routes->path());
-            $this->assertEquals(['prefix' => 'admin'], $routes->params());
+            $this->assertEquals(['prefix' => 'Admin'], $routes->params());
         });
 
         Router::prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {
             $this->assertSame('admin:', $routes->namePrefix());
-            $this->assertEquals(['prefix' => 'admin'], $routes->params());
+            $this->assertEquals(['prefix' => 'Admin'], $routes->params());
         });
     }
 
@@ -2929,12 +2935,12 @@ class RouterTest extends TestCase
     {
         Router::prefix('admin', ['param' => 'value'], function (RouteBuilder $routes) {
             $this->assertSame('/admin', $routes->path());
-            $this->assertEquals(['prefix' => 'admin', 'param' => 'value'], $routes->params());
+            $this->assertEquals(['prefix' => 'Admin', 'param' => 'value'], $routes->params());
         });
 
         Router::prefix('CustomPath', ['path' => '/custom-path'], function (RouteBuilder $routes) {
             $this->assertSame('/custom-path', $routes->path());
-            $this->assertEquals(['prefix' => 'custom_path'], $routes->params());
+            $this->assertEquals(['prefix' => 'CustomPath'], $routes->params());
         });
     }
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -885,7 +885,7 @@ class RouterTest extends TestCase
             'plugin' => 'MyPlugin',
             'controller' => 'Forms',
             'action' => 'edit',
-            2
+            2,
         ]);
         $expected = '/admin/my-plugin/forms/edit/2';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Update the routing scope helpers to create CamelCased prefix names. This is a breaking change but helps normalize routing the prefix parameter with other routing parameters.

I've added a deprecation for prefix inflection as I think we can remove it down the road if prefixes are created in PascalCase.
