### PR TITLE
Fix partially rendered content with errors

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -136,7 +136,6 @@ class ErrorHandler extends BaseErrorHandler
                 Router::getRequest()
             );
             $response = $renderer->render();
-            $this->_clearOutput();
             $this->_sendResponse($response);
         } catch (Throwable $exception) {
             $this->_logInternalError($exception);
@@ -174,20 +173,6 @@ class ErrorHandler extends BaseErrorHandler
         $factory = $renderer;
 
         return $factory($exception, $request);
-    }
-
-    /**
-     * Clear output buffers so error pages display properly.
-     *
-     * Easily stubbed in testing.
-     *
-     * @return void
-     */
-    protected function _clearOutput(): void
-    {
-        while (ob_get_level()) {
-            ob_end_clean();
-        }
     }
 
     /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -170,6 +170,21 @@ class ExceptionRenderer implements ExceptionRendererInterface
     }
 
     /**
+     * Clear output buffers so error pages display properly.
+     *
+     * @return void
+     */
+    protected function clearOutput(): void
+    {
+        if (in_array(PHP_SAPI, ['cli', 'phpdbg'])) {
+            return;
+        }
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
+    }
+
+    /**
      * Renders the response for the exception.
      *
      * @return \Cake\Http\Response The response to be sent.
@@ -180,6 +195,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
         $code = $this->_code($exception);
         $method = $this->_method($exception);
         $template = $this->_template($exception, $method, $code);
+        $this->clearOutput();
 
         if (method_exists($this, $method)) {
             return $this->_customMethod($method, $exception);

--- a/tests/test_app/TestApp/Error/TestErrorHandler.php
+++ b/tests/test_app/TestApp/Error/TestErrorHandler.php
@@ -18,16 +18,6 @@ class TestErrorHandler extends ErrorHandler
     public $response;
 
     /**
-     * Stub output clearing in tests.
-     *
-     * @return void
-     */
-    protected function _clearOutput(): void
-    {
-        // noop
-    }
-
-    /**
      * Stub sending responses
      *
      * @param \Cake\Http\Response $response


### PR DESCRIPTION
When we did some refactoring of the error page rendering, the clearOutput() method ceased to be called. This resulted in buffers not being cleared when an error is encountered part way through the view rendering.