### PR TITLE
Fix file creation success check.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -612,7 +612,8 @@ class ConsoleIo
         }
 
         $file->rewind();
-        if ($file->fwrite($contents) > 0) {
+        $file->fwrite($contents);
+        if (file_exists($path)) {
             $this->out("<success>Wrote</success> `{$path}`");
 
             return true;

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -678,6 +678,22 @@ class ConsoleIoTest extends TestCase
         $this->assertStringEqualsFile($file, $contents);
     }
 
+    public function testCreateFileEmptySuccess()
+    {
+        $this->err->expects($this->never())
+            ->method('write');
+        $path = TMP . 'shell_test';
+        mkdir($path);
+
+        $file = $path . DS . 'file_empty.php';
+        $contents = '';
+        $result = $this->io->createFile($file, $contents);
+
+        $this->assertTrue($result);
+        $this->assertFileExists($file);
+        $this->assertStringEqualsFile($file, $contents);
+    }
+
     public function testCreateFileDirectoryCreation()
     {
         $this->err->expects($this->never())


### PR DESCRIPTION
Newly created file could be empty, hence checking that greater than zero
bytes are written in invalid.