### PR TITLE
4.x - Added cakephp/i18n to database suggest list

### DIFF
--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -28,6 +28,9 @@
         "cakephp/core": "^4.0",
         "cakephp/datasource": "^4.0"
     },
+    "suggest": {
+        "cakephp/i18n": "If you are using locale-aware datetime formats or Chronos types."
+    },
     "autoload": {
         "psr-4": {
             "Cake\\Database\\": "."

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -34,7 +34,7 @@
     },
     "suggest": {
         "cakephp/cache": "If you decide to use Query caching.",
-        "cakephp/i18n": "If you are using Translate / Timestamp Behavior."
+        "cakephp/i18n": "If you are using Translate/TimestampBehavior or Chronos types."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/14000

Mentioned locale-aware use and Chronos types which is what I wanted when setting up ORM independently.