### PR TITLE
Use a single argument for ErrorHandlerMiddleware::__construct().

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -80,6 +80,15 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      */
     public function __construct($errorHandler = [])
     {
+        if (func_num_args() > 1) {
+            deprecationWarning(
+                'The signature of ErrorHandlerMiddleware::__construct() has changed. '
+                . 'Pass the config array as 1st argument instead.'
+            );
+
+            $errorHandler = func_get_arg(1);
+        }
+
         if (is_array($errorHandler)) {
             $this->setConfig($errorHandler);
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -21,6 +21,7 @@ use Cake\Core\InstanceConfigTrait;
 use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRenderer;
 use Cake\Http\Response;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -39,6 +40,8 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
 
     /**
      * Default configuration values.
+     *
+     * Ignored if contructor is passed an ErrorHandler instance.
      *
      * - `log` Enable logging of exceptions.
      * - `skipLog` List of exceptions to skip logging. Exceptions that
@@ -72,18 +75,25 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param \Cake\Error\ErrorHandler|null $errorHandler The error handler.
-     * @param array $config Configuration options for error handler.
-     *   These options will be ignored if an ErrorHandler instance is passed as
-     *   first argument.
+     * @param \Cake\Error\ErrorHandler|array $errorHandler The error handler instance
+     *  or config array.
      */
-    public function __construct($errorHandler = null, array $config = [])
+    public function __construct($errorHandler = [])
     {
-        $this->setConfig($config);
+        if (is_array($errorHandler)) {
+            $this->setConfig($errorHandler);
 
-        if ($errorHandler !== null) {
-            $this->errorHandler = $errorHandler;
+            return;
         }
+
+        if (!$errorHandler instanceof ErrorHandler) {
+            throw new InvalidArgumentException(sprintf(
+                '$errorHandler argument must be a config array or ErrorHandler instance. Got `%s` instead.',
+                getTypeName($errorHandler)
+            ));
+        }
+
+        $this->errorHandler = $errorHandler;
     }
 
     /**

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -188,7 +188,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
         ]);
-        $middleware = new ErrorHandlerMiddleware(null, ['log' => true, 'trace' => true]);
+        $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
         $handler = new TestRequestHandler(function ($req) {
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
@@ -218,7 +218,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
         ]);
-        $middleware = new ErrorHandlerMiddleware(null, ['log' => true, 'trace' => true]);
+        $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
         $handler = new TestRequestHandler(function ($req) {
             $previous = new \Cake\Datasource\Exception\RecordNotFoundException('Previous logged');
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!', null, $previous);
@@ -238,7 +238,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->logger->expects($this->never())->method('log');
 
         $request = ServerRequestFactory::fromGlobals();
-        $middleware = new ErrorHandlerMiddleware(null, [
+        $middleware = new ErrorHandlerMiddleware([
             'log' => true,
             'skipLog' => ['Cake\Http\Exception\NotFoundException'],
         ]);
@@ -270,7 +270,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             ));
 
         $request = ServerRequestFactory::fromGlobals();
-        $middleware = new ErrorHandlerMiddleware(null, ['log' => true]);
+        $middleware = new ErrorHandlerMiddleware(['log' => true]);
         $handler = new TestRequestHandler(function ($req) {
             throw new MissingControllerException(['class' => 'Articles']);
         });


### PR DESCRIPTION
This avoids the fugliness of passing null as 1st argument when you want to use config array.