### PR TITLE
Fix silent association failures

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -653,7 +653,8 @@ class EagerLoader
                 // If the path or alias has no key the required assoication load will fail.
                 // Nested paths are not subject to this condition because they could
                 // be attached to joined associations.
-                if (strpos($path, '.') === false &&
+                if (
+                    strpos($path, '.') === false &&
                     (!array_key_exists($path, $collected) || !array_key_exists($alias, $collected[$path]))
                 ) {
                     $message = "Unable to load `{$path}` association. Ensure foreign key on `{$alias}` is selected.";

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -650,14 +650,14 @@ class EagerLoader
 
             $requiresKeys = $instance->requiresKeys($config);
             if ($requiresKeys) {
-                // If the path or alias has no key the required assoication load will fail.
+                // If the path or alias has no key the required association load will fail.
                 // Nested paths are not subject to this condition because they could
                 // be attached to joined associations.
                 if (
                     strpos($path, '.') === false &&
                     (!array_key_exists($path, $collected) || !array_key_exists($alias, $collected[$path]))
                 ) {
-                    $message = "Unable to load `{$path}` association. Ensure foreign key on `{$alias}` is selected.";
+                    $message = "Unable to load `{$path}` association. Ensure foreign key in `{$alias}` is selected.";
                     throw new InvalidArgumentException($message);
                 }
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -636,6 +636,11 @@ class EagerLoader
         $driver = $query->getConnection()->getDriver();
         [$collected, $statement] = $this->_collectKeys($external, $query, $statement);
 
+        // No records found, skip trying to attach associations.
+        if (empty($collected) && $statement->count() === 0) {
+            return $statement;
+        }
+
         foreach ($external as $meta) {
             $contain = $meta->associations();
             $instance = $meta->instance();
@@ -644,8 +649,22 @@ class EagerLoader
             $path = $meta->aliasPath();
 
             $requiresKeys = $instance->requiresKeys($config);
-            if ($requiresKeys && empty($collected[$path][$alias])) {
-                continue;
+            if ($requiresKeys) {
+                // If the path or alias has no key the required assoication load will fail.
+                // Nested paths are not subject to this condition because they could
+                // be attached to joined associations.
+                if (strpos($path, '.') === false &&
+                    (!array_key_exists($path, $collected) || !array_key_exists($alias, $collected[$path]))
+                ) {
+                    $message = "Unable to load `{$path}` association. Ensure foreign key on `{$alias}` is selected.";
+                    throw new InvalidArgumentException($message);
+                }
+
+                // If the association foreign keys are missing skip loading
+                // as the association could be optional.
+                if (empty($collected[$path][$alias])) {
+                    continue;
+                }
             }
 
             $keys = $collected[$path][$alias] ?? null;
@@ -786,7 +805,6 @@ class EagerLoader
             }
             $collectKeys[$meta->aliasPath()] = [$alias, $pkFields, count($pkFields) === 1];
         }
-
         if (empty($collectKeys)) {
             return [[], $statement];
         }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -453,7 +453,7 @@ class BelongsToTest extends TestCase
             ->contain('Authors');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to load `Authors` association. Ensure foreign key on `Articles`');
+        $this->expectExceptionMessage('Unable to load `Authors` association. Ensure foreign key in `Articles`');
         $query->first();
     }
 }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -22,6 +22,7 @@ use Cake\Database\TypeMap;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * Tests BelongsTo class
@@ -407,15 +408,15 @@ class BelongsToTest extends TestCase
     }
 
     /**
-     * Test that failing to add the foreignKey to the list of fields will throw an
-     * exception
+     * Test that failing to add the foreignKey to the list of fields will
+     * still attach associated data.
      *
      * @return void
      */
     public function testAttachToNoFieldsSelected()
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $association = $articles->belongsTo('Authors');
+        $articles->belongsTo('Authors');
 
         $query = $articles->find()
             ->select(['Authors.name'])
@@ -426,5 +427,33 @@ class BelongsToTest extends TestCase
         $this->assertNotEmpty($result->author);
         $this->assertSame('mariano', $result->author->name);
         $this->assertSame(['author'], array_keys($result->toArray()), 'No other properties included.');
+    }
+
+    /**
+     * Test that not selecting join keys with strategy=select fails
+     *
+     * @return void
+     */
+    public function testAttachToNoForeignKeySelect()
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsTo('Authors')->setStrategy('select');
+
+        $query = $articles->find()
+            ->select(['Articles.title', 'Articles.author_id'])
+            ->where(['Articles.id' => 1])
+            ->contain('Authors');
+        $result = $query->firstOrFail();
+        $this->assertNotEmpty($result->author);
+        $this->assertSame(1, $result->author->id);
+
+        $query = $articles->find()
+            ->select(['Articles.title'])
+            ->where(['Articles.id' => 1])
+            ->contain('Authors');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to load `Authors` association. Ensure foreign key on `Articles`');
+        $query->first();
     }
 }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -29,6 +29,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use Closure;
+use InvalidArgumentException;
 
 /**
  * Tests HasMany class
@@ -283,12 +284,13 @@ class HasManyTest extends TestCase
         $association->eagerLoader([
             'conditions' => ['Articles.id !=' => 3],
             'sort' => ['title' => 'DESC'],
-            'fields' => ['title', 'author_id'],
+            'fields' => ['id', 'title', 'author_id'],
             'contain' => ['Comments' => ['fields' => ['comment', 'article_id']]],
             'keys' => $keys,
             'query' => $query,
         ]);
         $expected = [
+            'Articles__id' => 'Articles.id',
             'Articles__title' => 'Articles.title',
             'Articles__author_id' => 'Articles.author_id',
         ];
@@ -450,6 +452,25 @@ class HasManyTest extends TestCase
             ['id' => 2, 'title' => 'article 2', 'author_id' => 1, 'site_id' => 20],
         ];
         $this->assertEquals($row, $result);
+    }
+
+    /**
+     * Test that not selecting join keys fails with an error
+     *
+     * @return void
+     */
+    public function testEagerloaderNoForeignKeys()
+    {
+        $authors = $this->getTableLocator()->get('Authors');
+        $authors->hasMany('Articles');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to load `Articles` association. Ensure foreign key on `Authors`');
+        $query = $authors->find()
+            ->select(['Authors.name'])
+            ->where(['Authors.id' => 1])
+            ->contain('Articles');
+        $query->first();
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -465,7 +465,7 @@ class HasManyTest extends TestCase
         $authors->hasMany('Articles');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to load `Articles` association. Ensure foreign key on `Authors`');
+        $this->expectExceptionMessage('Unable to load `Articles` association. Ensure foreign key in `Authors`');
         $query = $authors->find()
             ->select(['Authors.name'])
             ->where(['Authors.id' => 1])


### PR DESCRIPTION
When selecting specific fields if foreign key columns are omitted, associations would silently fail to load. When we know that the source query returned results but that no foreign keys could be collected the ORM raises an error. This should help prevent missing associations. We do not raise an error for nested association loads as the nested association could be dependent on an optional association.

I can backport this fix to 3.x if folks are happy with it.

Fixes #13467 