### PR TITLE
4.x - Removed unnused magic property annotation in Message

### DIFF
--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -20,8 +20,6 @@ namespace Cake\Http\Client;
  *
  * Defines some common helper methods, constants
  * and properties.
- *
- * @property array $headers
  */
 class Message
 {


### PR DESCRIPTION
$header is not defined as a magic property in Message.

It is defined in an external trait that some subclasses use but as a protected property, not magic.