### PR TITLE
Add 7.2 and static analysis checks back to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,20 @@ cache:
     - $HOME/.composer/cache
 
 php:
+  - 7.2
   - 7.4snapshot
 
 env:
+  global:
+    - DEFAULT=1
+    - CHECKS=0
   matrix:
     - DB=mysql DB_DSN='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
     - DB=pgsql DB_DSN='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite DB_DSN='sqlite:///:memory:'
+  include:
+    - php: 7.3
+      env: CHECKS=1 DEFAULT=0
 
 matrix:
   fast_finish: true
@@ -50,8 +57,14 @@ script:
       if [[ $TRAVIS_PHP_VERSION == '7.4snapshot' ]]; then
         # This is necessary to skip memory usage tests
         CODECOVERAGE=1 vendor/bin/phpunit --verbose --coverage-clover=clover.xml
-      else
+      elif [[ $DEFAULT == '1' ]]; then
         vendor/bin/phpunit
+      fi
+  - |
+      if [[ $CHECKS == 1 ]]; then
+        composer phpstan-setup
+        composer phpstan
+        composer cs-check
       fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,13 @@ env:
     - DB=mysql DB_DSN='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
     - DB=pgsql DB_DSN='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite DB_DSN='sqlite:///:memory:'
-  include:
-    - php: 7.3
-      env: CHECKS=1 DEFAULT=0
 
 matrix:
   fast_finish: true
+
+  include:
+    - php: 7.3
+      env: CHECKS=1 DEFAULT=0
 
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
@@ -62,8 +63,8 @@ script:
       fi
   - |
       if [[ $CHECKS == 1 ]]; then
-        composer phpstan-setup
-        composer phpstan
+        composer pstan-setup
+        composer stan
         composer cs-check
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
       fi
   - |
       if [[ $CHECKS == 1 ]]; then
-        composer pstan-setup
+        composer stan-setup
         composer stan
         composer cs-check
       fi


### PR DESCRIPTION
We can remove them again once we are able to turn github checks back on.