### PR TITLE
Add test cases to demonstrate issue 13666

### DIFF
--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -828,6 +828,113 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyBelongsTo()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $authors = $table->belongsTo('Authors')->getTarget();
+        $authors->addBehavior('Translate', ['fields' => ['name']]);
+
+        $authors->setLocale('eng');
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Authors']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->author);
+        $this->assertFalse($entity->author->isDirty());
+
+        $entity = $table->get(1, ['contain' => ['Authors']]);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->author);
+        $this->assertFalse($entity->author->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyBelongsToMany()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $specialTags = $this->getTableLocator()->get('SpecialTags');
+        $specialTags->addBehavior('Translate', ['fields' => ['extra_info']]);
+
+        $table->belongsToMany('Tags', [
+            'through' => $specialTags,
+        ]);
+        $specialTags->setLocale('eng');
+
+        $entity = $table->get(2);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Tags']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->tags);
+        $this->assertFalse($entity->tags[0]->isDirty());
+
+        $entity = $table->get(2, ['contain' => 'Tags']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->tags);
+        $this->assertFalse($entity->tags[0]->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyHasOne()
+    {
+        $table = $this->getTableLocator()->get('Authors');
+        $table->hasOne('Articles');
+        $table->Articles->addBehavior('Translate', ['fields' => ['title']]);
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Articles']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->article);
+        $this->assertFalse($entity->article->isDirty());
+
+        $entity = $table->get(1, ['contain' => 'Articles']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->article);
+        $this->assertFalse($entity->article->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyHasMany()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->hasMany('Comments');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Comments']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->comments);
+        $this->assertFalse($entity->comments[0]->isDirty());
+
+        $entity = $table->get(1, ['contain' => 'Comments']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->comments);
+        $this->assertFalse($entity->comments[0]->isDirty());
+    }
+
+    /**
      * Tests that updating an existing record translations work
      *
      * @return void


### PR DESCRIPTION
Test cases to demonstrate issue #13666. Tests are included for both `loadInto` and `contain` methods, for all four types of containment. Some pass, some do not.