### PR TITLE
Update EntityInterface.php

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -108,7 +108,8 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     public function getError(string $field): array;
 
     /**
-     * Returns all invalids values fields from entity
+     * Get a list of invalid fields and their data for errors upon validation/patching
+     *
      * @return array
      */
     public function getInvalid(): array;

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -106,6 +106,12 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @return array
      */
     public function getError(string $field): array;
+    
+    /**
+    * Returns all invalids values fields from entity
+    * @return array
+    */
+    public function getInvalid(): array;
 
     /**
      * Sets error messages to the entity

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -106,7 +106,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * @return array
      */
     public function getError(string $field): array;
-    
+
     /**
      * Returns all invalids values fields from entity
      * @return array

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -108,9 +108,9 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     public function getError(string $field): array;
     
     /**
-    * Returns all invalids values fields from entity
-    * @return array
-    */
+     * Returns all invalids values fields from entity
+     * @return array
+     */
     public function getInvalid(): array;
 
     /**


### PR DESCRIPTION
Don't make sense, why EntityTrait is a basic implementation for every entity, and this don't have getInvalid function ? for me this is a mistake, what your think ?

https://github.com/cakephp/cakephp/blob/f449c372902cd9fb7f0a9c46fb3e90f41c1b2a2d/src/Datasource/EntityTrait.php#L1070

