### PR TITLE
Add "provide" to composer config of relevant split packages.

### DIFF
--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -26,6 +26,9 @@
         "cakephp/core": "^4.0",
         "psr/simple-cache": "^1.0.0"
     },
+    "provide": {
+        "psr/simple-cache-implementation": "^1.0.0"
+    },
     "autoload": {
         "psr-4": {
             "Cake\\Cache\\": "."

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -33,6 +33,9 @@
         "zendframework/zend-diactoros": "^2.1",
         "zendframework/zend-httphandlerrunner": "^1.0"
     },
+    "provide": {
+        "psr/http-client-implementation": "^1.0"
+    },
     "suggest": {
         "cakephp/cache": "To use cache session storage",
         "cakephp/orm": "To use database session storage"

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -27,6 +27,9 @@
         "cakephp/core": "^4.0",
         "psr/log": "^1.0.0"
     },
+    "provide": {
+        "psr/log-implementation": "^1.0.0"
+    },
     "autoload": {
         "psr-4": {
             "Cake\\Log\\": "."


### PR DESCRIPTION
This will increase the visibility of the standalone packages as
they will be listed on packagist when one is searching for implementations
of a particular PSR.

For e.g. `cakephp/log` would get listed here `https://packagist.org/providers/psr/log-implementation`

The `*-implementation` are virtual packages.