### PR TITLE
4.x - Added timezone parameter to Date and FrozenDate

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -234,7 +234,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, string given\\.$#"
-			count: 2
+			count: 1
 			path: src/I18n/Date.php
 
 		-
@@ -243,12 +243,22 @@ parameters:
 			path: src/I18n/Date.php
 
 		-
+			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, null given.$#"
+			count: 1
+			path: src/I18n/Date.php
+
+		-
 			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, string given\\.$#"
-			count: 2
+			count: 1
 			path: src/I18n/FrozenDate.php
 
 		-
 			message: "#^Parameter \\#5 \\$calendar of function datefmt_create expects int\\|IntlCalendar, null given\\.$#"
+			count: 1
+			path: src/I18n/FrozenDate.php
+
+		-
+			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, null given.$#"
 			count: 1
 			path: src/I18n/FrozenDate.php
 
@@ -259,11 +269,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, string given\\.$#"
-			count: 2
+			count: 1
 			path: src/I18n/FrozenTime.php
 
 		-
 			message: "#^Parameter \\#5 \\$calendar of function datefmt_create expects int\\|IntlCalendar, null given\\.$#"
+			count: 1
+			path: src/I18n/FrozenTime.php
+
+		-
+			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, null given.$#"
 			count: 1
 			path: src/I18n/FrozenTime.php
 
@@ -274,11 +289,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, string given\\.$#"
-			count: 2
+			count: 1
 			path: src/I18n/Time.php
 
 		-
 			message: "#^Parameter \\#5 \\$calendar of function datefmt_create expects int\\|IntlCalendar, null given\\.$#"
+			count: 1
+			path: src/I18n/Time.php
+
+		-
+			message: "#^Parameter \\#4 \\$timezone of function datefmt_create expects int, null given.$#"
 			count: 1
 			path: src/I18n/Time.php
 
@@ -496,5 +516,3 @@ parameters:
 			message: "#^Class Psy\\\\Shell not found\\.$#"
 			count: 1
 			path: src/basics.php
-
-

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Chronos\MutableDate;
-use DateTimeInterface;
 use IntlDateFormatter;
 
 /**
@@ -118,7 +117,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * You can specify the timezone for the $time parameter. This timezone will
      * not be used in any future modifications to the Date instance.
      *
-     * The $timezone parameter is ignored if $time is a DateTimeInterface
+     * The `$timezone` parameter is ignored if `$time` is a DateTimeInterface
      * instance.
      *
      * Date instances lack time components, however due to limitations in PHP's
@@ -127,7 +126,8 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTimeInterface|null $time Fixed or relative time
-     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
+     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken.
+     *                                  Ignored if `$time` is a DateTimeInterface instance.
      */
     public function __construct($time = 'now', $tz = null)
     {

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -115,20 +115,23 @@ class Date extends MutableDate implements I18nDateTimeInterface
     /**
      * Create a new FrozenDate instance.
      *
+     * You can specify the timezone for the $time parameter. This timezone will
+     * not be used in any future modifications to the Date instance.
+     *
+     * The $timezone parameter is ignored if $time is a DateTimeInterface
+     * instance.
+     *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
      * timezone will always be UTC. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTimeInterface|null $time Fixed or relative time
+     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
-    public function __construct($time = 'now')
+    public function __construct($time = 'now', $tz = null)
     {
-        if ($time instanceof DateTimeInterface) {
-            $time = $time->format('Y-m-d 00:00:00');
-        }
-
-        parent::__construct($time);
+        parent::__construct($time, $tz);
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -19,6 +19,8 @@ namespace Cake\I18n;
 use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\DifferenceFormatterInterface;
 use Cake\Chronos\MutableDate;
+use DateTime;
+use DateTimeZone;
 use IntlDateFormatter;
 use RuntimeException;
 
@@ -290,6 +292,10 @@ trait DateFormatTrait
      *
      * When no $format is provided, the `toString` format will be used.
      *
+     * The time zone of the returned instance is always converted to the default
+     * timezone even if the `$time` string specified a time zone. This is a
+     * limitation of IntlDateFormatter.
+     *
      * If it was impossible to parse the provided time, null will be returned.
      *
      * Example:
@@ -323,20 +329,20 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $defaultTimezone = static::$_isDateInstance ? 'UTC' : date_default_timezone_get();
         $formatter = datefmt_create(
             (string)static::$defaultLocale,
             (int)$dateFormat,
             (int)$timeFormat,
-            $defaultTimezone,
+            null,
             null,
             (string)$pattern
         );
         $time = $formatter->parse($time);
         if ($time !== false) {
-            $result = new static('@' . $time);
+            $dateTime = new DateTime('@' . $time);
+            $dateTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-            return static::$_isDateInstance ? $result : $result->setTimezone($defaultTimezone);
+            return new static($dateTime);
         }
 
         return null;

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -117,19 +117,22 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
     /**
      * Create a new Date instance.
      *
+     * You can specify the timezone for the $time parameter. This timezone will
+     * not be used in any future modifications to the Date instance.
+     *
+     * The $timezone parameter is ignored if $time is a DateTimeInterface
+     * instance.
+     *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
      * timezone will always be UTC. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTimeInterface|null $time Fixed or relative time
+     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
-    public function __construct($time = 'now')
+    public function __construct($time = 'now', $tz = null)
     {
-        if ($time instanceof DateTimeInterface) {
-            $time = $time->format('Y-m-d 00:00:00');
-        }
-
         parent::__construct($time);
     }
 

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Chronos\Date as ChronosDate;
-use DateTimeInterface;
 use IntlDateFormatter;
 
 /**
@@ -120,7 +119,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * You can specify the timezone for the $time parameter. This timezone will
      * not be used in any future modifications to the Date instance.
      *
-     * The $timezone parameter is ignored if $time is a DateTimeInterface
+     * The `$timezone` parameter is ignored if `$time` is a DateTimeInterface
      * instance.
      *
      * Date instances lack time components, however due to limitations in PHP's
@@ -129,11 +128,12 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTimeInterface|null $time Fixed or relative time
-     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
+     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken.
+     *                                  Ignored if `$time` is a DateTimeInterface instance.
      */
     public function __construct($time = 'now', $tz = null)
     {
-        parent::__construct($time);
+        parent::__construct($time, $tz);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -510,6 +510,20 @@ class DateTest extends TestCase
     }
 
     /**
+     * Tests that parsing a full date + time in a timezone other
+     * than UTC respects the timezone when grabbing the date.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseDateTimeDifferentTimezone($class)
+    {
+        date_default_timezone_set('America/Toronto');
+        $result = $class::parseDateTime('25-02-2016 23:00:00', 'd-M-y H:m:s');
+        $this->assertSame('25-02-2016', $result->format('d-m-Y'));
+    }
+
+    /**
      * Tests the default locale setter.
      *
      * @dataProvider classNameProvider


### PR DESCRIPTION
This passes the $tz parameter down to Chronos which was added in https://github.com/cakephp/chronos/pull/218

`Date::parseDateTime()` now respects local time when grabbing the date.  This does not add support for time zones to `parseDateTime()`.