### PR TITLE
2.x - Updated CakeTestSuiteCommand::run() exit logic to match phpunit's

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -101,12 +101,15 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
 		}
 
 		if ($exit) {
-			if (isset($result) && $result->wasSuccessful()) {
-				exit(PHPUnit_TextUI_TestRunner::SUCCESS_EXIT);
-			} elseif (!isset($result) || $result->errorCount() > 0) {
+			if (!isset($result) || $result->errorCount() > 0) {
 				exit(PHPUnit_TextUI_TestRunner::EXCEPTION_EXIT);
 			}
-			exit(PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
+			if ($result->failureCount() > 0) {
+				exit(PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
+			}
+
+			// Default to success even if there are warnings to match phpunit's behavior
+			exit(PHPUnit_TextUI_TestRunner::SUCCESS_EXIT);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/13492 (hopefully).

Giving 2.x a little easy love.
