### PR TITLE
Fix numeric string keys to work for cache and configure.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -505,7 +505,7 @@ class Cache
      */
     public static function groupConfigs(?string $group = null): array
     {
-        foreach (array_keys(static::$_config) as $config) {
+        foreach (static::configured() as $config) {
             static::pool($config);
         }
         if ($group === null) {

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -274,7 +274,11 @@ class Configure
      */
     public static function configured(): array
     {
-        return array_keys(static::$_engines);
+        $engines = array_keys(static::$_engines);
+
+        return array_map(function ($key) {
+            return (string)$key;
+        }, $engines);
     }
 
     /**

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -30,6 +30,11 @@ use Cake\TestSuite\TestCase;
 class ControllerAuthorizeTest extends TestCase
 {
     /**
+     * @var \Cake\Auth\ControllerAuthorize
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -32,7 +32,7 @@ class FilterIteratorTest extends TestCase
     public function testFilter()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = $this->getMockBuilder(\StdClass::class)
+        $callable = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['__invoke'])
             ->getMock();
         $callable->expects($this->at(0))

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -32,7 +32,7 @@ class ReplaceIteratorTest extends TestCase
     public function testReplace()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = $this->getMockBuilder(\StdClass::class)
+        $callable = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['__invoke'])
             ->getMock();
         $callable->expects($this->at(0))

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -475,7 +475,7 @@ class ConfigureTest extends TestCase
     }
 
     /**
-     * test adding new engines.
+     * Tests adding new engines.
      *
      * @return void
      */
@@ -492,6 +492,25 @@ class ConfigureTest extends TestCase
 
         $this->assertTrue(Configure::drop('test'));
         $this->assertFalse(Configure::drop('test'), 'dropping things that do not exist should return false.');
+    }
+
+    /**
+     * Tests adding new engines as numeric strings.
+     *
+     * @return void
+     */
+    public function testEngineSetupNumeric()
+    {
+        $engine = new PhpConfig();
+        Configure::config('123', $engine);
+        $configured = Configure::configured();
+
+        $this->assertContains('123', $configured);
+
+        $this->assertTrue(Configure::isConfigured('123'));
+
+        $this->assertTrue(Configure::drop('123'));
+        $this->assertFalse(Configure::drop('123'), 'dropping things that do not exist should return false.');
     }
 
     /**


### PR DESCRIPTION
Completes https://github.com/cakephp/cakephp/pull/14120 for other arrays.
In the future one could also check if objects might be the better fit than plain arrays for such collections.
Apparently they dont have this cast defect.

I was also to improve some tests around the new ->expectExpection() by properly moving it to before this is expected and clear out asserts that are not useful.