### PR TITLE
Pass URL and session ID as args to token data building method.

### DIFF
--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -85,12 +85,11 @@ class FormProtectionComponent extends Component
             && $this->_config['validate']
         ) {
             $session = $request->getSession();
-
             $session->start();
-            $sessionId = $session->id();
             $url = Router::url($request->getRequestTarget());
-            $formProtector = new FormProtector($url, $sessionId, $this->_config);
-            $isValid = $formProtector->validate($data, $url, $sessionId);
+
+            $formProtector = new FormProtector($this->_config);
+            $isValid = $formProtector->validate($data, $url, $session->id());
 
             if (!$isValid) {
                 return $this->validationFailure($formProtector);

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -47,20 +47,6 @@ class FormProtector
     protected $unlockedFields = [];
 
     /**
-     * Form URL
-     *
-     * @var string
-     */
-    protected $url = '';
-
-    /**
-     * Session Id
-     *
-     * @var string
-     */
-    protected $sessionId = '';
-
-    /**
      * Error message providing detail for failed validation.
      *
      * @var string|null
@@ -70,15 +56,10 @@ class FormProtector
     /**
      * Construct.
      *
-     * @param string $url Form URL.
-     * @param string $sessionId Session Id.
      * @param array $data Data array, can contain key `unlockedFields` with list of unlocked fields.
      */
-    public function __construct(string $url = '', string $sessionId = '', array $data = [])
+    public function __construct(array $data = [])
     {
-        $this->url = $url;
-        $this->sessionId = $sessionId;
-
         if (!empty($data['unlockedFields'])) {
             $this->unlockedFields = $data['unlockedFields'];
         }
@@ -392,10 +373,12 @@ class FormProtector
     /**
      * Generate the token data.
      *
+     * @param string $url Form URL.
+     * @param string $sessionId Session Id.
      * @return array The token data.
      * @psalm-return array{fields: string, unlocked: string}
      */
-    public function buildTokenData(): array
+    public function buildTokenData(string $url = '', string $sessionId = ''): array
     {
         $fields = $this->fields;
         $unlockedFields = $this->unlockedFields;
@@ -416,14 +399,14 @@ class FormProtector
         ksort($locked, SORT_STRING);
         $fields += $locked;
 
-        $fields = $this->generateHash($fields, $unlockedFields, $this->url, $this->sessionId);
+        $fields = $this->generateHash($fields, $unlockedFields, $url, $sessionId);
         $locked = implode('|', array_keys($locked));
 
         return [
             'fields' => urlencode($fields . ':' . $locked),
             'unlocked' => urlencode(implode('|', $unlockedFields)),
             'debug' => urlencode(json_encode([
-                $this->url,
+                $url,
                 $this->fields,
                 $this->unlockedFields,
             ])),
@@ -595,8 +578,6 @@ class FormProtector
     public function __debugInfo(): array
     {
         return [
-            'url' => $this->url,
-            'sessionId' => $this->sessionId,
             'fields' => $this->fields,
             'unlockedFields' => $this->unlockedFields,
             'debugMessage' => $this->debugMessage,

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -660,12 +660,12 @@ trait IntegrationTestTrait
                 return preg_replace('/(\.\d+)+$/', '', $field);
             }, array_keys(Hash::flatten($fields)));
 
-            $formProtector = new FormProtector($url, 'cli', ['unlockedFields' => $this->_unlockedFields]);
+            $formProtector = new FormProtector(['unlockedFields' => $this->_unlockedFields]);
             foreach ($keys as $field) {
                 /** @psalm-suppress PossiblyNullArgument */
                 $formProtector->addField($field);
             }
-            $tokenData = $formProtector->buildTokenData();
+            $tokenData = $formProtector->buildTokenData($url, 'cli');
 
             $data['_Token'] = $tokenData;
             $data['_Token']['debug'] = 'FormProtector debug data would be added here';

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -445,7 +445,7 @@ class FormHelper extends Helper
         if ($this->requestType !== 'get') {
             $formTokenData = $this->_View->getRequest()->getAttribute('formTokenData');
             if ($formTokenData !== null) {
-                $this->formProtector = $this->createFormProtector($this->_lastAction, $formTokenData);
+                $this->formProtector = $this->createFormProtector($formTokenData);
             }
 
             $append .= $this->_csrfField();
@@ -602,7 +602,10 @@ class FormHelper extends Helper
         $secureAttributes['secure'] = static::SECURE_SKIP;
         $secureAttributes['autocomplete'] = 'off';
 
-        $tokenData = $this->formProtector->buildTokenData();
+        $tokenData = $this->formProtector->buildTokenData(
+            $this->_lastAction,
+            $this->_View->getRequest()->getSession()->id()
+        );
         $tokenFields = array_merge($secureAttributes, [
             'value' => $tokenData['fields'],
         ]);
@@ -639,18 +642,15 @@ class FormHelper extends Helper
     /**
      * Create FormProtector instance.
      *
-     * @param string $url URL
      * @param array $formTokenData Token data.
      * @return \Cake\Form\FormProtector
      */
-    protected function createFormProtector(string $url, array $formTokenData): FormProtector
+    protected function createFormProtector(array $formTokenData): FormProtector
     {
         $session = $this->_View->getRequest()->getSession();
         $session->start();
 
         return new FormProtector(
-            $url,
-            $session->id(),
             $formTokenData
         );
     }
@@ -1807,7 +1807,7 @@ class FormHelper extends Helper
 
         $formTokenData = $this->_View->getRequest()->getAttribute('formTokenData');
         if ($formTokenData !== null) {
-            $this->formProtector = $this->createFormProtector($this->_lastAction, $formTokenData);
+            $this->formProtector = $this->createFormProtector($formTokenData);
         }
 
         $fields = [];


### PR DESCRIPTION
This gets token building inline with token verification and makes API more intuitive.
Earlier it wasn't clear that passing URL and ID to constructor was only necessary for token
data building.

`FormProtector` is marked as internal as we are still quite early in 4.0 release cycle so I don't think modifying it's API should be a problem.