### PR TITLE
Fix FormProtection not comparing unlocked fields properly

### DIFF
--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -84,13 +84,13 @@ class FormProtectionComponent extends Component
             && $hasData
             && $this->_config['validate']
         ) {
-            $formProtector = new FormProtector();
-            $request->getSession()->start();
-            $isValid = $formProtector->validate(
-                $data,
-                Router::url($request->getRequestTarget()),
-                $request->getSession()->id()
-            );
+            $session = $request->getSession();
+
+            $session->start();
+            $sessionId = $session->id();
+            $url = Router::url($request->getRequestTarget());
+            $formProtector = new FormProtector($url, $sessionId, $this->_config);
+            $isValid = $formProtector->validate($data, $url, $sessionId);
 
             if (!$isValid) {
                 return $this->validationFailure($formProtector);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -833,7 +833,7 @@ class IntegrationTestTraitTest extends TestCase
         ];
         $this->post('/posts/securePost', $data);
         $this->assertResponseCode(400);
-        $this->assertResponseContains('Invalid security debug token.');
+        $this->assertResponseContains('Invalid form protection debug token.');
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -28,7 +28,7 @@ class PostsController extends AppController
     {
         $this->loadComponent('Flash');
         $this->loadComponent('RequestHandler');
-        $this->loadComponent('Security');
+        $this->loadComponent('FormProtection');
     }
 
     /**
@@ -39,10 +39,10 @@ class PostsController extends AppController
     public function beforeFilter(EventInterface $event)
     {
         if ($this->request->getParam('action') !== 'securePost') {
-            $this->getEventManager()->off($this->Security);
+            $this->getEventManager()->off($this->FormProtection);
         }
 
-        $this->Security->setConfig('unlockedFields', ['some_unlocked_field']);
+        $this->FormProtection->setConfig('unlockedFields', ['some_unlocked_field']);
     }
 
     /**


### PR DESCRIPTION
While looking into #14085 further I started off by updating our integration tests to use the FormProtectionComponent and an existing test was failing. The failing test ensured that tokens generated with no unlocked fields are not accepted by controller actions that unlock fields. This scenario was failing as token generation under FormProtectionComponent was not forwarding the unlockedFields configuration.