### PR TITLE
4.x - Restrict phpunit to >=8.4 <8.5 to avoid breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "cakephp/cakephp-codesniffer": "dev-next",
         "mikey179/vfsstream": "^1.6",
         "paragonie/csp-builder": "^2.3",
-        "phpunit/phpunit": "^8.4"
+        "phpunit/phpunit": "~8.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`^8.4` will match up to `9.0` while `~8.4.0` will match up to `8.5`