### PR TITLE
Upgrade pdo_sqlsrv on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,9 +38,9 @@ install:
   - echo extension=fileinfo >> php.ini
   - php -v
 
-  - curl -fsS https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o pdosqlsrv.zip
+  - curl -fsS https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.6.1/php_pdo_sqlsrv-5.6.1-7.2-nts-vc15-x64.zip -o pdosqlsrv.zip
   - 7z x pdosqlsrv.zip -oC:\php\ext php_pdo_sqlsrv.dll -aoa > nul
-  - curl -fsS https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o sqlsrv.zip
+  - curl -fsS https://windows.php.net/downloads/pecl/releases/sqlsrv/5.6.1/php_sqlsrv-5.6.1-7.2-nts-vc15-x64.zip -o sqlsrv.zip
   - 7z x sqlsrv.zip -oC:\php\ext php_sqlsrv.dll -aoa > nul
   - echo extension=pdo_sqlsrv >> php.ini
   - echo extension=sqlsrv >> php.ini


### PR DESCRIPTION
There is shutdown crash in ODBC32.dll on AppVeyor.

pdo_sqlsrv v5.6.0 fixed similar crash, I hope it will fix AppVeyor build crashes.