### PR TITLE
Improve how debug() handles cyclic references

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -228,14 +228,14 @@ class Debugger
      * Recursively formats and outputs the contents of the supplied variable.
      *
      * @param mixed $var The variable to dump.
-     * @param int $depth The depth to output to. Defaults to 3.
+     * @param int $maxDepth The depth to output to. Defaults to 3.
      * @return void
      * @see \Cake\Error\Debugger::exportVar()
      * @link https://book.cakephp.org/4/en/development/debugging.html#outputting-values
      */
-    public static function dump($var, int $depth = 3): void
+    public static function dump($var, int $maxDepth = 3): void
     {
-        pr(static::exportVar($var, $depth));
+        pr(static::exportVar($var, $maxDepth));
     }
 
     /**
@@ -244,16 +244,16 @@ class Debugger
      *
      * @param mixed $var Variable or content to log.
      * @param int|string $level Type of log to use. Defaults to 'debug'.
-     * @param int $depth The depth to output to. Defaults to 3.
+     * @param int $maxDepth The depth to output to. Defaults to 3.
      * @return void
      */
-    public static function log($var, $level = 'debug', int $depth = 3): void
+    public static function log($var, $level = 'debug', int $maxDepth = 3): void
     {
         /** @var string $source */
         $source = static::trace(['start' => 1]);
         $source .= "\n";
 
-        Log::write($level, "\n" . $source . static::exportVar($var, $depth));
+        Log::write($level, "\n" . $source . static::exportVar($var, $maxDepth));
     }
 
     /**
@@ -490,12 +490,12 @@ class Debugger
      * shown in an error message if CakePHP is deployed in development mode.
      *
      * @param mixed $var Variable to convert.
-     * @param int $depth The depth to output to. Defaults to 3.
+     * @param int $maxDepth The depth to output to. Defaults to 3.
      * @return string Variable as a formatted string
      */
-    public static function exportVar($var, int $depth = 3): string
+    public static function exportVar($var, int $maxDepth = 3): string
     {
-        $context = new DumpContext($depth);
+        $context = new DumpContext($maxDepth);
 
         return static::_export($var, $context);
     }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -496,6 +496,7 @@ class Debugger
     public static function exportVar($var, int $depth = 3): string
     {
         $context = new DumpContext($depth);
+
         return static::_export($var, $context);
     }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -549,8 +549,7 @@ class Debugger
      * - schema
      *
      * @param array $var The array to export.
-     * @param int $depth The current depth, used for recursion tracking.
-     * @param int $indent The current indentation level.
+     * @param \Cake\Error\DumpContext $context The current dump context.
      * @return string Exported array.
      */
     protected static function _array(array $var, DumpContext $context): string

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -603,7 +603,7 @@ class Debugger
         $refNum = $context->getReferenceId($var);
 
         $className = get_class($var);
-        $out .= "object({$className}) #{$refNum} {";
+        $out .= "object({$className}) id:{$refNum} {";
         $indent = $context->getIndent();
         $break = "\n" . str_repeat("\t", $indent);
         $end = "\n" . str_repeat("\t", $indent - 1);

--- a/src/Error/DumpContext.php
+++ b/src/Error/DumpContext.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -48,6 +49,11 @@ class DumpContext
      */
     private $refs;
 
+    /**
+     * Constructor
+     *
+     * @param int $maxDepth The desired depth of dump output.
+     */
     public function __construct(int $maxDepth)
     {
         $this->maxDepth = $maxDepth;

--- a/src/Error/DumpContext.php
+++ b/src/Error/DumpContext.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error;
+
+use SplObjectStorage;
+
+/**
+ * Context tracking for Debugger::exportVar()
+ *
+ * This class is used by Debugger to track element depth,
+ * and indentation. In the longer term indentation should be extracted
+ * into a formatter (cli/html).
+ *
+ * @internal
+ */
+class DumpContext
+{
+    /**
+     * @var int
+     */
+    private $maxDepth = 0;
+
+    /**
+     * @var int
+     */
+    private $depth = 0;
+
+    /**
+     * @var int
+     */
+    private $indent = 0;
+
+    /**
+     * @var \SplObjectStorage
+     */
+    private $refs;
+
+    public function __construct(int $maxDepth)
+    {
+        $this->maxDepth = $maxDepth;
+        $this->refs = new SplObjectStorage();
+    }
+
+    /**
+     * Return a clone with increased depth.
+     *
+     * @return static
+     */
+    public function withAddedDepth()
+    {
+        $new = clone $this;
+        $new->depth += 1;
+
+        return $new;
+    }
+
+    /**
+     * Return a clone with increased depth and indent
+     *
+     * @return static
+     */
+    public function withAddedDepthAndIndent()
+    {
+        $new = clone $this;
+        $new->depth += 1;
+        $new->indent += 1;
+
+        return $new;
+    }
+
+    /**
+     * Get the current indent level.
+     *
+     * @return int
+     */
+    public function getIndent(): int
+    {
+        return $this->indent;
+    }
+
+    /**
+     * Get the remaining depth levels
+     *
+     * @return int
+     */
+    public function remainingDepth(): int
+    {
+        return $this->maxDepth - $this->depth;
+    }
+
+    /**
+     * Get the reference ID for an object.
+     *
+     * If this object does not exist in the reference storage,
+     * it will be added and the id will be returned.
+     *
+     * @param object $object The object to get a reference for.
+     * @return int
+     */
+    public function getReferenceId(object $object): int
+    {
+        if ($this->refs->contains($object)) {
+            return $this->refs[$object];
+        }
+        $refId = $this->refs->count();
+        $this->refs->attach($object, $refId);
+
+        return $refId;
+    }
+
+    /**
+     * Check whether an object has been seen before.
+     *
+     * @param object $object The object to get a reference for.
+     * @return bool
+     */
+    public function hasReference(object $object): bool
+    {
+        return $this->refs->contains($object);
+    }
+}

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -311,14 +311,14 @@ class DebuggerTest extends TestCase
 
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
-object(Cake\View\View) #0 {
-	Html => object(Cake\View\Helper\HtmlHelper) #1 {}
-	Form => object(Cake\View\Helper\FormHelper) #2 {}
+object(Cake\View\View) id:0 {
+	Html => object(Cake\View\Helper\HtmlHelper) id:1 {}
+	Form => object(Cake\View\Helper\FormHelper) id:2 {}
 	int => (int) 2
 	float => (float) 1.333
 	string => '  '
-	[protected] _helpers => object(Cake\View\HelperRegistry) #3 {}
-	[protected] Blocks => object(Cake\View\ViewBlock) #4 {}
+	[protected] _helpers => object(Cake\View\HelperRegistry) id:3 {}
+	[protected] Blocks => object(Cake\View\ViewBlock) id:4 {}
 	[protected] plugin => null
 	[protected] name => ''
 	[protected] helpers => [
@@ -334,8 +334,8 @@ object(Cake\View\View) #0 {
 	[protected] _ext => '.php'
 	[protected] subDir => ''
 	[protected] theme => null
-	[protected] request => object(Cake\Http\ServerRequest) #5 {}
-	[protected] response => object(Cake\Http\Response) #6 {}
+	[protected] request => object(Cake\Http\ServerRequest) id:5 {}
+	[protected] response => object(Cake\Http\Response) id:6 {}
 	[protected] elementCache => 'default'
 	[protected] _passedVars => [
 		(int) 0 => 'viewVars',
@@ -357,7 +357,7 @@ object(Cake\View\View) #0 {
 	[protected] _currentType => ''
 	[protected] _stack => []
 	[protected] _viewBlockClass => 'Cake\View\ViewBlock'
-	[protected] _eventManager => object(Cake\Event\EventManager) #7 {}
+	[protected] _eventManager => object(Cake\Event\EventManager) id:7 {}
 	[protected] _eventClass => 'Cake\Event\Event'
 	[protected] _config => []
 	[protected] _configInitialized => true
@@ -450,11 +450,11 @@ TEXT;
 
         $result = Debugger::exportVar($parent, 6);
         $expected = <<<TEXT
-object(stdClass) #0 {
+object(stdClass) id:0 {
 	name => 'cake'
-	child => object(stdClass) #1 {
+	child => object(stdClass) id:1 {
 		name => 'php'
-		child => object(stdClass) #0 {}
+		child => object(stdClass) id:0 {}
 	}
 }
 TEXT;
@@ -622,10 +622,10 @@ TEXT;
         $object = new DebuggableThing();
         $result = Debugger::exportVar($object, 2);
         $expected = <<<eos
-object(TestApp\Error\Thing\DebuggableThing) #0 {
+object(TestApp\Error\Thing\DebuggableThing) id:0 {
 
 	'foo' => 'bar',
-	'inner' => object(TestApp\Error\Thing\DebuggableThing) #1 {}
+	'inner' => object(TestApp\Error\Thing\DebuggableThing) id:1 {}
 
 }
 eos;
@@ -670,7 +670,7 @@ eos;
         Debugger::setOutputMask(['password' => '[**********]']);
         $object = new SecurityThing();
         $result = Debugger::exportVar($object);
-        $expected = 'object(TestApp\\Error\\Thing\\SecurityThing)#0{password=>[**********]}';
+        $expected = 'object(TestApp\\Error\\Thing\\SecurityThing)id:0{password=>[**********]}';
         $this->assertEquals($expected, preg_replace('/\s+/', '', $result));
     }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -622,10 +622,10 @@ TEXT;
         $object = new DebuggableThing();
         $result = Debugger::exportVar($object, 2);
         $expected = <<<eos
-object(TestApp\Error\Thing\DebuggableThing) {
+object(TestApp\Error\Thing\DebuggableThing) #0 {
 
 	'foo' => 'bar',
-	'inner' => object(TestApp\Error\Thing\DebuggableThing) {}
+	'inner' => object(TestApp\Error\Thing\DebuggableThing) #1 {}
 
 }
 eos;
@@ -670,7 +670,7 @@ eos;
         Debugger::setOutputMask(['password' => '[**********]']);
         $object = new SecurityThing();
         $result = Debugger::exportVar($object);
-        $expected = 'object(TestApp\\Error\\Thing\\SecurityThing){password=>[**********]}';
+        $expected = 'object(TestApp\\Error\\Thing\\SecurityThing)#0{password=>[**********]}';
         $this->assertEquals($expected, preg_replace('/\s+/', '', $result));
     }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -21,6 +21,7 @@ use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use stdClass;
 use TestApp\Error\TestDebugger;
 use TestApp\Error\Thing\DebuggableThing;
 use TestApp\Error\Thing\SecurityThing;
@@ -310,14 +311,14 @@ class DebuggerTest extends TestCase
 
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
-object(Cake\View\View) {
-	Html => object(Cake\View\Helper\HtmlHelper) {}
-	Form => object(Cake\View\Helper\FormHelper) {}
+object(Cake\View\View) #0 {
+	Html => object(Cake\View\Helper\HtmlHelper) #1 {}
+	Form => object(Cake\View\Helper\FormHelper) #2 {}
 	int => (int) 2
 	float => (float) 1.333
 	string => '  '
-	[protected] _helpers => object(Cake\View\HelperRegistry) {}
-	[protected] Blocks => object(Cake\View\ViewBlock) {}
+	[protected] _helpers => object(Cake\View\HelperRegistry) #3 {}
+	[protected] Blocks => object(Cake\View\ViewBlock) #4 {}
 	[protected] plugin => null
 	[protected] name => ''
 	[protected] helpers => [
@@ -333,8 +334,8 @@ object(Cake\View\View) {
 	[protected] _ext => '.php'
 	[protected] subDir => ''
 	[protected] theme => null
-	[protected] request => object(Cake\Http\ServerRequest) {}
-	[protected] response => object(Cake\Http\Response) {}
+	[protected] request => object(Cake\Http\ServerRequest) #5 {}
+	[protected] response => object(Cake\Http\Response) #6 {}
 	[protected] elementCache => 'default'
 	[protected] _passedVars => [
 		(int) 0 => 'viewVars',
@@ -356,13 +357,12 @@ object(Cake\View\View) {
 	[protected] _currentType => ''
 	[protected] _stack => []
 	[protected] _viewBlockClass => 'Cake\View\ViewBlock'
-	[protected] _eventManager => object(Cake\Event\EventManager) {}
+	[protected] _eventManager => object(Cake\Event\EventManager) #7 {}
 	[protected] _eventClass => 'Cake\Event\Event'
 	[protected] _config => []
 	[protected] _configInitialized => true
 }
 TEXT;
-
         $this->assertTextEquals($expected, $result);
 
         $data = [
@@ -429,6 +429,34 @@ TEXT;
 	'szero' => '0',
 	'zero' => (int) 0
 ]
+TEXT;
+        $this->assertTextEquals($expected, $result);
+    }
+
+    /**
+     * test exportVar with cyclic objects.
+     *
+     * @return void
+     */
+    public function testExportVarCyclicRef()
+    {
+        $parent = new stdClass();
+        $parent->name = 'cake';
+        $middle = new stdClass();
+        $parent->child = $middle;
+
+        $middle->name = 'php';
+        $middle->child = $parent;
+
+        $result = Debugger::exportVar($parent, 6);
+        $expected = <<<TEXT
+object(stdClass) #0 {
+	name => 'cake'
+	child => object(stdClass) #1 {
+		name => 'php'
+		child => object(stdClass) #0 {}
+	}
+}
 TEXT;
         $this->assertTextEquals($expected, $result);
     }


### PR DESCRIPTION
Right now if you dump an object that contains cyclic references somewhere in the requested depth the same objects are output multiple times. While this is annoying with small objects it makes reading debug() output for Table objects, or other complex objects really hard as the same content is output multiple times.

Now instead of duplicate content each object is assigned a context 'id'. When an object is encountered after the first time it is output only the short representation is emitted with the reference id. In a separate block of work I want to enhance the HTML output to include links to the original value from the cyclic reference. However, I felt this was a small/useful change on its own.