### PR TITLE
Shim add for usability with numeric array

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -472,6 +472,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (is_array($rule)) {
                 $rule += ['rule' => $name];
             }
+            if (!is_string($name)) {
+                $name = $rule['rule'];
+                if (isset($this->_rules[$name])) {
+                    throw new InvalidArgumentException('You cannot add a rule without a unique name, already existing rule found: ' . $name);
+                }
+            }
+
             $validationSet->add($name, $rule);
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -485,7 +485,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 }
 
                 deprecationWarning(
-                    'Using numeric indexes for adding validation rules is deprecated. Use string indexes instead.'
+                    'Adding validation rules without a name key is deprecated. Update rules array to have string keys.'
                 );
             }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -456,6 +456,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field The name of the field from which the rule will be added
      * @param array|string $name The alias for a single rule or multiple rules array
      * @param array|\Cake\Validation\ValidationRule $rule the rule to add
+     * @throws \InvalidArgumentException If numeric index cannot be resolved to a string one
      * @return $this
      */
     public function add(string $field, $name, $rule = [])
@@ -474,9 +475,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             }
             if (!is_string($name)) {
                 $name = $rule['rule'];
-                if (isset($this->_rules[$name])) {
-                    throw new InvalidArgumentException('You cannot add a rule without a unique name, already existing rule found: ' . $name);
+                if (is_array($name)) {
+                    $name = array_shift($name);
                 }
+
+                if ($validationSet->offsetExists($name)) {
+                    $message = 'You cannot add a rule without a unique name, already existing rule found: ' . $name;
+                    throw new InvalidArgumentException($message);
+                }
+
+                deprecationWarning(
+                    'Using numeric indexes for adding validation rules is deprecated. Use string indexes instead.'
+                );
             }
 
             $validationSet->add($name, $rule);


### PR DESCRIPTION
This could mitigate the issues people face when upgrading:
https://github.com/cakephp/cakephp/issues/14038

It does indeed make not much sense to un-dry rules if we allow such an array config for setup of validation rules. Most of the time people have to use the same key twice, redundant.
So why not allowing them to auto use the rule name here as long as there are no collisions, and only then require more creative setup?

What do you think?
We can add then some tests for this.