### PR TITLE
Reverted 'datetime' column back to DateTimeType for SqlServer

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -90,6 +90,11 @@ class SqlserverSchema extends BaseSchema
         if (in_array($col, ['date', 'time'])) {
             return ['type' => $col, 'length' => null];
         }
+
+        if ($col === 'datetime') {
+            // datetime cannot parse more than 3 digits of precision and isn't accurate
+            return ['type' => TableSchema::TYPE_DATETIME, 'length' => null];
+        }
         if (strpos($col, 'datetime') !== false) {
             $typeName = TableSchema::TYPE_DATETIME;
             if ($scale > 0) {

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -99,7 +99,7 @@ SQL;
                 null,
                 null,
                 3,
-                ['type' => 'datetimefractional', 'length' => null, 'precision' => 3],
+                ['type' => 'datetime', 'length' => null, 'precision' => null],
             ],
             [
                 'DATETIME2',
@@ -416,11 +416,11 @@ SQL;
                 'comment' => null,
             ],
             'created' => [
-                'type' => 'datetimefractional',
+                'type' => 'datetime',
                 'null' => true,
                 'default' => null,
                 'length' => null,
-                'precision' => 3,
+                'precision' => null,
                 'comment' => null,
             ],
             'created2' => [


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/14058

We don't have driver-specific formats. The deprecated `datetime` type has limited precision and can't parse more than 3 digits. The precision has large granularity (0.00333 seconds) and so isn't very accurate.

I was hoping we could just make `datetime` work with fractional by default, but seems there are issues.