### PR TITLE
Fix App path for usability.

### DIFF
--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -62,13 +62,13 @@ class CommandScanner
     {
         $appNamespace = Configure::read('App.namespace');
         $appShells = $this->scanDir(
-            App::path('Shell')[0],
+            App::classPath('Shell')[0],
             $appNamespace . '\Shell\\',
             '',
             []
         );
         $appCommands = $this->scanDir(
-            App::path('Command')[0],
+            App::classPath('Command')[0],
             $appNamespace . '\Command\\',
             '',
             []

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -179,31 +179,45 @@ class App
      * Will return the path for tables `src/Model/Table`.
      *
      * @param string $type type of path
-     * @param string|null $plugin This argument is deprecated.
-     *   Use \Cake\Core\Plugin::classPath()/templatePath() instead for plugin paths.
-     * @return array
+     * @param string|null $plugin This argument is deprecated for class paths.
+     *   Use \Cake\Core\Plugin::classPath() instead or directly the method on \Cake\Core\Plugin.
+     * @return string[]
+     * @deprecated 4.0 Use \Cake\Core\App::classPath()/templatePath() instead.
      * @link https://book.cakephp.org/4/en/core-libraries/app.html#finding-paths-to-namespaces
      */
     public static function path(string $type, ?string $plugin = null): array
     {
-        if (empty($plugin)) {
-            if ($type[0] === strtolower($type[0])) {
-                return (array)Configure::read('App.paths.' . $type);
-            }
-
-            return [APP . $type . DIRECTORY_SEPARATOR];
+        if ($plugin === null && $type[0] === strtolower($type[0])) {
+            return (array)Configure::read('App.paths.' . $type);
         }
-
-        deprecationWarning(
-            'Using App::path() with 2nd argument $plugin is deprecated.'
-            . ' Use \Cake\Core\Plugin::classPath()/templatePath() instead.'
-        );
 
         if ($type === 'templates') {
             return [Plugin::templatePath($plugin)];
         }
 
-        return [Plugin::classPath($plugin) . $type . DIRECTORY_SEPARATOR];
+        deprecationWarning(
+            'App::path() is deprecated for class path.'
+            . ' Use \Cake\Core\App::classPath() instead or directly the method on \Cake\Core\Plugin.'
+        );
+
+        return static::classPath($type, $plugin);
+    }
+
+    /**
+     * @param string $type
+     * @param string|null $plugin
+     *
+     * @return string[]
+     */
+    public static function classPath(string $type, ?string $plugin = null): array
+    {
+        if ($plugin !== null) {
+            return [
+                Plugin::classPath($plugin) . $type . DIRECTORY_SEPARATOR,
+            ];
+        }
+
+        return [APP . $type . DIRECTORY_SEPARATOR];
     }
 
     /**

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -204,6 +204,8 @@ class App
     }
 
     /**
+     * Get the path to a class type in the application or a plugin.
+     *
      * @param string $type
      * @param string|null $plugin
      *

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -197,7 +197,7 @@ class App
 
         deprecationWarning(
             'App::path() is deprecated for class path.'
-            . ' Use \Cake\Core\App::classPath() instead or directly the method on \Cake\Core\Plugin.'
+            . ' Use \Cake\Core\App::classPath() or \Cake\Core\Plugin::classPath() instead.'
         );
 
         return static::classPath($type, $plugin);

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -161,8 +161,13 @@ class App
     /**
      * Used to read information stored path.
      *
-     * If 1st character of $type argument is lower cased it will return the
+     * The 1st character of $type argument should be lower cased and will return the
      * value of `App.paths.$type` config.
+     *
+     * Default types:
+     * - plugins
+     * - templates
+     * - locales
      *
      * Example:
      *
@@ -171,12 +176,6 @@ class App
      * ```
      *
      * Will return the value of `App.paths.plugins` config.
-     *
-     * ```
-     * App::path('Model/Table');
-     * ```
-     *
-     * Will return the path for tables `src/Model/Table`.
      *
      * Deprecated: 4.0 App::path() is deprecated for class path (inside src/ directory).
      *   Use \Cake\Core\App::classPath() instead or directly the method on \Cake\Core\Plugin class.
@@ -210,13 +209,13 @@ class App
      * Example:
      *
      * ```
-     * App::path('Model/Table');
+     * App::classPath('Model/Table');
      * ```
      *
      * Will return the path for tables `src/Model/Table`.
      *
      * ```
-     * App::path('My/Plugin.Model/Table');
+     * App::classPath('My/Plugin.Model/Table');
      * ```
      *
      * Will return the plugin based path for those.

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -178,11 +178,12 @@ class App
      *
      * Will return the path for tables `src/Model/Table`.
      *
-     * @param string $type type of path
-     * @param string|null $plugin This argument is deprecated for class paths.
-     *   Use \Cake\Core\Plugin::classPath() instead or directly the method on \Cake\Core\Plugin.
+     * Deprecated: 4.0 App::path() is deprecated for class path (inside src/ directory).
+     *   Use \Cake\Core\App::classPath() instead or directly the method on \Cake\Core\Plugin class.
+     *
+     * @param string $type Type of path
+     * @param string|null $plugin Plugin name
      * @return string[]
-     * @deprecated 4.0 Use \Cake\Core\App::classPath()/templatePath() instead.
      * @link https://book.cakephp.org/4/en/core-libraries/app.html#finding-paths-to-namespaces
      */
     public static function path(string $type, ?string $plugin = null): array
@@ -204,7 +205,21 @@ class App
     }
 
     /**
-     * Get the path to a class type in the application or a plugin.
+     * Gets the path to a class type in the application or a plugin.
+     *
+     * Example:
+     *
+     * ```
+     * App::path('Model/Table');
+     * ```
+     *
+     * Will return the path for tables `src/Model/Table`.
+     *
+     * ```
+     * App::path('My/Plugin.Model/Table');
+     * ```
+     *
+     * Will return the plugin based path for those.
      *
      * @param string $type
      * @param string|null $plugin

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -212,10 +212,10 @@ class App
      * App::classPath('Model/Table');
      * ```
      *
-     * Will return the path for tables `src/Model/Table`.
+     * Will return the path for tables - e.g. `src/Model/Table/`.
      *
      * ```
-     * App::classPath('My/Plugin.Model/Table');
+     * App::classPath('Model/Table', 'My/Plugin');
      * ```
      *
      * Will return the plugin based path for those.

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -27,11 +27,11 @@ namespace Cake\Core;
  *
  * ### Inspecting loaded paths
  *
- * You can inspect the currently loaded paths using `App::path('Controller')` for example to see loaded
+ * You can inspect the currently loaded paths using `App::classPath('Controller')` for example to see loaded
  * controller paths.
  *
  * It is also possible to inspect paths for plugin classes, for instance, to get
- * the path to a plugin's helpers you would call `App::path('View/Helper', 'MyPlugin')`
+ * the path to a plugin's helpers you would call `App::classPath('View/Helper', 'MyPlugin')`
  *
  * ### Locating plugins
  *

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -41,10 +41,10 @@ class CommandTask extends Shell
         $plugins = Plugin::loaded();
         $shellList = array_fill_keys($plugins, null) + ['CORE' => null, 'app' => null];
 
-        $appPath = App::path('Shell');
+        $appPath = App::classPath('Shell');
         $shellList = $this->_findShells($shellList, $appPath[0], 'app', $skipFiles);
 
-        $appPath = App::path('Command');
+        $appPath = App::classPath('Command');
         $shellList = $this->_findShells($shellList, $appPath[0], 'app', $skipFiles);
 
         $skipCore = array_merge($skipFiles, $hiddenCommands, $shellList['app']);

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -225,8 +225,10 @@ class AppTest extends TestCase
     {
         $basepath = TEST_APP . 'Plugin' . DS;
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
+
         $result = App::classPath('Controller', 'TestPlugin');
         $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
+
         $result = App::classPath('Controller', 'Company/TestPluginThree');
         $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
         $this->assertPathEquals($expected, $result[0]);
@@ -243,8 +245,10 @@ class AppTest extends TestCase
         $this->deprecated(function () {
             $basepath = TEST_APP . 'Plugin' . DS;
             $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
+
             $result = App::path('Controller', 'TestPlugin');
             $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
+
             $result = App::path('Controller', 'Company/TestPluginThree');
             $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
             $this->assertPathEquals($expected, $result[0]);

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -36,7 +36,7 @@ class AppTest extends TestCase
     }
 
     /**
-     * testClassname
+     * testClassName
      *
      * $checkCake and $existsInCake are derived from the input parameters
      *
@@ -46,9 +46,9 @@ class AppTest extends TestCase
      * @param bool $existsInBase Whether class exists in base.
      * @param mixed $expected Expected value.
      * @return void
-     * @dataProvider classnameProvider
+     * @dataProvider classNameProvider
      */
-    public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false)
+    public function testClassName($class, $type, $suffix = '', $existsInBase = false, $expected = false)
     {
         static::setAppNamespace();
         $i = 0;
@@ -63,11 +63,11 @@ class AppTest extends TestCase
 
             return false;
         };
-        $return = TestApp::classname($class, $type, $suffix);
+        $return = TestApp::className($class, $type, $suffix);
         $this->assertSame($expected === false ? null : $expected, $return);
     }
 
-    public function testClassnameWithFqcn()
+    public function testClassNameWithFqcn()
     {
         $this->assertSame(TestCase::class, App::className(TestCase::class));
         $this->assertNull(App::className('\Foo'));
@@ -111,10 +111,10 @@ class AppTest extends TestCase
     }
 
     /**
-     * classnameProvider
+     * classNameProvider
      *
-     * Return test permutations for testClassname method. Format:
-     *  classname
+     * Return test permutations for testClassName method. Format:
+     *  className
      *  type
      *  suffix
      *  existsInBase (Base meaning App or plugin namespace)
@@ -122,7 +122,7 @@ class AppTest extends TestCase
      *
      * @return array
      */
-    public function classnameProvider()
+    public function classNameProvider()
     {
         return [
             ['Does', 'Not', 'Exist'],
@@ -156,7 +156,7 @@ class AppTest extends TestCase
             ['Auth', 'Controller/Component'],
             ['Unknown', 'Controller', 'Controller'],
 
-            // Real examples returning classnames
+            // Real examples returning class names
             ['App', 'Core', '', false, 'Cake\Core\App'],
             ['Auth', 'Controller/Component', 'Component', false, 'Cake\Controller\Component\AuthComponent'],
             ['File', 'Cache/Engine', 'Engine', false, 'Cake\Cache\Engine\FileEngine'],
@@ -169,8 +169,8 @@ class AppTest extends TestCase
     /**
      * pluginSplitNameProvider
      *
-     * Return test permutations for testClassname method. Format:
-     *  classname
+     * Return test permutations for testClassName method. Format:
+     *  className
      *  type
      *  suffix
      *  expected return value
@@ -206,7 +206,7 @@ class AppTest extends TestCase
 
             ['Muffin\Webservice\Webservice\EndpointWebservice', 'Webservice', 'Webservice', 'Muffin/Webservice.Endpoint'],
 
-            // Real examples returning classnames
+            // Real examples returning class names
             ['Cake\Core\App', 'Core', '', 'App'],
             ['Cake\Controller\Component\AuthComponent', 'Controller/Component', 'Component', 'Auth'],
             ['Cake\Cache\Engine\FileEngine', 'Cache/Engine', 'Engine', 'File'],
@@ -214,6 +214,22 @@ class AppTest extends TestCase
             ['Cake\Shell\Task\Upgrade\LocationsTask', 'Shell/Task', 'Task', 'Upgrade/Locations'],
             ['TestApp\Controller\PagesController', 'Controller', 'Controller', 'Pages'],
         ];
+    }
+
+    /**
+     * test classPath() with a plugin.
+     *
+     * @return void
+     */
+    public function testClassPathWithPlugins()
+    {
+        $basepath = TEST_APP . 'Plugin' . DS;
+        $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
+        $result = App::classPath('Controller', 'TestPlugin');
+        $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
+        $result = App::classPath('Controller', 'Company/TestPluginThree');
+        $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS . 'Controller' . DS;
+        $this->assertPathEquals($expected, $result[0]);
     }
 
     /**


### PR DESCRIPTION
Resolves problematic usability described in https://github.com/cakephp/cakephp/issues/13604

- `App::path()` remains for all non class path elements.
- `App::classPath()` has been added and can proxy Plugin::classPath()
- App::path() is allowed to also use plugin, same as others for convenience.

Does that make sense?

The changes mean that e.g. my IdeHelper can keep the simple App::className($type, $plugin) syntax here for simplicity.

I wasn't sure if we should extract also templatePath(), since locales and other such keys don't have this yet either.
Or do we plan to add `public function getLocalePath()` to Plugin class as well?