### PR TITLE
Check if the scheme and port is set in `Router.php:fullBaseUrl()`

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -620,8 +620,8 @@ class Router
 
         $parts = parse_url(static::$_fullBaseUrl);
         static::$_requestContext = [
-            '_scheme' => $parts['scheme'],
-            '_host' => $parts['host'],
+            '_scheme' => $parts['scheme'] ?? null,
+            '_host' => $parts['host'] ?? null,
             '_port' => $parts['port'] ?? null,
         ] + static::$_requestContext;
 


### PR DESCRIPTION
When I run `bin/cake --help`, I get the following output without this update:

```$ bin/cake --help
Notice Error: Undefined index: scheme
In [/var/www/vhosts/dev/vendor/cakephp/cakephp/src/Routing/Router.php, line 623]

Notice Error: Undefined index: host
In [/var/www/vhosts/dev/vendor/cakephp/cakephp/src/Routing/Router.php, line 624]
```
Does anyone else have that notice appear?