### PR TITLE
Only try to clean entities

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1285,7 +1285,9 @@ abstract class Association
             return $results
                 ->insert($property, $extracted)
                 ->map(function ($result) {
-                    $result->clean();
+                    if ($result instanceof EntityInterface) {
+                        $result->clean();
+                    }
 
                     return $result;
                 });


### PR DESCRIPTION
#14107 causes errors with non-hydrated result sets. This fixes that.