### PR TITLE
2.x - Ignore warnings when generating exit code for phpunit doRun() result

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -101,7 +101,7 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
 		}
 
 		if ($exit) {
-			if (isset($result) && $result->wasSuccessful()) {
+			if (isset($result) && $result->wasSuccessfulIgnoringWarnings()) {
 				exit(PHPUnit_TextUI_TestRunner::SUCCESS_EXIT);
 			} elseif (!isset($result) || $result->errorCount() > 0) {
 				exit(PHPUnit_TextUI_TestRunner::EXCEPTION_EXIT);


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/13492.

This syncs up with newer phpunit versions.  The 5.2.0 version this was originally based on incorrectly failed on warnings by default.