### PR TITLE
Split Form::schema() into getter and setter

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -136,25 +136,56 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     }
 
     /**
+     * Set the schema for this form.
+     *
+     * @since 4.1.0
+     * @param \Cake\Form\Schema $schema The schema to set
+     * @return $this
+     */
+    public function setSchema(Schema $schema)
+    {
+        $this->_schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Get the schema for this form.
+     *
+     * This method will call `_buildSchema()` when the schema
+     * is first built. This hook method lets you configure the
+     * schema or load a pre-defined one.
+     *
+     * @since 4.1.0
+     * @return \Cake\Form\Schema the schema instance.
+     */
+    public function getSchema(): Schema
+    {
+        if ($this->_schema === null) {
+            $this->_schema = $this->_buildSchema(new $this->_schemaClass());
+        }
+
+        return $this->_schema;
+    }
+
+    /**
      * Get/Set the schema for this form.
      *
      * This method will call `_buildSchema()` when the schema
      * is first built. This hook method lets you configure the
      * schema or load a pre-defined one.
      *
+     * @deprecated 4.1.0 Use setSchema()/getSchema() instead.
      * @param \Cake\Form\Schema|null $schema The schema to set, or null.
      * @return \Cake\Form\Schema the schema instance.
      */
     public function schema(?Schema $schema = null): Schema
     {
-        if ($schema === null && empty($this->_schema)) {
-            $schema = $this->_buildSchema(new $this->_schemaClass());
-        }
-        if ($schema) {
-            $this->_schema = $schema;
+        if ($schema !== null) {
+            $this->setSchema($schema);
         }
 
-        return $this->_schema;
+        return $this->getSchema();
     }
 
     /**
@@ -291,7 +322,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     public function __debugInfo(): array
     {
         $special = [
-            '_schema' => $this->schema()->__debugInfo(),
+            '_schema' => $this->getSchema()->__debugInfo(),
             '_errors' => $this->getErrors(),
             '_validator' => $this->getValidator()->__debugInfo(),
         ];

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -128,7 +128,7 @@ class FormContext implements ContextInterface
      */
     protected function _schemaDefault(string $field)
     {
-        $field = $this->_form->schema()->field($field);
+        $field = $this->_form->getSchema()->field($field);
         if ($field) {
             return $field['default'];
         }
@@ -201,7 +201,7 @@ class FormContext implements ContextInterface
      */
     public function fieldNames(): array
     {
-        return $this->_form->schema()->fields();
+        return $this->_form->getSchema()->fields();
     }
 
     /**
@@ -209,7 +209,7 @@ class FormContext implements ContextInterface
      */
     public function type(string $field): ?string
     {
-        return $this->_form->schema()->fieldType($field);
+        return $this->_form->getSchema()->fieldType($field);
     }
 
     /**
@@ -217,7 +217,7 @@ class FormContext implements ContextInterface
      */
     public function attributes(string $field): array
     {
-        $column = (array)$this->_form->schema()->field($field);
+        $column = (array)$this->_form->getSchema()->field($field);
         $whiteList = ['length' => null, 'precision' => null];
 
         return array_intersect_key($column, $whiteList);

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -31,6 +31,7 @@ class FormTest extends TestCase
     /**
      * Test schema()
      *
+     * @group deprecated
      * @return void
      */
     public function testSchema()
@@ -47,6 +48,27 @@ class FormTest extends TestCase
 
         $form = new AppForm();
         $this->assertInstanceOf(FormSchema::class, $form->schema());
+    }
+
+    /**
+     * Test setSchema() and getSchema()
+     *
+     * @return void
+     */
+    public function testSetGetSchema()
+    {
+        $form = new Form();
+        $schema = $form->getSchema();
+
+        $this->assertInstanceOf('Cake\Form\Schema', $schema);
+        $this->assertSame($schema, $form->getSchema(), 'Same instance each time');
+
+        $schema = new Schema();
+        $this->assertSame($form, $form->setSchema($schema));
+        $this->assertSame($schema, $form->getSchema());
+
+        $form = new AppForm();
+        $this->assertInstanceOf(FormSchema::class, $form->getSchema());
     }
 
     /**

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -156,7 +156,7 @@ class FormContextTest extends TestCase
     public function testValDefault()
     {
         $form = new Form();
-        $form->schema()->addField('name', ['default' => 'schema default']);
+        $form->getSchema()->addField('name', ['default' => 'schema default']);
         $context = new FormContext($this->request, ['entity' => $form]);
 
         $result = $context->val('title');
@@ -204,7 +204,7 @@ class FormContextTest extends TestCase
     public function testType()
     {
         $form = new Form();
-        $form->schema()
+        $form->getSchema()
             ->addField('email', 'string')
             ->addField('user_id', 'integer');
 
@@ -232,7 +232,7 @@ class FormContextTest extends TestCase
         $result = $context->fieldNames();
         $this->assertEquals($expected, $result);
 
-        $form->schema()
+        $form->getSchema()
             ->addField('email', 'string')
             ->addField('password', 'string');
         $context = new FormContext($this->request, [
@@ -252,7 +252,7 @@ class FormContextTest extends TestCase
     public function testAttributes()
     {
         $form = new Form();
-        $form->schema()
+        $form->getSchema()
             ->addField('email', [
                 'type' => 'string',
                 'length' => 10,


### PR DESCRIPTION
Although `\Cake\Form\Form::schema()` was not listed in #9978 , it seems like a combined getter/setter. Since `\Cake\ORM\Table::schema()` has been deprecated in 3.x and removed in 4.0, this method also should be deprecated. It will be removed in 5.0.