### PR TITLE
Fix default value for console options

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -421,7 +421,7 @@ class ConsoleOptionParser
             $defaults = [
                 'short' => '',
                 'help' => '',
-                'default' => '',
+                'default' => null,
                 'boolean' => false,
                 'multiple' => false,
                 'choices' => [],

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -160,8 +160,8 @@ class ConsoleOptionParserTest extends TestCase
             ->addOption('no-default', [
             ]);
         $result = $parser->parse(['--test']);
-        $this->assertEquals(
-            ['test' => 'default value', 'help' => false, 'no-default' => null],
+        $this->assertSame(
+            ['test' => 'default value', 'help' => false],
             $result[0],
             'Default value did not parse out'
         );


### PR DESCRIPTION
Don't set a non-null default value for options. Doing so prevents `Arguments::hasOption()` from working correctly.

