### PR TITLE
4.1 - Deprecate QueryExpression or_() and and_()

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -456,6 +456,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function and_($conditions, $types = [])
     {
+        deprecationWarning('QueryExpression::and_() is deprecated use and() instead.');
         return $this->and($conditions, $types);
     }
 
@@ -471,6 +472,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function or_($conditions, $types = [])
     {
+        deprecationWarning('QueryExpression::or_() is deprecated use or() instead.');
         return $this->or($conditions, $types);
     }
 // phpcs:enable


### PR DESCRIPTION
We no longer need to use these names as PHP7 supports methods that share names with operators.
