### PR TITLE
4.x - Explicit write & close of the session

### DIFF
--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -34,9 +34,6 @@ use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
  *
  * - It logs headers sent using CakePHP's logging tools.
  * - Cookies are emitted using setcookie() to not conflict with ext/session
- * - For fastcgi servers with PHP-FPM session_write_close() is called just
- *   before fastcgi_finish_request() to make sure session data is saved
- *   correctly (especially on slower session backends).
  */
 class ResponseEmitter implements EmitterInterface
 {
@@ -87,7 +84,6 @@ class ResponseEmitter implements EmitterInterface
         }
 
         if (function_exists('fastcgi_finish_request')) {
-            session_write_close();
             fastcgi_finish_request();
         }
 

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -87,7 +87,11 @@ class Server implements EventDispatcherInterface
 
         $this->dispatchEvent('Server.buildMiddleware', ['middleware' => $middleware]);
 
-        return $this->runner->run($middleware, $request, $this->app);
+        $response = $this->runner->run($middleware, $request, $this->app);
+
+        $request->getSession()->close();
+
+        return $response;
     }
 
     /**

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -89,7 +89,9 @@ class Server implements EventDispatcherInterface
 
         $response = $this->runner->run($middleware, $request, $this->app);
 
-        $request->getSession()->close();
+        if ($request instanceof ServerRequest) {
+            $request->getSession()->close();
+        }
 
         return $response;
     }

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -378,6 +378,12 @@ class Session
             return true;
         }
 
+        if ($this->_isCLI) {
+            $this->_started = false;
+
+            return true;
+        }
+
         if (!session_write_close()) {
             throw new RuntimeException('Could not close the session');
         }

--- a/src/TestSuite/Constraint/Session/FlashParamEquals.php
+++ b/src/TestSuite/Constraint/Session/FlashParamEquals.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Constraint\Session;
 
 use Cake\Http\Session;
+use Cake\Utility\Hash;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
 
@@ -76,9 +77,13 @@ class FlashParamEquals extends Constraint
      */
     public function matches($other): bool
     {
-        $messages = (array)$this->session->read('Flash.' . $this->key);
+        // Server::run calls Session::close at the end of the request.
+        // Which means, that we cannot use Session object here to access the session data.
+        // Call to Session::read will start new session (and will erase the data).
+
+        $messages = (array)Hash::get($_SESSION, 'Flash.' . $this->key);
         if ($this->at) {
-            $messages = [$this->session->read('Flash.' . $this->key . '.' . $this->at)];
+            $messages = [Hash::get($_SESSION, 'Flash.' . $this->key . '.' . $this->at)];
         }
 
         foreach ($messages as $message) {

--- a/src/TestSuite/Constraint/Session/SessionEquals.php
+++ b/src/TestSuite/Constraint/Session/SessionEquals.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Constraint\Session;
 
 use Cake\Http\Session;
+use Cake\Utility\Hash;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
 
@@ -65,7 +66,10 @@ class SessionEquals extends Constraint
      */
     public function matches($other): bool
     {
-        return $this->session->read($this->path) === $other;
+        // Server::run calls Session::close at the end of the request.
+        // Which means, that we cannot use Session object here to access the session data.
+        // Call to Session::read will start new session (and will erase the data).
+        return Hash::get($_SESSION, $this->path) === $other;
     }
 
     /**

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -192,9 +192,9 @@ class ServerTest extends TestCase
     }
 
     /**
-     * Test that run closes session after invoking the application.
+     * Test that run closes session after invoking the application (if CakePHP ServerRequest is used).
      */
-    public function testRunClosesSession()
+    public function testRunClosesSessionIfServerRequestUsed()
     {
         $sessionMock = $this->createMock(Session::class);
 
@@ -204,6 +204,30 @@ class ServerTest extends TestCase
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
         $request = new ServerRequest(['session' => $sessionMock]);
+        $res = $server->run($request);
+
+        // assert that app was executed correctly
+        $this->assertSame(
+            200,
+            $res->getStatusCode(),
+            "Application was expected to be executed"
+        );
+        $this->assertSame(
+            'source header',
+            $res->getHeaderLine('X-testing'),
+            "Application was expected to be executed"
+        );
+    }
+
+    /**
+     * Test that run does not close the session if CakePHP ServerRequest is not used.
+     */
+    public function testRunDoesNotCloseSessionIfServerRequestNotUsed()
+    {
+        $request = new \Zend\Diactoros\ServerRequest();
+
+        $app = new MiddlewareApplication($this->config);
+        $server = new Server($app);
         $res = $server->run($request);
 
         // assert that app was executed correctly

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -18,7 +18,8 @@ namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
+use InvalidArgumentException;
+use TestApp\Http\Session\TestAppLibSession;
 use TestApp\Http\Session\TestWebSession;
 
 /**
@@ -261,18 +262,13 @@ class SessionTest extends TestCase
      *
      * @return void
      */
-    public function testCloseFailure()
+    public function testCloseNotStarted()
     {
         $session = new Session();
-        $session->started();
         $this->assertTrue($session->start());
-        try {
-            $session->close();
-        } catch (RuntimeException $e) {
-            // closing the session in CLI should raise an error
-            // and won't close the session.
-            $this->assertTrue($session->started());
-        }
+
+        $session->close();
+        $this->assertFalse($session->started());
     }
 
     /**
@@ -489,7 +485,7 @@ class SessionTest extends TestCase
     public function testEngineWithPreMadeInstance()
     {
         static::setAppNamespace();
-        $engine = new \TestApp\Http\Session\TestAppLibSession();
+        $engine = new TestAppLibSession();
         $session = new Session(['handler' => ['engine' => $engine]]);
         $this->assertSame($engine, $session->engine());
 
@@ -505,7 +501,7 @@ class SessionTest extends TestCase
      */
     public function testBadEngine()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
         $session = new Session();
         $session->engine('Derp');


### PR DESCRIPTION
- so that any exceptions in session write go through regular error handling process
- see #13581 for details

I would like to implement some more tests:
- for the assumption, that the exception from `SessionHandlerInterface::close` propagates up correctly
- and that a call to `session_write_close` on already closed session is a noop

I'm also not sure that calling `session_register_shutdown` is a good idea, discussion in #13581 

Otherwise this should be good enough.