### PR TITLE
Updated phpunit.xml.dist default mysql DB_DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Assuming you have PHPUnit installed system wide using one of the methods stated
 tests for CakePHP by doing the following:
 
 1. Copy `phpunit.xml.dist` to `phpunit.xml`.
-2. Add the relevant database credentials to your `phpunit.xml` if you want to run tests against
-   a non-SQLite datasource.
-3. Run `phpunit`.
+2. Uncomment the `DB_DSN` env settings that matches your database.
+3. Update the database credentials in the `DB_DSN` string if needed.
+4. Create the `cake_test` database if using mysql, postgres or sqlserver.
+5. Run `phpunit` (or `composer test` if not installed system wide).
 
 ## Some Handy Links
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -48,7 +48,7 @@
         <env name="DB_DSN" value="postgres://localhost/cake_test?timezone=UTC"/>
         -->
         <!-- Mysql
-        <env name="DB_DSN" value="mysql://localhost/cake_test?timezone=UTC"/>
+        <env name="DB_DSN" value="mysql://localhost/cake_test?timezone=UTC&init[]=SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"/>
         -->
         <!-- SQL Server
         <env name="DB_DSN" value="sqlserver://localhost/cake_test?timezone=UTC"/>


### PR DESCRIPTION
Updated phpunit.xml.dist default mysql DB_DSN to disable ONLY_FUL_GROUP_BY for local tests

Updated the readme test steps to be more specific about what setting up local db for tests.