### PR TITLE
4.0: Fix element cache key generation

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1583,15 +1583,16 @@ class View implements EventDispatcherInterface
 
         [$plugin, $name] = $this->pluginSplit($name);
 
-        $underscored = null;
+        $pluginKey = null;
         if ($plugin) {
-            $underscored = Inflector::underscore($plugin);
+            $pluginKey = str_replace('/', '_', Inflector::underscore($plugin));
         }
+        $elementKey = str_replace(['\\', '/'], '_', $name);
 
         $cache = $options['cache'];
         unset($options['cache'], $options['callbacks'], $options['plugin']);
         $keys = array_merge(
-            [$underscored, $name],
+            [$pluginKey, $elementKey],
             array_keys($options),
             array_keys($data)
         );

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -824,6 +824,33 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test elementCache method with namespaces and subfolder
+     *
+     * @return void
+     */
+    public function testElementCacheSubfolder()
+    {
+        Cache::drop('test_view');
+        Cache::setConfig('test_view', [
+            'engine' => 'File',
+            'duration' => '+1 day',
+            'path' => CACHE . 'views/',
+            'prefix' => '',
+        ]);
+        Cache::clear('test_view');
+
+        $View = $this->PostsController->createView();
+        $View->setElementCache('test_view');
+
+        $result = $View->element('subfolder/test_element', [], ['cache' => true]);
+        $expected = 'this is the test element in subfolder';
+        $this->assertEquals($expected, trim($result));
+
+        $result = Cache::read('element__subfolder_test_element', 'test_view');
+        $this->assertEquals($expected, trim($result));
+    }
+
+    /**
      * Test element events
      *
      * @return void

--- a/tests/test_app/templates/element/subfolder/test_element.php
+++ b/tests/test_app/templates/element/subfolder/test_element.php
@@ -1,0 +1,1 @@
+this is the test element in subfolder


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/14144

Also fixed another issue that would occur with plugin namespace:

```php
->element('MyNamespace/MyPlugin.test_element', [], ['cache' => true])
```

This might be useful go get backported to 3.x.