### PR TITLE
Moved schemaDialect() from driver dialect traits to drivers

### DIFF
--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Dialect;
 
-use Cake\Database\Schema\MysqlSchemaDialect;
-use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\SqlDialectTrait;
 
 /**
@@ -43,30 +41,6 @@ trait MysqlDialectTrait
      * @var string
      */
     protected $_endQuote = '`';
-
-    /**
-     * The schema dialect class for this driver
-     *
-     * @var \Cake\Database\Schema\MysqlSchemaDialect
-     */
-    protected $_schemaDialect;
-
-    /**
-     * Get the schema dialect.
-     *
-     * Used by Cake\Database\Schema package to reflect schema and
-     * generate schema.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    public function schemaDialect(): SchemaDialect
-    {
-        if ($this->_schemaDialect === null) {
-            $this->_schemaDialect = new MysqlSchemaDialect($this);
-        }
-
-        return $this->_schemaDialect;
-    }
 
     /**
      * @inheritDoc

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -18,8 +18,6 @@ namespace Cake\Database\Dialect;
 
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Query;
-use Cake\Database\Schema\PostgresSchemaDialect;
-use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\SqlDialectTrait;
 
 /**
@@ -45,13 +43,6 @@ trait PostgresDialectTrait
      * @var string
      */
     protected $_endQuote = '"';
-
-    /**
-     * The schema dialect class for this driver
-     *
-     * @var \Cake\Database\Schema\PostgresSchemaDialect
-     */
-    protected $_schemaDialect;
 
     /**
      * Distinct clause needs no transformation
@@ -158,23 +149,6 @@ trait PostgresDialectTrait
                     ->add([') + (1' => 'literal']); // Postgres starts on index 0 but Sunday should be 1
                 break;
         }
-    }
-
-    /**
-     * Get the schema dialect.
-     *
-     * Used by Cake\Database\Schema package to reflect schema and
-     * generate schema.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    public function schemaDialect(): SchemaDialect
-    {
-        if ($this->_schemaDialect === null) {
-            $this->_schemaDialect = new PostgresSchemaDialect($this);
-        }
-
-        return $this->_schemaDialect;
     }
 
     /**

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -18,8 +18,6 @@ namespace Cake\Database\Dialect;
 
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\QueryCompiler;
-use Cake\Database\Schema\SchemaDialect;
-use Cake\Database\Schema\SqliteSchemaDialect;
 use Cake\Database\SqlDialectTrait;
 use Cake\Database\SqliteCompiler;
 
@@ -46,13 +44,6 @@ trait SqliteDialectTrait
      * @var string
      */
     protected $_endQuote = '"';
-
-    /**
-     * The schema dialect class for this driver
-     *
-     * @var \Cake\Database\Schema\SqliteSchemaDialect
-     */
-    protected $_schemaDialect;
 
     /**
      * Mapping of date parts.
@@ -157,23 +148,6 @@ trait SqliteDialectTrait
                     ->add([') + (1' => 'literal']); // Sqlite starts on index 0 but Sunday should be 1
                 break;
         }
-    }
-
-    /**
-     * Get the schema dialect.
-     *
-     * Used by Cake\Database\Schema package to reflect schema and
-     * generate schema.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    public function schemaDialect(): SchemaDialect
-    {
-        if ($this->_schemaDialect === null) {
-            $this->_schemaDialect = new SqliteSchemaDialect($this);
-        }
-
-        return $this->_schemaDialect;
     }
 
     /**

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -22,8 +22,6 @@ use Cake\Database\Expression\UnaryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
-use Cake\Database\Schema\SchemaDialect;
-use Cake\Database\Schema\SqlserverSchemaDialect;
 use Cake\Database\SqlDialectTrait;
 use Cake\Database\SqlserverCompiler;
 use Cake\Database\ValueBinder;
@@ -322,19 +320,6 @@ trait SqlserverDialectTrait
 
                 break;
         }
-    }
-
-    /**
-     * Get the schema dialect.
-     *
-     * Used by Cake\Schema package to reflect schema and
-     * generate schema.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    public function schemaDialect(): SchemaDialect
-    {
-        return new SqlserverSchemaDialect($this);
     }
 
     /**

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -19,6 +19,8 @@ namespace Cake\Database\Driver;
 use Cake\Database\Dialect\MysqlDialectTrait;
 use Cake\Database\Driver;
 use Cake\Database\Query;
+use Cake\Database\Schema\MysqlSchemaDialect;
+use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Statement\MysqlStatement;
 use Cake\Database\StatementInterface;
 use PDO;
@@ -47,6 +49,13 @@ class Mysql extends Driver
         'timezone' => null,
         'init' => [],
     ];
+
+    /**
+     * The schema dialect for this driver
+     *
+     * @var \Cake\Database\Schema\MysqlSchemaDialect
+     */
+    protected $_schemaDialect;
 
     /**
      * The server version
@@ -150,6 +159,23 @@ class Mysql extends Driver
         }
 
         return $result;
+    }
+
+    /**
+     * Get the schema dialect.
+     *
+     * Used by Cake\Database\Schema package to reflect schema and
+     * generate schema.
+     *
+     * @return \Cake\Database\Schema\SchemaDialect
+     */
+    public function schemaDialect(): SchemaDialect
+    {
+        if ($this->_schemaDialect === null) {
+            $this->_schemaDialect = new MysqlSchemaDialect($this);
+        }
+
+        return $this->_schemaDialect;
     }
 
     /**

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -18,6 +18,8 @@ namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\PostgresDialectTrait;
 use Cake\Database\Driver;
+use Cake\Database\Schema\PostgresSchemaDialect;
+use Cake\Database\Schema\SchemaDialect;
 use PDO;
 
 /**
@@ -45,6 +47,13 @@ class Postgres extends Driver
         'flags' => [],
         'init' => [],
     ];
+
+    /**
+     * The schema dialect class for this driver
+     *
+     * @var \Cake\Database\Schema\PostgresSchemaDialect
+     */
+    protected $_schemaDialect;
 
     /**
      * Establishes a connection to the database server
@@ -97,6 +106,23 @@ class Postgres extends Driver
     public function enabled(): bool
     {
         return in_array('pgsql', PDO::getAvailableDrivers(), true);
+    }
+
+    /**
+     * Get the schema dialect.
+     *
+     * Used by Cake\Database\Schema package to reflect schema and
+     * generate schema.
+     *
+     * @return \Cake\Database\Schema\SchemaDialect
+     */
+    public function schemaDialect(): SchemaDialect
+    {
+        if ($this->_schemaDialect === null) {
+            $this->_schemaDialect = new PostgresSchemaDialect($this);
+        }
+
+        return $this->_schemaDialect;
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -19,6 +19,8 @@ namespace Cake\Database\Driver;
 use Cake\Database\Dialect\SqliteDialectTrait;
 use Cake\Database\Driver;
 use Cake\Database\Query;
+use Cake\Database\Schema\SchemaDialect;
+use Cake\Database\Schema\SqliteSchemaDialect;
 use Cake\Database\Statement\PDOStatement;
 use Cake\Database\Statement\SqliteStatement;
 use Cake\Database\StatementInterface;
@@ -49,6 +51,13 @@ class Sqlite extends Driver
         'flags' => [],
         'init' => [],
     ];
+
+    /**
+     * The schema dialect class for this driver
+     *
+     * @var \Cake\Database\Schema\SqliteSchemaDialect
+     */
+    protected $_schemaDialect;
 
     /**
      * Establishes a connection to the database server
@@ -133,5 +142,22 @@ class Sqlite extends Driver
     public function supportsDynamicConstraints(): bool
     {
         return false;
+    }
+
+    /**
+     * Get the schema dialect.
+     *
+     * Used by Cake\Database\Schema package to reflect schema and
+     * generate schema.
+     *
+     * @return \Cake\Database\Schema\SchemaDialect
+     */
+    public function schemaDialect(): SchemaDialect
+    {
+        if ($this->_schemaDialect === null) {
+            $this->_schemaDialect = new SqliteSchemaDialect($this);
+        }
+
+        return $this->_schemaDialect;
     }
 }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -19,6 +19,8 @@ namespace Cake\Database\Driver;
 use Cake\Database\Dialect\SqlserverDialectTrait;
 use Cake\Database\Driver;
 use Cake\Database\Query;
+use Cake\Database\Schema\SchemaDialect;
+use Cake\Database\Schema\SqlserverSchemaDialect;
 use Cake\Database\Statement\SqlserverStatement;
 use Cake\Database\StatementInterface;
 use InvalidArgumentException;
@@ -54,6 +56,13 @@ class Sqlserver extends Driver
         'loginTimeout' => null,
         'multiSubnetFailover' => null,
     ];
+
+    /**
+     * The schema dialect class for this driver
+     *
+     * @var \Cake\Database\Schema\SqlserverSchemaDialect
+     */
+    protected $_schemaDialect;
 
     /**
      * Establishes a connection to the database server.
@@ -172,5 +181,22 @@ class Sqlserver extends Driver
     public function supportsDynamicConstraints(): bool
     {
         return true;
+    }
+
+    /**
+     * Get the schema dialect.
+     *
+     * Used by Cake\Schema package to reflect schema and
+     * generate schema.
+     *
+     * @return \Cake\Database\Schema\SchemaDialect
+     */
+    public function schemaDialect(): SchemaDialect
+    {
+        if ($this->_schemaDialect === null) {
+            $this->_schemaDialect = new SqlserverSchemaDialect($this);
+        }
+
+        return $this->_schemaDialect;
     }
 }


### PR DESCRIPTION
This is part of merging the driver traits with the drivers. This moves the `schemaDialect()` function from the driver dialect traits. 

This copies the functions instead of implementing a shared function in `Driver` for a couple reason:

- Need to support existing user drivers that implement `Driver::schemaDialect()`.
- `SchemaDialect::__construct()` calls `Driver::connect()`.

   If we create the `SchemaDialect` instance in `Driver::__construct()`, it will try to connect immediately. That could happen before the db-specific constructor has finished initializing.