### PR TITLE
4.0: Fix config path to be normalized

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -136,7 +136,7 @@ abstract class BaseApplication implements
      */
     public function bootstrap(): void
     {
-        require_once $this->configDir . '/bootstrap.php';
+        require_once $this->configDir . 'bootstrap.php';
     }
 
     /**
@@ -161,7 +161,7 @@ abstract class BaseApplication implements
     {
         // Only load routes if the router is empty
         if (!Router::routes()) {
-            require $this->configDir . '/routes.php';
+            require $this->configDir . 'routes.php';
         }
     }
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -82,7 +82,7 @@ abstract class BaseApplication implements
         ?EventManagerInterface $eventManager = null,
         ?ControllerFactoryInterface $controllerFactory = null
     ) {
-        $this->configDir = $configDir;
+        $this->configDir = rtrim($configDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $this->plugins = Plugin::getCollection();
         $this->_eventManager = $eventManager ?: EventManager::instance();
         $this->controllerFactory = $controllerFactory;


### PR DESCRIPTION
Note the double slash:

> PHP Warning:  Uncaught require(/.../sandbox.local/vendor/dereuromark/cakephp-feedback/config//routes.php): failed to open stream: No such file or directory

As our paths are all properly trailing slashed with one exception (ROOT), the extra slash should be removed.
