### PR TITLE
Use strict comparison.

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -614,7 +614,7 @@ class Session
             $params['httponly']
         );
 
-        if (session_id()) {
+        if (session_id() !== '') {
             session_regenerate_id(true);
         }
     }


### PR DESCRIPTION
This accounts for session id fixated to '0'.