### PR TITLE
Validate table schema against max alias length

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -32,6 +32,11 @@ use PDOException;
 abstract class Driver implements DriverInterface
 {
     /**
+     * @var int|null Maximum alias length or null if no limit
+     */
+    protected const MAX_ALIAS_LENGTH = null;
+
+    /**
      * Instance of PDO.
      *
      * @var \PDO
@@ -413,6 +418,17 @@ abstract class Driver implements DriverInterface
 
         /** @var \Cake\Database\Schema\TableSchema */
         return new $className($table, $columns);
+    }
+
+    /**
+     * Returns the maximum alias length allowed.
+     * This can be different than the maximum identifier length for columns.
+     *
+     * @return int|null Maximum alias length or null if no limit
+     */
+    public function getMaxAliasLength(): ?int
+    {
+        return static::MAX_ALIAS_LENGTH;
     }
 
     /**

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -31,6 +31,11 @@ class Mysql extends Driver
     use MysqlDialectTrait;
 
     /**
+     * @var int|null Maximum alias length or null if no limit
+     */
+    protected const MAX_ALIAS_LENGTH = 256;
+
+    /**
      * Base configuration settings for MySQL driver
      *
      * @var array

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -28,6 +28,11 @@ class Postgres extends Driver
     use PostgresDialectTrait;
 
     /**
+     * @var int|null Maximum alias length or null if no limit
+     */
+    protected const MAX_ALIAS_LENGTH = 63;
+
+    /**
      * Base configuration settings for Postgres driver
      *
      * @var array

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -32,6 +32,11 @@ class Sqlserver extends Driver
     use SqlserverDialectTrait;
 
     /**
+     * @var int|null Maximum alias length or null if no limit
+     */
+    protected const MAX_ALIAS_LENGTH = 128;
+
+    /**
      * Base configuration settings for Sqlserver driver
      *
      * @var array

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -23,6 +23,7 @@ use Closure;
 /**
  * Interface for database driver.
  *
+ * @method int|null getMaxAliasLength() Returns the maximum alias length allowed.
  */
 interface DriverInterface
 {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -374,6 +374,37 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests schema method with long identifiers
+     *
+     * @return void
+     */
+    public function testSetSchemaLongIdentifiers()
+    {
+        $schema = new TableSchema('long_identifiers', [
+            'this_is_invalid_because_it_is_very_very_very_long' => [
+                'type' => 'string',
+            ],
+        ]);
+        $table = new Table([
+            'table' => 'very_long_alias_name',
+            'connection' => $this->connection,
+        ]);
+
+        $maxAlias = $this->connection->getDriver()->getMaxAliasLength();
+        if ($maxAlias && $maxAlias < 72) {
+            $nameLength = $maxAlias - 2;
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                "ORM queries generate field aliases using the table name/alias and column name. " .
+                "The table alias `very_long_alias_name` and column `this_is_invalid_because_it_is_very_very_very_long` create an alias longer than ({$nameLength}). " .
+                "You must change the table schema in the database and shorten either the table or column " .
+                "identifier so they fit within the database alias limits."
+            );
+        }
+        $this->assertNotNull($table->setSchema($schema));
+    }
+
+    /**
      * Tests that _initializeSchema can be used to alter the database schema
      *
      * @return void


### PR DESCRIPTION
https://github.com/cakephp/cakephp/pull/13830

Until we can generate temporary alias names and use them when matching results, this prevents aliases from being truncated quietly causing unknown errors.

This is really only valid for PostgreSQL and SqlServer where the max alias length is the same as column identifier length.
