### PR TITLE
Ticket 13493 backport http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
         "aura/intl": "^3.0.0",
         "psr/log": "^1.0.0",
         "psr/simple-cache": "^1.0.0",
-        "zendframework/zend-diactoros": "^1.4.0"
+        "zendframework/zend-diactoros": "^1.4.0",
+        "paragonie/random_compat": "^1.4|9.99.99",
+        "paragonie/csp-builder": "^1.4"
     },
     "suggest": {
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
@@ -46,7 +48,6 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "cakephp/chronos": "^1.2.1",
-        "paragonie/csp-builder": "^1.4",
         "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -35,17 +35,18 @@
         "aura/intl": "^3.0.0",
         "psr/log": "^1.0.0",
         "psr/simple-cache": "^1.0.0",
-        "zendframework/zend-diactoros": "^1.4.0",
-        "paragonie/random_compat": "^2.0|9.99.99"
+        "zendframework/zend-diactoros": "^1.4.0"
     },
     "suggest": {
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
         "ext-curl": "To enable more efficient network calls in Http\\Client.",
-        "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
+        "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()",
+        "paragonie/csp-builder": "CSP builder, to use the CSP Middleware"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "cakephp/chronos": "^1.2.1",
+        "paragonie/csp-builder": "^1.4",
         "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -247,6 +247,16 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
+     * Check if the response status code was in the 2xx range
+     *
+     * @return bool
+     */
+    public function isSuccess()
+    {
+        return $this->code >= 200 && $this->code <= 299;
+    }
+
+    /**
      * Check if the response had a redirect status code.
      *
      * @return bool

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -126,6 +126,7 @@ class Cookie implements CookieInterface
      * @param string $domain Domain
      * @param bool $secure Is secure
      * @param bool $httpOnly HTTP Only
+     * @param null $sameSite Samesite
      */
     public function __construct(
         $name,
@@ -134,7 +135,8 @@ class Cookie implements CookieInterface
         $path = '/',
         $domain = '',
         $secure = false,
-        $httpOnly = false
+        $httpOnly = false,
+        $sameSite = null
     ) {
         $this->validateName($name);
         $this->name = $name;
@@ -156,6 +158,12 @@ class Cookie implements CookieInterface
             $expiresAt = $expiresAt->setTimezone(new DateTimeZone('GMT'));
         }
         $this->expiresAt = $expiresAt;
+
+        if ($sameSite !== null) {
+            $this->validateSameSiteValue($sameSite);
+            $this->sameSite = $sameSite;
+        }
+        $this->sameSite = $sameSite;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -103,7 +103,6 @@ class Cookie implements CookieInterface
      */
     protected $httpOnly = false;
 
-
     /**
      * Samesite
      *

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -103,6 +103,15 @@ class Cookie implements CookieInterface
      */
     protected $httpOnly = false;
 
+
+    /**
+     * Samesite
+     *
+     * @var string|null
+     * @psalm-var CookieInterface::SAMESITE_LAX|CookieInterface::SAMESITE_STRICT|CookieInterface::SAMESITE_NONE|null
+     */
+    protected $sameSite = null;
+
     /**
      * Constructor
      *
@@ -171,6 +180,9 @@ class Cookie implements CookieInterface
         }
         if ($this->domain !== '') {
             $headerValue[] = sprintf('domain=%s', $this->domain);
+        }
+        if ($this->sameSite) {
+            $headerValue[] = sprintf('samesite=%s', $this->sameSite);
         }
         if ($this->secure) {
             $headerValue[] = 'secure';
@@ -464,6 +476,45 @@ class Cookie implements CookieInterface
         $new->expiresAt = Chronos::createFromTimestamp(1);
 
         return $new;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSameSite()
+    {
+        return $this->sameSite;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withSameSite($sameSite)
+    {
+        if ($sameSite !== null) {
+            $this->validateSameSiteValue($sameSite);
+        }
+
+        $new = clone $this;
+        $new->sameSite = $sameSite;
+
+        return $new;
+    }
+
+    /**
+     * Check that value passed for SameSite is valid.
+     *
+     * @param string $sameSite SameSite value
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    protected static function validateSameSiteValue(string $sameSite)
+    {
+        if (!in_array($sameSite, CookieInterface::SAMESITE_VALUES, true)) {
+            throw new InvalidArgumentException(
+                'Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES)
+            );
+        }
     }
 
     /**

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -26,6 +26,36 @@ interface CookieInterface
     const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
 
     /**
+     * SameSite attribute value: Lax
+     *
+     * @var string
+     */
+    const SAMESITE_LAX = 'Lax';
+
+    /**
+     * SameSite attribute value: Strict
+     *
+     * @var string
+     */
+    const SAMESITE_STRICT = 'Strict';
+
+    /**
+     * SameSite attribute value: None
+     *
+     * @var string
+     */
+    const SAMESITE_NONE = 'None';
+
+    /**
+     * Valid values for "SameSite" attribute.
+     */
+    const SAMESITE_VALUES = [
+        self::SAMESITE_LAX,
+        self::SAMESITE_STRICT,
+        self::SAMESITE_NONE,
+    ];
+
+    /**
      * Sets the cookie name
      *
      * @param string $name Name of the cookie

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Http\Middleware;
+
+use ParagonIE\CSPBuilder\CSPBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+
+/**
+ * Content Security Policy Middleware
+ */
+class CspMiddleware
+{
+    /**
+     * CSP Builder
+     *
+     * @var \ParagonIE\CSPBuilder\CSPBuilder $csp CSP Builder or config array
+     */
+    protected $csp;
+
+    /**
+     * Constructor
+     *
+     * @param \ParagonIE\CSPBuilder\CSPBuilder|array $csp CSP object or config array
+     * @throws \RuntimeException
+     */
+    public function __construct($csp)
+    {
+        if (!class_exists(CSPBuilder::class)) {
+            throw new RuntimeException('You must install paragonie/csp-builder to use CspMiddleware');
+        }
+
+        if (!$csp instanceof CSPBuilder) {
+            $csp = new CSPBuilder($csp);
+        }
+
+        $this->csp = $csp;
+    }
+
+    /**
+     * Apply the middleware.
+     *
+     * This will inject CSP header into the response.
+     * @param ServerRequestInterface $requestInterface
+     * @param ResponseInterface $responseInterface
+     * @param callable $next
+     * @return \Psr\Http\Message\MessageInterface
+     */
+    public function __invoke(ServerRequestInterface $requestInterface, ResponseInterface $responseInterface, callable $next) {
+
+        $response = $this->csp->injectCSPHeader($responseInterface);
+        return $next($requestInterface, $response, $next);
+    }
+}

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -57,14 +57,13 @@ class CspMiddleware
      * Apply the middleware.
      *
      * This will inject CSP header into the response.
-     * @param ServerRequestInterface $requestInterface
-     * @param ResponseInterface $responseInterface
-     * @param callable $next
+     * @param ServerRequestInterface $requestInterface The Request.
+     * @param ResponseInterface $responseInterface The Response.
+     * @param callable $next Callback to invoke the next middleware.
      * @return \Psr\Http\Message\MessageInterface
      */
     public function __invoke(ServerRequestInterface $requestInterface, ResponseInterface $responseInterface, callable $next)
     {
-
         $response = $this->csp->injectCSPHeader($responseInterface);
 
         return $next($requestInterface, $response, $next);

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -62,9 +62,11 @@ class CspMiddleware
      * @param callable $next
      * @return \Psr\Http\Message\MessageInterface
      */
-    public function __invoke(ServerRequestInterface $requestInterface, ResponseInterface $responseInterface, callable $next) {
+    public function __invoke(ServerRequestInterface $requestInterface, ResponseInterface $responseInterface, callable $next)
+    {
 
         $response = $this->csp->injectCSPHeader($responseInterface);
+
         return $next($requestInterface, $response, $next);
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2222,6 +2222,7 @@ class Response implements ResponseInterface
      * - `domain`: Domain the cookie is for.
      * - `secure`: Is the cookie https?
      * - `httpOnly`: Is the cookie available in the client?
+     * - `sameSite`: Is the cookie available in the client?
      *
      * ### Examples
      *
@@ -2260,6 +2261,7 @@ class Response implements ResponseInterface
                 'domain' => '',
                 'secure' => false,
                 'httpOnly' => false,
+                'sameSite' => null,
             ];
             $expires = $data['expire'] ? new DateTime('@' . $data['expire']) : null;
             $cookie = new Cookie(
@@ -2269,7 +2271,8 @@ class Response implements ResponseInterface
                 $data['path'],
                 $data['domain'],
                 $data['secure'],
-                $data['httpOnly']
+                $data['httpOnly'],
+                $data['sameSite']
             );
         }
 

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -207,7 +207,8 @@ class ResponseEmitter implements EmitterInterface
                     $cookie['path'],
                     $cookie['domain'],
                     $cookie['secure'],
-                    $cookie['httpOnly']
+                    $cookie['httpOnly'],
+                    $cookie['sameSite']
                 );
                 continue;
             }
@@ -228,6 +229,7 @@ class ResponseEmitter implements EmitterInterface
                 'domain' => '',
                 'secure' => false,
                 'httponly' => false,
+                'samesite' => null,
             ];
 
             foreach ($parts as $part) {
@@ -251,7 +253,8 @@ class ResponseEmitter implements EmitterInterface
                 $data['path'],
                 $data['domain'],
                 $data['secure'],
-                $data['httponly']
+                $data['httponly'],
+                $data['samesite'],
             );
         }
     }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -200,15 +200,20 @@ class ResponseEmitter implements EmitterInterface
     {
         foreach ($cookies as $cookie) {
             if (is_array($cookie)) {
+                $path = $cookie['path'];
+                $sameSite = array_key_exists('sameSite', $cookie) ? $cookie['sameSite'] : null;
+                if ($sameSite !== null) {
+                    $path .= '; samesite=' . $sameSite;
+                }
+
                 setcookie(
                     $cookie['name'],
                     $cookie['value'],
                     $cookie['expire'],
-                    $cookie['path'],
+                    $path,
                     $cookie['domain'],
                     $cookie['secure'],
-                    $cookie['httpOnly'],
-                    $cookie['sameSite']
+                    $cookie['httpOnly']
                 );
                 continue;
             }
@@ -229,7 +234,6 @@ class ResponseEmitter implements EmitterInterface
                 'domain' => '',
                 'secure' => false,
                 'httponly' => false,
-                'samesite' => null,
             ];
 
             foreach ($parts as $part) {
@@ -253,8 +257,7 @@ class ResponseEmitter implements EmitterInterface
                 $data['path'],
                 $data['domain'],
                 $data['secure'],
-                $data['httponly'],
-                $data['samesite'],
+                $data['httponly']
             );
         }
     }

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -257,6 +257,77 @@ XML;
     }
 
     /**
+     * provider for isSuccess.
+     *
+     * @return array
+     */
+    public static function isSuccessProvider()
+    {
+        return [
+            [
+                true,
+                new Response([
+                    'HTTP/1.1 200 OK',
+                    'Content-Type: text/html',
+                ], 'ok'),
+            ],
+            [
+                true,
+                new Response([
+                    'HTTP/1.1 201 Created',
+                    'Content-Type: text/html',
+                ], 'ok'),
+            ],
+            [
+                true,
+                new Response([
+                    'HTTP/1.1 202 Accepted',
+                    'Content-Type: text/html',
+                ], 'ok'),
+            ],
+            [
+                true,
+                new Response([
+                    'HTTP/1.1 203 Non-Authoritative Information',
+                    'Content-Type: text/html',
+                ], 'ok'),
+            ],
+            [
+                true,
+                new Response([
+                    'HTTP/1.1 204 No Content',
+                    'Content-Type: text/html',
+                ], ''),
+            ],
+            [
+                false,
+                new Response([
+                    'HTTP/1.1 301 Moved Permanently',
+                    'Content-Type: text/html',
+                ], ''),
+            ],
+            [
+                false,
+                new Response([
+                    'HTTP/1.0 404 Not Found',
+                    'Content-Type: text/html',
+                ], ''),
+            ],
+        ];
+    }
+
+    /**
+     * Test isSuccess()
+     *
+     * @dataProvider isSuccessProvider
+     * @return void
+     */
+    public function testIsSuccess($expected, Response $response)
+    {
+        $this->assertEquals($expected, $response->isSuccess());
+    }
+
+    /**
      * Test isRedirect()
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -14,6 +14,7 @@ namespace Cake\Test\TestCase\Http\Cookie;
 
 use Cake\Chronos\Chronos;
 use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieInterface;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -80,10 +81,11 @@ class CookieTest extends TestCase
         $cookie = $cookie->withDomain('cakephp.org')
             ->withExpiry($date)
             ->withHttpOnly(true)
+            ->withSameSite(CookieInterface::SAMESITE_STRICT)
             ->withSecure(true);
         $result = $cookie->toHeaderValue();
 
-        $expected = 'cakephp=cakephp-rocks; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org; secure; httponly';
+        $expected = 'cakephp=cakephp-rocks; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org; samesite=Strict; secure; httponly';
         $this->assertEquals($expected, $result);
     }
 
@@ -221,6 +223,34 @@ class CookieTest extends TestCase
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertContains('path=/', $cookie->toHeaderValue());
+    }
+
+    /**
+     * Test setting SameSite in cookies
+     *
+     * @return void
+     */
+    public function testWithSameSite()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withSameSite(CookieInterface::SAMESITE_LAX);
+        $this->assertNotSame($new, $cookie, 'Should make a clone');
+        $this->assertTextNotContains('samesite=Lax', $cookie->toHeaderValue(), 'old instance not modified');
+        $this->assertTextContains('samesite=Lax', $new->toHeaderValue());
+    }
+
+    /**
+     * Test setting SameSite in cookies
+     *
+     * @return void
+     */
+    public function testWithSameSiteException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
+
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie->withSameSite('invalid');
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Http\Middleware\CspMiddleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use ParagonIE\CSPBuilder\CSPBuilder;
+use TestApp\Http\TestRequestHandler;
+
+/**
+ * Content Security Policy Middleware Test
+ */
+class CspMiddlewareTest extends TestCase
+{
+    /**
+     * testInvoke
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $request = new ServerRequest();
+
+        $middleware = new CspMiddleware([
+            'script-src' => [
+                'allow' => [
+                    'https://www.google-analytics.com',
+                ],
+                'self' => true,
+                'unsafe-inline' => false,
+                'unsafe-eval' => false,
+            ],
+        ]);
+
+        $next = function ($request, $response) {
+            $expected = [
+                'script-src \'self\' https://www.google-analytics.com; ',
+            ];
+            $headers = $response->getHeaders();
+            $this->assertNotEmpty($headers['Content-Security-Policy']);
+            $this->assertEquals($expected, $headers['Content-Security-Policy']);
+        };
+
+        $response = new Response();
+        $middleware($request, $response, $next);
+    }
+
+    /**
+     * testPassingACSPBuilderInstance
+     *
+     * @return void
+     */
+    public function testPassingACSPBuilderInstance()
+    {
+        $request = new ServerRequest();
+
+        $config = [
+            'script-src' => [
+                'allow' => [
+                    'https://www.google-analytics.com',
+                ],
+                'self' => true,
+                'unsafe-inline' => false,
+                'unsafe-eval' => false,
+            ],
+        ];
+
+        $cspBuilder = new CSPBuilder($config);
+        $middleware = new CspMiddleware($cspBuilder);
+
+        $next = function ($request, $response) {
+            $headers = $response->getHeaders();
+            $expected = [
+                'script-src \'self\' https://www.google-analytics.com; ',
+            ];
+
+            $this->assertNotEmpty($headers['Content-Security-Policy']);
+            $this->assertEquals($expected, $headers['Content-Security-Policy']);
+        };
+
+        $response = new Response();
+        $middleware($request, $response, $next);
+    }
+}

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -114,8 +114,8 @@ class ResponseEmitterTest extends TestCase
             ->withCookie(new Cookie('simple', 'val', null, '/', '', true))
             ->withAddedHeader('Set-Cookie', 'google=not=nice;Path=/accounts; HttpOnly')
             ->withHeader('Content-Type', 'text/plain');
-        $response->getBody()->write('ok');
 
+        $response->getBody()->write('ok');
         ob_start();
         $this->emitter->emit($response);
         $out = ob_get_clean();

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Http;
+
+use Cake\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class TestRequestHandler
+{
+    public $callable;
+
+    public function __construct(callable $callable = null)
+    {
+        $this->callable = $callable ?: function ($request) {
+            return new Response();
+        };
+    }
+
+    public function handle(ServerRequestInterface $request)
+    {
+        return call_user_func($this->callable, $request);
+    }
+}


### PR DESCRIPTION
I tried my best to add the HTTP part of this ticket:
https://github.com/cakephp/cakephp/issues/13493

Note that I had to downgrade paragonie/random_compat to ^1.4, because paragonie/csp-builder ^1.4 requires it. I could not use a later version of the csp-builder as it requires php ^7.0.