### PR TITLE
Don't map() when we don't need to.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1264,7 +1264,7 @@ abstract class Association
 
         $property = $options['propertyPath'];
         $propertyPath = explode('.', $property);
-        $query->formatResults(function ($results) use ($formatters, $property, $propertyPath) {
+        $query->formatResults(function ($results) use ($formatters, $property, $propertyPath, $query) {
             $extracted = [];
             foreach ($results as $result) {
                 foreach ($propertyPath as $propertyPathItem) {
@@ -1282,15 +1282,16 @@ abstract class Association
             }
 
             /** @var \Cake\Collection\CollectionInterface $results */
-            return $results
-                ->insert($property, $extracted)
-                ->map(function ($result) {
-                    if ($result instanceof EntityInterface) {
-                        $result->clean();
-                    }
+            $results = $results->insert($property, $extracted);
+            if ($query->isHydrationEnabled()) {
+                $results = $results->map(function ($result) {
+                    $result->clean();
 
                     return $result;
                 });
+            }
+
+            return $results;
         }, Query::PREPEND);
     }
 


### PR DESCRIPTION
If query hydration is disabled we don't need to map + clean the results.

Refs #14133