### PR TITLE
4.0: Fix numeric string keys to work for log engines.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -315,7 +315,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     public function reset()
     {
         foreach (array_keys($this->_loaded) as $name) {
-            $this->unload($name);
+            $this->unload((string)$name);
         }
 
         return $this;

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -172,7 +172,11 @@ trait StaticConfigTrait
      */
     public static function configured(): array
     {
-        return array_keys(static::$_config);
+        $configurations = array_keys(static::$_config);
+
+        return array_map(function ($key) {
+            return (string)$key;
+        }, $configurations);
     }
 
     /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -92,14 +92,31 @@ class LogTest extends TestCase
     }
 
     /**
+     * test config() with valid numeric key name
+     *
+     * @return void
+     */
+    public function testValidKeyNameNumeric()
+    {
+        Log::setConfig('404', ['engine' => 'File']);
+        $stream = Log::engine('404');
+        $this->assertInstanceOf(FileLog::class, $stream);
+
+        $configured = Log::configured();
+        $this->assertSame(['404'], $configured);
+    }
+
+    /**
      * test that loggers have to implement the correct interface.
      *
      * @return void
      */
     public function testNotImplementingInterface()
     {
-        $this->expectException(\RuntimeException::class);
         Log::setConfig('fail', ['engine' => '\stdClass']);
+
+        $this->expectException(\RuntimeException::class);
+
         Log::engine('fail');
     }
 


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/14119
I added a test case that also showed that reset() requires the auto casted key to be fixed up before passing it along to typehinted methods.