### PR TITLE
Added 4.x backport for Client/Response->isSuccess() and tests.

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -247,6 +247,16 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
+     * Check if the response status code was in the 2xx range
+     *
+     * @return bool
+     */
+    public function isSuccess()
+    {
+        return $this->code >= 200 && $this->code <= 299;
+    }
+
+    /**
      * Check if the response had a redirect status code.
      *
      * @return bool

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -257,6 +257,70 @@ XML;
     }
 
     /**
+     * Test isSuccess()
+     *
+     * @return void
+     */
+    public function testIsSuccess()
+    {
+        $headers = [
+            'HTTP/1.1 200 OK',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 201 Created',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 202 Accepted',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 203 Non-Authoritative Information',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, 'ok');
+        $this->assertTrue($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 204 No Content',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers);
+        $this->assertTrue($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 301 Moved Permanently',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, '');
+        $this->assertFalse($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 404 Not Found',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, '');
+        $this->assertFalse($response->isSuccess());
+
+        $headers = [
+            'HTTP/1.1 500 Internal Server Error',
+            'Content-Type: text/html',
+        ];
+        $response = new Response($headers, '');
+        $this->assertFalse($response->isSuccess());
+    }
+
+    /**
      * Test isRedirect()
      *
      * @return void


### PR DESCRIPTION
I tried my best to add the Client/Response->isSuccess() part of this ticket:
https://github.com/cakephp/cakephp/issues/13493