### PR TITLE
Drop "safe" option for HtmlHelper::script()/scriptBlock().

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -533,8 +533,6 @@ class HtmlHelper extends Helper
      *
      * ### Options
      *
-     * - `safe` (boolean) Whether or not the $script should be wrapped in `<![CDATA[ ]]>`.
-     *   Defaults to `false`.
      * - `block` Set to true to append output to view block "script" or provide
      *   custom block name.
      *
@@ -546,11 +544,7 @@ class HtmlHelper extends Helper
      */
     public function scriptBlock(string $script, array $options = []): ?string
     {
-        $options += ['safe' => false, 'block' => null];
-        if ($options['safe']) {
-            $script = "\n" . '//<![CDATA[' . "\n" . $script . "\n" . '//]]>' . "\n";
-        }
-        unset($options['safe']);
+        $options += ['block' => null];
 
         $out = $this->formatTemplate('javascriptblock', [
             'attrs' => $this->templater()->formatAttributes($options, ['block']),
@@ -575,8 +569,6 @@ class HtmlHelper extends Helper
      *
      * ### Options
      *
-     * - `safe` (boolean) Whether or not the $script should be wrapped in `<![CDATA[ ]]>`.
-     *   See scriptBlock().
      * - `block` Set to true to append output to view block "script" or provide
      *   custom block name.
      *

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1192,20 +1192,10 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->scriptBlock('window.foo = 2;', ['safe' => false]);
+        $result = $this->Html->scriptBlock('window.foo = 2;');
         $expected = [
             '<script',
             'window.foo = 2;',
-            '/script',
-        ];
-        $this->assertHtml($expected, $result);
-
-        $result = $this->Html->scriptBlock('window.foo = 2;', ['safe' => true]);
-        $expected = [
-            '<script',
-            $this->cDataStart,
-            'window.foo = 2;',
-            $this->cDataEnd,
             '/script',
         ];
         $this->assertHtml($expected, $result);
@@ -1224,7 +1214,7 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->scriptBlock('alert("hi")', ['block' => 'scriptTop']);
         $this->assertNull($result);
 
-        $result = $this->Html->scriptBlock('window.foo = 2;', ['safe' => false, 'encoding' => 'utf-8']);
+        $result = $this->Html->scriptBlock('window.foo = 2;', ['encoding' => 'utf-8']);
         $expected = [
             'script' => ['encoding' => 'utf-8'],
             'window.foo = 2;',
@@ -1252,7 +1242,7 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->scriptStart(['safe' => false]);
+        $result = $this->Html->scriptStart();
         $this->assertNull($result);
         echo 'this is some javascript';
 
@@ -1263,43 +1253,6 @@ class HtmlHelperTest extends TestCase
             '/script',
         ];
         $this->assertHtml($expected, $result);
-
-        $result = $this->Html->scriptStart(['safe' => true]);
-        $this->assertNull($result);
-        echo 'this is some javascript';
-
-        $result = $this->Html->scriptEnd();
-        $expected = [
-            '<script',
-            $this->cDataStart,
-            'this is some javascript',
-            $this->cDataEnd,
-            '/script',
-        ];
-        $this->assertHtml($expected, $result);
-
-        $result = $this->Html->scriptStart(['safe' => true, 'type' => 'text/x-handlebars-template']);
-        $this->assertNull($result);
-        echo 'this is some template';
-
-        $result = $this->Html->scriptEnd();
-        $expected = [
-            'script' => ['type' => 'text/x-handlebars-template'],
-            $this->cDataStart,
-            'this is some template',
-            $this->cDataEnd,
-            '/script',
-        ];
-        $this->assertHtml($expected, $result);
-
-        $this->View->expects($this->once())
-            ->method('append');
-        $result = $this->Html->scriptStart(['safe' => false, 'block' => true]);
-        $this->assertNull($result);
-        echo 'this is some javascript';
-
-        $result = $this->Html->scriptEnd();
-        $this->assertNull($result);
     }
 
     /**


### PR DESCRIPTION
Using CDATA tag was only required for XHTML which is defunct now.