### PR TITLE
Added type docblock to Query constants

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -37,8 +37,19 @@ class Query implements ExpressionInterface, IteratorAggregate
 {
     use TypeMapTrait;
 
+    /**
+     * @var string
+     */
     public const JOIN_TYPE_INNER = 'INNER';
+
+    /**
+     * @var string
+     */
     public const JOIN_TYPE_LEFT = 'LEFT';
+
+    /**
+     * @var string
+     */
     public const JOIN_TYPE_RIGHT = 'RIGHT';
 
     /**


### PR DESCRIPTION
They show up as blank in the new api docs.
