### PR TITLE
4.x - Added TableSchemaInterface::getPrimaryKey()

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -448,7 +448,7 @@ class MysqlSchema extends BaseSchema
             $out .= ' NOT NULL';
         }
         $addAutoIncrement = (
-            (array)$schema->primaryKey() === [$name] &&
+            (array)$schema->getPrimaryKey() === [$name] &&
             !$schema->hasAutoincrement() &&
             !isset($data['autoIncrement'])
         );

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -403,7 +403,7 @@ class PostgresSchema extends BaseSchema
 
         if ($data['type'] === TableSchema::TYPE_INTEGER || $data['type'] === TableSchema::TYPE_BIGINTEGER) {
             $type = $data['type'] === TableSchema::TYPE_INTEGER ? ' INTEGER' : ' BIGINT';
-            if ($schema->primaryKey() === [$name] || $data['autoIncrement'] === true) {
+            if ($schema->getPrimaryKey() === [$name] || $data['autoIncrement'] === true) {
                 $type = $data['type'] === TableSchema::TYPE_INTEGER ? ' SERIAL' : ' BIGSERIAL';
                 unset($data['null'], $data['default']);
             }

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -350,7 +350,7 @@ class SqliteSchema extends BaseSchema
             isset($data['unsigned']) &&
             $data['unsigned'] === true
         ) {
-            if ($data['type'] !== TableSchema::TYPE_INTEGER || (array)$schema->primaryKey() !== [$name]) {
+            if ($data['type'] !== TableSchema::TYPE_INTEGER || (array)$schema->getPrimaryKey() !== [$name]) {
                 $out .= ' UNSIGNED';
             }
         }
@@ -397,7 +397,7 @@ class SqliteSchema extends BaseSchema
         if (
             in_array($data['type'], $integerTypes, true) &&
             isset($data['length']) &&
-            (array)$schema->primaryKey() !== [$name]
+            (array)$schema->getPrimaryKey() !== [$name]
         ) {
             $out .= '(' . (int)$data['length'] . ')';
         }
@@ -417,7 +417,7 @@ class SqliteSchema extends BaseSchema
             $out .= ' NOT NULL';
         }
 
-        if ($data['type'] === TableSchema::TYPE_INTEGER && (array)$schema->primaryKey() === [$name]) {
+        if ($data['type'] === TableSchema::TYPE_INTEGER && (array)$schema->getPrimaryKey() === [$name]) {
             $out .= ' PRIMARY KEY AUTOINCREMENT';
         }
 

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -394,7 +394,7 @@ class SqlserverSchema extends BaseSchema
         }
 
         if ($data['type'] === TableSchema::TYPE_INTEGER || $data['type'] === TableSchema::TYPE_BIGINTEGER) {
-            if ($schema->primaryKey() === [$name] || $data['autoIncrement'] === true) {
+            if ($schema->getPrimaryKey() === [$name] || $data['autoIncrement'] === true) {
                 unset($data['null'], $data['default']);
                 $out .= ' IDENTITY(1, 1)';
             }
@@ -633,7 +633,7 @@ class SqlserverSchema extends BaseSchema
         ];
 
         // Restart identity sequences
-        $pk = $schema->primaryKey();
+        $pk = $schema->getPrimaryKey();
         if (count($pk) === 1) {
             /** @var array $column */
             $column = $schema->getColumn($pk[0]);

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -522,6 +522,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
     /**
      * @inheritDoc
+     * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -525,6 +525,14 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function primaryKey(): array
     {
+        return $this->getPrimarykey();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPrimaryKey(): array
+    {
         foreach ($this->_constraints as $data) {
             if ($data['type'] === static::CONSTRAINT_PRIMARY) {
                 return $data['columns'];

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -521,7 +521,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     }
 
     /**
-     * @inheritDoc
+     * Get the column(s) used for the primary key.
+     *
+     * @return array Column name(s) for the primary key. An
+     *   empty list will be returned when the table has no primary key.
      * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -201,6 +201,14 @@ interface TableSchemaInterface extends SchemaInterface
     public function primaryKey(): array;
 
     /**
+     * Get the column(s) used for the primary key.
+     *
+     * @return array Column name(s) for the primary key. An
+     *   empty list will be returned when the table has no primary key.
+     */
+    public function getPrimaryKey(): array;
+
+    /**
      * Add an index.
      *
      * Used to add indexes, and full text indexes in platforms that support

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -198,14 +198,6 @@ interface TableSchemaInterface extends SchemaInterface
      * @return array Column name(s) for the primary key. An
      *   empty list will be returned when the table has no primary key.
      */
-    public function primaryKey(): array;
-
-    /**
-     * Get the column(s) used for the primary key.
-     *
-     * @return array Column name(s) for the primary key. An
-     *   empty list will be returned when the table has no primary key.
-     */
     public function getPrimaryKey(): array;
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -595,7 +595,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getPrimaryKey()
     {
         if ($this->_primaryKey === null) {
-            $key = (array)$this->getSchema()->primaryKey();
+            $key = (array)$this->getSchema()->getPrimaryKey();
             if (count($key) === 1) {
                 $key = $key[0];
             }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -406,7 +406,7 @@ SQL;
                 'comment' => null,
             ],
         ];
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
             $this->assertEquals(
                 $definition,

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -309,7 +309,7 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('public.schema_articles');
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         $this->assertSame('schema_articles', $result->name());
     }
 
@@ -448,7 +448,7 @@ SQL;
                 'comment' => null,
             ],
         ];
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
             $this->assertEquals($definition, $result->getColumn($field));
         }
@@ -476,7 +476,7 @@ SQL;
         $result = $schema->describe('schema_composite');
         $connection->execute('DROP TABLE schema_composite');
 
-        $this->assertEquals(['id', 'site_id'], $result->primaryKey());
+        $this->assertEquals(['id', 'site_id'], $result->getPrimaryKey());
         $this->assertTrue($result->getColumn('id')['autoIncrement'], 'id should be autoincrement');
         $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
     }
@@ -540,7 +540,7 @@ SQL;
                 'comment' => null,
             ],
         ];
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
             $this->assertEquals($definition, $result->getColumn($field), "Mismatch in $field column");
         }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -213,7 +213,7 @@ class SqliteSchemaTest extends TestCase
         $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field1);
         $dialect->convertColumnDescription($table, $field2);
-        $this->assertEquals(['field1', 'field2'], $table->primaryKey());
+        $this->assertEquals(['field1', 'field2'], $table->getPrimaryKey());
     }
 
     /**
@@ -378,7 +378,7 @@ SQL;
             ],
         ];
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
             $this->assertEquals($definition, $result->getColumn($field));
         }
@@ -399,7 +399,7 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_composite');
 
-        $this->assertEquals(['id', 'site_id'], $result->primaryKey());
+        $this->assertEquals(['id', 'site_id'], $result->getPrimaryKey());
         $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
         $this->assertNull($result->getColumn('id')['autoIncrement'], 'id should not be autoincrement');
     }

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -483,7 +483,7 @@ SQL;
                 'collate' => 'SQL_Latin1_General_CP1_CI_AS',
             ],
         ];
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
             $column = $result->getColumn($field);
             $this->assertEquals($definition, $column, 'Failed to match field ' . $field);
@@ -514,7 +514,7 @@ SQL;
         $result = $schema->describe('schema_composite');
         $connection->execute('DROP TABLE schema_composite');
 
-        $this->assertEquals(['id', 'site_id'], $result->primaryKey());
+        $this->assertEquals(['id', 'site_id'], $result->getPrimaryKey());
         $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
         $this->assertTrue($result->getColumn('id')['autoIncrement'], 'id should be autoincrement');
     }
@@ -531,7 +531,7 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('dbo.schema_articles');
-        $this->assertEquals(['id'], $result->primaryKey());
+        $this->assertEquals(['id'], $result->getPrimaryKey());
         $this->assertSame('schema_articles', $result->name());
     }
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -497,13 +497,13 @@ class TableSchemaTest extends TestCase
                 'type' => 'primary',
                 'columns' => ['id'],
             ]);
-        $this->assertEquals(['id'], $table->primaryKey());
+        $this->assertEquals(['id'], $table->getPrimaryKey());
 
         $table = new TableSchema('articles');
         $table->addColumn('id', 'integer')
             ->addColumn('title', 'string')
             ->addColumn('author_id', 'integer');
-        $this->assertEquals([], $table->primaryKey());
+        $this->assertEquals([], $table->getPrimaryKey());
     }
 
     /**


### PR DESCRIPTION
Shouldn't we align this name with other getters()?