### PR TITLE
Replace Zend framework packages with Laminas.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,13 @@
         "aura/intl": "^3.0.0",
         "cakephp/chronos": "^2.0",
         "composer/ca-bundle": "^1.2",
+        "laminas/laminas-diactoros": "^2.2.2",
+        "laminas/laminas-httphandlerrunner": "^1.1",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0.0",
-        "psr/simple-cache": "^1.0.0",
-        "zendframework/zend-diactoros": "^2.0",
-        "zendframework/zend-httphandlerrunner": "^1.0"
+        "psr/simple-cache": "^1.0.0"
     },
     "suggest": {
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",

--- a/src/Http/CallbackStream.php
+++ b/src/Http/CallbackStream.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
-use Zend\Diactoros\CallbackStream as BaseCallbackStream;
+use Laminas\Diactoros\CallbackStream as BaseCallbackStream;
 
 /**
  * Implementation of PSR HTTP streams.
  *
- * This differs from Zend\Diactoros\Callback stream in that
+ * This differs from Laminas\Diactoros\Callback stream in that
  * it allows the use of `echo` inside the callback, and gracefully
  * handles the callback not returning a string.
  *

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -27,10 +27,10 @@ use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Cookie\CookieInterface;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Zend\Diactoros\Uri;
 
 /**
  * The end user interface for doing HTTP requests.

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Client;
 
+use Laminas\Diactoros\RequestTrait;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\RequestInterface;
-use Zend\Diactoros\RequestTrait;
-use Zend\Diactoros\Stream;
 
 /**
  * Implements methods for HTTP requests.

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 namespace Cake\Http\Client;
 
 use Cake\Http\Cookie\CookieCollection;
+use Laminas\Diactoros\MessageTrait;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use SimpleXMLElement;
-use Zend\Diactoros\MessageTrait;
-use Zend\Diactoros\Stream;
 
 /**
  * Implements methods for HTTP responses.

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -18,11 +18,11 @@ namespace Cake\Http\Middleware;
 
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\RedirectResponse;
 
 /**
  * Enforces use of HTTPS (SSL) for requests.

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -24,11 +24,11 @@ use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
+use Laminas\Diactoros\MessageTrait;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use SplFileInfo;
-use Zend\Diactoros\MessageTrait;
-use Zend\Diactoros\Stream;
 
 /**
  * Responses contain the response text, status and headers of a HTTP response.

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Http\Cookie\Cookie;
+use Laminas\Diactoros\RelativeStream;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
-use Zend\Diactoros\RelativeStream;
-use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
 /**
  * Emits a Response to the PHP Server API.

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -23,9 +23,9 @@ use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use InvalidArgumentException;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 
 /**
  * Runs an application invoking all the PSR7 middleware and the registered application.
@@ -118,7 +118,7 @@ class Server implements EventDispatcherInterface
      * Emit the response using the PHP SAPI.
      *
      * @param \Psr\Http\Message\ResponseInterface $response The response to emit
-     * @param \Zend\HttpHandlerRunner\Emitter\EmitterInterface|null $emitter The emitter to use.
+     * @param \Laminas\HttpHandlerRunner\Emitter\EmitterInterface|null $emitter The emitter to use.
      *   When null, a SAPI Stream Emitter will be used.
      * @return void
      */

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -22,13 +22,13 @@ use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
+use Laminas\Diactoros\PhpInputStream;
+use Laminas\Diactoros\Stream;
+use Laminas\Diactoros\UploadedFile;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
-use Zend\Diactoros\PhpInputStream;
-use Zend\Diactoros\Stream;
-use Zend\Diactoros\UploadedFile;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -21,9 +21,9 @@ use Cake\Utility\Hash;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
-use function Zend\Diactoros\marshalHeadersFromSapi;
-use function Zend\Diactoros\marshalUriFromSapi;
-use function Zend\Diactoros\normalizeServer;
+use function Laminas\Diactoros\marshalHeadersFromSapi;
+use function Laminas\Diactoros\marshalUriFromSapi;
+use function Laminas\Diactoros\normalizeServer;
 
 /**
  * Factory for making ServerRequest instances.

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -19,12 +19,12 @@ namespace Cake\Routing\Middleware;
 use Cake\Core\Plugin;
 use Cake\Http\Response;
 use Cake\Utility\Inflector;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use SplFileInfo;
-use Zend\Diactoros\Stream;
 
 /**
  * Handles serving plugin assets in development mode.

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -24,11 +24,11 @@ use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\RedirectResponse;
 
 /**
  * Applies routing rules to the request and creates the controller

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -58,10 +58,10 @@ use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Cake\Utility\Text;
 use Exception;
+use Laminas\Diactoros\Uri;
 use LogicException;
 use PHPUnit\Framework\Error\Error as PhpUnitError;
 use Throwable;
-use Zend\Diactoros\Uri;
 
 /**
  * A trait intended to make integration tests of your controllers easier.

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -23,11 +23,11 @@ use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
+use Laminas\Diactoros\Stream;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
 use ReflectionException;
-use Zend\Diactoros\Stream;
 
 /**
  * Dispatches a request capturing the response for integration

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -25,13 +25,13 @@ use Cake\Http\ServerRequest;
 use Cake\ORM\Table;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Uri;
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning;
 use ReflectionFunction;
 use TestApp\Controller\Admin\PostsController;
 use TestApp\Controller\TestController;
 use TestPlugin\Controller\TestPluginController;
-use Zend\Diactoros\Uri;
 
 /**
  * ControllerTest class
@@ -966,7 +966,7 @@ class ControllerTest extends TestCase
         $controller = new PostsController();
 
         $controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
-            /** @var Controller $controller */
+            /** @var \Cake\Controller\Controller $controller */
             $controller = $event->getSubject();
 
             $controller->set('testVariable', 'test');

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -829,7 +829,7 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
-                $this->assertInstanceOf('Zend\Diactoros\Request', $request);
+                $this->assertInstanceOf('Laminas\Diactoros\Request', $request);
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
@@ -840,7 +840,7 @@ class ClientTest extends TestCase
             ->will($this->returnValue([$response]));
 
         $http = new Client(['adapter' => $mock]);
-        $request = new \Zend\Diactoros\Request(
+        $request = new \Laminas\Diactoros\Request(
             'http://cakephp.org/test.html',
             Request::METHOD_GET,
             'php://temp',

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -20,10 +20,10 @@ use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Response as DiactorosResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\TestRequestHandler;
-use Zend\Diactoros\Response as DiactorosResponse;
-use Zend\Diactoros\Response\RedirectResponse;
 
 /**
  * Test for CsrfProtection

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -22,9 +22,9 @@ use Cake\Http\Middleware\HttpsEnforcerMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Uri;
 use TestApp\Http\TestRequestHandler;
-use Zend\Diactoros\Response\RedirectResponse;
-use Zend\Diactoros\Uri;
 
 /**
  * Test for HttpsEnforcerMiddleware

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -19,8 +19,8 @@ namespace Cake\Test\TestCase\Http\Middleware;
 use Cake\Http\Middleware\SecurityHeadersMiddleware;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Response;
 use TestApp\Http\TestRequestHandler;
-use Zend\Diactoros\Response;
 
 /**
  * Test for SecurityMiddleware

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -27,7 +27,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Stream;
 
 /**
  * ResponseTest
@@ -1136,7 +1136,7 @@ class ResponseTest extends TestCase
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $body = $new->getBody();
-        $this->assertInstanceOf('Zend\Diactoros\Stream', $body);
+        $this->assertInstanceOf('Laminas\Diactoros\Stream', $body);
 
         $expected = '/* this is the test asset css file */';
         $this->assertEquals($expected, trim($body->getContents()));

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -20,8 +20,8 @@ use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\UploadedFile;
 use Psr\Http\Message\UploadedFileInterface;
-use Zend\Diactoros\UploadedFile;
 
 /**
  * Test case for the server factory.
@@ -111,7 +111,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertArrayHasKey('image', $res->getData());
         $this->assertCount(1, $res->getUploadedFiles());
 
-        /** @var \Zend\Diactoros\UploadedFile $expected */
+        /** @var \Laminas\Diactoros\UploadedFile $expected */
         $expected = $res->getData('image');
         $this->assertInstanceOf(UploadedFileInterface::class, $expected);
         $this->assertSame($_FILES['image']['size'], $expected->getSize());
@@ -312,7 +312,7 @@ class ServerRequestFactoryTest extends TestCase
         ];
         $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
 
-        /** @var \Zend\Diactoros\UploadedFile $expected */
+        /** @var \Laminas\Diactoros\UploadedFile $expected */
         $expected = $request->getData('file');
         $this->assertSame($files['file']['size'], $expected->getSize());
         $this->assertSame($files['file']['error'], $expected->getError());

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -24,8 +24,8 @@ use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
-use Zend\Diactoros\UploadedFile;
-use Zend\Diactoros\Uri;
+use Laminas\Diactoros\UploadedFile;
+use Laminas\Diactoros\Uri;
 
 /**
  * ServerRequest Test

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -27,8 +27,8 @@ use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Laminas\Diactoros\Response;
 use TestApp\Http\MiddlewareApplication;
-use Zend\Diactoros\Response;
 
 require_once __DIR__ . '/server_mocks.php';
 
@@ -224,7 +224,7 @@ class ServerTest extends TestCase
      */
     public function testRunDoesNotCloseSessionIfServerRequestNotUsed()
     {
-        $request = new \Zend\Diactoros\ServerRequest();
+        $request = new \Laminas\Diactoros\ServerRequest();
 
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
@@ -257,7 +257,7 @@ class ServerTest extends TestCase
             ->withHeader('X-First', 'first')
             ->withHeader('X-Second', 'second');
 
-        $emitter = $this->getMockBuilder('Zend\HttpHandlerRunner\Emitter\EmitterInterface')->getMock();
+        $emitter = $this->getMockBuilder('Laminas\HttpHandlerRunner\Emitter\EmitterInterface')->getMock();
         $emitter->expects($this->once())
             ->method('emit')
             ->with($final);

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -19,9 +19,9 @@ namespace Cake\Test\TestCase\I18n\Middleware;
 use Cake\I18n\I18n;
 use Cake\I18n\Middleware\LocaleSelectorMiddleware;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\ServerRequestFactory;
 use Locale;
 use TestApp\Http\TestRequestHandler;
-use Zend\Diactoros\ServerRequestFactory;
 
 /**
  * Test for LocaleSelectorMiddleware

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -20,8 +20,8 @@ use Cake\Core\Configure;
 use Cake\Mailer\Message;
 use Cake\Mailer\Transport\DebugTransport;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\UploadedFile;
 use TestApp\Mailer\TestMessage;
-use Zend\Diactoros\UploadedFile;
 
 /**
  * MessageTest class

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -25,10 +25,10 @@ use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Response;
 use TestApp\Application;
 use TestApp\Http\TestRequestHandler;
 use TestApp\Middleware\DumbMiddleware;
-use Zend\Diactoros\Response;
 
 /**
  * Test for RoutingMiddleware

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -30,8 +30,8 @@ use Cake\Test\Fixture\AssertIntegrationTestCase;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
+use Laminas\Diactoros\UploadedFile;
 use PHPUnit\Framework\AssertionFailedError;
-use Zend\Diactoros\UploadedFile;
 
 /**
  * Self test of the IntegrationTestTrait

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -22,9 +22,9 @@ use Cake\Filesystem\File;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
+use Laminas\Diactoros\UploadedFile;
 use Locale;
 use stdClass;
-use Zend\Diactoros\UploadedFile;
 
 require_once __DIR__ . '/stubs.php';
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -22,7 +22,7 @@ use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\UploadedFile;
 
 /**
  * Tests Validator class


### PR DESCRIPTION
The new laminas packages also include aliases for the old names within `Zend` namespace so app/plugin code using them shouldn't be affected.

I also opened a PR to fix few issues I found with the aliased functions https://github.com/laminas/laminas-diactoros/pull/30

Refs #14109