### PR TITLE
4.1 - Moved class_alias for SqlDialectTrait to old location

### DIFF
--- a/src/Database/Driver/SqlDialectTrait.php
+++ b/src/Database/Driver/SqlDialectTrait.php
@@ -305,8 +305,3 @@ trait SqlDialectTrait
         return 'ROLLBACK TO SAVEPOINT LEVEL' . $name;
     }
 }
-
-// phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Driver\SqlDialectTrait', 'Cake\Database\SqlDialectTrait');
-// phpcs:enable

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -1,5 +1,5 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
-trait_exists('Cake\Database\Driver\SqlDialectTrait');
+// @deprecated 4.1.0 Add backwards compatible alias.
+class_alias('Cake\Database\Driver\SqlDialectTrait', 'Cake\Database\SqlDialectTrait');


### PR DESCRIPTION
Cleaning up alias from file moves. We don't need the special trait_exists > class_alias setup for traits as they cannot be function parameters and will always load.

@garas 