### PR TITLE
Fix FileWidget with FormProtection and PSR7 file objects.

### DIFF
--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\View\Widget;
 
+use Cake\Core\Configure;
 use Cake\View\Form\ContextInterface;
 
 /**
@@ -74,6 +75,12 @@ class FileWidget extends BasicWidget
      */
     public function secureFields(array $data): array
     {
+        // PSR7 UploadedFileInterface objects are used.
+        if (Configure::read('App.uploadedFilesAsObjects', true)) {
+            return [$data['name']];
+        }
+
+        // Backwards compatibility for array files.
         $fields = [];
         foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
             $fields[] = $data['name'] . '[' . $suffix . ']';

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2258,11 +2258,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
 
         $this->Form->file('Attachment.file');
-        $expected = [
-            'Attachment.file.name', 'Attachment.file.type',
-            'Attachment.file.tmp_name', 'Attachment.file.error',
-            'Attachment.file.size',
-        ];
+        $expected = ['Attachment.file'];
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
@@ -98,5 +99,23 @@ class FileWidgetTest extends TestCase
             ],
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test secureFields
+     *
+     * @return void
+     */
+    public function testSecureFields()
+    {
+        $input = new FileWidget($this->templates);
+        $data = ['name' => 'image', 'required' => true, 'val' => 'nope'];
+        $this->assertEquals(['image'], $input->secureFields($data));
+
+        Configure::write('App.uploadedFilesAsObjects', false);
+        $this->assertEquals(
+            ['image[name]', 'image[type]', 'image[tmp_name]', 'image[error]', 'image[size]'],
+            $input->secureFields($data)
+        );
     }
 }


### PR DESCRIPTION
Don't include additional array fields when requests are using file
objects.

Fixes #14178
