### PR TITLE
4.x - Removed DateTimeType::_parseValue()

### DIFF
--- a/src/Database/Type/DateTimeFractionalType.php
+++ b/src/Database/Type/DateTimeFractionalType.php
@@ -25,16 +25,4 @@ class DateTimeFractionalType extends DateTimeType
      * @inheritDoc
      */
     protected $_format = 'Y-m-d H:i:s.u';
-
-    /**
-     * @inheritDoc
-     */
-    protected $_marshalFormats = [
-        'Y-m-d H:i:s.u',
-        'Y-m-d H:i:s',
-        'Y-m-d\TH:i:s.u',
-        'Y-m-d\TH:i:s',
-        'Y-m-d\TH:i:s.uP',
-        'Y-m-d\TH:i:sP',
-    ];
 }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -54,17 +54,6 @@ class DateTimeType extends BaseType
     protected $_format = 'Y-m-d H:i:s';
 
     /**
-     * The DateTime formats allowed by `marshal()`.
-     *
-     * @var array
-     */
-    protected $_marshalFormats = [
-        'Y-m-d H:i:s',
-        'Y-m-d\TH:i:s',
-        'Y-m-d\TH:i:sP',
-    ];
-
-    /**
      * Whether `marshal()` should use locale-aware parser with `_localeMarshalFormat`.
      *
      * @var bool
@@ -257,7 +246,7 @@ class DateTimeType extends BaseType
             } elseif ($isString && $this->_useLocaleMarshal) {
                 return $this->_parseLocaleValue($value);
             } elseif ($isString) {
-                return $this->_parseValue($value);
+                return new $class($value);
             }
         } catch (Exception $e) {
             return null;
@@ -403,35 +392,6 @@ class DateTimeType extends BaseType
         $class = $this->_className;
 
         return $class::parseDateTime($value, $this->_localeMarshalFormat);
-    }
-
-    /**
-     * Converts a string into a DateTime object after parsing it using the
-     * formats in `_marshalFormats`.
-     *
-     * @param string $value The value to parse and convert to an object.
-     * @return \DateTimeInterface|null
-     */
-    protected function _parseValue(string $value)
-    {
-        /** @var \DateTime|\DateTimeImmutable $class */
-        $class = $this->_className;
-
-        foreach ($this->_marshalFormats as $format) {
-            try {
-                $dateTime = $class::createFromFormat($format, $value);
-                // Check for false in case DateTime is used directly
-                if ($dateTime !== false) {
-                    return $dateTime;
-                }
-            } catch (InvalidArgumentException $e) {
-                // Chronos wraps DateTime::createFromFormat and throws
-                // exception if parse fails.
-                continue;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -25,7 +25,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
-use InvalidArgumentException;
 use PDO;
 use RuntimeException;
 
@@ -246,6 +245,7 @@ class DateTimeType extends BaseType
             } elseif ($isString && $this->_useLocaleMarshal) {
                 return $this->_parseLocaleValue($value);
             } elseif ($isString) {
+                /** @var \DateTimeInterface */
                 return new $class($value);
             }
         } catch (Exception $e) {

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -33,13 +33,6 @@ class DateType extends DateTimeType
     protected $_format = 'Y-m-d';
 
     /**
-     * @inheritDoc
-     */
-    protected $_marshalFormats = [
-        'Y-m-d',
-    ];
-
-    /**
      * In this class we want Date objects to  have their time
      * set to the beginning of the day.
      *

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -31,13 +31,6 @@ class TimeType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected $_marshalFormats = [
-        'H:i:s',
-    ];
-
-    /**
-     * @inheritDoc
-     */
     protected function _parseLocaleValue(string $value)
     {
         /** @var \Cake\I18n\I18nDateTimeInterface $class */

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -233,14 +233,16 @@ class DateTimeFractionalTypeTest extends TestCase
             ['', null],
             ['derpy', null],
             ['2013-nope!', null],
-            ['2014-02-14T13:14:15.1234567', null],
-            ['2017-04-05T17:18:00.1234567+00:00', null],
 
             // valid string types
             ['2014-02-14 00:00:00.123456', new FrozenTime('2014-02-14 00:00:00.123456')],
             ['2014-02-14 13:14:15.123456', new FrozenTime('2014-02-14 13:14:15.123456')],
             ['2014-02-14T13:14:15.123456', new FrozenTime('2014-02-14T13:14:15.123456')],
             ['2017-04-05T17:18:00.123456+00:00', new FrozenTime('2017-04-05T17:18:00.123456+00:00')],
+
+            // ignore extra fractional digits
+            ['2014-02-14T13:14:15.1234567', new FrozenTime('2014-02-14T13:14:15.123456')],
+            ['2017-04-05T17:18:00.1234567+00:00', new FrozenTime('2017-04-05T17:18:00.123456+00:00')],
 
             // valid array types
             [

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -313,13 +313,14 @@ class DateTimeTypeTest extends TestCase
      */
     public function testLocaleParserDisable()
     {
-        $expected = new Time('13-10-2013 23:28:00');
+        $expected = new Time('2013-10-13 23:28:00');
         $this->type->useLocaleParser();
-        $result = $this->type->marshal('10/13/2013 11:28pm');
+        $this->type->setLocaleFormat('y-d M m-ha');
+        $result = $this->type->marshal('2013-13 10 28:11pm');
         $this->assertEquals($expected, $result);
 
         $this->type->useLocaleParser(false);
-        $result = $this->type->marshal('10/13/2013 11:28pm');
+        $result = $this->type->marshal('2013-13 10 28:11pm');
         $this->assertNotEquals($expected, $result);
     }
 

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -126,12 +126,14 @@ class DateTypeTest extends TestCase
             ['', null],
             ['derpy', null],
             ['2013-nope!', null],
-            ['2014-02-14 13:14:15', null],
 
             // valid string types
             ['1392387900', $date],
             [1392387900, $date],
             ['2014-02-14', new Date('2014-02-14')],
+
+            // time is ignored
+            ['2014-02-14 13:14:15', new Date('2014-02-14')],
 
             // valid array types
             [

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -146,13 +146,15 @@ class TimeTypeTest extends TestCase
             ['', null],
             ['derpy', null],
             ['16-nope!', null],
-            ['14:15', null],
-            ['2014-02-14 13:14:15', null],
 
             // valid string types
             ['1392387900', $date],
             [1392387900, $date],
             ['13:10:10', new Time('13:10:10')],
+            ['14:15', new Time('14:15:00')],
+
+            // date is not set to now
+            ['2014-02-14 13:14:15', new Time('2014-02-14 13:14:15')],
 
             // valid array types
             [


### PR DESCRIPTION
Removed the extensive list of formats we try to parse in `DateTimeType::_parseValue()`.  We can just let `DateTime` constructor parse everything it supports and pull out the values we need on saving.

This is to reduce things before adding more formats like time zone formats.  

We discussed this in https://github.com/cakephp/cakephp/pull/13752, but kept format parsing in place to help test the first set of changes.