### PR TITLE
Fix trace/context for errors wrapped by debug kit

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -148,9 +148,19 @@ abstract class BaseErrorHandler
 
         $debug = Configure::read('debug');
         if ($debug) {
+            // By default trim 3 frames off for the public and protected methods
+            // used by ErrorHandler instances.
+            $start = 3;
+
+            // Can be used by error handlers that wrap other error handlers
+            // to coerce the generated stack trace to the correct point.
+            if (isset($context['_trace_offset'])) {
+                $start += $context['_trace_offset'];
+                unset($context['_trace_offset']);
+            }
             $data += [
                 'context' => $context,
-                'start' => 3,
+                'start' => $start,
                 'path' => Debugger::trimPath($file),
             ];
         }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -150,6 +150,38 @@ class ErrorHandlerTest extends TestCase
         $this->assertRegExp('/<pre class="cake-error">/', $result);
         $this->assertRegExp('/<b>Notice<\/b>/', $result);
         $this->assertRegExp('/variable:\s+wrong/', $result);
+        $this->assertContains(
+            'ErrorHandlerTest.php, line ' . (__LINE__ - 7),
+            $result,
+            'Should contain file and line reference'
+        );
+    }
+
+    /**
+     * test error handling with the _trace_offset context variable
+     *
+     * @return void
+     */
+    public function testHandleErrorTraceOffset()
+    {
+        $this->_restoreError = true;
+
+        set_error_handler(function ($code, $message, $file, $line, $context = null) {
+            $errorHandler = new ErrorHandler();
+            $context['_trace_offset'] = 3;
+            $errorHandler->handleError($code, $message, $file, $line, $context);
+        });
+
+        ob_start();
+        $wrong = $wrong + 1;
+        $result = ob_get_clean();
+
+        $this->assertNotContains(
+            'ErrorHandlerTest.php, line ' . (__LINE__ - 4),
+            $result,
+            'Should not contain file and line reference'
+        );
+        $this->assertNotContains('_trace_offset', $result);
     }
 
     /**


### PR DESCRIPTION
Add a magic `_trace_frame_offset` context value that allows error handling wrappers to offset the stack trace that is displayed. This is not a great solution, but given how PHP error handling works and our backwards compatibility requirements this is what I could come up with.

I'm open to suggestions or alternate approaches we could take.
