### PR TITLE
Fix url option in first() and last()

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1072,7 +1072,7 @@ class PaginatorHelper extends Helper
         } elseif ($params['page'] > 1 && is_string($first)) {
             $first = $options['escape'] ? h($first) : $first;
             $out .= $this->templater()->format('first', [
-                'url' => $this->generateUrl(['page' => 1], $options['model']),
+                'url' => $this->generateUrl(['page' => 1], $options['model'], $options['url']),
                 'text' => $first,
             ]);
         }
@@ -1132,7 +1132,7 @@ class PaginatorHelper extends Helper
         } elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
             $last = $options['escape'] ? h($last) : $last;
             $out .= $this->templater()->format('last', [
-                'url' => $this->generateUrl(['page' => $params['pageCount']], $options['model']),
+                'url' => $this->generateUrl(['page' => $params['pageCount']], $options['model'], $options['url']),
                 'text' => $last,
             ]);
         }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2659,6 +2659,16 @@ class PaginatorHelperTest extends TestCase
             '/li',
         ];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->first('first', ['url' => ['action' => 'paged']]);
+        $expected = [
+            'li' => ['class' => 'first'],
+            'a' => ['href' => '/paged'],
+            'first',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -2860,6 +2870,17 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->last(3);
         $this->assertSame('', $result, 'When inside the last links range, no links should be made');
+
+
+        $result = $this->Paginator->last('lastest', ['url' => ['action' => 'paged']]);
+        $expected = [
+            'li' => ['class' => 'last'],
+            'a' => ['href' => '/paged?page=7'],
+            'lastest',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2871,7 +2871,6 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->last(3);
         $this->assertSame('', $result, 'When inside the last links range, no links should be made');
 
-
         $result = $this->Paginator->last('lastest', ['url' => ['action' => 'paged']]);
         $expected = [
             'li' => ['class' => 'last'],


### PR DESCRIPTION
Correct URL generation when the title is a string and the `url` option
is used.

Fixes #14155
