### PR TITLE
Fix optional routing keys with braced placeholders

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -753,6 +753,14 @@ class Route
         }
         $url += $hostOptions;
 
+        // Ensure controller/action keys are not null.
+        if (
+            (isset($keyNames['controller']) && !isset($url['controller'])) ||
+            (isset($keyNames['action']) && !isset($url['action']))
+        ) {
+            return false;
+        }
+
         return $this->_writeUrl($url, $pass, $query);
     }
 
@@ -803,12 +811,10 @@ class Route
 
         $search = $replace = [];
         foreach ($this->keys as $key) {
-            $string = null;
-            if (isset($params[$key])) {
-                $string = $params[$key];
-            } elseif (strpos($out, $key) != strlen($out) - strlen($key)) {
-                $key .= '/';
+            if (!array_key_exists($key, $params)) {
+                throw new InvalidArgumentException("Missing required route key `{$key}`");
             }
+            $string = $params[$key];
             if ($this->braceKeys) {
                 $search[] = "{{$key}}";
             } else {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1532,6 +1532,34 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Test match handles optional keys
+     *
+     * @return void
+     */
+    public function testMatchNullValueOptionalKey()
+    {
+        $route = new Route('/path/:optional/fixed');
+        $this->assertSame('/path/fixed', $route->match(['optional' => null]));
+
+        $route = new Route('/path/{optional}/fixed');
+        $this->assertSame('/path/fixed', $route->match(['optional' => null]));
+    }
+
+    /**
+     * Test matching fails on required keys (controller/action)
+     *
+     * @return void
+     */
+    public function testMatchControllerRequiredKeys()
+    {
+        $route = new Route('/:controller/:action', ['action' => 'test']);
+        $this->assertFalse($route->match(['controller' => null]));
+
+        $route = new Route('/test/:action', ['controller' => 'thing']);
+        $this->assertFalse($route->match(['action' => null]));
+    }
+
+    /**
      * Test restructuring args with pass key
      *
      * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -66,7 +66,7 @@ class RouterTest extends TestCase
     {
         $this->assertRegExp('/^http(s)?:\/\//', Router::url('/', true));
         $this->assertRegExp('/^http(s)?:\/\//', Router::url(null, true));
-        $this->assertRegExp('/^http(s)?:\/\//', Router::url(['_full' => true]));
+        $this->assertRegExp('/^http(s)?:\/\//', Router::url(['controller' => 'test', '_full' => true]));
     }
 
     /**
@@ -149,25 +149,14 @@ class RouterTest extends TestCase
     }
 
     /**
-     * testRouteDefaultParams method
-     *
-     * @return void
-     */
-    public function testRouteDefaultParams()
-    {
-        Router::connect('/:controller', ['controller' => 'posts']);
-        $this->assertEquals(Router::url(['action' => 'index']), '/');
-    }
-
-    /**
      * testRouteExists method
      *
      * @return void
      */
     public function testRouteExists()
     {
-        Router::connect('/:controller/:action', ['controller' => 'posts']);
-        $this->assertTrue(Router::routeExists(['action' => 'view']));
+        Router::connect('/posts/:action', ['controller' => 'posts']);
+        $this->assertTrue(Router::routeExists(['controller' => 'posts', 'action' => 'view']));
 
         $this->assertFalse(Router::routeExists(['action' => 'view', 'controller' => 'users', 'plugin' => 'test']));
     }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -117,6 +117,7 @@ class HtmlHelperTest extends TestCase
     public function testLink()
     {
         Router::reload();
+        Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action/*');
 
         $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', ''));
@@ -125,17 +126,13 @@ class HtmlHelperTest extends TestCase
         $expected = ['a' => ['href' => '/home'], 'preg:/\/home/', '/a'];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->link(['action' => 'login', '<[You]>']);
+        $result = $this->Html->link(['controller' => 'users',  'action' => 'login', '<[You]>']);
         $expected = [
-            'a' => ['href' => '/login/%3C%5BYou%5D%3E'],
-            'preg:/\/login\/&lt;\[You\]&gt;/',
+            'a' => ['href' => '/users/login/%3C%5BYou%5D%3E'],
+            'preg:/\/users\/login\/&lt;\[You\]&gt;/',
             '/a',
         ];
         $this->assertHtml($expected, $result);
-
-        Router::reload();
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action/*');
 
         $result = $this->Html->link('Posts', ['controller' => 'posts', 'action' => 'index', '_full' => true]);
         $expected = ['a' => ['href' => Router::fullBaseUrl() . '/posts'], 'Posts', '/a'];

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -126,7 +126,7 @@ class HtmlHelperTest extends TestCase
         $expected = ['a' => ['href' => '/home'], 'preg:/\/home/', '/a'];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->link(['controller' => 'users',  'action' => 'login', '<[You]>']);
+        $result = $this->Html->link(['controller' => 'users', 'action' => 'login', '<[You]>']);
         $expected = [
             'a' => ['href' => '/users/login/%3C%5BYou%5D%3E'],
             'preg:/\/users\/login\/&lt;\[You\]&gt;/',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -55,6 +55,9 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/',
             'params' => [
+                'plugin' => null,
+                'controller' => '',
+                'action' => 'index',
                 'paging' => [
                     'Article' => [
                         'page' => 1,
@@ -76,6 +79,7 @@ class PaginatorHelperTest extends TestCase
         Router::reload();
         Router::connect('/:controller/:action/*');
         Router::connect('/:plugin/:controller/:action/*');
+        Router::pushRequest($request);
 
         $this->locale = I18n::getLocale();
     }


### PR DESCRIPTION
Optional parameters were not working correctly with braced parameters. While non-core parameters can be optional the controller + action parameters should never be null as that will result in invalid URLs generated or incorrect results that only contain the action parameter.

I've removed a few invalid test cases that were providing keys as both in the template and as a default. This has not worked for a long time and these tests were relying on the now invalid behavior.

Fixes #13997