### PR TITLE
4.1 - Added AggregateExpression for aggregate functions

### DIFF
--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+/**
+ * This represents a SQL aggregate function expression in a SQL statement.
+ * Calls can be constructed by passing the name of the function and a list of params.
+ * For security reasons, all params passed are quoted by default unless
+ * explicitly told otherwise.
+ */
+class AggregateExpression extends FunctionExpression
+{
+}

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\AggregateExpression;
+
+/**
+ * Tests FunctionExpression class
+ */
+class AggregateExpressionTest extends FunctionExpressionTest
+{
+    /**
+     * @var string The expression class to test with
+     */
+    protected $expressionClass = AggregateExpression::class;
+}

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -27,13 +27,18 @@ use Cake\TestSuite\TestCase;
 class FunctionExpressionTest extends TestCase
 {
     /**
+     * @var string The expression class to test with
+     */
+    protected $expressionClass = FunctionExpression::class;
+
+    /**
      * Tests generating a function with no arguments
      *
      * @return void
      */
     public function testArityZero()
     {
-        $f = new FunctionExpression('MyFunction');
+        $f = new $this->expressionClass('MyFunction');
         $this->assertSame('MyFunction()', $f->sql(new ValueBinder()));
     }
 
@@ -45,7 +50,7 @@ class FunctionExpressionTest extends TestCase
      */
     public function testArityMultiplePlainValues()
     {
-        $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
+        $f = new $this->expressionClass('MyFunction', ['foo', 'bar']);
         $binder = new ValueBinder();
         $this->assertSame('MyFunction(:param0, :param1)', $f->sql($binder));
 
@@ -53,7 +58,7 @@ class FunctionExpressionTest extends TestCase
         $this->assertSame('bar', $binder->bindings()[':param1']['value']);
 
         $binder = new ValueBinder();
-        $f = new FunctionExpression('MyFunction', ['bar']);
+        $f = new $this->expressionClass('MyFunction', ['bar']);
         $this->assertSame('MyFunction(:param0)', $f->sql($binder));
         $this->assertSame('bar', $binder->bindings()[':param0']['value']);
     }
@@ -66,7 +71,7 @@ class FunctionExpressionTest extends TestCase
     public function testLiteralParams()
     {
         $binder = new ValueBinder();
-        $f = new FunctionExpression('MyFunction', ['foo' => 'literal', 'bar']);
+        $f = new $this->expressionClass('MyFunction', ['foo' => 'literal', 'bar']);
         $this->assertSame('MyFunction(foo, :param0)', $f->sql($binder));
     }
 
@@ -79,8 +84,8 @@ class FunctionExpressionTest extends TestCase
     public function testFunctionNesting()
     {
         $binder = new ValueBinder();
-        $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
-        $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
+        $f = new $this->expressionClass('MyFunction', ['foo', 'bar']);
+        $g = new $this->expressionClass('Wrapper', ['bar' => 'literal', $f]);
         $this->assertSame('Wrapper(bar, MyFunction(:param0, :param1))', $g->sql($binder));
     }
 
@@ -94,7 +99,7 @@ class FunctionExpressionTest extends TestCase
     {
         $binder = new ValueBinder();
         $q = new QueryExpression('a');
-        $f = new FunctionExpression('MyFunction', [$q]);
+        $f = new $this->expressionClass('MyFunction', [$q]);
         $this->assertSame('MyFunction(a)', $f->sql($binder));
     }
 
@@ -110,7 +115,7 @@ class FunctionExpressionTest extends TestCase
             ->select(['column']);
 
         $binder = new ValueBinder();
-        $function = new FunctionExpression('MyFunction', [$query]);
+        $function = new $this->expressionClass('MyFunction', [$query]);
         $this->assertEquals(
             'MyFunction((SELECT column))',
             preg_replace('/[`"\[\]]/', '', $function->sql($binder))
@@ -130,7 +135,7 @@ class FunctionExpressionTest extends TestCase
             ->select(['column']);
 
         $binder = new ValueBinder();
-        $function = new FunctionExpression('MyFunction', [$query]);
+        $function = new $this->expressionClass('MyFunction', [$query]);
         $this->assertEquals(
             'MyFunction((SELECT Articles.column AS Articles__column FROM articles Articles))',
             preg_replace('/[`"\[\]]/', '', $function->sql($binder))
@@ -145,10 +150,10 @@ class FunctionExpressionTest extends TestCase
     public function testNumericLiteral()
     {
         $binder = new ValueBinder();
-        $f = new FunctionExpression('MyFunction', ['a_field' => 'literal', '32' => 'literal']);
+        $f = new $this->expressionClass('MyFunction', ['a_field' => 'literal', '32' => 'literal']);
         $this->assertSame('MyFunction(a_field, 32)', $f->sql($binder));
 
-        $f = new FunctionExpression('MyFunction', ['a_field' => 'literal', 32 => 'literal']);
+        $f = new $this->expressionClass('MyFunction', ['a_field' => 'literal', 32 => 'literal']);
         $this->assertSame('MyFunction(a_field, 32)', $f->sql($binder));
     }
 
@@ -159,9 +164,9 @@ class FunctionExpressionTest extends TestCase
      */
     public function testGetSetReturnType()
     {
-        $f = new FunctionExpression('MyFunction');
+        $f = new $this->expressionClass('MyFunction');
         $f = $f->setReturnType('foo');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $f);
+        $this->assertInstanceOf($this->expressionClass, $f);
         $this->assertSame('foo', $f->getReturnType());
     }
 }

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database;
 
+use Cake\Database\Expression\AggregateExpression;
+use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\FunctionsBuilder;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
@@ -43,11 +45,27 @@ class FunctionsBuilderTest extends TestCase
     public function testArbitrary()
     {
         $function = $this->functions->MyFunc(['b' => 'literal']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('MyFunc', $function->getName());
         $this->assertSame('MyFunc(b)', $function->sql(new ValueBinder()));
 
         $function = $this->functions->MyFunc(['b'], ['string'], 'integer');
+        $this->assertSame('integer', $function->getReturnType());
+    }
+
+    /**
+     * Tests generating a generic aggregate call
+     *
+     * @return void
+     */
+    public function testArbitraryAggregate()
+    {
+        $function = $this->functions->aggregate('MyFunc', ['b' => 'literal']);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
+        $this->assertSame('MyFunc', $function->getName());
+        $this->assertSame('MyFunc(b)', $function->sql(new ValueBinder()));
+
+        $function = $this->functions->aggregate('MyFunc', ['b'], ['string'], 'integer');
         $this->assertSame('integer', $function->getReturnType());
     }
 
@@ -59,12 +77,12 @@ class FunctionsBuilderTest extends TestCase
     public function testSum()
     {
         $function = $this->functions->sum('total');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('SUM(total)', $function->sql(new ValueBinder()));
         $this->assertSame('float', $function->getReturnType());
 
         $function = $this->functions->sum('total', ['integer']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('SUM(total)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
     }
@@ -77,7 +95,7 @@ class FunctionsBuilderTest extends TestCase
     public function testAvg()
     {
         $function = $this->functions->avg('salary');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('AVG(salary)', $function->sql(new ValueBinder()));
         $this->assertSame('float', $function->getReturnType());
     }
@@ -90,7 +108,7 @@ class FunctionsBuilderTest extends TestCase
     public function testMAX()
     {
         $function = $this->functions->max('created', ['datetime']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('MAX(created)', $function->sql(new ValueBinder()));
         $this->assertSame('datetime', $function->getReturnType());
     }
@@ -103,7 +121,7 @@ class FunctionsBuilderTest extends TestCase
     public function testMin()
     {
         $function = $this->functions->min('created', ['date']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('MIN(created)', $function->sql(new ValueBinder()));
         $this->assertSame('date', $function->getReturnType());
     }
@@ -116,7 +134,7 @@ class FunctionsBuilderTest extends TestCase
     public function testCount()
     {
         $function = $this->functions->count('*');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('COUNT(*)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
     }
@@ -129,7 +147,7 @@ class FunctionsBuilderTest extends TestCase
     public function testConcat()
     {
         $function = $this->functions->concat(['title' => 'literal', ' is a string']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('CONCAT(title, :param0)', $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
     }
@@ -142,7 +160,7 @@ class FunctionsBuilderTest extends TestCase
     public function testCoalesce()
     {
         $function = $this->functions->coalesce(['NULL' => 'literal', '1', 'a'], ['a' => 'date']);
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('COALESCE(NULL, :param0, :param1)', $function->sql(new ValueBinder()));
         $this->assertSame('date', $function->getReturnType());
     }
@@ -155,17 +173,17 @@ class FunctionsBuilderTest extends TestCase
     public function testNow()
     {
         $function = $this->functions->now();
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('NOW()', $function->sql(new ValueBinder()));
         $this->assertSame('datetime', $function->getReturnType());
 
         $function = $this->functions->now('date');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('CURRENT_DATE()', $function->sql(new ValueBinder()));
         $this->assertSame('date', $function->getReturnType());
 
         $function = $this->functions->now('time');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('CURRENT_TIME()', $function->sql(new ValueBinder()));
         $this->assertSame('time', $function->getReturnType());
     }
@@ -178,12 +196,12 @@ class FunctionsBuilderTest extends TestCase
     public function testExtract()
     {
         $function = $this->functions->extract('day', 'created');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('EXTRACT(day FROM created)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
 
         $function = $this->functions->datePart('year', 'modified');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('EXTRACT(year FROM modified)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
     }
@@ -196,7 +214,7 @@ class FunctionsBuilderTest extends TestCase
     public function testDateAdd()
     {
         $function = $this->functions->dateAdd('created', -3, 'day');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('DATE_ADD(created, INTERVAL -3 day)', $function->sql(new ValueBinder()));
         $this->assertSame('datetime', $function->getReturnType());
     }
@@ -209,12 +227,12 @@ class FunctionsBuilderTest extends TestCase
     public function testDayOfWeek()
     {
         $function = $this->functions->dayOfWeek('created');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
 
         $function = $this->functions->weekday('created');
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('DAYOFWEEK(created)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
     }
@@ -227,7 +245,7 @@ class FunctionsBuilderTest extends TestCase
     public function testRand()
     {
         $function = $this->functions->rand();
-        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('RAND()', $function->sql(new ValueBinder()));
         $this->assertSame('float', $function->getReturnType());
     }


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/14080

This is the first part of window function support. This adds the necessary classes and API in Query to start building.

The AggregateExpression class will support the extended API for window functions.  We can also add full support for extended aggregate expression clauses in the future.

~The existing aggregate functions in FunctionsBuilder will still work, but they will not be extendable. Eventually, we can deprecate them in favor of the extensible versions.~

As there is no new behavior in this copy, the unit tests are just copying the FunctionExpression tests.
