### PR TITLE
Fixed testWithModified() using different 'now' for comparison

### DIFF
--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -1089,11 +1089,11 @@ class ResponseTest extends TestCase
 
         $now = time();
         $new = $response->withModified($now);
-        $this->assertEquals(gmdate($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertEquals(gmdate($format, $now) . ' GMT', $new->getHeaderLine('Last-Modified'));
 
         $now = new \DateTimeImmutable();
         $new = $response->withModified($now);
-        $this->assertEquals(gmdate($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertEquals(gmdate($format, $now->getTimestamp()) . ' GMT', $new->getHeaderLine('Last-Modified'));
 
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $new = $response->withModified('+1 day');


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/13900