### PR TITLE
Fix warning on empty data

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -173,15 +173,14 @@ class RequestHandlerComponent extends Component
             $this->ext = 'ajax';
         }
 
-        if (
-            !$request->is(['get', 'head', 'options'])
-            && $request->getParsedBody() === []
-            && !empty($request->input())
-        ) {
-            deprecationWarning(
-                'Request\'s input data parsing feature has been removed from RequestHandler. '
-                . 'Use the BodyParserMiddleware in your Application class instead.'
-            );
+        if (!$request->is(['get', 'head', 'options']) && $request->getParsedBody() === []) {
+            $input = $request->input();
+            if (!in_array($input, ['', '[]', '{}'], true)) {
+                deprecationWarning(
+                    'Request input data parsing feature has been removed from RequestHandler. '
+                    . 'Use the BodyParserMiddleware in your Application class instead.'
+                );
+            }
         }
     }
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -177,8 +177,8 @@ class RequestHandlerComponent extends Component
             $input = $request->input();
             if (!in_array($input, ['', '[]', '{}'], true)) {
                 deprecationWarning(
-                    'Request input data parsing feature has been removed from RequestHandler. '
-                    . 'Use the BodyParserMiddleware in your Application class instead.'
+                    'Request input data parsing feature has been removed from RequestHandler. ' .
+                    'Use the BodyParserMiddleware in your Application class instead.'
                 );
             }
         }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -29,6 +29,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\AjaxView;
 use Cake\View\JsonView;
 use Cake\View\XmlView;
+use PHPUnit\Framework\Error\Deprecated;
 use TestApp\Controller\Component\RequestHandlerExtComponent;
 use TestApp\Controller\RequestHandlerTestController;
 use TestApp\View\AppView;
@@ -335,11 +336,23 @@ class RequestHandlerComponentTest extends TestCase
         ]);
         $this->Controller->setRequest($request->withMethod('POST'));
 
-        $this->deprecated(function () {
-            $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
-        });
+        $this->expectException(Deprecated::class);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
+    }
 
-        $this->assertEmpty($request->getData());
+    /**
+     * Test that startup() throws deprecation warning if input data is available and request data is not populated.
+     *
+     * @return void
+     */
+    public function testInitializeInputNoWarningEmptyJsonObject()
+    {
+        $request = new ServerRequest([
+            'input' => json_encode([]),
+        ]);
+        $this->Controller->setRequest($request->withMethod('POST'));
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
+        $this->assertSame([], $request->getParsedBody());
     }
 
     /**


### PR DESCRIPTION
When the request input is an empty object we shouldn't emit a deprecation warning. While this won't handle empty XML objects I think those are rare in practice.

Fixes #13980
