### PR TITLE
Fixed contain() BelongsToMany association restricting fields

### DIFF
--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -131,6 +131,14 @@ class SelectWithPivotLoader extends SelectLoader
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function _assertFieldsPresent(Query $fetchQuery, array $key): void
+    {
+        // _buildQuery() manually adds in required fields from junction table
+    }
+
+    /**
      * Generates a string used as a table field that contains the values upon
      * which the filter should be applied
      *

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1255,6 +1255,19 @@ class BelongsToManyTest extends TestCase
 
         $this->assertNotEmpty($result->tags[0]->id);
         $this->assertEmpty($result->tags[0]->name);
+
+        $result = $table
+            ->find()
+            ->contain([
+                'Tags' => [
+                    'fields' => [
+                        'Tags.name',
+                    ],
+                ],
+            ])
+            ->first();
+        $this->assertNotEmpty($result->tags[0]->name);
+        $this->assertEmpty($result->tags[0]->id);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -155,12 +155,14 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingBelongsToManyList()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'finder' => 'list',
         ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('"_joinData" is missing from the belongsToMany results');
         $table->find()->contain('Tags')->toArray();
     }
 


### PR DESCRIPTION
The user is not responsible for selecting the pivot table fields used to match up the data.

`SelectWithPivotLoader::_buildQuery()` calls parent `_buildQuery()` which asserts on selected fields containing the keys. However, when using pivot loader, the keys are manually added in afterwards.
