### PR TITLE
4.x - Added ContextInterface::getPrimaryKey() to use instead of primaryKey()

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -107,19 +107,7 @@ class ArrayContext implements ContextInterface
      */
     public function primaryKey(): array
     {
-        if (
-            empty($this->_context['schema']['_constraints']) ||
-            !is_array($this->_context['schema']['_constraints'])
-        ) {
-            return [];
-        }
-        foreach ($this->_context['schema']['_constraints'] as $data) {
-            if (isset($data['type']) && $data['type'] === 'primary') {
-                return (array)($data['columns'] ?? []);
-            }
-        }
-
-        return [];
+        return $this->getPrimaryKey();
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -103,8 +103,31 @@ class ArrayContext implements ContextInterface
      * Get the fields used in the context as a primary key.
      *
      * @return string[]
+     * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array
+    {
+        if (
+            empty($this->_context['schema']['_constraints']) ||
+            !is_array($this->_context['schema']['_constraints'])
+        ) {
+            return [];
+        }
+        foreach ($this->_context['schema']['_constraints'] as $data) {
+            if (isset($data['type']) && $data['type'] === 'primary') {
+                return (array)($data['columns'] ?? []);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Get the fields used in the context as a primary key.
+     *
+     * @return string[]
+     */
+    public function getPrimaryKey(): array
     {
         if (
             empty($this->_context['schema']['_constraints']) ||

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -149,7 +149,7 @@ class ArrayContext implements ContextInterface
      */
     public function isPrimaryKey(string $field): bool
     {
-        $primaryKey = $this->primaryKey();
+        $primaryKey = $this->getPrimaryKey();
 
         return in_array($field, $primaryKey, true);
     }
@@ -165,7 +165,7 @@ class ArrayContext implements ContextInterface
      */
     public function isCreate(): bool
     {
-        $primary = $this->primaryKey();
+        $primary = $this->getPrimaryKey();
         foreach ($primary as $column) {
             if (!empty($this->_context['defaults'][$column])) {
                 return false;

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -26,7 +26,7 @@ interface ContextInterface
      *
      * @return string[]
      */
-    public function primaryKey(): array;
+    public function getPrimaryKey(): array;
 
     /**
      * Returns true if the passed field name is part of the primary key for this context

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -177,8 +177,21 @@ class EntityContext implements ContextInterface
      * Gets the primary key columns from the root entity's schema.
      *
      * @return string[]
+     * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array
+    {
+        return (array)$this->_tables[$this->_rootName]->getPrimaryKey();
+    }
+
+    /**
+     * Get the primary key data for the context.
+     *
+     * Gets the primary key columns from the root entity's schema.
+     *
+     * @return string[]
+     */
+    public function getPrimaryKey(): array
     {
         return (array)$this->_tables[$this->_rootName]->getPrimaryKey();
     }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -57,9 +57,20 @@ class FormContext implements ContextInterface
     }
 
     /**
-     * @inheritDoc
+     * Get the fields used in the context as a primary key.
+     *
+     * @return string[]
+     * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPrimaryKey(): array
     {
         return [];
     }

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -45,9 +45,20 @@ class NullContext implements ContextInterface
     }
 
     /**
-     * @inheritDoc
+     * Get the fields used in the context as a primary key.
+     *
+     * @return string[]
+     * @deprecated 4.0.0 Renamed to getPrimaryKey()
      */
     public function primaryKey(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPrimaryKey(): array
     {
         return [];
     }

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -61,14 +61,14 @@ class ArrayContextTest extends TestCase
     public function testPrimaryKey()
     {
         $context = new ArrayContext($this->request, []);
-        $this->assertEquals([], $context->primaryKey());
+        $this->assertEquals([], $context->getPrimaryKey());
 
         $context = new ArrayContext($this->request, [
             'schema' => [
                 '_constraints' => 'mistake',
             ],
         ]);
-        $this->assertEquals([], $context->primaryKey());
+        $this->assertEquals([], $context->getPrimaryKey());
 
         $data = [
             'schema' => [
@@ -80,7 +80,7 @@ class ArrayContextTest extends TestCase
         $context = new ArrayContext($this->request, $data);
 
         $expected = ['id'];
-        $this->assertEquals($expected, $context->primaryKey());
+        $this->assertEquals($expected, $context->getPrimaryKey());
     }
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -100,7 +100,7 @@ class EntityContextTest extends TestCase
         $context = new EntityContext($this->request, [
             'entity' => $row,
         ]);
-        $this->assertEquals(['id'], $context->primaryKey());
+        $this->assertEquals(['id'], $context->getPrimaryKey());
     }
 
     /**

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -74,7 +74,7 @@ class FormContextTest extends TestCase
     public function testPrimaryKey()
     {
         $context = new FormContext($this->request, ['entity' => new Form()]);
-        $this->assertEquals([], $context->primaryKey());
+        $this->assertEquals([], $context->getPrimaryKey());
     }
 
     /**


### PR DESCRIPTION
Shouldn't we align this name with other getters()?