### PR TITLE
Fixed preserving spaces in Text::slug

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1179,7 +1179,7 @@ class Text
             '/[' . $regex . ']/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
-        if ($options['replacement']) {
+        if (isset($options['replacement']) && strlen($options['replacement'])) {
             $map[sprintf('/[%s]+/mu', $quotedReplacement)] = $options['replacement'];
         }
         $string = preg_replace(array_keys($map), $map, $string);

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1170,16 +1170,18 @@ class Text
             $string = static::transliterate($string, $options['transliteratorId']);
         }
 
-        $regex = '^\s\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}';
+        $regex = '^\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}';
         if ($options['preserve']) {
             $regex .= preg_quote($options['preserve'], '/');
         }
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [
-            '/[' . $regex . ']/mu' => ' ',
-            '/[\s]+/mu' => $options['replacement'],
+            '/[' . $regex . ']/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
+        if ($options['replacement']) {
+            $map[sprintf('/[%s]+/mu', $quotedReplacement)] = $options['replacement'];
+        }
         $string = preg_replace(array_keys($map), $map, $string);
 
         return $string;

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1179,7 +1179,7 @@ class Text
             '/[' . $regex . ']/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
-        if (isset($options['replacement']) && strlen($options['replacement'])) {
+        if (is_string($options['replacement']) && strlen($options['replacement']) > 0) {
             $map[sprintf('/[%s]+/mu', $quotedReplacement)] = $options['replacement'];
         }
         $string = preg_replace(array_keys($map), $map, $string);

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1879,6 +1879,14 @@ HTML;
                 'cl#e|an(me.jpg', ['preserve' => '.'],
                 'cl-e-an-me.jpg',
             ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['preserve' => ' '],
+                'Foo Bar- Not just for breakfast any-more',
+            ],
+            [
+                'Foo Bar: Not just for (breakfast) any-more', ['preserve' => ' ()'],
+                'Foo Bar- Not just for (breakfast) any-more',
+            ],
         ];
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1887,6 +1887,14 @@ HTML;
                 'Foo Bar: Not just for (breakfast) any-more', ['preserve' => ' ()'],
                 'Foo Bar- Not just for (breakfast) any-more',
             ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => null],
+                'FooBarNotjustforbreakfastanymore',
+            ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => false],
+                'FooBarNotjustforbreakfastanymore',
+            ],
         ];
     }
 


### PR DESCRIPTION
Previously the regex used a space as a temporary placeholder so it would be replaced regardless of its presence in the "preserve" option.
