### PR TITLE
Improve performance in eagerloader

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -809,7 +809,7 @@ class EagerLoader
     protected function _groupKeys(BufferedStatement $statement, array $collectKeys): array
     {
         $keys = [];
-        while ($result = $statement->fetch('assoc')) {
+        foreach ($statement->fetchAll('assoc') as $result) {
             foreach ($collectKeys as $nestKey => $parts) {
                 // Missed joins will have null in the results.
                 if ($parts[2] === true && !isset($result[$parts[1][0]])) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -809,7 +809,7 @@ class EagerLoader
     protected function _groupKeys(BufferedStatement $statement, array $collectKeys): array
     {
         $keys = [];
-        foreach ($statement->fetchAll('assoc') as $result) {
+        foreach (($statement->fetchAll('assoc') ?: []) as $result) {
             foreach ($collectKeys as $nestKey => $parts) {
                 // Missed joins will have null in the results.
                 if ($parts[2] === true && !isset($result[$parts[1][0]])) {


### PR DESCRIPTION
When loading external associations we need to enumerate all the records in the statement. Using fetchAll() results in fewer lines of code running and fewer allocations as the buffered results are not resized multiple times.
