### PR TITLE
Run post install command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ dist/cakephp-$(DASH_VERSION).zip: build/app build/cakephp composer.phar
 	mkdir -p dist
 	@echo "Installing app dependencies with composer"
 	# Install deps with composer
-	cd build/app && php ../../composer.phar install
+	cd build/app && php ../../composer.phar install && ../../composer.phar run-script post-install-cmd --no-interaction
 	# Copy the current cakephp libs up so we don't have to wait
 	# for packagist to refresh.
 	rm -rf build/app/vendor/cakephp/cakephp


### PR DESCRIPTION
Without that the zip is not actually usable.
When no composer.lock is present a "composer install" gets effectively turned into "composer update".