### PR TITLE
Time::setJsonEncodeFormat() can set a closure for json serialization

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -52,7 +52,7 @@ trait DateFormatTrait
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|array|int|callable
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH':'mm':'ssxxx";
@@ -284,8 +284,11 @@ trait DateFormatTrait
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
+     * Alternatively, the format can provide a callback. In this case, the callback
+     * can receive this datetime object and return a formatted string.
+     *
      * @see \Cake\I18n\Time::i18nFormat()
-     * @param string|array|int $format Format.
+     * @param string|array|int|callable $format Format.
      * @return void
      */
     public static function setJsonEncodeFormat($format)
@@ -422,6 +425,10 @@ trait DateFormatTrait
      */
     public function jsonSerialize()
     {
+        if (is_callable(static::$_jsonEncodeFormat)) {
+            return call_user_func(static::$_jsonEncodeFormat, $this);
+        }
+
         return $this->i18nFormat(static::$_jsonEncodeFormat);
     }
 

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -164,6 +164,23 @@ class DateTest extends TestCase
     }
 
     /**
+     * Tests change json encoding format
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSetJsonEncodeFormat($class)
+    {
+        $date = new $class('2015-11-06 11:32:45');
+
+        $class::setJsonEncodeFormat(static function ($d) { return $d->format(DATE_ATOM); });
+        $this->assertEquals('"2015-11-06T00:00:00+00:00"', json_encode($date));
+
+        $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");
+        $this->assertEquals('"2015-11-06T00:00:00Z"', json_encode($date));
+    }
+
+    /**
      * test parseDate()
      *
      * @dataProvider classNameProvider

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -173,7 +173,9 @@ class DateTest extends TestCase
     {
         $date = new $class('2015-11-06 11:32:45');
 
-        $class::setJsonEncodeFormat(static function ($d) { return $d->format(DATE_ATOM); });
+        $class::setJsonEncodeFormat(static function ($d) {
+            return $d->format(DATE_ATOM);
+        });
         $this->assertEquals('"2015-11-06T00:00:00+00:00"', json_encode($date));
 
         $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -789,7 +789,9 @@ class TimeTest extends TestCase
     {
         $time = new $class('2014-04-20 10:10:10');
 
-        $class::setJsonEncodeFormat(static function ($t) { return $t->format(DATE_ATOM); });
+        $class::setJsonEncodeFormat(static function ($t) {
+            return $t->format(DATE_ATOM);
+        });
         $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
 
         $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -780,6 +780,23 @@ class TimeTest extends TestCase
     }
 
     /**
+     * Tests change json encoding format
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSetJsonEncodeFormat($class)
+    {
+        $time = new $class('2014-04-20 10:10:10');
+
+        $class::setJsonEncodeFormat(static function ($t) { return $t->format(DATE_ATOM); });
+        $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
+
+        $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");
+        $this->assertEquals('"2014-04-20T10:10:10Z"', json_encode($time));
+    }
+
+    /**
      * Tests debugInfo
      *
      * @dataProvider classNameProvider


### PR DESCRIPTION
This param are determining format method when converting time object to json.

refs #14015
