### PR TITLE
4.x Reduce mocks, and add ArrayLog

### DIFF
--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakefoundation.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Log\Engine;
+
+/**
+ * Array logger.
+ *
+ * Collects log messages in memory. Intended primarily for usage
+ * in testing where using mocks would be complicated. But can also
+ * be used in scenarios where you need to capture logs in application code.
+ */
+class ArrayLog extends BaseLog
+{
+    /**
+     * Captured messages
+     *
+     * @var array
+     */
+    protected $content = [];
+
+    /**
+     * Implements writing to the internal storage.
+     *
+     * @param mixed $level The severity level of log you are making.
+     * @param string $message The message you want to log.
+     * @param array $context Additional information about the logged message
+     * @return void success of write.
+     * @see Cake\Log\Log::$_levels
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->content[] = $this->_format($message, $context);
+    }
+
+    /**
+     * Read the internal storage
+     *
+     * @return string[]
+     */
+    public function read(): array
+    {
+        return $this->content;
+    }
+
+    /**
+     * Reset internal storage.
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->content = [];
+    }
+}

--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -43,7 +43,7 @@ class ArrayLog extends BaseLog
      */
     public function log($level, $message, array $context = [])
     {
-        $this->content[] = $this->_format($message, $context);
+        $this->content[] = $level . ' ' . $this->_format($message, $context);
     }
 
     /**

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -41,10 +41,7 @@ class ControllerAuthorizeTest extends TestCase
             ->setMethods(['isAuthorized'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->components = $this->getMockBuilder(ComponentRegistry::class)->getMock();
-        $this->components->expects($this->any())
-            ->method('getController')
-            ->will($this->returnValue($this->controller));
+        $this->components = new ComponentRegistry($this->controller);
 
         $this->auth = new ControllerAuthorize($this->components);
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -952,7 +952,7 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertSame('duration=0 rows=0 SELECT 1', $messages[0]);
+        $this->assertSame('debug duration=0 rows=0 SELECT 1', $messages[0]);
     }
 
     /**
@@ -980,8 +980,8 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertSame('duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('duration=0 rows=0 ROLLBACK', $messages[1]);
+        $this->assertSame('debug duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug duration=0 rows=0 ROLLBACK', $messages[1]);
     }
 
     /**
@@ -1004,8 +1004,8 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertSame('duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('duration=0 rows=0 COMMIT', $messages[1]);
+        $this->assertSame('debug duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug duration=0 rows=0 COMMIT', $messages[1]);
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -22,7 +22,6 @@ use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\NestedTransactionRollbackException;
-use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Schema\CachedCollection;
@@ -55,17 +54,29 @@ class ConnectionTest extends TestCase
      */
     protected $nestedTransactionStates = [];
 
+
+    /**
+     * @var bool|null
+     */
+    protected $logState;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
+
+        $this->logState = $this->connection->isQueryLoggingEnabled();
+        $this->connection->disableQueryLogging();
+
         static::setAppNamespace();
     }
 
     public function tearDown(): void
     {
-        Log::reset();
         $this->connection->disableSavePoints();
+        $this->connection->enableQueryLogging($this->logState);
+
+        Log::reset();
         unset($this->connection);
         parent::tearDown();
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -54,7 +54,6 @@ class ConnectionTest extends TestCase
      */
     protected $nestedTransactionStates = [];
 
-
     /**
      * @var bool|null
      */

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -64,7 +64,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^duration=\d rows=3 SELECT bar FROM foo$/', $messages[0]);
+        $this->assertRegExp('/^debug duration=\d rows=3 SELECT bar FROM foo$/', $messages[0]);
     }
 
     /**
@@ -86,7 +86,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^duration=\d rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
+        $this->assertRegExp('/^debug duration=\d rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
     }
 
     /**
@@ -117,8 +117,8 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertRegExp("/^duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
-        $this->assertRegExp("/^duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
+        $this->assertRegExp("/^debug duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
+        $this->assertRegExp("/^debug duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
     }
 
     /**
@@ -147,7 +147,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp("/^duration=\d rows=0 SELECT bar FROM foo$/", $messages[0]);
+        $this->assertRegExp("/^debug duration=\d rows=0 SELECT bar FROM foo$/", $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -21,13 +21,30 @@ use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\StatementInterface;
+use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use LogicException;
 
 /**
  * Tests LoggingStatement class
  */
 class LoggingStatementTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        Log::setConfig('queries', [
+            'className' => 'Array',
+            'scopes' => ['queriesLog'],
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Log::drop('queries');
+    }
+
     /**
      * Tests that queries are logged when executed without params
      *
@@ -39,30 +56,15 @@ class LoggingStatementTest extends TestCase
         $inner->method('rowCount')->will($this->returnValue(3));
         $inner->method('execute')->will($this->returnValue(true));
 
-        $logger = $this->getMockBuilder(QueryLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $logger
-            ->expects($this->once())
-            ->method('debug')
-            ->with(
-                $this->stringContains('SELECT bar FROM foo'),
-                $this->callback(function ($context) {
-                    $query = $context['query'];
-
-                    return $query instanceof LoggedQuery
-                        && $query->query === 'SELECT bar FROM foo'
-                        && $query->numRows === 3
-                        && $query->params === [];
-                })
-            );
-
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger($logger);
+        $st->setLogger(new QueryLogger());
         $st->execute();
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
+        $this->assertRegExp('/^duration=\d rows=3 SELECT bar FROM foo$/', $messages[0]);
     }
 
     /**
@@ -76,30 +78,15 @@ class LoggingStatementTest extends TestCase
         $inner->method('rowCount')->will($this->returnValue(4));
         $inner->method('execute')->will($this->returnValue(true));
 
-        $logger = $this->getMockBuilder(QueryLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $logger
-            ->expects($this->once())
-            ->method('debug')
-            ->with(
-                $this->stringContains('SELECT bar FROM foo'),
-                $this->callback(function ($context) {
-                    $query = $context['query'];
-
-                    return $query instanceof LoggedQuery
-                        && $query->query === 'SELECT bar FROM foo'
-                        && $query->numRows === 4
-                        && $query->params == ['a' => 1, 'b' => 2];
-                })
-            );
-
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
-        $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger($logger);
+        $st->queryString = 'SELECT bar FROM foo WHERE x=:a AND y=:b';
+        $st->setLogger(new QueryLogger());
         $st->execute(['a' => 1, 'b' => 2]);
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
+        $this->assertRegExp('/^duration=\d rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
     }
 
     /**
@@ -113,51 +100,25 @@ class LoggingStatementTest extends TestCase
         $inner->method('rowCount')->will($this->returnValue(4));
         $inner->method('execute')->will($this->returnValue(true));
 
-        $logger = $this->getMockBuilder(QueryLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $logger
-            ->expects($this->at(0))
-            ->method('debug')
-            ->with(
-                $this->stringContains('SELECT bar FROM foo'),
-                $this->callback(function ($context) {
-                    $query = $context['query'];
-
-                    return $query instanceof LoggedQuery
-                        && $query->query === 'SELECT bar FROM foo'
-                        && $query->numRows === 4
-                        && $query->params == ['a' => 1, 'b' => '2013-01-01'];
-                })
-            );
-        $logger
-            ->expects($this->at(1))
-            ->method('debug')
-            ->with(
-                $this->stringContains('SELECT bar FROM foo'),
-                $this->callback(function ($context) {
-                    $query = $context['query'];
-
-                    return $query instanceof LoggedQuery
-                        && $query->query === 'SELECT bar FROM foo'
-                        && $query->numRows === 4
-                        && $query->params == ['a' => 1, 'b' => '2014-01-01'];
-                })
-            );
-
         $date = new \DateTime('2013-01-01');
         $inner->expects($this->at(0))->method('bindValue')->with('a', 1);
         $inner->expects($this->at(1))->method('bindValue')->with('b', $date);
+
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);
-        $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger($logger);
+        $st->queryString = 'SELECT bar FROM foo WHERE a=:a AND b=:b';
+        $st->setLogger(new QueryLogger());
         $st->bindValue('a', 1);
         $st->bindValue('b', $date, 'date');
         $st->execute();
+
         $st->bindValue('b', new \DateTime('2014-01-01'), 'date');
         $st->execute();
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(2, $messages);
+        $this->assertRegExp("/^duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
+        $this->assertRegExp("/^duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
     }
 
     /**
@@ -167,38 +128,26 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithError()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('This is bad');
-        $exception = new \LogicException('This is bad');
+        $exception = new LogicException('This is bad');
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())
             ->method('execute')
             ->will($this->throwException($exception));
 
-        $logger = $this->getMockBuilder(QueryLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $logger
-            ->expects($this->once())
-            ->method('debug')
-            ->with(
-                $this->stringContains('SELECT bar FROM foo'),
-                $this->callback(function ($context) use ($exception) {
-                    $query = $context['query'];
-
-                    return $query instanceof LoggedQuery
-                        && $query->query === 'SELECT bar FROM foo'
-                        && $query->params === []
-                        && $query->error === $exception;
-                })
-            );
-
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger($logger);
-        $st->execute();
+        $st->setLogger(new QueryLogger());
+        try {
+            $st->execute();
+        } catch (LogicException $e) {
+            $this->assertSame('This is bad', $e->getMessage());
+            $this->assertSame($st->queryString, $e->queryString);
+        }
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
+        $this->assertRegExp("/^duration=\d rows=0 SELECT bar FROM foo$/", $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Log;
 
 use Cake\Database\DriverInterface;
-use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\StatementInterface;

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -208,9 +208,7 @@ class LoggingStatementTest extends TestCase
      */
     public function testSetAndGetLogger()
     {
-        $logger = $this->getMockBuilder(QueryLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $logger = new QueryLogger();
         $st = new LoggingStatement(
             $this->getMockBuilder(StatementInterface::class)->getMock(),
             $this->getMockBuilder(DriverInterface::class)->getMock()

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -28,17 +28,6 @@ use Psr\Log\LogLevel;
 class QueryLoggerTest extends TestCase
 {
     /**
-     * Set up
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-        Log::reset();
-    }
-
-    /**
      * Tear down
      *
      * @return void
@@ -46,7 +35,8 @@ class QueryLoggerTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        Log::reset();
+        Log::drop('queryLoggerTest');
+        Log::drop('queryLoggerTest2');
     }
 
     /**
@@ -62,19 +52,17 @@ class QueryLoggerTest extends TestCase
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
         $query->params = ['string', '3', null];
 
-        $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->setConstructorArgs(['scopes' => ['queriesLog']])
-            ->getMock();
-        Log::engine('queryLoggerTest');
-
-        $engine2 = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->setConstructorArgs(['scopes' => ['foo']])
-            ->getMock();
-        Log::engine('queryLoggerTest2');
-
-        $engine2->expects($this->never())->method('log');
+        Log::setConfig('queryLoggerTest', [
+            'className' => 'Array',
+            'scopes' => ['queriesLog'],
+        ]);
+        Log::setConfig('queryLoggerTest2', [
+            'className' => 'Array',
+            'scopes' => ['foo'],
+        ]);
         $logger->log(LogLevel::DEBUG, (string)$query, compact('query'));
+
+        $this->assertCount(1, Log::engine('queryLoggerTest')->read());
+        $this->assertCount(0, Log::engine('queryLoggerTest2')->read());
     }
 }

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Cache\Cache;
-use Cake\Cache\Engine\NullEngine;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\SchemaCache;
 use Cake\Datasource\ConnectionManager;

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Datasource;
 use Cake\Cache\Cache;
 use Cake\Datasource\QueryCacher;
 use Cake\TestSuite\TestCase;
+use stdClass;
 
 /**
  * Query cacher test
@@ -61,7 +62,7 @@ class QueryCacherTest extends TestCase
     public function testFetchFunctionKey()
     {
         $this->_mockRead('my_key', 'A winner');
-        $query = $this->getMockBuilder('stdClass')->getMock();
+        $query = new stdClass();
 
         $cacher = new QueryCacher(function ($q) use ($query) {
             $this->assertSame($query, $q);
@@ -83,7 +84,7 @@ class QueryCacherTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cache key functions must return a string. Got false.');
         $this->_mockRead('my_key', 'A winner');
-        $query = $this->getMockBuilder('stdClass')->getMock();
+        $query = new stdClass();
 
         $cacher = new QueryCacher(function ($q) {
             return false;
@@ -101,7 +102,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', 'queryCache');
-        $query = $this->getMockBuilder('stdClass')->getMock();
+        $query = new stdClass();
         $result = $cacher->fetch($query);
         $this->assertSame('A winner', $result);
     }
@@ -115,7 +116,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', $this->engine);
-        $query = $this->getMockBuilder('stdClass')->getMock();
+        $query = new stdClass();
         $result = $cacher->fetch($query);
         $this->assertSame('A winner', $result);
     }
@@ -129,7 +130,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', false);
         $cacher = new QueryCacher('my_key', $this->engine);
-        $query = $this->getMockBuilder('stdClass')->getMock();
+        $query = new stdClass();
         $result = $cacher->fetch($query);
         $this->assertNull($result, 'Cache miss should not have an isset() return.');
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -440,29 +440,21 @@ TEXT;
      */
     public function testLog()
     {
-        $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->getMock();
-        Log::setConfig('test', ['engine' => $mock]);
-
-        $mock->expects($this->at(0))
-            ->method('log')
-            ->with('debug', $this->logicalAnd(
-                $this->stringContains('DebuggerTest::testLog'),
-                $this->stringContains('cool')
-            ));
-
-        $mock->expects($this->at(1))
-            ->method('log')
-            ->with('debug', $this->logicalAnd(
-                $this->stringContains('DebuggerTest::testLog'),
-                $this->stringContains('[main]'),
-                $this->stringContains("'whatever',"),
-                $this->stringContains("'here'")
-            ));
-
+        Log::setConfig('test', [
+            'className' => 'Array',
+        ]);
         Debugger::log('cool');
         Debugger::log(['whatever', 'here']);
+
+        $messages = Log::engine('test')->read();
+        $this->assertCount(2, $messages);
+        $this->assertStringContainsString('DebuggerTest::testLog', $messages[0]);
+        $this->assertStringContainsString('cool', $messages[0]);
+
+        $this->assertStringContainsString('DebuggerTest::testLog', $messages[1]);
+        $this->assertStringContainsString('[main]', $messages[1]);
+        $this->assertStringContainsString("'whatever'", $messages[1]);
+        $this->assertStringContainsString("'here'", $messages[1]);
 
         Log::drop('test');
     }
@@ -474,23 +466,18 @@ TEXT;
      */
     public function testLogDepth()
     {
-        $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->getMock();
-        Log::setConfig('test', ['engine' => $mock]);
-
-        $mock->expects($this->at(0))
-            ->method('log')
-            ->with('debug', $this->logicalAnd(
-                $this->stringContains('DebuggerTest::testLog'),
-                $this->stringContains('test'),
-                $this->logicalNot($this->stringContains('val'))
-            ));
-
+        Log::setConfig('test', [
+            'className' => 'Array',
+        ]);
         $val = [
             'test' => ['key' => 'val'],
         ];
         Debugger::log($val, 'debug', 0);
+
+        $messages = Log::engine('test')->read();
+        $this->assertStringContainsString('DebuggerTest::testLogDepth', $messages[0]);
+        $this->assertStringContainsString('test', $messages[0]);
+        $this->assertStringNotContainsString('val', $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -26,7 +26,6 @@ use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 use TestApp\Error\TestErrorHandler;
 
@@ -281,7 +280,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertRegExp('/^error/', $messages[1]);
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[1]);
         $this->assertStringNotContainsString(
-            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'), 
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
             $messages[1]
         );
     }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -200,8 +200,9 @@ class ErrorHandlerTest extends TestCase
         $out = $out + 1;
 
         $messages = $this->logger->read();
+        $this->assertRegExp('/^(notice|debug)/', $messages[0]);
         $this->assertStringContainsString(
-            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 4) . ']' . "\n\n",
+            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 5) . ']' . "\n\n",
             $messages[0]
         );
     }
@@ -221,8 +222,9 @@ class ErrorHandlerTest extends TestCase
         $out = $out + 1;
 
         $messages = $this->logger->read();
+        $this->assertRegExp('/^(notice|debug)/', $messages[0]);
         $this->assertStringContainsString(
-            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 4) . ']',
+            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 5) . ']',
             $messages[0]
         );
         $this->assertStringContainsString('Trace:', $messages[0]);
@@ -262,6 +264,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString('Kaboom!', (string)$errorHandler->response->getBody(), 'message missing.');
 
         $messages = $this->logger->read();
+        $this->assertRegExp('/^error/', $messages[0]);
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[0]);
         $this->assertStringContainsString(
             str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
@@ -275,6 +278,7 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->handleException($error);
 
         $messages = $this->logger->read();
+        $this->assertRegExp('/^error/', $messages[1]);
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[1]);
         $this->assertStringNotContainsString(
             str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'), 
@@ -301,6 +305,7 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->handleException($error);
 
         $messages = $this->logger->read();
+        $this->assertRegExp('/^error/', $messages[0]);
         $this->assertStringContainsString(
             '[Cake\Http\Exception\MissingControllerException] Controller class Derp could not be found.',
             $messages[0]
@@ -366,6 +371,7 @@ class ErrorHandlerTest extends TestCase
 
         $messages = $this->logger->read();
         $this->assertCount(1, $messages);
+        $this->assertRegExp('/^error/', $messages[0]);
         $this->assertStringContainsString(
             '[Cake\Http\Exception\ForbiddenException] Fooled you!',
             $messages[0]

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -38,13 +38,12 @@ class ErrorHandlerTest extends TestCase
     protected $_restoreError = false;
 
     /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\Log\Engine\ArrayLog
      */
-    protected $_logger;
+    protected $logger;
 
     /**
      * error level property
-     *
      */
     private static $errorLevel;
 
@@ -68,12 +67,9 @@ class ErrorHandlerTest extends TestCase
         Router::setRequest($request);
         Configure::write('debug', true);
 
-        $this->_logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-
         Log::reset();
-        Log::setConfig('error_test', [
-            'engine' => $this->_logger,
-        ]);
+        Log::setConfig('error_test', ['className' => 'Array']);
+        $this->logger = Log::engine('error_test');
     }
 
     /**
@@ -201,14 +197,13 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->register();
         $this->_restoreError = true;
 
-        $this->_logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->matchesRegularExpression('(notice|debug)'),
-                'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ + 3) . ']' . "\n\n"
-            );
-
         $out = $out + 1;
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString(
+            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 4) . ']' . "\n\n",
+            $messages[0]
+        );
     }
 
     /**
@@ -223,20 +218,17 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->register();
         $this->_restoreError = true;
 
-        $this->_logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->matchesRegularExpression('(notice|debug)'),
-                $this->logicalAnd(
-                    $this->stringContains('Notice (8): Undefined variable: out in '),
-                    $this->stringContains('Trace:'),
-                    $this->stringContains(__NAMESPACE__ . '\ErrorHandlerTest::testHandleErrorLoggingTrace()'),
-                    $this->stringContains('Request URL:'),
-                    $this->stringContains('Referer URL:')
-                )
-            );
-
         $out = $out + 1;
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString(
+            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 4) . ']',
+            $messages[0]
+        );
+        $this->assertStringContainsString('Trace:', $messages[0]);
+        $this->assertStringContainsString(__NAMESPACE__ . '\ErrorHandlerTest::testHandleErrorLoggingTrace()', $messages[0]);
+        $this->assertStringContainsString('Request URL:', $messages[0]);
+        $this->assertStringContainsString('Referer URL:', $messages[0]);
     }
 
     /**
@@ -266,29 +258,28 @@ class ErrorHandlerTest extends TestCase
         ]);
 
         $error = new NotFoundException('Kaboom!');
-
-        $this->_logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->stringContains(str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'))
-            ));
-
-        $this->_logger->expects($this->at(1))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->logicalNot($this->stringContains(str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php')))
-            ));
-
         $errorHandler->handleException($error);
         $this->assertStringContainsString('Kaboom!', (string)$errorHandler->response->getBody(), 'message missing.');
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[0]);
+        $this->assertStringContainsString(
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
+            $messages[0]
+        );
 
         $errorHandler = new TestErrorHandler([
             'log' => true,
             'trace' => false,
         ]);
         $errorHandler->handleException($error);
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[1]);
+        $this->assertStringNotContainsString(
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'), 
+            $messages[1]
+        );
     }
 
     /**
@@ -304,32 +295,25 @@ class ErrorHandlerTest extends TestCase
         ]);
 
         $error = new MissingControllerException(['class' => 'Derp']);
-
-        $this->_logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains(
-                    '[Cake\Http\Exception\MissingControllerException] ' .
-                    'Controller class Derp could not be found.'
-                ),
-                $this->stringContains('Exception Attributes:'),
-                $this->stringContains('Request URL:'),
-                $this->stringContains('Referer URL:')
-            ));
-
-        $this->_logger->expects($this->at(1))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains(
-                    '[Cake\Http\Exception\MissingControllerException] ' .
-                    'Controller class Derp could not be found.'
-                ),
-                $this->logicalNot($this->stringContains('Exception Attributes:'))
-            ));
         $errorHandler->handleException($error);
 
         Configure::write('debug', false);
         $errorHandler->handleException($error);
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString(
+            '[Cake\Http\Exception\MissingControllerException] Controller class Derp could not be found.',
+            $messages[0]
+        );
+        $this->assertStringContainsString('Exception Attributes:', $messages[0]);
+        $this->assertStringContainsString('Request URL:', $messages[0]);
+        $this->assertStringContainsString('Referer URL:', $messages[0]);
+
+        $this->assertStringContainsString(
+            '[Cake\Http\Exception\MissingControllerException] Controller class Derp could not be found.',
+            $messages[1]
+        );
+        $this->assertStringNotContainsString('Exception Attributes:', $messages[1]);
     }
 
     /**
@@ -346,16 +330,18 @@ class ErrorHandlerTest extends TestCase
 
         $previous = new RecordNotFoundException('Previous logged');
         $error = new NotFoundException('Kaboom!', null, $previous);
-
-        $this->_logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->stringContains('Caused by: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged'),
-                $this->stringContains(str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'))
-            ));
-
         $errorHandler->handleException($error);
+
+        $messages = $this->logger->read();
+        $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $messages[0]);
+        $this->assertStringContainsString(
+            'Caused by: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged',
+            $messages[0]
+        );
+        $this->assertStringContainsString(
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
+            $messages[0]
+        );
     }
 
     /**
@@ -367,14 +353,6 @@ class ErrorHandlerTest extends TestCase
     {
         $notFound = new NotFoundException('Kaboom!');
         $forbidden = new ForbiddenException('Fooled you!');
-
-        $this->_logger->expects($this->once())
-            ->method('log')
-            ->with(
-                'error',
-                $this->stringContains('[Cake\Http\Exception\ForbiddenException] Fooled you!')
-            );
-
         $errorHandler = new TestErrorHandler([
             'log' => true,
             'skipLog' => ['Cake\Http\Exception\NotFoundException'],
@@ -385,6 +363,13 @@ class ErrorHandlerTest extends TestCase
 
         $errorHandler->handleException($forbidden);
         $this->assertStringContainsString('Fooled you!', (string)$errorHandler->response->getBody(), 'message missing.');
+
+        $messages = $this->logger->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString(
+            '[Cake\Http\Exception\ForbiddenException] Fooled you!',
+            $messages[0]
+        );
     }
 
     /**
@@ -440,19 +425,15 @@ class ErrorHandlerTest extends TestCase
      */
     public function testHandleFatalErrorLog()
     {
-        $this->_logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains(__FILE__ . ', line ' . (__LINE__ + 9)),
-                $this->stringContains('Fatal Error (1)'),
-                $this->stringContains('Something wrong')
-            ));
-        $this->_logger->expects($this->at(1))
-            ->method('log')
-            ->with('error', $this->stringContains('[Cake\Error\FatalErrorException] Something wrong'));
-
         $errorHandler = new TestErrorHandler(['log' => true]);
         $errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, __LINE__);
+
+        $messages = $this->logger->read();
+        $this->assertCount(2, $messages);
+        $this->assertStringContainsString(__FILE__ . ', line ' . (__LINE__ - 4), $messages[0]);
+        $this->assertStringContainsString('Fatal Error (1)', $messages[0]);
+        $this->assertStringContainsString('Something wrong', $messages[0]);
+        $this->assertStringContainsString('[Cake\Error\FatalErrorException] Something wrong', $messages[1]);
     }
 
     /**

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Form;
 
 use Cake\Form\Form;
+use Cake\Form\Schema;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use TestApp\Form\AppForm;
@@ -40,7 +41,7 @@ class FormTest extends TestCase
         $this->assertInstanceOf('Cake\Form\Schema', $schema);
         $this->assertSame($schema, $form->schema(), 'Same instance each time');
 
-        $schema = $this->getMockBuilder('Cake\Form\Schema')->getMock();
+        $schema = new Schema();
         $this->assertSame($schema, $form->schema($schema));
         $this->assertSame($schema, $form->schema());
 
@@ -73,7 +74,7 @@ class FormTest extends TestCase
     public function testSetValidator()
     {
         $form = new Form();
-        $validator = $this->getMockBuilder('Cake\Validation\Validator')->getMock();
+        $validator = new Validator();
 
         $form->setValidator('default', $validator);
         $this->assertSame($validator, $form->getValidator());
@@ -179,18 +180,12 @@ class FormTest extends TestCase
      */
     public function testExecuteValid()
     {
-        $form = $this->getMockBuilder('Cake\Form\Form')
-            ->setMethods(['_execute'])
-            ->getMock();
+        $form = new Form();
         $form->getValidator()
             ->add('email', 'format', ['rule' => 'email']);
         $data = [
             'email' => 'test@example.com',
         ];
-        $form->expects($this->once())
-            ->method('_execute')
-            ->with($data)
-            ->will($this->returnValue(true));
 
         $this->assertTrue($form->execute($data));
     }

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1426,34 +1426,25 @@ class EmailTest extends TestCase
      */
     public function testSendWithLog()
     {
-        $log = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->setConstructorArgs([['scopes' => 'email']])
-            ->getMock();
-
-        $message = 'Logging This';
-
-        $log->expects($this->once())
-            ->method('log')
-            ->with(
-                'debug',
-                $this->logicalAnd(
-                    $this->stringContains($message),
-                    $this->stringContains('cake@cakephp.org'),
-                    $this->stringContains('me@cakephp.org')
-                )
-            );
-
-        Log::setConfig('email', $log);
+        Log::setConfig('email', [
+            'className' => 'Array',
+        ]);
 
         $this->Email->setTransport('debug');
         $this->Email->setTo('me@cakephp.org');
         $this->Email->setFrom('cake@cakephp.org');
         $this->Email->setSubject('My title');
         $this->Email->setProfile(['log' => 'debug']);
-        $result = $this->Email->send($message);
 
+        $text = 'Logging This';
+        $result = $this->Email->send($text);
         $this->assertNotEmpty($result);
+
+        $messages = Log::engine('email')->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString($text, $messages[0]);
+        $this->assertStringContainsString('cake@cakephp.org', $messages[0]);
+        $this->assertStringContainsString('me@cakephp.org', $messages[0]);
     }
 
     /**
@@ -1463,31 +1454,25 @@ class EmailTest extends TestCase
      */
     public function testSendWithLogAndScope()
     {
-        $message = 'Logging This';
-
-        $log = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
-            ->setMethods(['log'])
-            ->setConstructorArgs(['scopes' => ['email']])
-            ->getMock();
-        $log->expects($this->once())
-            ->method('log')
-            ->with(
-                'debug',
-                $this->logicalAnd(
-                    $this->stringContains($message),
-                    $this->stringContains('cake@cakephp.org'),
-                    $this->stringContains('me@cakephp.org')
-                )
-            );
-
-        Log::setConfig('email', $log);
+        Log::setConfig('email', [
+            'className' => 'Array',
+            'scopes' => ['email'],
+        ]);
 
         $this->Email->setTransport('debug');
         $this->Email->setTo('me@cakephp.org');
         $this->Email->setFrom('cake@cakephp.org');
         $this->Email->setSubject('My title');
         $this->Email->setProfile(['log' => ['scope' => 'email']]);
-        $this->Email->send($message);
+
+        $text = 'Logging This';
+        $this->Email->send($text);
+
+        $messages = Log::engine('email')->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString($text, $messages[0]);
+        $this->assertStringContainsString('cake@cakephp.org', $messages[0]);
+        $this->assertStringContainsString('me@cakephp.org', $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -1323,34 +1323,25 @@ class MailerTest extends TestCase
      */
     public function testSendWithLog()
     {
-        $log = $this->getMockBuilder(BaseLog::class)
-            ->setMethods(['log'])
-            ->setConstructorArgs([['scopes' => 'email']])
-            ->getMock();
-
-        $message = 'Logging This';
-
-        $log->expects($this->once())
-            ->method('log')
-            ->with(
-                'debug',
-                $this->logicalAnd(
-                    $this->stringContains($message),
-                    $this->stringContains('cake@cakephp.org'),
-                    $this->stringContains('me@cakephp.org')
-                )
-            );
-
-        Log::setConfig('email', $log);
+        Log::setConfig('email', [
+            'className' => 'Array',
+        ]);
 
         $this->mailer->setTransport('debug');
         $this->mailer->setTo('me@cakephp.org');
         $this->mailer->setFrom('cake@cakephp.org');
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['log' => 'debug']);
-        $result = $this->mailer->deliver($message);
 
+        $text = 'Logging This';
+        $result = $this->mailer->deliver($text);
         $this->assertNotEmpty($result);
+
+        $messages = Log::engine('email')->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString($text, $messages[0]);
+        $this->assertStringContainsString('cake@cakephp.org', $messages[0]);
+        $this->assertStringContainsString('me@cakephp.org', $messages[0]);
     }
 
     /**
@@ -1360,31 +1351,24 @@ class MailerTest extends TestCase
      */
     public function testSendWithLogAndScope()
     {
-        $message = 'Logging This';
-
-        $log = $this->getMockBuilder(BaseLog::class)
-            ->setMethods(['log'])
-            ->setConstructorArgs(['scopes' => ['email']])
-            ->getMock();
-        $log->expects($this->once())
-            ->method('log')
-            ->with(
-                'debug',
-                $this->logicalAnd(
-                    $this->stringContains($message),
-                    $this->stringContains('cake@cakephp.org'),
-                    $this->stringContains('me@cakephp.org')
-                )
-            );
-
-        Log::setConfig('email', $log);
+        Log::setConfig('email', [
+            'className' => 'Array',
+            'scopes' => ['email'],
+        ]);
 
         $this->mailer->setTransport('debug');
         $this->mailer->setTo('me@cakephp.org');
         $this->mailer->setFrom('cake@cakephp.org');
         $this->mailer->setSubject('My title');
         $this->mailer->setProfile(['log' => ['scope' => 'email']]);
-        $this->mailer->deliver($message);
+        $text = 'Logging This';
+        $this->mailer->deliver($text);
+
+        $messages = Log::engine('email')->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString($text, $messages[0]);
+        $this->assertStringContainsString('cake@cakephp.org', $messages[0]);
+        $this->assertStringContainsString('me@cakephp.org', $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Mailer;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
-use Cake\Log\Engine\BaseLog;
 use Cake\Log\Log;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Exception\MissingActionException;

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -45,9 +45,7 @@ class DebugTransportTest extends TestCase
      */
     public function testSend()
     {
-        $message = $this->getMockBuilder(Message::class)
-            ->setMethods(['getBody'])
-            ->getMock();
+        $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
         $message->setCc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
@@ -56,7 +54,7 @@ class DebugTransportTest extends TestCase
         $message->setSubject('Testing Message');
         $date = date(DATE_RFC2822);
         $message->setHeaders(['Date' => $date, 'o:tag' => ['foo', 'bar']]);
-        $message->expects($this->once())->method('getBody')->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+        $message->setBody(['text' => "First Line\nSecond Line\n.Third Line\n"]);
 
         $headers = "From: CakePHP Test <noreply@cakephp.org>\r\n";
         $headers .= "To: CakePHP <cake@cakephp.org>\r\n";
@@ -72,7 +70,7 @@ class DebugTransportTest extends TestCase
 
         $data = "First Line\r\n";
         $data .= "Second Line\r\n";
-        $data .= ".Third Line\r\n"; // Not use 'RFC5321 4.5.2.Transparency' in DebugTransport.
+        $data .= ".Third Line\r\n\r\n"; // Not use 'RFC5321 4.5.2.Transparency' in DebugTransport.
 
         $result = $this->DebugTransport->send($message);
 

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -62,9 +62,7 @@ class MailTransportTest extends TestCase
      */
     public function testSendData()
     {
-        $message = $this->getMockBuilder(Message::class)
-            ->setMethods(['getBody'])
-            ->getMock();
+        $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $message->setTo('cake@cakephp.org', 'CakePHP');
@@ -79,8 +77,7 @@ class MailTransportTest extends TestCase
             'Date' => $date,
             'X-add' => mb_encode_mimeheader($longNonAscii, 'utf8', 'B'),
         ]);
-        $message->expects($this->any())->method('getBody')
-            ->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+        $message->setBody(['text' => "First Line\nSecond Line\n.Third Line"]);
 
         $encoded = '=?UTF-8?B?Rm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXog?=';
         $encoded .= ' =?UTF-8?B?Rm/DuCBCw6VyIELDqXo=?=';
@@ -101,7 +98,7 @@ class MailTransportTest extends TestCase
             ->with(
                 'CakePHP <cake@cakephp.org>',
                 $encoded,
-                implode(PHP_EOL, ['First Line', 'Second Line', '.Third Line', '']),
+                implode(PHP_EOL, ['First Line', 'Second Line', '.Third Line', '', '']),
                 $data,
                 '-f'
             );

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -351,10 +351,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testSendData()
     {
-        $message = $this->getMockBuilder(Message::class)
-            ->setMethods(['getBody'])
-            ->getMock();
-        /** @var \Cake\Mailer\Message $message */
+        $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $message->setTo('cake@cakephp.org', 'CakePHP');
@@ -364,9 +361,7 @@ class SmtpTransportTest extends TestCase
         $message->setSubject('Testing SMTP');
         $date = date(DATE_RFC2822);
         $message->setHeaders(['Date' => $date]);
-        $message->expects($this->once())
-            ->method('getBody')
-            ->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+        $message->setBody(['text' => "First Line\nSecond Line\n.Third Line"]);
 
         $data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
         $data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>\r\n";
@@ -381,7 +376,7 @@ class SmtpTransportTest extends TestCase
         $data .= "\r\n";
         $data .= "First Line\r\n";
         $data .= "Second Line\r\n";
-        $data .= "..Third Line\r\n"; // RFC5321 4.5.2.Transparency
+        $data .= "..Third Line\r\n\r\n"; // RFC5321 4.5.2.Transparency
         $data .= "\r\n";
         $data .= "\r\n\r\n.\r\n";
 

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -403,20 +403,15 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimple()
     {
-        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
-        $mock->method('init')
-            ->will($this->returnValue(true));
-        $mock->method('get')
-            ->will($this->returnValue(null));
-        $mock->expects($this->once())
-            ->method('set')
-            ->with('cell_test_app_view_cell_articles_cell_display_default', "dummy\n")
-            ->will($this->returnValue(true));
-        Cache::setConfig('default', $mock);
+        Cache::setConfig('default', ['className' => 'Array']);
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
-        $this->assertEquals("dummy\n", $result);
+        $expected = "dummy\n";
+        $this->assertEquals($expected, $result);
+
+        $result = Cache::read('cell_test_app_view_cell_articles_cell_display_default', 'default');
+        $this->assertEquals($expected, $result);
         Cache::drop('default');
     }
 
@@ -427,18 +422,12 @@ class CellTest extends TestCase
      */
     public function testReadCachedCell()
     {
-        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
-        $mock->method('init')
-            ->will($this->returnValue(true));
-        $mock->method('get')
-            ->will($this->returnValue("dummy\n"));
-        $mock->expects($this->never())
-            ->method('set');
-        Cache::setConfig('default', $mock);
+        Cache::setConfig('default', ['className' => 'Array']);
+        Cache::write('cell_test_app_view_cell_articles_cell_display_default', 'from cache');
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
-        $this->assertEquals("dummy\n", $result);
+        $this->assertEquals('from cache', $result);
         Cache::drop('default');
     }
 
@@ -449,22 +438,14 @@ class CellTest extends TestCase
      */
     public function testCachedRenderArrayConfig()
     {
-        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
-        $mock->method('init')
-            ->will($this->returnValue(true));
-        $mock->method('get')
-            ->will($this->returnValue(null));
-        $mock->expects($this->once())
-            ->method('set')
-            ->with('my_key', "dummy\n")
-            ->will($this->returnValue(true));
-        Cache::setConfig('cell', $mock);
+        Cache::setConfig('cell', ['className' => 'Array']);
+        Cache::write('my_key', 'from cache', 'cell');
 
         $cell = $this->View->cell('Articles', [], [
             'cache' => ['key' => 'my_key', 'config' => 'cell'],
         ]);
         $result = $cell->render();
-        $this->assertEquals("dummy\n", $result);
+        $this->assertEquals('from cache', $result);
         Cache::drop('cell');
     }
 
@@ -475,21 +456,15 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimpleCustomTemplate()
     {
-        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
-        $mock->method('init')
-            ->will($this->returnValue(true));
-        $mock->method('get')
-            ->will($this->returnValue(null));
-        $mock->expects($this->once())
-            ->method('set')
-            ->with('cell_test_app_view_cell_articles_cell_customTemplateViewBuilder_default', "<h1>This is the alternate template</h1>\n")
-            ->will($this->returnValue(true));
-        Cache::setConfig('default', $mock);
+        Cache::setConfig('default', ['className' => 'Array']);
 
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => true]);
         $result = $cell->render();
-        $this->assertStringContainsString('This is the alternate template', $result);
+        $expected = 'This is the alternate template';
+        $this->assertStringContainsString($expected, $result);
 
+        $result = Cache::read('cell_test_app_view_cell_articles_cell_customTemplateViewBuilder_default');
+        $this->assertStringContainsString($expected, $result);
         Cache::drop('default');
     }
 
@@ -501,17 +476,14 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimpleCustomTemplateViewBuilder()
     {
-        Cache::setConfig('default', [
-            'className' => 'File',
-            'path' => CACHE,
-        ]);
+        Cache::setConfig('default', ['className' => 'Array']);
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => ['key' => 'celltest']]);
         $result = $cell->render();
         $this->assertEquals(1, $cell->counter);
         $cell->render();
+
         $this->assertEquals(1, $cell->counter);
         $this->assertStringContainsString('This is the alternate template', $result);
-        Cache::delete('celltest');
         Cache::drop('default');
     }
 
@@ -523,10 +495,7 @@ class CellTest extends TestCase
      */
     public function testACachedViewCellReRendersWhenGivenADifferentTemplate()
     {
-        Cache::setConfig('default', [
-            'className' => 'File',
-            'path' => CACHE,
-        ]);
+        Cache::setConfig('default', ['className' => 'Array']);
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => true]);
         $result = $cell->render('alternate_teaser_list');
         $result2 = $cell->render('not_the_alternate_teaser_list');

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -196,7 +197,7 @@ class ViewBuilderTest extends TestCase
     {
         $request = new ServerRequest();
         $response = new Response();
-        $events = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
+        $events = new EventManager();
 
         $builder = new ViewBuilder();
         $builder->setName('Articles')

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\BasicWidget;
 
@@ -32,7 +34,7 @@ class BasicWidgetTest extends TestCase
             'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\ButtonWidget;
 
@@ -32,7 +34,7 @@ class ButtonWidgetTest extends TestCase
             'button' => '<button{{attrs}}>{{text}}</button>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\CheckboxWidget;
 
@@ -37,7 +39,7 @@ class CheckboxWidgetTest extends TestCase
             'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\DateTimeWidget;
 
@@ -37,7 +39,7 @@ class DateTimeWidgetTest extends TestCase
             'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
         $this->DateTime = new DateTimeWidget($this->templates);
     }
 

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\FileWidget;
 
@@ -37,7 +39,7 @@ class FileWidgetTest extends TestCase
             'file' => '<input type="file" name="{{name}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\LabelWidget;
 
@@ -37,7 +39,7 @@ class LabelWidgetTest extends TestCase
             'label' => '<label{{attrs}}>{{text}}</label>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\LabelWidget;
 use Cake\View\Widget\MultiCheckboxWidget;
@@ -45,7 +47,7 @@ class MultiCheckboxWidgetTest extends TestCase
             'selectedClass' => 'selected',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\Collection\Collection;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\NestingLabelWidget;
 use Cake\View\Widget\RadioWidget;
@@ -42,7 +44,7 @@ class RadioWidgetTest extends TestCase
             'selectedClass' => 'selected',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
     }
 
     /**

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\Collection\Collection;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\SelectBoxWidget;
 
@@ -40,7 +42,7 @@ class SelectBoxWidgetTest extends TestCase
             'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
             'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
         ];
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
         $this->templates = new StringTemplate($templates);
     }
 

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\TextareaWidget;
 
@@ -36,7 +38,7 @@ class TextareaWidgetTest extends TestCase
         $templates = [
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
         ];
-        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
+        $this->context = new NullContext(new ServerRequest(), []);
         $this->templates = new StringTemplate($templates);
     }
 


### PR DESCRIPTION
Reduce usage of mocks further. We mocked logging in a few places, so I added `ArrayLog`. This logger is analogous to the `ArrayEngine` for caching. By collecting messages in memory we can more easily do assertions than with mocks.