### PR TITLE
Supress PHPUnit ReflectionType deprecation warnings on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ matrix:
     - php: 7.3
       env: CODECOVERAGE=1 DEFAULT=0
 
-  allow_failures:
-    - php: 7.4
-
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
   - |

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -93,7 +93,7 @@ class CacheRegistry extends ObjectRegistry
         }
 
         $config = $instance->getConfig();
-        if ($config['probability'] && time() % $config['probability'] === 0) {
+        if (isset($config['probability']) && time() % $config['probability'] === 0) {
             $instance->gc();
         }
 

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -96,7 +96,7 @@ class TupleComparison extends Comparison
             if ($isMulti) {
                 $bound = [];
                 foreach ($value as $k => $val) {
-                    $valType = $multiType ? $type[$k] : $type;
+                    $valType = $multiType && isset($type[$k]) ? $type[$k] : $type;
                     $bound[] = $this->_bindValue($generator, $val, $valType);
                 }
 

--- a/src/TestSuite/MockBuilder.php
+++ b/src/TestSuite/MockBuilder.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.8.8
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use PHPUnit\Framework\MockObject\MockBuilder as BaseMockBuilder;
+
+/**
+ * PHPUnit MockBuilder with muted Reflection errors
+ *
+ * @internal
+ */
+class MockBuilder extends BaseMockBuilder
+{
+    /**
+     * @inheritDoc
+     */
+    public function getMock()
+    {
+        $errorLevel = error_reporting();
+        error_reporting(E_ALL ^ E_DEPRECATED);
+        try {
+            return parent::getMock();
+        } finally {
+            error_reporting($errorLevel);
+        }
+    }
+}

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -738,6 +738,68 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function getMockClass(
+        $originalClassName,
+        $methods = [],
+        array $arguments = [],
+        $mockClassName = '',
+        $callOriginalConstructor = false,
+        $callOriginalClone = true,
+        $callAutoload = true,
+        $cloneArguments = false
+    ) {
+        $errorLevel = error_reporting();
+        error_reporting(E_ALL ^ E_DEPRECATED);
+        try {
+            return parent::getMockClass(
+                $originalClassName,
+                $methods,
+                $arguments,
+                $mockClassName,
+                $callOriginalConstructor,
+                $callOriginalClone,
+                $callAutoload,
+                $cloneArguments
+            );
+        } finally {
+            error_reporting($errorLevel);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMockForAbstractClass(
+        $originalClassName,
+        array $arguments = [],
+        $mockClassName = '',
+        $callOriginalConstructor = true,
+        $callOriginalClone = true,
+        $callAutoload = true,
+        $mockedMethods = [],
+        $cloneArguments = false
+    ) {
+        $errorLevel = error_reporting();
+        error_reporting(E_ALL ^ E_DEPRECATED);
+        try {
+            return parent::getMockForAbstractClass(
+                $originalClassName,
+                $arguments,
+                $mockClassName,
+                $callOriginalConstructor,
+                $callOriginalClone,
+                $callAutoload,
+                $mockedMethods,
+                $cloneArguments
+            );
+        } finally {
+            error_reporting($errorLevel);
+        }
+    }
+
+    /**
      * Mock a model, maintain fixtures and table association
      *
      * @param string $alias The model to get a mock for.

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -730,6 +730,14 @@ abstract class TestCase extends BaseTestCase
 // @codingStandardsIgnoreEnd
 
     /**
+     * @inheritDoc
+     */
+    public function getMockBuilder($className)
+    {
+        return new MockBuilder($this, $className);
+    }
+
+    /**
      * Mock a model, maintain fixtures and table association
      *
      * @param string $alias The model to get a mock for.

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -15,5 +15,6 @@ if (class_exists('PHPUnit_Runner_Version')) {
         class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
         class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
         class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
+        class_alias('PHPUnit_Framework_MockObject_MockBuilder', 'PHPUnit\Framework\MockObject\MockBuilder');
     }
 }


### PR DESCRIPTION
Fix 2 `Trying to access array offset on value of type null` warnings which revealed after suppressing reflection errors.

Supress `ReflectionType` deprecation errors when generating mocks in `TestCase::getMockBuilder() -> MockBuilder::getMock()`, `TestCase::getMockClass()` and `TestCase::getMockForAbstractClass()`.

Plugins, which uses `Cake\TestSuite\TestCase` in their tests, will get suppressed warnings too.
