### PR TITLE
Reduce the number of php configs in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: php
 dist: xenial
 
 php:
-  - 7.0
   - 5.6
-  - 7.2
-  - 7.3
   - 7.4
 
 env:
@@ -45,10 +42,7 @@ matrix:
 
 before_install:
   - echo cakephp version && tail -1 VERSION.txt
-  - |
-      if [[ ${TRAVIS_PHP_VERSION} != "7.4" ]]; then
-        phpenv config-rm xdebug.ini
-      fi
+  - phpenv config-rm xdebug.ini
 
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi


### PR DESCRIPTION
We don't need to build every single version combination.  We really only need to test min and max.