### PR TITLE
Fix dirty associations that use formatResults

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1282,7 +1282,13 @@ abstract class Association
             }
 
             /** @var \Cake\Collection\CollectionInterface $results */
-            return $results->insert($property, $extracted);
+            return $results
+                ->insert($property, $extracted)
+                ->map(function ($result) {
+                    $result->clean();
+
+                    return $result;
+                });
         }, Query::PREPEND);
     }
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -445,4 +445,27 @@ class BelongsToTest extends TestCase
         $this->assertSame('mariano', $result->author->name);
         $this->assertSame(['author'], array_keys($result->toArray()), 'No other properties included.');
     }
+
+    /**
+     * Test that formatResults in a joined association finder doesn't dirty
+     * the root entity.
+     *
+     * @return void
+     */
+    public function testAttachToFormatResultsNoDirtyResults()
+    {
+        $this->setAppNamespace('TestApp');
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsTo('Authors')
+            ->setFinder('formatted');
+
+        $query = $articles->find()
+            ->where(['Articles.id' => 1])
+            ->contain('Authors');
+        $result = $query->firstOrFail();
+
+        $this->assertNotEmpty($result->author);
+        $this->assertNotEmpty($result->author->formatted);
+        $this->assertFalse($result->isDirty(), 'Record should be clean as it was pulled from the db.');
+    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -859,36 +859,6 @@ class TranslateBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testGetAssociationNotDirtyBelongsToMany()
-    {
-        $table = $this->getTableLocator()->get('Articles');
-        $specialTags = $this->getTableLocator()->get('SpecialTags');
-        $specialTags->addBehavior('Translate', ['fields' => ['extra_info']]);
-
-        $table->belongsToMany('Tags', [
-            'through' => $specialTags,
-        ]);
-        $specialTags->setLocale('eng');
-
-        $entity = $table->get(2);
-        $this->assertNotEmpty($entity);
-        $entity = $table->loadInto($entity, ['Tags']);
-        $this->assertFalse($entity->isDirty());
-        $this->assertNotEmpty($entity->tags);
-        $this->assertFalse($entity->tags[0]->isDirty());
-
-        $entity = $table->get(2, ['contain' => 'Tags']);
-        $this->assertNotEmpty($entity);
-        $this->assertFalse($entity->isDirty());
-        $this->assertNotEmpty($entity->tags);
-        $this->assertFalse($entity->tags[0]->isDirty());
-    }
-
-    /**
-     * Tests that parent entity isn't dirty when containing a translated association
-     *
-     * @return void
-     */
     public function testGetAssociationNotDirtyHasOne()
     {
         $table = $this->getTableLocator()->get('Authors');
@@ -907,31 +877,6 @@ class TranslateBehaviorTest extends TestCase
         $this->assertFalse($entity->isDirty());
         $this->assertNotEmpty($entity->article);
         $this->assertFalse($entity->article->isDirty());
-    }
-
-    /**
-     * Tests that parent entity isn't dirty when containing a translated association
-     *
-     * @return void
-     */
-    public function testGetAssociationNotDirtyHasMany()
-    {
-        $table = $this->getTableLocator()->get('Articles');
-        $table->hasMany('Comments');
-        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
-
-        $entity = $table->get(1);
-        $this->assertNotEmpty($entity);
-        $entity = $table->loadInto($entity, ['Comments']);
-        $this->assertFalse($entity->isDirty());
-        $this->assertNotEmpty($entity->comments);
-        $this->assertFalse($entity->comments[0]->isDirty());
-
-        $entity = $table->get(1, ['contain' => 'Comments']);
-        $this->assertNotEmpty($entity);
-        $this->assertFalse($entity->isDirty());
-        $this->assertNotEmpty($entity->comments);
-        $this->assertFalse($entity->comments[0]->isDirty());
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -828,6 +828,113 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyBelongsTo()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $authors = $table->belongsTo('Authors')->getTarget();
+        $authors->addBehavior('Translate', ['fields' => ['name']]);
+
+        $authors->setLocale('eng');
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Authors']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->author);
+        $this->assertFalse($entity->author->isDirty());
+
+        $entity = $table->get(1, ['contain' => ['Authors']]);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->author);
+        $this->assertFalse($entity->author->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyBelongsToMany()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $specialTags = $this->getTableLocator()->get('SpecialTags');
+        $specialTags->addBehavior('Translate', ['fields' => ['extra_info']]);
+
+        $table->belongsToMany('Tags', [
+            'through' => $specialTags,
+        ]);
+        $specialTags->setLocale('eng');
+
+        $entity = $table->get(2);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Tags']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->tags);
+        $this->assertFalse($entity->tags[0]->isDirty());
+
+        $entity = $table->get(2, ['contain' => 'Tags']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->tags);
+        $this->assertFalse($entity->tags[0]->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyHasOne()
+    {
+        $table = $this->getTableLocator()->get('Authors');
+        $table->hasOne('Articles');
+        $table->Articles->addBehavior('Translate', ['fields' => ['title']]);
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Articles']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->article);
+        $this->assertFalse($entity->article->isDirty());
+
+        $entity = $table->get(1, ['contain' => 'Articles']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->article);
+        $this->assertFalse($entity->article->isDirty());
+    }
+
+    /**
+     * Tests that parent entity isn't dirty when containing a translated association
+     *
+     * @return void
+     */
+    public function testGetAssociationNotDirtyHasMany()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->hasMany('Comments');
+        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
+
+        $entity = $table->get(1);
+        $this->assertNotEmpty($entity);
+        $entity = $table->loadInto($entity, ['Comments']);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->comments);
+        $this->assertFalse($entity->comments[0]->isDirty());
+
+        $entity = $table->get(1, ['contain' => 'Comments']);
+        $this->assertNotEmpty($entity);
+        $this->assertFalse($entity->isDirty());
+        $this->assertNotEmpty($entity->comments);
+        $this->assertFalse($entity->comments[0]->isDirty());
+    }
+
+    /**
      * Tests that updating an existing record translations work
      *
      * @return void

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -31,6 +31,7 @@ class ArticlesTable extends Table
      * Find published
      *
      * @param \Cake\ORM\Query $query The query
+     * @param array $options The options
      * @return \Cake\ORM\Query
      */
     public function findPublished($query, array $options = [])

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -34,4 +34,22 @@ class AuthorsTable extends Table
 
         return $query;
     }
+
+    /**
+     * Finder that applies a formatter to test dirty associations
+     *
+     * @param \Cake\ORM\Query $query The query
+     * @param array $options The options
+     * @return \Cake\ORM\Query
+     */
+    public function findFormatted(Query $query, array $options = [])
+    {
+        return $query->formatResults(function ($results) {
+            return $results->map(function ($author) {
+                $author->formatted = $author->name . '!!';
+
+                return $author;
+            });
+        });
+    }
 }


### PR DESCRIPTION
This is a continuation of #14062 with a solution. When a joined association uses formatResults the parent entity should not be marked dirty if the result formatter modifieds the association entity.

While this may not be the optimal place to do this performance wise it does solve the problem and I'd like to revise the dirty/clean flagging that happens multiple times during association construction anyways.

~~Targeting 3.next as that is what the original pull request was aimed at. I can backport these changes to `master` and `3.x` or rebase just the fix and BelongsTo test if folks are ok with that.~~

Will port to 4.x once this has merged.