### PR TITLE
Make Validator::allowEmptyFor() only allow null as empty when no flags are specified.

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -202,7 +202,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
             $canBeEmpty = $this->_canBeEmpty($field, $context);
 
-            $flags = static::EMPTY_ALL;
+            $flags = 0;
             if (isset($this->_allowEmptyFlags[$name])) {
                 $flags = $this->_allowEmptyFlags[$name];
             }
@@ -699,7 +699,12 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         foreach ($field as $fieldName => $setting) {
             $settings = $this->_convertValidatorToArray($fieldName, $defaults, $setting);
             $fieldName = array_keys($settings)[0];
-            $this->allowEmptyFor($fieldName, null, $settings[$fieldName]['when'], $settings[$fieldName]['message']);
+            $this->allowEmptyFor(
+                $fieldName,
+                static::EMPTY_ALL,
+                $settings[$fieldName]['when'],
+                $settings[$fieldName]['message']
+            );
         }
 
         return $this;
@@ -1149,6 +1154,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $whenSetting = $this->invertWhenClause($settings[$fieldName]['when']);
 
             $this->field($fieldName)->allowEmpty($whenSetting);
+            $this->_allowEmptyFlags[$fieldName] = static::EMPTY_ALL;
             if ($settings[$fieldName]['message']) {
                 $this->_allowEmptyMessages[$fieldName] = $settings[$fieldName]['message'];
             }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -53,6 +53,15 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * A flag for allowEmptyFor()
      *
+     * When `null` is given, it will be recognized as empty.
+     *
+     * @var int
+     */
+    public const EMPTY_NULL = 0;
+
+    /**
+     * A flag for allowEmptyFor()
+     *
      * When an empty string is given, it will be recognized as empty.
      *
      * @var int
@@ -202,7 +211,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
             $canBeEmpty = $this->_canBeEmpty($field, $context);
 
-            $flags = 0;
+            $flags = static::EMPTY_NULL;
             if (isset($this->_allowEmptyFlags[$name])) {
                 $flags = $this->_allowEmptyFlags[$name];
             }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -770,7 +770,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * ```
      *
      * @param string $field The name of the field.
-     * @param int|null $flags A bitmask of EMPTY_* flags which specify what is empty
+     * @param int|null $flags A bitmask of EMPTY_* flags which specify what is empty.
+     *   If no flags/bitmask is provided only `null` will be allowed as empty value.
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1714,7 +1714,7 @@ class TranslateBehaviorTest extends TestCase
             'fields' => ['title', 'body'],
             'validator' => 'custom',
         ]);
-        $validator = (new Validator())->add('title', 'notBlank', ['rule' => 'notBlank']);
+        $validator = (new Validator())->notEmptyString('title');
         $table->setValidator('custom', $validator);
         $translate = $table->behaviors()->get('Translate');
 
@@ -1797,7 +1797,7 @@ class TranslateBehaviorTest extends TestCase
             'fields' => ['title', 'body'],
             'validator' => 'custom',
         ]);
-        $validator = (new Validator())->add('title', 'notBlank', ['rule' => 'notBlank']);
+        $validator = (new Validator())->notEmptyString('title');
         $table->setValidator('custom', $validator);
         $translate = $table->behaviors()->get('Translate');
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5932,7 +5932,7 @@ class TableTest extends TestCase
 
         $articles = $this->getTableLocator()->get('Articles');
         $validator = new Validator();
-        $validator->notBlank('title');
+        $validator->notEmptyString('title');
         $articles->setValidator('default', $validator);
 
         $articles->findOrCreate(['title' => '']);

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -625,7 +625,8 @@ class ValidatorTest extends TestCase
         $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
 
         $validator
-            ->allowEmptyFor('name', Validator::EMPTY_STRING);
+            ->allowEmptyFor('name', Validator::EMPTY_STRING)
+            ->minLength('name', 5, 'Min. length 5 chars');
 
         $results = $validator->errors(['name' => null]);
         $this->assertSame([], $results);
@@ -633,11 +634,11 @@ class ValidatorTest extends TestCase
         $results = $validator->errors(['name' => '']);
         $this->assertSame([], $results);
 
-        $results = $validator->errors(['title' => 0]);
-        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+        $results = $validator->errors(['name' => 0]);
+        $this->assertSame(['name' => ['minLength' => 'Min. length 5 chars']], $results);
 
-        $results = $validator->errors(['title' => []]);
-        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+        $results = $validator->errors(['name' => []]);
+        $this->assertSame(['name' => ['minLength' => 'Min. length 5 chars']], $results);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -618,6 +618,12 @@ class ValidatorTest extends TestCase
         $results = $validator->errors(['title' => '']);
         $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
 
+        $results = $validator->errors(['title' => 0]);
+        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+
+        $results = $validator->errors(['title' => []]);
+        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+
         $validator
             ->allowEmptyFor('name', Validator::EMPTY_STRING);
 
@@ -626,6 +632,12 @@ class ValidatorTest extends TestCase
 
         $results = $validator->errors(['name' => '']);
         $this->assertSame([], $results);
+
+        $results = $validator->errors(['title' => 0]);
+        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+
+        $results = $validator->errors(['title' => []]);
+        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -601,6 +601,34 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the testAllowEmptyFor method
+     *
+     * @return void
+     */
+    public function testAllowEmptyFor()
+    {
+        $validator = new Validator();
+        $validator
+            ->allowEmptyFor('title')
+            ->minLength('title', 5, 'Min. length 5 chars');
+
+        $results = $validator->errors(['title' => null]);
+        $this->assertSame([], $results);
+
+        $results = $validator->errors(['title' => '']);
+        $this->assertSame(['title' => ['minLength' => 'Min. length 5 chars']], $results);
+
+        $validator
+            ->allowEmptyFor('name', Validator::EMPTY_STRING);
+
+        $results = $validator->errors(['name' => null]);
+        $this->assertSame([], $results);
+
+        $results = $validator->errors(['name' => '']);
+        $this->assertSame([], $results);
+    }
+
+    /**
      * Tests the allowEmpty method
      *
      * @return void
@@ -2157,7 +2185,9 @@ class ValidatorTest extends TestCase
             ],
             '_presenceMessages' => [],
             '_allowEmptyMessages' => [],
-            '_allowEmptyFlags' => [],
+            '_allowEmptyFlags' => [
+                'published' => Validator::EMPTY_ALL,
+            ],
             '_useI18n' => true,
         ];
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Refs #13901.