### PR TITLE
Use Arguments::getOption() instead of hasOption().

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -197,7 +197,7 @@ class I18nExtractCommand extends Command
             $this->_getPaths($io);
         }
 
-        if ($args->hasOption('extract-core')) {
+        if ($args->getOption('extract-core')) {
             $this->_extractCore = !(strtolower((string)$args->getOption('extract-core')) === 'no');
         } else {
             $response = $io->askChoice(
@@ -208,7 +208,7 @@ class I18nExtractCommand extends Command
             $this->_extractCore = strtolower((string)$response) === 'y';
         }
 
-        if ($args->hasOption('exclude-plugins') && $this->_isExtractingApp()) {
+        if ($args->getOption('exclude-plugins') && $this->_isExtractingApp()) {
             $this->_exclude = array_merge($this->_exclude, App::path('plugins'));
         }
 
@@ -216,9 +216,9 @@ class I18nExtractCommand extends Command
             $this->_paths[] = CAKE;
         }
 
-        if ($args->hasOption('output')) {
+        if ($args->getOption('output')) {
             $this->_output = (string)$args->getOption('output');
-        } elseif ($args->hasOption('plugin')) {
+        } elseif ($args->getOption('plugin')) {
             $this->_output = Plugin::path($plugin)
                 . 'resources' . DIRECTORY_SEPARATOR
                 . 'locales' . DIRECTORY_SEPARATOR;
@@ -252,7 +252,7 @@ class I18nExtractCommand extends Command
             }
         }
 
-        if ($args->hasOption('merge')) {
+        if ($args->getOption('merge')) {
             $this->_merge = !(strtolower((string)$args->getOption('merge')) === 'no');
         } else {
             $io->out();

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -57,7 +57,7 @@ class I18nInitCommand extends Command
         }
 
         $paths = App::path('locales');
-        if ($args->hasOption('plugin')) {
+        if ($args->getOption('plugin')) {
             $plugin = Inflector::camelize((string)$args->getOption('plugin'));
             $paths = [Plugin::path($plugin) . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR];
         }


### PR DESCRIPTION
That latter always returns true for any option declared in ConsoleOptionParser
regardless of whether value for the option is passed during command execution.

Closes #14027