### PR TITLE
4.x - Http Server

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -48,7 +48,7 @@ class Server implements EventDispatcherInterface
      * Constructor
      *
      * @param \Cake\Core\HttpApplicationInterface $app The application to use.
-     * @param \Cake\Server\Runner $runner Application runner.
+     * @param \Cake\Http\Runner|null $runner Application runner.
      */
     public function __construct(HttpApplicationInterface $app, ?Runner $runner = null)
     {

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -68,16 +68,19 @@ class Server implements EventDispatcherInterface
      * - Run the middleware queue including the application.
      *
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The request to use or null.
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue MiddlewareQueue or null.
      * @return \Psr\Http\Message\ResponseInterface
      * @throws \RuntimeException When the application does not make a response.
      */
-    public function run(?ServerRequestInterface $request = null): ResponseInterface
-    {
+    public function run(
+        ?ServerRequestInterface $request = null,
+        ?MiddlewareQueue $middlewareQueue = null
+    ): ResponseInterface {
         $this->bootstrap();
 
         $request = $request ?: ServerRequestFactory::fromGlobals();
 
-        $middleware = $this->app->middleware(new MiddlewareQueue());
+        $middleware = $this->app->middleware($middlewareQueue ?? new MiddlewareQueue());
         if ($this->app instanceof PluginApplicationInterface) {
             $middleware = $this->app->pluginMiddleware($middleware);
         }

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -53,7 +53,7 @@ class Server implements EventDispatcherInterface
     public function __construct(HttpApplicationInterface $app, ?Runner $runner = null)
     {
         $this->app = $app;
-        $this->setRunner($runner ?? new Runner());
+        $this->runner = $runner ?? new Runner();
     }
 
     /**
@@ -129,19 +129,6 @@ class Server implements EventDispatcherInterface
     public function getApp(): HttpApplicationInterface
     {
         return $this->app;
-    }
-
-    /**
-     * Set the runner
-     *
-     * @param \Cake\Http\Runner $runner The runner to use.
-     * @return $this
-     */
-    public function setRunner(Runner $runner)
-    {
-        $this->runner = $runner;
-
-        return $this;
     }
 
     /**

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -150,7 +150,7 @@ class Server implements EventDispatcherInterface
      */
     public function getEventManager(): EventManagerInterface
     {
-        if ($this->app instanceof PluginApplicationInterface) {
+        if ($this->app instanceof EventDispatcherInterface) {
             return $this->app->getEventManager();
         }
 
@@ -168,7 +168,7 @@ class Server implements EventDispatcherInterface
      */
     public function setEventManager(EventManagerInterface $eventManager)
     {
-        if ($this->app instanceof PluginApplicationInterface) {
+        if ($this->app instanceof EventDispatcherInterface) {
             $this->app->setEventManager($eventManager);
 
             return $this;

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -48,11 +48,12 @@ class Server implements EventDispatcherInterface
      * Constructor
      *
      * @param \Cake\Core\HttpApplicationInterface $app The application to use.
+     * @param \Cake\Server\Runner $runner Application runner.
      */
-    public function __construct(HttpApplicationInterface $app)
+    public function __construct(HttpApplicationInterface $app, ?Runner $runner = null)
     {
         $this->app = $app;
-        $this->setRunner(new Runner());
+        $this->setRunner($runner ?? new Runner());
     }
 
     /**


### PR DESCRIPTION
- Allow `Runner` instance to be injected into `Server` constructor and remove `Server::setRunner()`. I can't think of a use case where you would need to change the runner after server instance is created.
- `Server::setEventManager/getEventManager()` now check if application implements `EventDispatcherInterface` instead of `PluginApplicationInterface`. An application should be able to use events without using plugins.
- Allow passing `MiddlewareQueue` instance to `Server::run()` which was previously hard coded in the method.