### PR TITLE
Fix type error in authenticator with null passwords

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -123,6 +123,16 @@ abstract class BaseAuthenticate implements EventListenerInterface
         if ($password !== null) {
             $hasher = $this->passwordHasher();
             $hashedPassword = $result->get($passwordField);
+
+            if ($hashedPassword === null || $hashedPassword === '') {
+                // Waste time hashing the password, to prevent
+                // timing side-channels to distinguish whether
+                // user has password or not.
+                $hasher->hash($password);
+
+                return false;
+            }
+
             if (!$hasher->check($password, $hashedPassword)) {
                 return false;
             }

--- a/tests/test_app/TestApp/Auth/CallCounterPasswordHasher.php
+++ b/tests/test_app/TestApp/Auth/CallCounterPasswordHasher.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth;
+
+use Cake\Auth\AbstractPasswordHasher;
+use InvalidArgumentException;
+
+class CallCounterPasswordHasher extends AbstractPasswordHasher
+{
+    public $callCount = 0;
+
+    /**
+     * @inheritDoc
+     */
+    public function hash(string $password)
+    {
+        $this->callCount++;
+
+        return 'hash123';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function check(string $password, string $hashedPassword): bool
+    {
+        if ($hashedPassword === '') {
+            throw new InvalidArgumentException('Empty hash not expected');
+        }
+
+        $this->callCount++;
+
+        return false;
+    }
+}


### PR DESCRIPTION
Replaces #14165.

Fix type error in  `DefaultPasswordHasher::check()` when the saved hashed password is `null`.

Because `password_verify($password, $hash)` with empty `$hash` takes less time than with normal hash,  call `hash()` instead of `check()` to prevent timing side-channels.

Add tests to check if all cases (user not exists, user has no password, user has password) _always_ takes same time by calling either `hash()` or `check()`.

Also add tests to check if password-less authenticators takes same time  and _never_ uses password hasher to prevent issue from #12472. `DigestAuthenticateTest` used hard coded username, so it always found user and not triggered error. Also use dummy password hasher classname in case it tries to init password hasher.
