### PR TITLE
Fix query string set to uri.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -354,6 +354,9 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         $this->url = substr($uri->getPath(), 1);
         $this->here = $this->base . '/' . $this->url;
 
+        $this->query = $this->_processGet($config['query'], $querystr);
+        $this->uri = $this->uri->withQuery(http_build_query($this->query, null, '&', PHP_QUERY_RFC3986));
+
         if (isset($config['input'])) {
             $stream = new Stream('php://memory', 'rw');
             $stream->write($config['input']);
@@ -365,7 +368,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
 
         $config['post'] = $this->_processPost($config['post']);
         $this->data = $this->_processFiles($config['post'], $config['files']);
-        $this->query = $this->_processGet($config['query'], $querystr);
         $this->params = $config['params'];
         $this->session = $config['session'];
     }
@@ -423,6 +425,9 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
             parse_str($queryString, $queryArgs);
             $query += $queryArgs;
         }
+
+        parse_str($this->uri->getQuery(), $queryArgs);
+        $query += $queryArgs;
 
         return $query;
     }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -752,7 +752,8 @@ trait IntegrationTestTrait
     {
         $uri = new Uri($url);
         $path = $uri->getPath();
-        $query = $uri->getQuery();
+        parse_str($uri->getQuery(), $query);
+        $query = http_build_query($query, null, '&', PHP_QUERY_RFC3986);
 
         $hostData = [];
         if ($uri->getHost()) {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -1250,7 +1250,7 @@ XML;
                 $this->Controller->response
             );
             $data = json_decode($response, true);
-            $this->assertEquals('/request_action/params_pass', $data['here']);
+            $this->assertEquals('/request_action/params_pass?a=b&x=y%3Fish', $data['here']);
 
             $response = $this->RequestHandler->beforeRedirect(
                 $event,

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -155,7 +155,7 @@ class ServerRequestTest extends TestCase
         ];
         $request = new ServerRequest($data);
         $this->assertEquals($request->getQueryParams(), $data['query']);
-        $this->assertEquals('/some/path', $request->getRequestTarget());
+        $this->assertEquals('/some/path?one=param&two=banana', $request->getRequestTarget());
     }
 
     /**


### PR DESCRIPTION
Bug:
```php
		$server = [
			'REQUEST_URI' => '/posts/home',
		];
		$query = [
			'foo' => 'bar',
			'key' => 'val',
		];

		$request = ServerRequestFactory::fromGlobals(
			$server,
			$query
		);
		dd($request->getRequestTarget()); // Just '/posts/home'
```

Same for
```php
        $request = new ServerRequest([
            'url' => '/posts/home',
            'query' => $query,
        ]);
```

Seems like it never properly sets the uri->query part here.
So when you remove deprecations in Cake3 from 
`request->here()` to `request->getRequestTarget()` as outlined in the deprecation messages thrown, all breaks.

This here could be a fix, it seems to work.
Might need some follow up - I am happy to pass this on at this point.