### PR TITLE
Add more coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,13 @@
     <filter>
         <whitelist>
             <directory suffix=".php">src/</directory>
+            <exclude>
+                <!--
+                This file contains a few functions that cannot be tested
+                as they contain die; or breakpoint functionality.
+                -->
+                <file>src/basics.php</file>
+            </exclude>
         </whitelist>
     </filter>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,6 +35,8 @@
                 as they contain die; or breakpoint functionality.
                 -->
                 <file>src/basics.php</file>
+                <!-- This file is deprecated and unused -->
+                <file>src/Core/ClassLoader.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Core/ClassLoader.php
+++ b/src/Core/ClassLoader.php
@@ -17,6 +17,8 @@ namespace Cake\Core;
 
 /**
  * ClassLoader
+ *
+ * @deprecated 4.0.3 Use composer to generate autoload files instead.
  */
 class ClassLoader
 {

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -278,10 +278,8 @@ class File
      */
     public function delete(): bool
     {
-        if (is_resource($this->handle)) {
-            fclose($this->handle);
-            $this->handle = null;
-        }
+        $this->close();
+        $this->handle = null;
         if ($this->exists()) {
             return unlink($this->path);
         }

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -76,6 +76,21 @@ class CacheCommandsTest extends ConsoleIntegrationTestCase
     }
 
     /**
+     * Test list output
+     *
+     * @return void
+     */
+    public function testList()
+    {
+        $this->exec('cache list');
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertOutputContains('- test');
+        $this->assertOutputContains('- _cake_core_');
+        $this->assertOutputContains('- _cake_model_');
+    }
+
+    /**
      * Test help output
      *
      * @return void

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -124,6 +124,27 @@ class I18nExtractCommandTest extends ConsoleIntegrationTestCase
     }
 
     /**
+     * testExecute with no paths
+     *
+     * @return void
+     */
+    public function testExecuteNoPathOption()
+    {
+        $this->exec(
+            'i18n extract ' .
+            '--merge=no ' .
+            '--extract-core=no ' .
+            '--output=' . $this->path . DS,
+            [
+                TEST_APP . 'templates' . DS,
+                'D'
+            ]
+        );
+        $this->assertExitSuccess();
+        $this->assertFileExists($this->path . DS . 'default.pot');
+    }
+
+    /**
      * testExecute with merging on method
      *
      * @return void

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -137,7 +137,7 @@ class I18nExtractCommandTest extends ConsoleIntegrationTestCase
             '--output=' . $this->path . DS,
             [
                 TEST_APP . 'templates' . DS,
-                'D'
+                'D',
             ]
         );
         $this->assertExitSuccess();

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -236,7 +236,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->assertStringContainsString('error', $logs[0]);
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $logs[0]);
         $this->assertStringContainsString(
-            'Caused by: [Cake\Datasource\Exception\RecordNotFoundException]', 
+            'Caused by: [Cake\Datasource\Exception\RecordNotFoundException]',
             $logs[0]
         );
         $this->assertStringContainsString(

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -26,7 +26,6 @@ use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Error;
 use LogicException;
-use Psr\Log\LoggerInterface;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -34,6 +33,9 @@ use TestApp\Http\TestRequestHandler;
  */
 class ErrorHandlerMiddlewareTest extends TestCase
 {
+    /**
+     * @var \Cake\Log\Engine\ArrayLog
+     */
     protected $logger;
 
     /**
@@ -46,12 +48,12 @@ class ErrorHandlerMiddlewareTest extends TestCase
         parent::setUp();
 
         static::setAppNamespace();
-        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
         Log::reset();
         Log::setConfig('error_test', [
-            'engine' => $this->logger,
+            'className' => 'Array',
         ]);
+        $this->logger = Log::engine('error_test');
     }
 
     /**
@@ -72,13 +74,12 @@ class ErrorHandlerMiddlewareTest extends TestCase
      */
     public function testNoErrorResponse()
     {
-        $this->logger->expects($this->never())->method('log');
-
         $request = ServerRequestFactory::fromGlobals();
 
         $middleware = new ErrorHandlerMiddleware();
         $result = $middleware->process($request, new TestRequestHandler());
         $this->assertInstanceOf(Response::class, $result);
+        $this->assertCount(0, $this->logger->read());
     }
 
     /**
@@ -105,7 +106,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new LogicException('Something bad');
         });
         $middleware->process($request, $handler);
@@ -120,7 +121,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new \Cake\Http\Exception\NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -140,7 +141,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $request = $request->withHeader('Accept', 'application/json');
 
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new \Cake\Http\Exception\NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -172,29 +173,29 @@ class ErrorHandlerMiddlewareTest extends TestCase
      */
     public function testHandleExceptionLogAndTrace()
     {
-        $this->logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->stringContains(str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php')),
-                $this->stringContains('Request URL: /target/url'),
-                $this->stringContains('Referer URL: /other/path'),
-                $this->logicalNot(
-                    $this->stringContains('Previous: ')
-                )
-            ));
-
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
         $this->assertEquals(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
+
+        $logs = $this->logger->read();
+        $this->assertCount(1, $logs);
+        $this->assertStringContainsString('error', $logs[0]);
+        $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $logs[0]);
+        $this->assertStringContainsString(
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
+            $logs[0]
+        );
+        $this->assertStringContainsString('Request URL: /target/url', $logs[0]);
+        $this->assertStringContainsString('Referer URL: /other/path', $logs[0]);
+        $this->assertStringNotContainsString('Previous:', $logs[0]);
     }
 
     /**
@@ -204,16 +205,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
      */
     public function testHandleExceptionLogAndTraceWithPrevious()
     {
-        $this->logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains('[Cake\Http\Exception\NotFoundException] Kaboom!'),
-                $this->stringContains('Caused by: [Cake\Datasource\Exception\RecordNotFoundException] Previous logged'),
-                $this->stringContains(str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php')),
-                $this->stringContains('Request URL: /target/url'),
-                $this->stringContains('Referer URL: /other/path')
-            ));
-
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
@@ -226,6 +217,21 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $result = $middleware->process($request, $handler);
         $this->assertEquals(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
+
+        $logs = $this->logger->read();
+        $this->assertCount(1, $logs);
+        $this->assertStringContainsString('error', $logs[0]);
+        $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $logs[0]);
+        $this->assertStringContainsString(
+            'Caused by: [Cake\Datasource\Exception\RecordNotFoundException]', 
+            $logs[0]
+        );
+        $this->assertStringContainsString(
+            str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
+            $logs[0]
+        );
+        $this->assertStringContainsString('Request URL: /target/url', $logs[0]);
+        $this->assertStringContainsString('Referer URL: /other/path', $logs[0]);
     }
 
     /**
@@ -235,19 +241,19 @@ class ErrorHandlerMiddlewareTest extends TestCase
      */
     public function testHandleExceptionSkipLog()
     {
-        $this->logger->expects($this->never())->method('log');
-
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware([
             'log' => true,
             'skipLog' => ['Cake\Http\Exception\NotFoundException'],
         ]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
         $this->assertEquals(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
+
+        $this->assertCount(0, $this->logger->read());
     }
 
     /**
@@ -257,25 +263,22 @@ class ErrorHandlerMiddlewareTest extends TestCase
      */
     public function testHandleExceptionLogAttributes()
     {
-        $this->logger->expects($this->at(0))
-            ->method('log')
-            ->with('error', $this->logicalAnd(
-                $this->stringContains(
-                    '[Cake\Http\Exception\MissingControllerException] ' .
-                    'Controller class Articles could not be found.'
-                ),
-                $this->stringContains('Exception Attributes:'),
-                $this->stringContains("'class' => 'Articles'"),
-                $this->stringContains('Request URL:')
-            ));
-
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware(['log' => true]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new MissingControllerException(['class' => 'Articles']);
         });
         $result = $middleware->process($request, $handler);
         $this->assertEquals(404, $result->getStatusCode());
+
+        $logs = $this->logger->read();
+        $this->assertStringContainsString(
+            '[Cake\Http\Exception\MissingControllerException] Controller class Articles could not be found.',
+            $logs[0]
+        );
+        $this->assertStringContainsString('Exception Attributes:', $logs[0]);
+        $this->assertStringContainsString("'class' => 'Articles'", $logs[0]);
+        $this->assertStringContainsString('Request URL:', $logs[0]);
     }
 
     /**
@@ -300,7 +303,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function () {
             throw new \Cake\Http\Exception\ServiceUnavailableException('whoops');
         });
         $response = $middleware->process($request, $handler);

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -25,6 +25,7 @@ use Cake\Http\ServerRequestFactory;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Error;
+use InvalidArgumentException;
 use LogicException;
 use TestApp\Http\TestRequestHandler;
 
@@ -65,6 +66,18 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         parent::tearDown();
         Log::drop('error_test');
+    }
+
+    /**
+     * Test constructor error
+     *
+     * @return void
+     */
+    public function testConstructorInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$errorHandler argument must be a config array or ErrorHandler');
+        new ErrorHandlerMiddleware('nope');
     }
 
     /**

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -576,10 +576,12 @@ class FileTest extends TestCase
         if (!file_exists($tmpFile)) {
             touch($tmpFile);
         }
-        $TmpFile = new File($tmpFile);
+        $file = new File($tmpFile);
         $this->assertFileExists($tmpFile);
-        $result = $TmpFile->delete();
-        $this->assertTrue($result);
+
+        $file->read();
+        $this->assertTrue($file->delete());
+        $this->assertFalse($file->exists());
         $this->assertFileNotExists($tmpFile);
 
         $TmpFile = new File('/this/does/not/exist');


### PR DESCRIPTION
I went through a recent report in coveralls and found a few easy wins. I also cleaned up another logger mock, and deprecated `ClassLoader` which is something we missed when doing 4.0 cleanup work.