### PR TITLE
Update stickler configuration

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,12 +1,9 @@
 ---
 linters:
   phpcs:
-    standard: ./phpcs.xml.dist
+    standard: CakePHP4
     extensions: 'php,ctp'
     fixer: true
-
-branches:
-  ignore: ['2.x', '4.x']
 
 fixers:
   enable: true


### PR DESCRIPTION
There is a new CakePHP4 standard which points at the dev-next branch of the codesniffer repository.
