### PR TITLE
Nested Joins acting incorrectly

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -220,10 +220,10 @@ class QueryCompiler
     protected function _buildJoinPart($parts, $query, $generator)
     {
         $joins = $this->_arrangeJoins($query->getEagerLoader()->getContain(), $parts, $query, $generator);
-        
+
         return $joins;
     }
-    
+
     /**
      * Helper function used to build the string representation of multiple JOIN clauses,
      * it constructs the joins list taking care of aliasing and converting
@@ -236,40 +236,42 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
      * @return string
      */
-    protected function _arrangeJoins($associations, $parts, $query, $generator) {
+    protected function _arrangeJoins($associations, $parts, $query, $generator)
+    {
         $joins = '';
-        foreach($associations as $association => $subAssociation){
-            if(!isset($parts[$association])){
+        foreach ($associations as $association => $subAssociation) {
+            if (!isset($parts[$association])) {
                 continue;
             }
-            
+
             $join = $parts[$association];
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = $join['table']->sql($generator);
             }
-            
+
             if ($subquery) {
                 $join['table'] = '(' . $join['table'] . ')';
             }
-            
+
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if(is_array($subAssociation) && count($subAssociation)){
+            if (is_array($subAssociation) && count($subAssociation)) {
                 $joins .= $this->_arrangeJoins($subAssociation, $parts, $query, $generator);
             }
             $joins .= ')';
-            
+
             $condition = '';
             if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
                 $condition = $join['conditions']->sql($generator);
             }
-            
+
             if (strlen($condition)) {
                 $joins .= " ON {$condition}";
             } else {
                 $joins .= ' ON 1 = 1';
             }
         }
+
         return $joins;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -209,6 +209,7 @@ class QueryCompiler
 
         return sprintf($select, implode(', ', $normalized));
     }
+
     /**
      * Method called to start _buildNestedJoins method.
      *
@@ -220,8 +221,10 @@ class QueryCompiler
     protected function _buildJoinPart($parts, $query, $generator)
     {
         $joins = $this->_buildNestedJoins($parts, $query, $generator, $query->getEagerLoader()->getContain());
+
         return $joins;
     }
+
     /**
      * Helper function used to build the string representation of multiple JOIN clauses,
      * it constructs the joins list taking care of aliasing and converting
@@ -237,8 +240,8 @@ class QueryCompiler
     protected function _buildNestedJoins(&$parts, $query, $generator, $associations)
     {
         $joins = '';
-        foreach($associations as $association => $subAssociation){
-            if(!isset($parts[$association])){
+        foreach ($associations as $association => $subAssociation) {
+            if (!isset($parts[$association])) {
                 continue;
             }
             $join = $parts[$association];
@@ -252,7 +255,7 @@ class QueryCompiler
                 $join['table'] = '(' . $join['table'] . ')';
             }
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if(is_array($subAssociation) && count($subAssociation)){
+            if (is_array($subAssociation) && count($subAssociation)) {
                 $joins .= $this->_buildNestedJoins($parts, $query, $generator, $subAssociation);
             }
             $joins .= ')';
@@ -266,15 +269,15 @@ class QueryCompiler
                 $joins .= ' ON 1 = 1';
             }
         }
-        
-        if($associations == $query->getEagerLoader()->getContain() && count($parts)){
+
+        if ($associations == $query->getEagerLoader()->getContain() && count($parts)) {
             $associations = [];
-            foreach(array_keys($parts) as $part){
+            foreach (array_keys($parts) as $part) {
                 $associations[$part] = [];
             }
             $joins .= $this->_buildNestedJoins($parts, $query, $generator, $associations);
         }
-        
+
         return $joins;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -88,7 +88,7 @@ class QueryCompiler
         $query->traverse(
             $this->_sqlCompiler($sql, $query, $generator),
             $this->{'_' . $type . 'Parts'}
-            );
+        );
         // Propagate bound parameters from sub-queries if the
         // placeholders can be found in the SQL statement.
         if ($query->getValueBinder() !== $generator) {
@@ -113,19 +113,20 @@ class QueryCompiler
     protected function _sqlCompiler(&$sql, $query, $generator)
     {
         return function ($parts, $name) use (&$sql, $query, $generator) {
-            if (
-                !isset($parts) ||
+            if (!isset($parts) ||
                 ((is_array($parts) || $parts instanceof \Countable) && !count($parts))
                 ) {
                     return;
-                }
-                if ($parts instanceof ExpressionInterface) {
-                    $parts = [$parts->sql($generator)];
-                }
-                if (isset($this->_templates[$name])) {
-                    $parts = $this->_stringifyExpressions((array)$parts, $generator);
-                    return $sql .= sprintf($this->_templates[$name], implode(', ', $parts));
-                }
+            }
+            if ($parts instanceof ExpressionInterface) {
+                $parts = [$parts->sql($generator)];
+            }
+            if (isset($this->_templates[$name])) {
+                $parts = $this->_stringifyExpressions((array)$parts, $generator);
+
+                return $sql .= sprintf($this->_templates[$name], implode(', ', $parts));
+            }
+
                 return $sql .= $this->{'_build' . ucfirst($name) . 'Part'}($parts, $query, $generator);
         };
     }
@@ -187,6 +188,7 @@ class QueryCompiler
             }
             $normalized[] = $p;
         }
+
         return sprintf($select, implode(', ', $normalized));
     }
     /**
@@ -217,8 +219,8 @@ class QueryCompiler
     protected function _buildNestedJoins(&$parts, $query, $generator, $associations)
     {
         $joins = '';
-        foreach($associations as $association => $subAssociation){
-            if(!isset($parts[$association])){
+        foreach ($associations as $association => $subAssociation) {
+            if (!isset($parts[$association])) {
                 continue;
             }
             $join = $parts[$association];
@@ -231,7 +233,7 @@ class QueryCompiler
                 $join['table'] = '(' . $join['table'] . ')';
             }
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if(is_array($subAssociation) && count($subAssociation)){
+            if (is_array($subAssociation) && count($subAssociation)) {
                 $joins .= $this->_buildNestedJoins($parts, $query, $generator, $subAssociation);
             }
             $joins .= ')';
@@ -245,15 +247,15 @@ class QueryCompiler
                 $joins .= ' ON 1 = 1';
             }
         }
-        
-        if($associations == $query->getEagerLoader()->getContain() && count($parts)){
+
+        if ($associations == $query->getEagerLoader()->getContain() && count($parts)) {
             $associations = [];
-            foreach(array_keys($parts) as $part){
+            foreach (array_keys($parts) as $part) {
                 $associations[$part] = [];
             }
             $joins .= $this->_buildNestedJoins($parts, $query, $generator, $associations);
         }
-        
+
         return $joins;
     }
     /**
@@ -297,11 +299,13 @@ class QueryCompiler
             if ($this->_orderedUnion) {
                 return "{$prefix}({$p['query']})";
             }
+
             return $prefix . $p['query'];
         }, $parts);
-            if ($this->_orderedUnion) {
-                return sprintf(")\nUNION %s", implode("\nUNION ", $parts));
-            }
+        if ($this->_orderedUnion) {
+            return sprintf(")\nUNION %s", implode("\nUNION ", $parts));
+        }
+
             return sprintf("\nUNION %s", implode("\nUNION ", $parts));
     }
     /**

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -210,10 +210,7 @@ class QueryCompiler
     }
 
     /**
-     * Helper function used to build the string representation of multiple JOIN clauses,
-     * it constructs the joins list taking care of aliasing and converting
-     * expression objects to string in both the table to be joined and the conditions
-     * to be used.
+     * Function used to start JOIN builder
      *
      * @param array $parts list of joins to be transformed to string
      * @param \Cake\Database\Query $query The query that is being compiled
@@ -223,46 +220,56 @@ class QueryCompiler
     protected function _buildJoinPart($parts, $query, $generator)
     {
         $joins = $this->_arrangeJoins($query->getEagerLoader()->getContain(), $parts, $query, $generator);
-
+        
         return $joins;
     }
-
-    protected function _arrangeJoins($associations, $parts, $query, $generator)
-    {
+    
+    /**
+     * Helper function used to build the string representation of multiple JOIN clauses,
+     * it constructs the joins list taking care of aliasing and converting
+     * expression objects to string in both the table to be joined and the conditions
+     * to be used.
+     *
+     * @param array $associations associations structure
+     * @param array $parts list of joins to be transformed to string
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @return string
+     */
+    protected function _arrangeJoins($associations, $parts, $query, $generator) {
         $joins = '';
-        foreach ($associations as $association => $subAssociation) {
-            if (!isset($parts[$association])) {
+        foreach($associations as $association => $subAssociation){
+            if(!isset($parts[$association])){
                 continue;
             }
-
+            
             $join = $parts[$association];
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = $join['table']->sql($generator);
             }
-
+            
             if ($subquery) {
                 $join['table'] = '(' . $join['table'] . ')';
             }
-
+            
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if (is_array($subAssociation) && sizeof($subAssociation)) {
+            if(is_array($subAssociation) && count($subAssociation)){
                 $joins .= $this->_arrangeJoins($subAssociation, $parts, $query, $generator);
             }
             $joins .= ')';
-
+            
             $condition = '';
             if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
                 $condition = $join['conditions']->sql($generator);
             }
-
+            
             if (strlen($condition)) {
                 $joins .= " ON {$condition}";
             } else {
                 $joins .= ' ON 1 = 1';
             }
         }
-
         return $joins;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -220,10 +220,10 @@ class QueryCompiler
     protected function _buildJoinPart($parts, Query $query, $generator)
     {
         $joins = $this->_arrangeJoins($query->getEagerLoader()->getContain(), $parts, $query, $generator);
-        
+
         return $joins;
     }
-    
+
     /**
      * Helper function used to build the string representation of multiple JOIN clauses,
      * it constructs the joins list taking care of aliasing and converting
@@ -236,42 +236,44 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
      * @return string
      */
-    protected function _arrangeJoins($associations, $parts, $query, $generator) {
+    protected function _arrangeJoins($associations, $parts, $query, $generator)
+    {
         $joins = '';
-        foreach($associations as $association => $subAssociation){
-            if(!isset($parts[$association])){
+        foreach ($associations as $association => $subAssociation) {
+            if (!isset($parts[$association])) {
                 continue;
             }
-            
+
             $join = $parts[$association];
             unset($parts[$association]);
-            
+
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = $join['table']->sql($generator);
             }
-            
+
             if ($subquery) {
                 $join['table'] = '(' . $join['table'] . ')';
             }
-            
+
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if(is_array($subAssociation) && count($subAssociation)){
+            if (is_array($subAssociation) && count($subAssociation)) {
                 $joins .= $this->_arrangeJoins($subAssociation, $parts, $query, $generator);
             }
             $joins .= ')';
-            
+
             $condition = '';
             if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
                 $condition = $join['conditions']->sql($generator);
             }
-            
+
             if (strlen($condition)) {
                 $joins .= " ON {$condition}";
             } else {
                 $joins .= ' ON 1 = 1';
             }
         }
+
         return $joins;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -217,13 +217,13 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
      * @return string
      */
-    protected function _buildJoinPart($parts, $query, $generator)
+    protected function _buildJoinPart($parts, Query $query, $generator)
     {
         $joins = $this->_arrangeJoins($query->getEagerLoader()->getContain(), $parts, $query, $generator);
-
+        
         return $joins;
     }
-
+    
     /**
      * Helper function used to build the string representation of multiple JOIN clauses,
      * it constructs the joins list taking care of aliasing and converting
@@ -236,42 +236,42 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
      * @return string
      */
-    protected function _arrangeJoins($associations, $parts, $query, $generator)
-    {
+    protected function _arrangeJoins($associations, $parts, $query, $generator) {
         $joins = '';
-        foreach ($associations as $association => $subAssociation) {
-            if (!isset($parts[$association])) {
+        foreach($associations as $association => $subAssociation){
+            if(!isset($parts[$association])){
                 continue;
             }
-
+            
             $join = $parts[$association];
+            unset($parts[$association]);
+            
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = $join['table']->sql($generator);
             }
-
+            
             if ($subquery) {
                 $join['table'] = '(' . $join['table'] . ')';
             }
-
+            
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if (is_array($subAssociation) && count($subAssociation)) {
+            if(is_array($subAssociation) && count($subAssociation)){
                 $joins .= $this->_arrangeJoins($subAssociation, $parts, $query, $generator);
             }
             $joins .= ')';
-
+            
             $condition = '';
             if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
                 $condition = $join['conditions']->sql($generator);
             }
-
+            
             if (strlen($condition)) {
                 $joins .= " ON {$condition}";
             } else {
                 $joins .= ' ON 1 = 1';
             }
         }
-
         return $joins;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -223,44 +223,46 @@ class QueryCompiler
     protected function _buildJoinPart($parts, $query, $generator)
     {
         $joins = $this->_arrangeJoins($query->getEagerLoader()->getContain(), $parts, $query, $generator);
-        
+
         return $joins;
     }
-    
-    protected function _arrangeJoins($associations, $parts, $query, $generator) {
+
+    protected function _arrangeJoins($associations, $parts, $query, $generator)
+    {
         $joins = '';
-        foreach($associations as $association => $subAssociation){
-            if(!isset($parts[$association])){
+        foreach ($associations as $association => $subAssociation) {
+            if (!isset($parts[$association])) {
                 continue;
             }
-            
+
             $join = $parts[$association];
             $subquery = $join['table'] instanceof Query || $join['table'] instanceof QueryExpression;
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = $join['table']->sql($generator);
             }
-            
+
             if ($subquery) {
                 $join['table'] = '(' . $join['table'] . ')';
             }
-            
+
             $joins .= sprintf(' %s JOIN (%s %s', $join['type'], $join['table'], $join['alias']);
-            if(is_array($subAssociation) && sizeof($subAssociation)){
+            if (is_array($subAssociation) && sizeof($subAssociation)) {
                 $joins .= $this->_arrangeJoins($subAssociation, $parts, $query, $generator);
             }
             $joins .= ')';
-            
+
             $condition = '';
             if (isset($join['conditions']) && $join['conditions'] instanceof ExpressionInterface) {
                 $condition = $join['conditions']->sql($generator);
             }
-            
+
             if (strlen($condition)) {
                 $joins .= " ON {$condition}";
             } else {
                 $joins .= ' ON 1 = 1';
             }
         }
+
         return $joins;
     }
 


### PR DESCRIPTION
If table A is linked to table B by a left join, and the table B is linked to table C by a inner join, when you try to access the table C from table A, the query acts like table A was linked to table B by a inner join.
I modified  the "_buildJoinPart" method to group nested joins by parentheses, and that is working fine now.