### PR TITLE
Make Configure::version() more resiliant

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -411,12 +411,20 @@ class Configure
      */
     public static function version(): string
     {
-        if (!isset(static::$_values['Cake']['version'])) {
-            $config = require dirname(dirname(__DIR__)) . '/config/config.php';
-            static::write($config);
+        $version = static::read('Cake.version');
+        if ($version !== null) {
+            return $version;
         }
 
-        return static::$_values['Cake']['version'];
+        $path = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'config/config.php';
+        if (file_exists($path)) {
+            $config = require $path;
+            static::write($config);
+
+            return static::read('Cake.version');
+        }
+
+        return 'unknown';
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -464,8 +464,14 @@ class ConfigureTest extends TestCase
      */
     public function testVersion()
     {
-        $result = Configure::version();
-        $this->assertTrue(version_compare($result, '4.0', '>='));
+        $original = Configure::version();
+        $this->assertTrue(version_compare($original, '4.0', '>='));
+
+        Configure::write('Cake.version', 'banana');
+        $this->assertSame('banana', Configure::version('Cake.version'));
+
+        Configure::delete('Cake.version');
+        $this->assertSame($original, Configure::version());
     }
 
     /**


### PR DESCRIPTION
In addition to checking for the config/config.php file we should also honour the return type even when we don't know which version of CakePHP is being run.
