### PR TITLE
Fix CSRF tokens not being set on diactoros responses

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -183,8 +183,11 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ResponseInterface $response The response.
      * @return \Psr\Http\Message\ResponseInterface $response Modified response.
      */
-    protected function _addTokenCookie(string $token, ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
-    {
+    protected function _addTokenCookie(
+        string $token,
+        ServerRequestInterface $request,
+        ResponseInterface $response
+    ): ResponseInterface {
         $cookie = Cookie::create(
             $this->_config['cookieName'],
             $token,

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -181,7 +181,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param string $token The token to add.
      * @param \Psr\Http\Message\ServerRequestInterface $request The request to validate against.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @return \Cake\Http\Response $response Modified response.
+     * @return \Psr\Http\Message\ResponseInterface $response Modified response.
      */
     protected function _addTokenCookie(string $token, ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -22,8 +22,8 @@ use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\TestRequestHandler;
-use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Diactoros\Response as DiactorosResponse;
+use Zend\Diactoros\Response\RedirectResponse;
 
 /**
  * Test for CsrfProtection

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -23,6 +23,7 @@ use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\TestRequestHandler;
 use Zend\Diactoros\Response\RedirectResponse;
+use Zend\Diactoros\Response as DiactorosResponse;
 
 /**
  * Test for CsrfProtection
@@ -121,28 +122,41 @@ class CsrfProtectionMiddlewareTest extends TestCase
     }
 
     /**
-     * Test that the CSRF tokens are not set for redirect responses
+     * Test that the CSRF tokens are set for redirect responses
      *
      * @return void
      */
-    public function testRedirectResponseCookiesNotSet()
+    public function testRedirectResponseCookies()
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
-        $expectedResponse = new RedirectResponse('/');
-        $handler = new TestRequestHandler(function ($request) use ($expectedResponse) {
-
-            return $expectedResponse;
+        $handler = new TestRequestHandler(function () {
+            return new RedirectResponse('/');
         });
 
-        $middleware = $this->getMockBuilder(CsrfProtectionMiddleware::class)
-            ->onlyMethods(['_addTokenCookie'])
-            ->getMock();
-        $middleware->expects($this->never())
-            ->method('_addTokenCookie');
+        $middleware = new CsrfProtectionMiddleware();
         $response = $middleware->process($request, $handler);
-        $this->assertSame($expectedResponse, $response);
+        $this->assertStringContainsString('csrfToken=', $response->getHeaderLine('Set-Cookie'));
+    }
+
+    /**
+     * Test that the CSRF tokens are set for diactoros responses
+     *
+     * @return void
+     */
+    public function testDiactorosResponseCookies()
+    {
+        $request = new ServerRequest([
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+        ]);
+        $handler = new TestRequestHandler(function () {
+            return new DiactorosResponse();
+        });
+
+        $middleware = new CsrfProtectionMiddleware();
+        $response = $middleware->process($request, $handler);
+        $this->assertStringContainsString('csrfToken=', $response->getHeaderLine('Set-Cookie'));
     }
 
     /**


### PR DESCRIPTION
Update typehints and implementation to be compatible with diactoros response. Thankfully Cookie now has a `toHeaderValue()` method which enables CSRF tokens to be set on diactoros response objects. 