### PR TITLE
Fix path output for CLI.

### DIFF
--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -141,14 +141,15 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     {
         $paths = [];
         if (Configure::check('App.dir')) {
+            $appPath = rtrim(Configure::read('App.dir'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             // Extra space is to align output
-            $paths['app'] = ' ' . Configure::read('App.dir');
+            $paths['app'] = ' ' . $appPath;
         }
         if (defined('ROOT')) {
-            $paths['root'] = rtrim(ROOT, DIRECTORY_SEPARATOR);
+            $paths['root'] = rtrim(ROOT, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         }
         if (defined('CORE_PATH')) {
-            $paths['core'] = rtrim(CORE_PATH, DIRECTORY_SEPARATOR);
+            $paths['core'] = rtrim(CORE_PATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         }
         if (!count($paths)) {
             return;


### PR DESCRIPTION
I once normalized this for Shell afaik

The path info should show paths always normalized with trailing slash:
```
Current Paths:

* app:  src/
* root: /.../cake4.local/
* core: /.../cake4.local/vendor/cakephp/cakephp/
```