### PR TITLE
Fix static call of _stop on Console Error Handler

### DIFF
--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -60,7 +60,7 @@ class ConsoleErrorHandler {
 		));
 		$code = $exception->getCode();
 		$code = ($code && is_int($code)) ? $code : 1;
-		return $this->_stop($code);
+		return static::_stop($code);
 	}
 
 /**


### PR DESCRIPTION
Uncaught Error: Using $this when not in object context in /cakephp/lib/Cake/Console/ConsoleErrorHandler.php:63

Throwing an uncaught Exception in the Cake Shell would cause the error above. this patch fixes the error.
