### PR TITLE
Autoload PHPUnit aliases in MockBuilder

### DIFF
--- a/src/TestSuite/MockBuilder.php
+++ b/src/TestSuite/MockBuilder.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\TestSuite;
 
+loadPHPUnitAliases();
+
 use PHPUnit\Framework\MockObject\MockBuilder as BaseMockBuilder;
 
 /**


### PR DESCRIPTION
Fix https://github.com/cakephp/cakephp/pull/14061#issuecomment-569508411

Tests might fail if PHPUnit aliases not loaded. Extend https://github.com/cakephp/cakephp/pull/10821.