### PR TITLE
Use the CommandInterface for constants instead of Command class.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -14,7 +14,7 @@
  * @since         1.1.11
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$versionFile = file(CORE_PATH . 'VERSION.txt');
+$versionFile = file(dirname(__DIR__) . '/VERSION.txt');
 
 return [
     'Cake.version' => trim(array_pop($versionFile)),

--- a/src/Command/CacheClearCommand.php
+++ b/src/Command/CacheClearCommand.php
@@ -21,7 +21,6 @@ use Cake\Cache\Engine\ApcuEngine;
 use Cake\Cache\Engine\WincacheEngine;
 use Cake\Cache\InvalidArgumentException;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/CacheClearallCommand.php
+++ b/src/Command/CacheClearallCommand.php
@@ -18,7 +18,6 @@ namespace Cake\Command;
 
 use Cake\Cache\Cache;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/CacheListCommand.php
+++ b/src/Command/CacheListCommand.php
@@ -18,7 +18,6 @@ namespace Cake\Command;
 
 use Cake\Cache\Cache;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\BaseCommand;
+use Cake\Console\ConsoleIo;
+use Cake\Datasource\ModelAwareTrait;
+use Cake\Log\LogTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * Base class for commands using the full stack
+ * CakePHP Framework.
+ *
+ * Includes traits that integrate logging
+ * and ORM models to console commands.
+ */
+class Command extends BaseCommand
+{
+    use LocatorAwareTrait;
+    use LogTrait;
+    use ModelAwareTrait;
+
+    /**
+     * Constructor
+     *
+     * By default CakePHP will construct command objects when
+     * building the CommandCollection for your application.
+     */
+    public function __construct()
+    {
+        $this->modelFactory('Table', function ($alias) {
+            return $this->getTableLocator()->get($alias);
+        });
+
+        if (isset($this->modelClass)) {
+            $this->loadModel();
+        }
+    }
+
+    /**
+     * Implement this method with your command's logic.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null|void The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+    }
+}

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;

--- a/src/Command/I18nCommand.php
+++ b/src/Command/I18nCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\App;

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\App;

--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/PluginLoadedCommand.php
+++ b/src/Command/PluginLoadedCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Plugin;

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 

--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Http\ServerRequest;

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Routing\Router;

--- a/src/Command/RoutesGenerateCommand.php
+++ b/src/Command/RoutesGenerateCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Routing\Exception\MissingRouteException;

--- a/src/Command/SchemacacheBuildCommand.php
+++ b/src/Command/SchemacacheBuildCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\SchemaCache;

--- a/src/Command/SchemacacheClearCommand.php
+++ b/src/Command/SchemacacheClearCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\SchemaCache;

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -2,62 +2,10 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.6.0
- * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @deprecated 4.0.0 Use Cake\Command\Command instead.
  */
-namespace Cake\Console;
 
-use Cake\Datasource\ModelAwareTrait;
-use Cake\Log\LogTrait;
-use Cake\ORM\Locator\LocatorAwareTrait;
-
-/**
- * Base class for commands using the full stack
- * CakePHP Framework.
- *
- * Includes traits that integrate logging
- * and ORM models to console commands.
- */
-class Command extends BaseCommand
-{
-    use LocatorAwareTrait;
-    use LogTrait;
-    use ModelAwareTrait;
-
-    /**
-     * Constructor
-     *
-     * By default CakePHP will construct command objects when
-     * building the CommandCollection for your application.
-     */
-    public function __construct()
-    {
-        $this->modelFactory('Table', function ($alias) {
-            return $this->getTableLocator()->get($alias);
-        });
-
-        if (isset($this->modelClass)) {
-            $this->loadModel();
-        }
-    }
-
-    /**
-     * Implement this method with your command's logic.
-     *
-     * @param \Cake\Console\Arguments $args The command arguments.
-     * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null|void The exit code or null for success
-     */
-    public function execute(Arguments $args, ConsoleIo $io)
-    {
-    }
-}
+class_alias(
+    'Cake\Command\Command',
+    'Cake\Console\Command'
+);

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Console\Command;
 
 use ArrayIterator;
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         3.6.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Command;
+namespace Cake\Console\Command;
 
 use ArrayIterator;
 use Cake\Console\Arguments;

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -157,10 +157,10 @@ class CommandRunner implements EventDispatcherInterface
         } catch (MissingOptionException $e) {
             $io->error($e->getFullMessage());
 
-            return Command::CODE_ERROR;
+            return CommandInterface::CODE_ERROR;
         }
 
-        $result = Command::CODE_ERROR;
+        $result = CommandInterface::CODE_ERROR;
         $shell = $this->getShell($io, $commands, $name);
         if ($shell instanceof Shell) {
             $result = $this->runShell($shell, $argv);
@@ -170,13 +170,13 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         if ($result === null || $result === true) {
-            return Command::CODE_SUCCESS;
+            return CommandInterface::CODE_SUCCESS;
         }
         if (is_int($result) && $result >= 0 && $result <= 255) {
             return $result;
         }
 
-        return Command::CODE_ERROR;
+        return CommandInterface::CODE_ERROR;
     }
 
     /**

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -161,7 +161,7 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         $result = CommandInterface::CODE_ERROR;
-        $shell = $this->getShell($io, $commands, $name);
+        $shell = $this->getCommand($io, $commands, $name);
         if ($shell instanceof Shell) {
             $result = $this->runShell($shell, $argv);
         }
@@ -239,11 +239,11 @@ class CommandRunner implements EventDispatcherInterface
      * @param string $name The command name to find
      * @return \Cake\Console\Shell|\Cake\Console\CommandInterface
      */
-    protected function getShell(ConsoleIo $io, CommandCollection $commands, string $name)
+    protected function getCommand(ConsoleIo $io, CommandCollection $commands, string $name)
     {
         $instance = $commands->get($name);
         if (is_string($instance)) {
-            $instance = $this->createShell($instance, $io);
+            $instance = $this->createCommand($instance, $io);
         }
         if ($instance instanceof Shell) {
             $instance->setRootName($this->root);
@@ -364,7 +364,7 @@ class CommandRunner implements EventDispatcherInterface
      * @param \Cake\Console\ConsoleIo $io The IO wrapper for the created shell class.
      * @return \Cake\Console\Shell|\Cake\Console\CommandInterface
      */
-    protected function createShell(string $className, ConsoleIo $io)
+    protected function createCommand(string $className, ConsoleIo $io)
     {
         $shell = $this->factory->create($className);
         if ($shell instanceof Shell) {

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Console;
 
-use Cake\Command\HelpCommand;
 use Cake\Command\VersionCommand;
+use Cake\Console\Command\HelpCommand;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -132,9 +132,11 @@ class CommandRunner implements EventDispatcherInterface
         $this->bootstrap();
 
         $commands = new CommandCollection([
-            'version' => VersionCommand::class,
             'help' => HelpCommand::class,
         ]);
+        if (class_exists(VersionCommand::class)) {
+            $commands->add('version', VersionCommand::class);
+        }
         $commands = $this->app->console($commands);
 
         if ($this->app instanceof PluginApplicationInterface) {

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -114,6 +114,9 @@ class CommandScanner
             return [];
         }
 
+        // This ensures `Command` class is not added to the list.
+        $hide[] = '';
+
         $classPattern = '/(Shell|Command)\.php$/';
         $fs = new Filesystem();
         /** @var \SplFileInfo[] $files */
@@ -137,7 +140,7 @@ class CommandScanner
                 continue;
             }
             if (is_subclass_of($class, CommandInterface::class)) {
-                /** @var \Cake\Console\Command $class */
+                /** @var \Cake\Console\BaseCommand $class */
                 $name = $class::defaultName();
             }
             $shells[$path . $file] = [

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -268,7 +268,7 @@ class ConsoleIo
      * @return void
      * @throws \Cake\Console\Exception\StopException
      */
-    public function abort($message, $code = Command::CODE_ERROR): void
+    public function abort($message, $code = CommandInterface::CODE_ERROR): void
     {
         $this->error($message);
 

--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Console\Exception;
 
-use Cake\Console\Command;
+use Cake\Console\CommandInterface;
 use Cake\Core\Exception\Exception;
 
 /**
@@ -29,5 +29,5 @@ class ConsoleException extends Exception
      *
      * @var int
      */
-    protected $_defaultCode = Command::CODE_ERROR;
+    protected $_defaultCode = CommandInterface::CODE_ERROR;
 }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -412,7 +412,7 @@ class Configure
     public static function version(): string
     {
         if (!isset(static::$_values['Cake']['version'])) {
-            $config = require CORE_PATH . 'config/config.php';
+            $config = require dirname(dirname(__DIR__)) . '/config/config.php';
             static::write($config);
         }
 

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Configure;
 use Cake\Routing\Router;
 use Cake\TestSuite\ConsoleIntegrationTestCase;

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Filesystem\File;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Command/PluginLoadedCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadedCommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Routing\Router;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
 

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         3.5.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Command;
+namespace Cake\Test\TestCase\Console\Command;
 
 use Cake\Console\Command;
 use Cake\Core\Plugin;

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Core\Plugin;
 use Cake\Http\BaseApplication;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -164,7 +164,7 @@ class CommandRunnerTest extends TestCase
             "\n" .
             "Other valid choices:\n" .
             "\n" .
-            "- version",
+            "- help",
             $messages
         );
     }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Exception\StopException;

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -465,7 +465,7 @@ class ConfigureTest extends TestCase
     public function testVersion()
     {
         $result = Configure::version();
-        $this->assertTrue(version_compare($result, '1.2', '>='));
+        $this->assertTrue(version_compare($result, '4.0', '>='));
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Command/WidgetCommand.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Command/WidgetCommand.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace TestPlugin\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 
 class WidgetCommand extends Command

--- a/tests/test_app/TestApp/Command/AbortCommand.php
+++ b/tests/test_app/TestApp/Command/AbortCommand.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace TestApp\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 
 class AbortCommand extends Command

--- a/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
+++ b/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Command;
 
-use Cake\Console\Command;
+use Cake\Command\Command;
 
 class AutoLoadModelCommand extends Command
 {

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace TestApp\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 
 class DemoCommand extends Command


### PR DESCRIPTION
Refs #13930.

The use of `VersionCommand` and `HelpCommand` needs to be addressed. We can either move then under `Console` or add check to use them only if the class exists.