### PR TITLE
Add helper method to load routes in tests

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -90,7 +90,7 @@ class MiddlewareDispatcher
             $app = $reflect->newInstanceArgs($this->_constructorArgs);
             $this->app = $app;
         } catch (ReflectionException $e) {
-            throw new LogicException("Cannot load `{$this->_class}` for use in integration testing.", null, $e);
+            throw new LogicException("Cannot load `{$this->_class}` for use in integration testing.", 0, $e);
         }
     }
 

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -90,7 +90,7 @@ class MiddlewareDispatcher
             $app = $reflect->newInstanceArgs($this->_constructorArgs);
             $this->app = $app;
         } catch (ReflectionException $e) {
-            throw new LogicException(sprintf('Cannot load "%s" for use in integration testing.', $this->_class));
+            throw new LogicException("Cannot load `{$this->_class}` for use in integration testing.", null, $e);
         }
     }
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -30,6 +30,7 @@ use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\Utility\Inflector;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
+use ReflectionException;
 use RuntimeException;
 
 /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -212,7 +212,7 @@ abstract class TestCase extends BaseTestCase
      */
     public function loadRoutes(?array $appArgs = null): void
     {
-        $appArgs = $appArgs ?? [CONFIG];
+        $appArgs = $appArgs ?? [rtrim(CONFIG, DIRECTORY_SEPARATOR)];
         $className = Configure::read('App.namespace') . '\\Application';
         try {
             $reflect = new ReflectionClass($className);

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -219,7 +219,7 @@ abstract class TestCase extends BaseTestCase
             /** @var \Cake\Routing\RoutingApplicationInterface $app */
             $app = $reflect->newInstanceArgs($appArgs);
         } catch (ReflectionException $e) {
-            throw new LogicException(sprintf('Cannot load "%s" to load routes from.', $className), null, $e);
+            throw new LogicException(sprintf('Cannot load "%s" to load routes from.', $className), 0, $e);
         }
         $builder = Router::createRouteBuilder('/');
         $app->routes($builder);

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -28,6 +28,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\Utility\Inflector;
+use LogicException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use ReflectionException;
@@ -211,11 +212,11 @@ abstract class TestCase extends BaseTestCase
      */
     public function loadRoutes(?array $appArgs = null): void
     {
-        $appArgs = $appArgs === null ? [CONFIG] : $appArgs;
+        $appArgs = $appArgs ?? [CONFIG];
         $className = Configure::read('App.namespace') . '\\Application';
         try {
             $reflect = new ReflectionClass($className);
-            /** @var \Cake\Core\HttpApplicationInterface $app */
+            /** @var \Cake\Routing\RoutingApplicationInterface $app */
             $app = $reflect->newInstanceArgs($appArgs);
         } catch (ReflectionException $e) {
             throw new LogicException(sprintf('Cannot load "%s" to load routes from.', $className), null, $e);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -381,7 +381,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testConfigApplication()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot load "TestApp\MissingApp" for use in integration');
+        $this->expectExceptionMessage('Cannot load `TestApp\MissingApp` for use in integration');
         $this->configApplication('TestApp\MissingApp', []);
         $this->get('/request_action/test_request_action');
     }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -16,12 +16,15 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
+use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventList;
 use Cake\Event\EventManager;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Cake\Routing\Exception\MissingRouteException;
+use Cake\Routing\Router;
 use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
@@ -236,7 +239,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextStartsWith()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertStringStartsWith("some\nstring", $stringDirty);
         $this->assertStringStartsNotWith("some\r\nstring\r\nwith", $stringDirty);
@@ -254,7 +256,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextStartsNotWith()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertTextStartsNotWith("some\nstring\nwithout", $stringDirty);
     }
@@ -267,7 +268,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextEndsWith()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertTextEndsWith("string\nwith\r\ndifferent\rline endings!", $stringDirty);
         $this->assertTextEndsWith("string\r\nwith\ndifferent\nline endings!", $stringDirty);
@@ -281,7 +281,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextEndsNotWith()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertStringEndsNotWith("different\nline endings", $stringDirty);
         $this->assertTextEndsNotWith("different\rline endings", $stringDirty);
@@ -295,7 +294,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextContains()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertStringContainsString('different', $stringDirty);
         $this->assertStringNotContainsString("different\rline", $stringDirty);
@@ -311,7 +309,6 @@ class TestCaseTest extends TestCase
     public function testAssertTextNotContains()
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
-        $stringClean = "some\nstring\nwith\ndifferent\nline endings!";
 
         $this->assertTextNotContains("different\rlines", $stringDirty);
     }
@@ -467,5 +464,25 @@ class TestCaseTest extends TestCase
 
         $Tags = $this->getMockForModel('Tags', ['save']);
         $this->assertSame('tags', $Tags->getTable());
+    }
+
+    /**
+     * Test loadRoutes() helper
+     *
+     * @return void
+     */
+    public function testLoadRoutes()
+    {
+        $url = ['controller' => 'Articles', 'action' => 'index'];
+        try {
+            Router::url($url);
+        } catch (MissingRouteException $e) {
+            $this->assertTrue(true, 'Route should fail.');
+        }
+        Configure::write('App.namespace', 'TestApp');
+        $this->loadRoutes();
+
+        $result = Router::url($url);
+        $this->assertSame('/app/articles', $result);
     }
 }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -476,8 +476,8 @@ class TestCaseTest extends TestCase
         $url = ['controller' => 'Articles', 'action' => 'index'];
         try {
             Router::url($url);
+            $this->fail('Missing URL should throw an exception');
         } catch (MissingRouteException $e) {
-            $this->assertTrue(true, 'Route should fail.');
         }
         Configure::write('App.namespace', 'TestApp');
         $this->loadRoutes();


### PR DESCRIPTION
Add a helper method to load routes similar to how we have helper methods to load plugins. This will make testing mailers and helpers simpler and require less duplicate code as the real application routes can be used.

Refs #13978