### PR TITLE
3.x form empty

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2530,6 +2530,8 @@ class FormHelper extends Helper
             // Pass boolean/scalar empty options to each type.
             if (is_array($options[$type]) && isset($options['empty']) && !is_array($options['empty'])) {
                 $options[$type]['empty'] = $options['empty'];
+            } elseif (is_array($options[$type]) && !empty($options['empty'])) {
+                $options[$type]['empty'] = $options['empty'];
             }
 
             // Move empty options into each type array.

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6392,6 +6392,45 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test datetime with array empty value, ensuring
+     * empty options aren't duplicated.
+     *
+     * @return void
+     */
+    public function testDatetimeEmptyArrayFormKeyValue()
+    {
+        extract($this->dateRegex);
+
+        $result = $this->Form->dateTime('Contact.date', [
+            'minYear' => '2017',
+            'maxYear' => '2019',
+            'empty' => [
+                '' => '-',
+            ],
+            'hour' => false,
+            'minute' => false,
+            'second' => false,
+            'meridian' => false,
+        ]);
+        $expected = [
+            ['select' => ['name' => 'Contact[date][year]']],
+            ['option' => ['value' => '', 'selected' => 'selected']], '-', '/option',
+            '*/select',
+
+            ['select' => ['name' => 'Contact[date][month]']],
+            ['option' => ['value' => '', 'selected' => 'selected']], '-', '/option',
+            $monthsRegex,
+            '*/select',
+
+            ['select' => ['name' => 'Contact[date][day]']],
+            ['option' => ['value' => '', 'selected' => 'selected']], '-', '/option',
+            $daysRegex,
+            '*/select',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * testDatetimeMinuteInterval method
      *
      * Test datetime with interval option.


### PR DESCRIPTION
https://github.com/cakephp/cakephp/pull/13782 introduced a small regression
```php
echo $this->Form->control('birthday', [
    'type' => 'date', 'dateFormat' => 'DMY', 'minYear' => date('Y')-USER_AGE_MAX, 'maxYear' => date('Y')-USER_AGE_MIN+1, 
    'empty' => ['' => '- -']
]);
```

This form suddenly lost its empty value, making all forms auto select the first date element, creating issues along the line.