### PR TITLE
[3.x] Skip unchanged files when extracting translation strings

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -622,7 +622,7 @@ class ExtractTask extends Shell
             $filename = str_replace('/', '_', $domain) . '.pot';
             $File = new File($this->_output . $filename);
 
-            if ($this->_checkUnchanged($File, $headerLength, $output) === true) {
+            if ($File->exists() && $this->_checkUnchanged($File, $headerLength, $output) === true) {
                 $this->out($filename . ' is unchanged. Skipping.');
                 $File->close();
                 continue;

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -601,12 +601,14 @@ class ExtractTask extends Shell
      */
     protected function _writeFiles()
     {
+        $this->out();
         $overwriteAll = false;
         if (!empty($this->params['overwrite'])) {
             $overwriteAll = true;
         }
         foreach ($this->_storage as $domain => $sentences) {
             $output = $this->_writeHeader();
+            $headerLength = strlen($output);
             foreach ($sentences as $sentence => $header) {
                 $output .= $header . $sentence;
             }
@@ -619,6 +621,13 @@ class ExtractTask extends Shell
 
             $filename = str_replace('/', '_', $domain) . '.pot';
             $File = new File($this->_output . $filename);
+
+            if ($this->_checkUnchanged($File, $headerLength, $output) === true) {
+                $this->out($filename . ' is unchanged. Skipping.');
+                $File->close();
+                continue;
+            }
+
             $response = '';
             while ($overwriteAll === false && $File->exists() && strtoupper($response) !== 'Y') {
                 $this->out();
@@ -667,6 +676,26 @@ class ExtractTask extends Shell
         $output .= "\"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n\"\n\n";
 
         return $output;
+    }
+
+    /**
+     * Check whether the old and new output are the same, thus unchanged
+     *
+     * Compares the sha1 hashes of the old and new file without header.
+     *
+     * @param File $oldFile The existing file.
+     * @param int $headerLength The length of the file header in bytes.
+     * @param string $newFileContent The content of the new file.
+     * @return bool Whether or not the old and new file are unchanged.
+     */
+    protected function _checkUnchanged(File $oldFile, $headerLength, $newFileContent)
+    {
+        $oldFileContent = $oldFile->read();
+
+        $oldChecksum = sha1(substr($oldFileContent, $headerLength));
+        $newChecksum = sha1(substr($newFileContent, $headerLength));
+
+        return $oldChecksum === $newChecksum;
     }
 
     /**


### PR DESCRIPTION
We heavily use translations in our applications. In some cases we have multiple translation domains (strored in several translation templates; POTs).

Every time we extract the translation strings, even though there were no changed made to any translation string, it leads to slightly changed POTs as they have an updated "POT-Creation-Date" line.
These POTs need to be reverted afterwards every time.

This improvement prevents "POT-Creation-Date" being the only line changing in the file every time one extracts the translation strings with unchanged translation strings.