### PR TITLE
Improve error messages when replies run out.

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -26,6 +26,7 @@ use Cake\TestSuite\Constraint\Console\ContentsRegExp;
 use Cake\TestSuite\Constraint\Console\ExitCode;
 use Cake\TestSuite\Stub\ConsoleInput;
 use Cake\TestSuite\Stub\ConsoleOutput;
+use Cake\TestSuite\Stub\MissingConsoleInputException;
 
 /**
  * A test case class intended to make integration tests of cake console commands
@@ -88,6 +89,12 @@ trait ConsoleIntegrationTestTrait
 
         try {
             $this->_exitCode = $runner->run($args, $io);
+        } catch (MissingConsoleInputException $e) {
+            $messages = $this->_out->messages();
+            if (count($messages)) {
+                $e->setQuestion($messages[count($messages) - 1]);
+            }
+            throw $e;
         } catch (StopException $exception) {
             $this->_exitCode = $exception->getCode();
         }

--- a/src/TestSuite/Stub/ConsoleInput.php
+++ b/src/TestSuite/Stub/ConsoleInput.php
@@ -14,7 +14,7 @@
 namespace Cake\TestSuite\Stub;
 
 use Cake\Console\ConsoleInput as ConsoleInputBase;
-use Cake\Console\Exception\ConsoleException;
+use Cake\TestSuite\Stub\MissingConsoleInputException;
 use NumberFormatter;
 
 /**
@@ -67,8 +67,8 @@ class ConsoleInput extends ConsoleInputBase
 
             $replies = implode(', ', $this->replies);
             $message = "There are no more input replies available. This is the {$nth} read operation, " .
-                "only {$total} replies were set. The provided replies are: {$replies}";
-            throw new ConsoleException($message);
+                "only {$total} replies were set.\nThe provided replies are: {$replies}";
+            throw new MissingConsoleInputException($message);
         }
 
         return $this->replies[$this->currentIndex];

--- a/src/TestSuite/Stub/MissingConsoleInputException.php
+++ b/src/TestSuite/Stub/MissingConsoleInputException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Stub;
+
+use RuntimeException;
+
+/**
+ * Exception class used to indicate missing console input.
+ */
+class MissingConsoleInputException extends RuntimeException
+{
+    /**
+     * Update the exception message with the question text
+     *
+     * @param string $question The question text.
+     * @return void
+     */
+    public function setQuestion($question)
+    {
+        $this->message .= "\nThe question asked was: " . $question;
+    }
+}

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -17,6 +17,7 @@ use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\Stub\MissingConsoleInputException;
 use PHPUnit\Framework\AssertionFailedError;
 
 class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
@@ -150,7 +151,7 @@ class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
      */
     public function testExecWithMissingInput()
     {
-        $this->expectException(ConsoleException::class);
+        $this->expectException(MissingConsoleInputException::class);
         $this->expectExceptionMessage('no more input');
         $this->exec('integration bridge', ['cake']);
     }


### PR DESCRIPTION
When an console integration test runs out of replies we currently tell you what the replies were but not what question went un-answered. This should make that easier.

Targeting master with this as while it does add a new class it is primarily trying to make testing easier.