### PR TITLE
Re-add DS convenience constant

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -17,6 +17,13 @@ declare(strict_types=1);
 
 use Cake\Core\Configure;
 
+if (!defined('DS')) {
+    /**
+     * Defines DS as short form of DIRECTORY_SEPARATOR.
+     */
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
 if (!function_exists('h')) {
     /**
      * Convenience method for htmlspecialchars.


### PR DESCRIPTION
Reverts https://github.com/cakephp/cakephp/commit/2685f4c476ed2415d2e64b52f49bc901b4ae88c5#diff-3eef224990686c2ba0091a717d935856

This is actually quite painful for both upgrades (e.g. plugins and their code) as well as readability if you defined paths "OS safe". Even if core for "split package" reasons doesn't use it directly, we should still enable user land and plugin eco system to rely on those.