### PR TITLE
Add assertRedirectEquals, to allow assertions against non-full URLs

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -858,7 +858,7 @@ trait IntegrationTestTrait
     }
 
     /**
-     * Asserts that the Location header is correct.
+     * Asserts that the Location header is correct. Comparison is made against a full URL.
      *
      * @param string|array|null $url The URL you expected the client to go to. This
      *   can either be a string URL or an array compatible with Router::url(). Use null to
@@ -873,6 +873,25 @@ trait IntegrationTestTrait
 
         if ($url) {
             $this->assertThat(Router::url($url, ['_full' => true]), new HeaderEquals($this->_response, 'Location'), $verboseMessage);
+        }
+    }
+
+    /**
+     * Asserts that the Location header is correct. Comparison is made against exactly the URL provided.
+     *
+     * @param string|array|null $url The URL you expected the client to go to. This
+     *   can either be a string URL or an array compatible with Router::url(). Use null to
+     *   simply check for the existence of this header.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertRedirectEquals($url = null, $message = '')
+    {
+        $verboseMessage = $this->extractVerboseMessage($message);
+        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+
+        if ($url) {
+            $this->assertThat(Router::url($url), new HeaderEquals($this->_response, 'Location'), $verboseMessage);
         }
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1088,6 +1088,23 @@ class IntegrationTestTraitTest extends IntegrationTestCase
     }
 
     /**
+     * Test the location header assertion.
+     *
+     * @return void
+     */
+    public function testAssertRedirectEquals()
+    {
+        $this->_response = new Response();
+        $this->_response = $this->_response->withHeader('Location', '/get/tasks/index');
+
+        $this->assertRedirect();
+        $this->assertRedirectEquals('/get/tasks/index');
+        $this->assertRedirectEquals(['controller' => 'Tasks', 'action' => 'index']);
+
+        $this->assertResponseEmpty();
+    }
+
+    /**
      * Test the location header assertion string not contains
      *
      * @return void


### PR DESCRIPTION
Addition per discussion at https://github.com/cakephp/authentication/issues/305.