### PR TITLE
4.x - Updated QueryExpression exception message when null is used

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -782,7 +782,7 @@ class QueryExpression implements ExpressionInterface, Countable
         }
 
         if ($value === null && $this->_conjunction !== ',') {
-            throw new InvalidArgumentException('Invalid or missing operator together with `null` usage.');
+            throw new InvalidArgumentException('Expression is missing operator (IS, IS NOT) with `null` value.');
         }
 
         return new Comparison($expression, $value, $type, $operator);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4119,7 +4119,7 @@ class QueryTest extends TestCase
     public function testIsNullInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid or missing operator together with `null` usage.');
+        $this->expectExceptionMessage('Expression is missing operator (IS, IS NOT) with `null` value.');
 
         $this->loadFixtures('Authors');
         (new Query($this->connection))


### PR DESCRIPTION
When I ran into this upgrading an app to 4.0.0-RC1 it felt awkward even though I knew what the issue was.

Since this is probably a common issue upgrading, I tried to make it clearer.