### PR TITLE
prevent TypeError on preg_match when param is an integer

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -707,7 +707,7 @@ class Route
         // check patterns for routed params
         if (!empty($this->options)) {
             foreach ($this->options as $key => $pattern) {
-                if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', $url[$key])) {
+                if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])) {
                     return null;
                 }
             }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1008,6 +1008,9 @@ class RouteTest extends TestCase
         $result = $route->match(['controller' => 'posts', 'action' => 'view', 'id' => 'foo']);
         $this->assertNull($result);
 
+        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 9]);
+        $this->assertSame('/posts/view/9', $result);
+
         $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '9']);
         $this->assertSame('/posts/view/9', $result);
 


### PR DESCRIPTION
When trying to access : 
`http://localhost:8080/cars`

With this route : 
`
    $builder
        ->connect('/cars/{id}', ['controller' => 'Cars', 'action' => 'view'])
        ->setPatterns(['id' => '\d+'])
        ->setPass(['id']);
`

their's a TypeError from preg_match that require a string on second parameter