### PR TITLE
Remove duplicate calling TableLocator::clear()

### DIFF
--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -93,17 +93,6 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * tearDown
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * testPaginatorSetting
      *
      * @return void

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -55,7 +55,6 @@ class TableTest extends TestCase
 
     public function tearDown()
     {
-        $this->getTableLocator()->clear();
         Type::clear();
         Type::setMap($this->_map);
         parent::tearDown();

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -63,17 +63,6 @@ class PaginatorTest extends TestCase
     }
 
     /**
-     * tearDown
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Test that non-numeric values are rejected for page, and limit
      *
      * @return void

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -54,7 +54,6 @@ class DatabaseSessionTest extends TestCase
     public function tearDown()
     {
         unset($this->storage);
-        $this->getTableLocator()->clear();
         parent::tearDown();
     }
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -72,17 +72,6 @@ class BelongsToTest extends TestCase
     }
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Test that foreignKey generation
      *
      * @return void

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -87,17 +87,6 @@ class HasManyTest extends TestCase
     }
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that foreignKey() returns the correct configured value
      *
      * @return void

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -52,17 +52,6 @@ class HasOneTest extends TestCase
     }
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that foreignKey() returns the correct configured value
      *
      * @group deprecated

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -33,17 +33,6 @@ class AssociationProxyTest extends TestCase
     ];
 
     /**
-     * Teardown
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that it is possible to get associations as a property
      *
      * @return void

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -74,17 +74,6 @@ class AssociationTest extends TestCase
     }
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that _options acts as a callback where subclasses can add their own
      * initialization code based on the passed configuration array
      *

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -102,7 +102,6 @@ class CounterCacheBehaviorTest extends TestCase
         parent::tearDown();
 
         unset($this->user, $this->post);
-        $this->getTableLocator()->clear();
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -57,7 +57,6 @@ class TranslateBehaviorTest extends TestCase
     {
         parent::tearDown();
         I18n::setLocale(I18n::getDefaultLocale());
-        $this->getTableLocator()->clear();
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -41,12 +41,6 @@ class TreeBehaviorTest extends TestCase
         $this->table->addBehavior('Tree');
     }
 
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
     /**
      * Sanity test
      *

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -128,17 +128,6 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that fully defined belongsTo and hasOne relationships are joined correctly
      *
      * @return void

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -170,7 +170,6 @@ class MarshallerTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        $this->getTableLocator()->clear();
         unset($this->articles, $this->comments, $this->users, $this->tags);
     }
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -51,18 +51,6 @@ class QueryRegressionTest extends TestCase
     public $autoFixtures = false;
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Test for https://github.com/cakephp/cakephp/issues/3087
      *
      * @return void

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -98,17 +98,6 @@ class QueryTest extends TestCase
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Data provider for the two types of strategies HasMany implements
      *
      * @return array

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -37,17 +37,6 @@ class RulesCheckerIntegrationTest extends TestCase
     ];
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests saving belongsTo association and get a validation error
      *
      * @group save

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -33,18 +33,6 @@ class TableRegressionTest extends TestCase
     ];
 
     /**
-     * Tear down
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Tests that an exception is thrown if the transaction is aborted
      * in the afterSave callback
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -136,7 +136,6 @@ class TableTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        $this->getTableLocator()->clear();
         $this->clearPlugins();
     }
 

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -48,17 +48,6 @@ class TableUuidTest extends TestCase
     }
 
     /**
-     * teardown
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->getTableLocator()->clear();
-    }
-
-    /**
      * Provider for testing that string and binary uuids work the same
      *
      * @return array

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -201,7 +201,6 @@ class FormHelperTest extends TestCase
     {
         parent::tearDown();
         unset($this->Form, $this->Controller, $this->View);
-        $this->getTableLocator()->clear();
     }
 
     /**


### PR DESCRIPTION
In `Cake\TestSuite\TestCase::tearDown()`, `$this->getTableLocator()->clear()` is called.
So each subclasses' `tearDown()` don't have to call it.

This PR is to

- Remove duplication calling `TableLocator::clear()`
- Remove `tearDown()` implemented only to call `TableLocator::clear()`