### PR TITLE
3.9 - Renamed Validator::errors() to Validator::validate()

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -239,7 +239,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
                 $validator = $this->validator();
             }
         }
-        $this->_errors = $validator->errors($data);
+        $this->_errors = $validator->validate($data);
 
         return count($this->_errors) === 0;
     }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -257,7 +257,7 @@ class Marshaller
             );
         }
 
-        return $validator->errors($data, $isNew);
+        return $validator->validate($data, $isNew);
     }
 
     /**

--- a/src/Validation/README.md
+++ b/src/Validation/README.md
@@ -26,7 +26,7 @@ $validator
     ->requirePresence('comment')
     ->notEmpty('comment', 'You need to give a comment.');
 
-$errors = $validator->errors($_POST);
+$errors = $validator->validate($_POST);
 if (!empty($errors)) {
     // display errors.
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -160,14 +160,26 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
-     * Returns an array of fields that have failed validation. On the current model. This method will
-     * actually run validation rules over data, not just return the messages.
+     * Validates and returns an array of failed fields and their error messages.
      *
      * @param array $data The data to be checked for errors
      * @param bool $newRecord whether the data to be validated is new or to be updated.
-     * @return array Array of invalid fields
+     * @return array Array of failed fields
+     * @deprecated 3.9.0 Renamed to validate()
      */
     public function errors(array $data, $newRecord = true)
+    {
+        return $this->validate($data, $newRecord);
+    }
+
+    /**
+     * Validates and returns an array of failed fields and their error messages.
+     *
+     * @param array $data The data to be checked for errors
+     * @param bool $newRecord whether the data to be validated is new or to be updated.
+     * @return array Array of failed fields
+     */
+    public function validate(array $data, $newRecord = true)
     {
         $errors = [];
 
@@ -500,7 +512,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             foreach ($this->providers() as $provider) {
                 $validator->setProvider($provider, $this->getProvider($provider));
             }
-            $errors = $validator->errors($value, $context['newRecord']);
+            $errors = $validator->validate($value, $context['newRecord']);
 
             $message = $message ? [static::NESTED => $message] : [];
 
@@ -547,7 +559,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 if (!is_array($row)) {
                     return false;
                 }
-                $check = $validator->errors($row, $context['newRecord']);
+                $check = $validator->validate($row, $context['newRecord']);
                 if (!empty($check)) {
                     $errors[$i] = $check;
                 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6040,28 +6040,28 @@ class TableTest extends TestCase
         $validator->setProvider('table', $table);
 
         $data = ['username' => ['larry', 'notthere']];
-        $this->assertNotEmpty($validator->errors($data));
+        $this->assertNotEmpty($validator->validate($data));
 
         $data = ['username' => 'larry'];
-        $this->assertNotEmpty($validator->errors($data));
+        $this->assertNotEmpty($validator->validate($data));
 
         $data = ['username' => 'jose'];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = ['username' => 'larry', 'id' => 3];
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertEmpty($validator->validate($data, false));
 
         $data = ['username' => 'larry', 'id' => 3];
-        $this->assertNotEmpty($validator->errors($data));
+        $this->assertNotEmpty($validator->validate($data));
 
         $data = ['username' => 'larry'];
-        $this->assertNotEmpty($validator->errors($data, false));
+        $this->assertNotEmpty($validator->validate($data, false));
 
         $validator->add('username', 'unique', [
             'rule' => 'validateUnique', 'provider' => 'table',
         ]);
         $data = ['username' => 'larry'];
-        $this->assertNotEmpty($validator->errors($data, false));
+        $this->assertNotEmpty($validator->validate($data, false));
     }
 
     /**
@@ -6079,13 +6079,13 @@ class TableTest extends TestCase
         ]);
         $validator->setProvider('table', $table);
         $data = ['username' => 'larry', 'id' => 3];
-        $this->assertNotEmpty($validator->errors($data));
+        $this->assertNotEmpty($validator->validate($data));
 
         $data = ['username' => 'larry', 'id' => 1];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = ['username' => 'jose'];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
     }
 
     /**
@@ -6121,7 +6121,7 @@ class TableTest extends TestCase
 
         $data = ['site_id' => 1, 'author_id' => null, 'title' => 'Null dupe'];
         $expected = ['site_id' => ['unique' => 'Must be unique.']];
-        $this->assertEquals($expected, $validator->errors($data));
+        $this->assertEquals($expected, $validator->validate($data));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -137,7 +137,7 @@ class ValidatorTest extends TestCase
         }]);
         $validator->addNested('user', $inner);
 
-        $result = $validator->errors(['user' => ['username' => 'example']]);
+        $result = $validator->validate(['user' => ['username' => 'example']]);
         $this->assertNotEmpty($result, 'Validation should fail');
     }
 
@@ -159,16 +159,16 @@ class ValidatorTest extends TestCase
         $rule = $validator->field('user')->rule(Validator::NESTED);
         $this->assertSame('create', $rule->get('on'));
 
-        $errors = $validator->errors(['user' => 'string']);
+        $errors = $validator->validate(['user' => 'string']);
         $this->assertArrayHasKey('user', $errors);
         $this->assertArrayHasKey(Validator::NESTED, $errors['user']);
         $this->assertSame('errors found', $errors['user'][Validator::NESTED]);
 
-        $errors = $validator->errors(['user' => ['key' => 'value']]);
+        $errors = $validator->validate(['user' => ['key' => 'value']]);
         $this->assertArrayHasKey('user', $errors);
         $this->assertArrayHasKey(Validator::NESTED, $errors['user']);
 
-        $this->assertEmpty($validator->errors(['user' => ['key' => 'value']], false));
+        $this->assertEmpty($validator->validate(['user' => ['key' => 'value']], false));
     }
 
     /**
@@ -204,7 +204,7 @@ class ValidatorTest extends TestCase
         }]);
         $validator->addNestedMany('comments', $inner);
 
-        $result = $validator->errors(['comments' => [['comment' => 'example']]]);
+        $result = $validator->validate(['comments' => [['comment' => 'example']]]);
         $this->assertNotEmpty($result, 'Validation should fail');
     }
 
@@ -226,21 +226,21 @@ class ValidatorTest extends TestCase
         $rule = $validator->field('comments')->rule(Validator::NESTED);
         $this->assertSame('create', $rule->get('on'));
 
-        $errors = $validator->errors(['comments' => 'string']);
+        $errors = $validator->validate(['comments' => 'string']);
         $this->assertArrayHasKey('comments', $errors);
         $this->assertArrayHasKey(Validator::NESTED, $errors['comments']);
         $this->assertSame('errors found', $errors['comments'][Validator::NESTED]);
 
-        $errors = $validator->errors(['comments' => ['string']]);
+        $errors = $validator->validate(['comments' => ['string']]);
         $this->assertArrayHasKey('comments', $errors);
         $this->assertArrayHasKey(Validator::NESTED, $errors['comments']);
         $this->assertSame('errors found', $errors['comments'][Validator::NESTED]);
 
-        $errors = $validator->errors(['comments' => [['body' => null]]]);
+        $errors = $validator->validate(['comments' => [['body' => null]]]);
         $this->assertArrayHasKey('comments', $errors);
         $this->assertArrayHasKey(Validator::NESTED, $errors['comments']);
 
-        $this->assertEmpty($validator->errors(['comments' => [['body' => null]]], false));
+        $this->assertEmpty($validator->validate(['comments' => [['body' => null]]], false));
     }
 
     /**
@@ -411,14 +411,14 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->requirePresence('title');
-        $errors = $validator->errors(['foo' => 'something']);
+        $errors = $validator->validate(['foo' => 'something']);
         $expected = ['title' => ['_required' => 'This field is required']];
         $this->assertEquals($expected, $errors);
 
-        $this->assertEmpty($validator->errors(['title' => 'bar']));
+        $this->assertEmpty($validator->validate(['title' => 'bar']));
 
         $validator->requirePresence('title', false);
-        $this->assertEmpty($validator->errors(['foo' => 'bar']));
+        $this->assertEmpty($validator->validate(['foo' => 'bar']));
     }
 
     /**
@@ -438,13 +438,13 @@ class ValidatorTest extends TestCase
         ];
 
         $expected = [];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
 
         $this->assertEquals($expected, $result);
     }
 
     /**
-     * Test that errors() can work with nested data.
+     * Test that validate() can work with nested data.
      *
      * @return void
      */
@@ -468,7 +468,7 @@ class ValidatorTest extends TestCase
                 ['comment' => 'is wrong'],
             ],
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $expected = [
             'user' => [
                 'username' => ['letter' => 'The provided value is invalid'],
@@ -496,7 +496,7 @@ class ValidatorTest extends TestCase
         $data = [
             'user' => 'a string',
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $expected = [
             'user' => ['_nested' => 'The provided value is invalid'],
         ];
@@ -519,7 +519,7 @@ class ValidatorTest extends TestCase
         $data = [
             'comments' => 'a string',
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $expected = [
             'comments' => ['_nested' => 'The provided value is invalid'],
         ];
@@ -546,7 +546,7 @@ class ValidatorTest extends TestCase
                 ['comment' => 'more invalid'],
             ],
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $expected = [
             'comments' => [
                 '_nested' => 'The provided value is invalid',
@@ -564,7 +564,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->requirePresence('title', true, 'Custom message');
-        $errors = $validator->errors(['foo' => 'something']);
+        $errors = $validator->validate(['foo' => 'something']);
         $expected = ['title' => ['_required' => 'Custom message']];
         $this->assertEquals($expected, $errors);
     }
@@ -578,7 +578,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->requirePresence(['title', 'content'], true, 'Custom message');
-        $errors = $validator->errors(['foo' => 'something']);
+        $errors = $validator->validate(['foo' => 'something']);
         $expected = [
             'title' => ['_required' => 'Custom message'],
             'content' => ['_required' => 'Custom message'],
@@ -591,7 +591,7 @@ class ValidatorTest extends TestCase
             ],
             'content',
         ], true, 'Custom message');
-        $errors = $validator->errors(['foo' => 'something']);
+        $errors = $validator->validate(['foo' => 'something']);
         $expected = [
             'title' => ['_required' => 'Test message'],
             'content' => ['_required' => 'Custom message'],
@@ -635,7 +635,7 @@ class ValidatorTest extends TestCase
                 'day' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty date');
 
         $data = [
@@ -649,7 +649,7 @@ class ValidatorTest extends TestCase
                 'meridian' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty datetime');
 
         $data = [
@@ -659,7 +659,7 @@ class ValidatorTest extends TestCase
                 'meridian' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty time');
     }
 
@@ -682,7 +682,7 @@ class ValidatorTest extends TestCase
                 'error' => UPLOAD_ERR_NO_FILE,
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty file');
 
         $data = [
@@ -692,7 +692,7 @@ class ValidatorTest extends TestCase
                 UPLOAD_ERR_NO_FILE
             ),
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty file');
 
         $data = [
@@ -703,7 +703,7 @@ class ValidatorTest extends TestCase
                 'error' => UPLOAD_ERR_OK,
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertNotEmpty($result, 'Invalid file should be caught still.');
     }
 
@@ -736,7 +736,7 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->field('updated_at')->isEmptyAllowed());
         $this->assertEquals('update', $validator->field('show_at')->isEmptyAllowed());
 
-        $errors = $validator->errors([
+        $errors = $validator->validate([
             'title' => '',
             'subject' => null,
             'posted_at' => null,
@@ -781,17 +781,17 @@ class ValidatorTest extends TestCase
         $data = [
             'title' => '',
         ];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = [
             'title' => null,
         ];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = [
             'title' => [],
         ];
-        $this->assertNotEmpty($validator->errors($data));
+        $this->assertNotEmpty($validator->validate($data));
 
         $validator = new Validator();
         $validator->allowEmptyString('title', 'message', 'update');
@@ -804,8 +804,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'title' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -828,8 +828,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'title' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -852,8 +852,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'title' => ['_empty' => 'This field cannot be left empty'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -870,20 +870,20 @@ class ValidatorTest extends TestCase
         $this->assertFalse($validator->isEmptyAllowed('title', false));
 
         $data = ['title' => '0'];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = ['title' => 0];
-        $this->assertEmpty($validator->errors($data), 'empty ok on create');
-        $this->assertEmpty($validator->errors($data, false), 'empty ok on update');
+        $this->assertEmpty($validator->validate($data), 'empty ok on create');
+        $this->assertEmpty($validator->validate($data, false), 'empty ok on update');
 
         $data = ['title' => []];
-        $this->assertEmpty($validator->errors($data), 'empty array is no good');
+        $this->assertEmpty($validator->validate($data), 'empty array is no good');
 
         $expected = [
             'title' => ['_empty' => 'not empty'],
         ];
         $data = ['title' => ''];
-        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertSame($expected, $validator->validate($data, true));
     }
 
     /**
@@ -902,13 +902,13 @@ class ValidatorTest extends TestCase
             'title' => ['_empty' => 'message'],
         ];
         $data = ['title' => null];
-        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertSame($expected, $validator->validate($data, true));
 
         $data = ['title' => ''];
-        $this->assertSame($expected, $validator->errors($data, true));
+        $this->assertSame($expected, $validator->validate($data, true));
 
         $data = ['title' => ''];
-        $this->assertEmpty($validator->errors($data, false), 'empty allowed on update');
+        $this->assertEmpty($validator->validate($data, false), 'empty allowed on update');
     }
 
     /**
@@ -931,13 +931,13 @@ class ValidatorTest extends TestCase
             'title' => ['_empty' => 'message'],
         ];
         $data = ['title' => ''];
-        $this->assertSame($error, $validator->errors($data));
+        $this->assertSame($error, $validator->validate($data));
 
         $data = ['title' => '', 'emptyOk' => false];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = ['title' => '', 'emptyOk' => true];
-        $this->assertSame($error, $validator->errors($data));
+        $this->assertSame($error, $validator->validate($data));
     }
 
     /**
@@ -956,19 +956,19 @@ class ValidatorTest extends TestCase
         $data = [
             'items' => '',
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'items' => null,
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'items' => [],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
@@ -979,7 +979,7 @@ class ValidatorTest extends TestCase
                 'hasAtMost' => 'The provided value is invalid',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($expected, $result);
     }
 
@@ -1001,8 +1001,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'items' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1025,8 +1025,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'items' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1045,21 +1045,21 @@ class ValidatorTest extends TestCase
             'items' => ['_empty' => 'not empty'],
         ];
         $data = ['items' => ''];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['items' => null];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['items' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = [
             'items' => [1],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
     }
 
@@ -1084,13 +1084,13 @@ class ValidatorTest extends TestCase
                 'error' => UPLOAD_ERR_NO_FILE,
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'photo' => null,
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
@@ -1106,7 +1106,7 @@ class ValidatorTest extends TestCase
                 'uploadedFile' => 'The provided value is invalid',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($expected, $result);
 
         $data = [
@@ -1117,11 +1117,11 @@ class ValidatorTest extends TestCase
                 'uploadedFile' => 'The provided value is invalid',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($expected, $result);
 
         $data = ['photo' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($expected, $result);
 
         $validator = new Validator();
@@ -1135,8 +1135,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'photo' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1159,8 +1159,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'photo' => ['_empty' => 'message'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1185,19 +1185,19 @@ class ValidatorTest extends TestCase
             ],
         ];
         $error = ['photo' => ['_empty' => 'required field']];
-        $this->assertSame($error, $validator->errors($data));
+        $this->assertSame($error, $validator->validate($data));
 
         $data = ['photo' => null];
-        $this->assertSame($error, $validator->errors($data));
+        $this->assertSame($error, $validator->validate($data));
 
         // Empty string and empty array don't trigger errors
         // as rejecting them here would mean accepting them in
         // allowEmptyFile() which is not desirable.
         $data = ['photo' => ''];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = ['photo' => []];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
 
         $data = [
             'photo' => [
@@ -1207,7 +1207,7 @@ class ValidatorTest extends TestCase
                 'error' => UPLOAD_ERR_FORM_SIZE,
             ],
         ];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
     }
 
     /**
@@ -1226,8 +1226,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'photo' => ['_empty' => 'message'],
         ];
-        $this->assertEmpty($validator->errors($data, true));
-        $this->assertSame($expected, $validator->errors($data, false));
+        $this->assertEmpty($validator->validate($data, true));
+        $this->assertSame($expected, $validator->validate($data, false));
     }
 
     /**
@@ -1250,23 +1250,23 @@ class ValidatorTest extends TestCase
                 'day' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'date' => '',
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'date' => null,
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = ['date' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
     }
 
@@ -1288,8 +1288,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'date' => ['_empty' => 'be valid'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1312,8 +1312,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'date' => ['_empty' => 'be valid'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1337,19 +1337,19 @@ class ValidatorTest extends TestCase
                 'day' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['date' => ''];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['date' => null];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['date' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = [
@@ -1359,7 +1359,7 @@ class ValidatorTest extends TestCase
                 'day' => 17,
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
     }
 
@@ -1377,8 +1377,8 @@ class ValidatorTest extends TestCase
 
         $data = ['date' => null];
         $expected = ['date' => ['_empty' => 'message']];
-        $this->assertSame($expected, $validator->errors($data, false));
-        $this->assertEmpty($validator->errors($data, true));
+        $this->assertSame($expected, $validator->validate($data, false));
+        $this->assertEmpty($validator->validate($data, true));
     }
 
     /**
@@ -1401,23 +1401,23 @@ class ValidatorTest extends TestCase
                 'second' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'time' => '',
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'time' => null,
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = ['time' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
     }
 
@@ -1439,8 +1439,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'time' => ['_empty' => 'valid time'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1463,8 +1463,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'time' => ['_empty' => 'valid time'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1488,23 +1488,23 @@ class ValidatorTest extends TestCase
                 'second' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['time' => ''];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['time' => null];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['time' => []];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['time' => ['hour' => 12, 'minute' => 12, 'second' => 12]];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
     }
 
@@ -1522,8 +1522,8 @@ class ValidatorTest extends TestCase
 
         $data = ['time' => null];
         $expected = ['time' => ['_empty' => 'message']];
-        $this->assertEmpty($validator->errors($data, true));
-        $this->assertSame($expected, $validator->errors($data, false));
+        $this->assertEmpty($validator->validate($data, true));
+        $this->assertSame($expected, $validator->validate($data, false));
     }
 
     /**
@@ -1549,23 +1549,23 @@ class ValidatorTest extends TestCase
                 'second' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'published' => '',
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
             'published' => null,
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = ['published' => []];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
     }
 
     /**
@@ -1586,8 +1586,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'published' => ['_empty' => 'datetime required'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1610,8 +1610,8 @@ class ValidatorTest extends TestCase
         $expected = [
             'published' => ['_empty' => 'datetime required'],
         ];
-        $this->assertSame($expected, $validator->errors($data, true));
-        $this->assertEmpty($validator->errors($data, false));
+        $this->assertSame($expected, $validator->validate($data, true));
+        $this->assertEmpty($validator->validate($data, false));
     }
 
     /**
@@ -1638,19 +1638,19 @@ class ValidatorTest extends TestCase
                 'second' => '',
             ],
         ];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['published' => ''];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['published' => null];
-        $result = $validator->errors($data);
+        $result = $validator->validate($data);
         $this->assertSame($error, $result);
 
         $data = ['published' => []];
-        $this->assertSame($error, $validator->errors($data));
+        $this->assertSame($error, $validator->validate($data));
 
         $data = [
             'published' => [
@@ -1662,7 +1662,7 @@ class ValidatorTest extends TestCase
                 'second' => '33',
             ],
         ];
-        $this->assertEmpty($validator->errors($data));
+        $this->assertEmpty($validator->validate($data));
     }
 
     /**
@@ -1679,8 +1679,8 @@ class ValidatorTest extends TestCase
 
         $data = ['published' => null];
         $expected = ['published' => ['_empty' => 'message']];
-        $this->assertSame($expected, $validator->errors($data, false));
-        $this->assertEmpty($validator->errors($data, true));
+        $this->assertSame($expected, $validator->validate($data, false));
+        $this->assertEmpty($validator->validate($data, true));
     }
 
     /**
@@ -1734,7 +1734,7 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->isEmptyAllowed('posted_at', false));
         $this->assertTrue($validator->field('subject')->isEmptyAllowed());
 
-        $errors = $validator->errors([
+        $errors = $validator->validate([
             'title' => '',
             'content' => '',
             'posted_at' => null,
@@ -1889,25 +1889,25 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->notEmpty('title');
-        $errors = $validator->errors(['title' => '']);
+        $errors = $validator->validate(['title' => '']);
         $expected = ['title' => ['_empty' => 'This field cannot be left empty']];
         $this->assertEquals($expected, $errors);
 
-        $errors = $validator->errors(['title' => []]);
+        $errors = $validator->validate(['title' => []]);
         $expected = ['title' => ['_empty' => 'This field cannot be left empty']];
         $this->assertEquals($expected, $errors);
 
-        $errors = $validator->errors(['title' => null]);
+        $errors = $validator->validate(['title' => null]);
         $expected = ['title' => ['_empty' => 'This field cannot be left empty']];
         $this->assertEquals($expected, $errors);
 
-        $errors = $validator->errors(['title' => 0]);
+        $errors = $validator->validate(['title' => 0]);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => '0']);
+        $errors = $validator->validate(['title' => '0']);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => false]);
+        $errors = $validator->validate(['title' => false]);
         $this->assertEmpty($errors);
     }
 
@@ -1920,7 +1920,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->allowEmpty('title', false, 'Custom message');
-        $errors = $validator->errors(['title' => null]);
+        $errors = $validator->validate(['title' => null]);
         $expected = ['title' => ['_empty' => 'Custom message']];
         $this->assertEquals($expected, $errors);
     }
@@ -1934,7 +1934,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->notEmpty('title', 'Custom message');
-        $errors = $validator->errors(['title' => '']);
+        $errors = $validator->validate(['title' => '']);
         $expected = ['title' => ['_empty' => 'Custom message']];
         $this->assertEquals($expected, $errors);
     }
@@ -1948,25 +1948,25 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->allowEmpty('title');
-        $errors = $validator->errors(['title' => '']);
+        $errors = $validator->validate(['title' => '']);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => []]);
+        $errors = $validator->validate(['title' => []]);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => null]);
+        $errors = $validator->validate(['title' => null]);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => 0]);
+        $errors = $validator->validate(['title' => 0]);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => 0.0]);
+        $errors = $validator->validate(['title' => 0.0]);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => '0']);
+        $errors = $validator->validate(['title' => '0']);
         $this->assertEmpty($errors);
 
-        $errors = $validator->errors(['title' => false]);
+        $errors = $validator->validate(['title' => false]);
         $this->assertEmpty($errors);
     }
 
@@ -1991,7 +1991,7 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Tests errors() method when using validators from the default provider, this proves
+     * Tests validate() method when using validators from the default provider, this proves
      * that it returns a default validation message and the custom one set in the rule
      *
      * @return void
@@ -2003,7 +2003,7 @@ class ValidatorTest extends TestCase
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('email', 'notBlank', ['rule' => 'notBlank'])
             ->add('email', 'email', ['rule' => 'email', 'message' => 'Y u no write email?']);
-        $errors = $validator->errors(['email' => 'not an email!']);
+        $errors = $validator->validate(['email' => 'not an email!']);
         $expected = [
             'email' => [
                 'alpha' => 'The provided value is invalid',
@@ -2051,7 +2051,7 @@ class ValidatorTest extends TestCase
             }));
 
         $validator->setProvider('thing', $thing);
-        $errors = $validator->errors(['email' => '!', 'title' => 'bar']);
+        $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
         $expected = [
             'email' => ['alpha' => 'The provided value is invalid'],
             'title' => ['cool' => "That ain't cool, yo"],
@@ -2098,7 +2098,7 @@ class ValidatorTest extends TestCase
                 return "That ain't cool, yo";
             }));
         $validator->setProvider('thing', $thing);
-        $errors = $validator->errors(['email' => '!', 'title' => 'bar']);
+        $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
         $expected = [
             'title' => ['cool' => "That ain't cool, yo"],
         ];
@@ -2121,7 +2121,7 @@ class ValidatorTest extends TestCase
             },
         ]);
         $expected = ['name' => ['myRule' => 'You fail']];
-        $this->assertEquals($expected, $validator->errors(['name' => 'foo']));
+        $this->assertEquals($expected, $validator->validate(['name' => 'foo']));
     }
 
     /**
@@ -2135,7 +2135,7 @@ class ValidatorTest extends TestCase
         $validator
             ->add('email', 'alpha', ['rule' => 'alphanumeric', 'last' => true])
             ->add('email', 'email', ['rule' => 'email', 'message' => 'Y u no write email?']);
-        $errors = $validator->errors(['email' => 'not an email!']);
+        $errors = $validator->validate(['email' => 'not an email!']);
         $expected = [
             'email' => [
                 'alpha' => 'The provided value is invalid',
@@ -2262,7 +2262,7 @@ class ValidatorTest extends TestCase
             'password' => 'test',
             'password_compare' => 'not the same',
         ];
-        $this->assertNotEmpty($validator->errors($data), 'Validation should fail.');
+        $this->assertNotEmpty($validator->validate($data), 'Validation should fail.');
     }
 
     /**
@@ -2318,8 +2318,8 @@ class ValidatorTest extends TestCase
         $inner = new Validator();
         $inner->add('username', 'email', ['rule' => 'email', 'on' => 'create']);
         $validator->addNested('user', $inner);
-        $this->assertNotEmpty($validator->errors(['user' => ['username' => 'example']], true));
-        $this->assertEmpty($validator->errors(['user' => ['username' => 'a']], false));
+        $this->assertNotEmpty($validator->validate(['user' => ['username' => 'example']], true));
+        $this->assertEmpty($validator->validate(['user' => ['username' => 'a']], false));
     }
 
     /**
@@ -2334,8 +2334,8 @@ class ValidatorTest extends TestCase
         $inner = new Validator();
         $inner->add('username', 'email', ['rule' => 'email', 'on' => 'create']);
         $validator->addNestedMany('user', $inner);
-        $this->assertNotEmpty($validator->errors(['user' => [['username' => 'example']]], true));
-        $this->assertEmpty($validator->errors(['user' => [['username' => 'a']]], false));
+        $this->assertNotEmpty($validator->validate(['user' => [['username' => 'example']]], true));
+        $this->assertEmpty($validator->validate(['user' => [['username' => 'a']]], false));
     }
 
     /**
@@ -2347,7 +2347,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notBlank');
-        $this->assertNotEmpty($validator->errors(['username' => '  ']));
+        $this->assertNotEmpty($validator->validate(['username' => '  ']));
     }
 
     /**
@@ -2359,7 +2359,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'alphaNumeric');
-        $this->assertNotEmpty($validator->errors(['username' => '$']));
+        $this->assertNotEmpty($validator->validate(['username' => '$']));
     }
 
     /**
@@ -2371,7 +2371,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lengthBetween', [5, 7], [5, 7]);
-        $this->assertNotEmpty($validator->errors(['username' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo']));
     }
 
     /**
@@ -2395,7 +2395,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'creditCard', 'all', ['all', true], 'creditCard');
-        $this->assertNotEmpty($validator->errors(['username' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo']));
     }
 
     /**
@@ -2407,7 +2407,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThan', 5, [Validation::COMPARE_GREATER, 5], 'comparison');
-        $this->assertNotEmpty($validator->errors(['username' => 2]));
+        $this->assertNotEmpty($validator->validate(['username' => 2]));
     }
 
     /**
@@ -2419,7 +2419,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, [Validation::COMPARE_GREATER_OR_EQUAL, 5], 'comparison');
-        $this->assertNotEmpty($validator->errors(['username' => 2]));
+        $this->assertNotEmpty($validator->validate(['username' => 2]));
     }
 
     /**
@@ -2431,7 +2431,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThan', 5, [Validation::COMPARE_LESS, 5], 'comparison');
-        $this->assertNotEmpty($validator->errors(['username' => 5]));
+        $this->assertNotEmpty($validator->validate(['username' => 5]));
     }
 
     /**
@@ -2443,7 +2443,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, [Validation::COMPARE_LESS_OR_EQUAL, 5], 'comparison');
-        $this->assertNotEmpty($validator->errors(['username' => 6]));
+        $this->assertNotEmpty($validator->validate(['username' => 6]));
     }
 
     /**
@@ -2455,8 +2455,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'equals', 5, [Validation::COMPARE_EQUAL, 5], 'comparison');
-        $this->assertEmpty($validator->errors(['username' => 5]));
-        $this->assertNotEmpty($validator->errors(['username' => 6]));
+        $this->assertEmpty($validator->validate(['username' => 5]));
+        $this->assertNotEmpty($validator->validate(['username' => 6]));
     }
 
     /**
@@ -2468,7 +2468,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEquals', 5, [Validation::COMPARE_NOT_EQUAL, 5], 'comparison');
-        $this->assertNotEmpty($validator->errors(['username' => 5]));
+        $this->assertNotEmpty($validator->validate(['username' => 5]));
     }
 
     /**
@@ -2480,8 +2480,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', Validation::COMPARE_SAME], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 'foo']));
-        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => '1']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => '1']));
     }
 
     /**
@@ -2493,7 +2493,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', Validation::COMPARE_NOT_SAME], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
     }
 
     /**
@@ -2505,8 +2505,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', Validation::COMPARE_EQUAL], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 'foo']));
-        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'bar']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'bar']));
     }
 
     /**
@@ -2518,7 +2518,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', Validation::COMPARE_NOT_EQUAL], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
+        $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
     }
 
     /**
@@ -2530,8 +2530,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', Validation::COMPARE_GREATER], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
-        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
+        $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
+        $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
     }
 
     /**
@@ -2543,7 +2543,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', Validation::COMPARE_GREATER_OR_EQUAL], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 2]));
+        $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
     }
 
     /**
@@ -2555,8 +2555,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', Validation::COMPARE_LESS], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 1, 'other' => 1]));
-        $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
+        $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
+        $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
     }
 
     /**
@@ -2568,7 +2568,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', Validation::COMPARE_LESS_OR_EQUAL], 'compareFields');
-        $this->assertNotEmpty($validator->errors(['username' => 2, 'other' => 1]));
+        $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
     }
 
     /**
@@ -2580,7 +2580,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'containsNonAlphaNumeric', 2, [2]);
-        $this->assertNotEmpty($validator->errors(['username' => '$']));
+        $this->assertNotEmpty($validator->validate(['username' => '$']));
     }
 
     /**
@@ -2592,7 +2592,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'date', ['ymd'], [['ymd']]);
-        $this->assertNotEmpty($validator->errors(['username' => 'not a date']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
     }
 
     /**
@@ -2604,7 +2604,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'dateTime', ['ymd'], [['ymd']], 'datetime');
-        $this->assertNotEmpty($validator->errors(['username' => 'not a date']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
     }
 
     /**
@@ -2616,7 +2616,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'time');
-        $this->assertNotEmpty($validator->errors(['username' => 'not a time']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not a time']));
     }
 
     /**
@@ -2628,7 +2628,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'localizedTime', 'date', ['date']);
-        $this->assertNotEmpty($validator->errors(['username' => 'not a date']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
     }
 
     /**
@@ -2640,7 +2640,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'boolean');
-        $this->assertNotEmpty($validator->errors(['username' => 'not a boolean']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not a boolean']));
     }
 
     /**
@@ -2652,7 +2652,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'decimal', 2, [2]);
-        $this->assertNotEmpty($validator->errors(['username' => 10.1]));
+        $this->assertNotEmpty($validator->validate(['username' => 10.1]));
     }
 
     /**
@@ -2664,13 +2664,13 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'ip');
-        $this->assertNotEmpty($validator->errors(['username' => 'not ip']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not ip']));
 
         $this->assertProxyMethod($validator, 'ipv4', null, ['ipv4'], 'ip');
-        $this->assertNotEmpty($validator->errors(['username' => 'not ip']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not ip']));
 
         $this->assertProxyMethod($validator, 'ipv6', null, ['ipv6'], 'ip');
-        $this->assertNotEmpty($validator->errors(['username' => 'not ip']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not ip']));
     }
 
     /**
@@ -2682,7 +2682,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLength', 2, [2]);
-        $this->assertNotEmpty($validator->errors(['username' => 'a']));
+        $this->assertNotEmpty($validator->validate(['username' => 'a']));
     }
 
     /**
@@ -2694,7 +2694,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLengthBytes', 11, [11]);
-        $this->assertNotEmpty($validator->errors(['username' => 'ÆΔΩЖÇ']));
+        $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
     }
 
     /**
@@ -2706,7 +2706,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLength', 2, [2]);
-        $this->assertNotEmpty($validator->errors(['username' => 'aaa']));
+        $this->assertNotEmpty($validator->validate(['username' => 'aaa']));
     }
 
     /**
@@ -2718,7 +2718,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLengthBytes', 9, [9]);
-        $this->assertNotEmpty($validator->errors(['username' => 'ÆΔΩЖÇ']));
+        $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
     }
 
     /**
@@ -2730,8 +2730,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'numeric');
-        $this->assertEmpty($validator->errors(['username' => '22']));
-        $this->assertNotEmpty($validator->errors(['username' => 'a']));
+        $this->assertEmpty($validator->validate(['username' => '22']));
+        $this->assertNotEmpty($validator->validate(['username' => 'a']));
     }
 
     /**
@@ -2743,7 +2743,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'naturalNumber', null, [false]);
-        $this->assertNotEmpty($validator->errors(['username' => 0]));
+        $this->assertNotEmpty($validator->validate(['username' => 0]));
     }
 
     /**
@@ -2755,7 +2755,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'nonNegativeInteger', null, [true], 'naturalNumber');
-        $this->assertNotEmpty($validator->errors(['username' => -1]));
+        $this->assertNotEmpty($validator->validate(['username' => -1]));
     }
 
     /**
@@ -2767,7 +2767,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'range', [1, 4], [1, 4]);
-        $this->assertNotEmpty($validator->errors(['username' => 5]));
+        $this->assertNotEmpty($validator->validate(['username' => 5]));
     }
 
     /**
@@ -2791,7 +2791,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'url', null, [false]);
-        $this->assertNotEmpty($validator->errors(['username' => 'not url']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not url']));
     }
 
     /**
@@ -2803,7 +2803,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'urlWithProtocol', null, [true], 'url');
-        $this->assertNotEmpty($validator->errors(['username' => 'google.com']));
+        $this->assertNotEmpty($validator->validate(['username' => 'google.com']));
     }
 
     /**
@@ -2815,7 +2815,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'inList', ['a', 'b'], [['a', 'b']]);
-        $this->assertNotEmpty($validator->errors(['username' => 'c']));
+        $this->assertNotEmpty($validator->validate(['username' => 'c']));
     }
 
     /**
@@ -2827,7 +2827,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uuid');
-        $this->assertNotEmpty($validator->errors(['username' => 'not uuid']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not uuid']));
     }
 
     /**
@@ -2839,7 +2839,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uploadedFile', ['foo' => 'bar'], [['foo' => 'bar']]);
-        $this->assertNotEmpty($validator->errors(['username' => []]));
+        $this->assertNotEmpty($validator->validate(['username' => []]));
     }
 
     /**
@@ -2851,13 +2851,13 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'latLong', null, [], 'geoCoordinate');
-        $this->assertNotEmpty($validator->errors(['username' => 2000]));
+        $this->assertNotEmpty($validator->validate(['username' => 2000]));
 
         $this->assertProxyMethod($validator, 'latitude');
-        $this->assertNotEmpty($validator->errors(['username' => 2000]));
+        $this->assertNotEmpty($validator->validate(['username' => 2000]));
 
         $this->assertProxyMethod($validator, 'longitude');
-        $this->assertNotEmpty($validator->errors(['username' => 2000]));
+        $this->assertNotEmpty($validator->validate(['username' => 2000]));
     }
 
     /**
@@ -2869,7 +2869,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'ascii');
-        $this->assertNotEmpty($validator->errors(['username' => 'ü']));
+        $this->assertNotEmpty($validator->validate(['username' => 'ü']));
     }
 
     /**
@@ -2884,8 +2884,8 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
 
         $this->assertProxyMethod($validator, 'utf8', null, [['extended' => false]]);
-        $this->assertEmpty($validator->errors(['username' => 'ü']));
-        $this->assertNotEmpty($validator->errors(['username' => $extended]));
+        $this->assertEmpty($validator->validate(['username' => 'ü']));
+        $this->assertNotEmpty($validator->validate(['username' => $extended]));
     }
 
     /**
@@ -2900,8 +2900,8 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
 
         $this->assertProxyMethod($validator, 'utf8Extended', null, [['extended' => true]], 'utf8');
-        $this->assertEmpty($validator->errors(['username' => 'ü']));
-        $this->assertEmpty($validator->errors(['username' => $extended]));
+        $this->assertEmpty($validator->validate(['username' => 'ü']));
+        $this->assertEmpty($validator->validate(['username' => $extended]));
     }
 
     /**
@@ -2913,8 +2913,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->email('username');
-        $this->assertEmpty($validator->errors(['username' => 'test@example.com']));
-        $this->assertNotEmpty($validator->errors(['username' => 'not an email']));
+        $this->assertEmpty($validator->validate(['username' => 'test@example.com']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not an email']));
     }
 
     /**
@@ -2926,7 +2926,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'integer', null, [], 'isInteger');
-        $this->assertNotEmpty($validator->errors(['username' => 'not integer']));
+        $this->assertNotEmpty($validator->validate(['username' => 'not integer']));
     }
 
     /**
@@ -2938,8 +2938,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->isArray('username');
-        $this->assertEmpty($validator->errors(['username' => [1, 2, 3]]));
-        $this->assertNotEmpty($validator->errors(['username' => 'is not an array']));
+        $this->assertEmpty($validator->validate(['username' => [1, 2, 3]]));
+        $this->assertNotEmpty($validator->validate(['username' => 'is not an array']));
     }
 
     /**
@@ -2951,8 +2951,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->scalar('username');
-        $this->assertEmpty($validator->errors(['username' => 'scalar']));
-        $this->assertNotEmpty($validator->errors(['username' => ['array']]));
+        $this->assertEmpty($validator->validate(['username' => 'scalar']));
+        $this->assertNotEmpty($validator->validate(['username' => ['array']]));
     }
 
     /**
@@ -2964,8 +2964,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'hexColor');
-        $this->assertEmpty($validator->errors(['username' => '#FFFFFF']));
-        $this->assertNotEmpty($validator->errors(['username' => 'FFFFFF']));
+        $this->assertEmpty($validator->validate(['username' => '#FFFFFF']));
+        $this->assertNotEmpty($validator->validate(['username' => 'FFFFFF']));
     }
 
     /**
@@ -2992,7 +2992,7 @@ class ValidatorTest extends TestCase
             'multiple'
         );
 
-        $this->assertNotEmpty($validator->errors(['username' => '']));
+        $this->assertNotEmpty($validator->validate(['username' => '']));
     }
 
     /**
@@ -3004,17 +3004,17 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->hasAtLeast('things', 3);
-        $this->assertEmpty($validator->errors(['things' => [1, 2, 3]]));
-        $this->assertEmpty($validator->errors(['things' => [1, 2, 3, 4]]));
-        $this->assertNotEmpty($validator->errors(['things' => [1, 2]]));
-        $this->assertNotEmpty($validator->errors(['things' => []]));
-        $this->assertNotEmpty($validator->errors(['things' => 'string']));
+        $this->assertEmpty($validator->validate(['things' => [1, 2, 3]]));
+        $this->assertEmpty($validator->validate(['things' => [1, 2, 3, 4]]));
+        $this->assertNotEmpty($validator->validate(['things' => [1, 2]]));
+        $this->assertNotEmpty($validator->validate(['things' => []]));
+        $this->assertNotEmpty($validator->validate(['things' => 'string']));
 
-        $this->assertEmpty($validator->errors(['things' => ['_ids' => [1, 2, 3]]]));
-        $this->assertEmpty($validator->errors(['things' => ['_ids' => [1, 2, 3, 4]]]));
-        $this->assertNotEmpty($validator->errors(['things' => ['_ids' => [1, 2]]]));
-        $this->assertNotEmpty($validator->errors(['things' => ['_ids' => []]]));
-        $this->assertNotEmpty($validator->errors(['things' => ['_ids' => 'string']]));
+        $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3]]]));
+        $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3, 4]]]));
+        $this->assertNotEmpty($validator->validate(['things' => ['_ids' => [1, 2]]]));
+        $this->assertNotEmpty($validator->validate(['things' => ['_ids' => []]]));
+        $this->assertNotEmpty($validator->validate(['things' => ['_ids' => 'string']]));
     }
 
     /**
@@ -3026,13 +3026,13 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->hasAtMost('things', 3);
-        $this->assertEmpty($validator->errors(['things' => [1, 2, 3]]));
-        $this->assertEmpty($validator->errors(['things' => [1]]));
-        $this->assertNotEmpty($validator->errors(['things' => [1, 2, 3, 4]]));
+        $this->assertEmpty($validator->validate(['things' => [1, 2, 3]]));
+        $this->assertEmpty($validator->validate(['things' => [1]]));
+        $this->assertNotEmpty($validator->validate(['things' => [1, 2, 3, 4]]));
 
-        $this->assertEmpty($validator->errors(['things' => ['_ids' => [1, 2, 3]]]));
-        $this->assertEmpty($validator->errors(['things' => ['_ids' => [1, 2]]]));
-        $this->assertNotEmpty($validator->errors(['things' => ['_ids' => [1, 2, 3, 4]]]));
+        $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3]]]));
+        $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2]]]));
+        $this->assertNotEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3, 4]]]));
     }
 
     /**
@@ -3044,8 +3044,8 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'regex', '/(?<!\\S)\\d++(?!\\S)/', ['/(?<!\\S)\\d++(?!\\S)/'], 'custom');
-        $this->assertEmpty($validator->errors(['username' => '123']));
-        $this->assertNotEmpty($validator->errors(['username' => 'Foo']));
+        $this->assertEmpty($validator->validate(['username' => '123']));
+        $this->assertNotEmpty($validator->validate(['username' => 'Foo']));
     }
 
     /**


### PR DESCRIPTION
A suggestion for fixing https://github.com/cakephp/cakephp/issues/13952.

I think this tells the user what is happening and you still expect results back.  This would be nice to have available for the 4.0 transition.