### PR TITLE
Fix year widget not being compatible with Date objects

### DIFF
--- a/src/View/Widget/YearWidget.php
+++ b/src/View/Widget/YearWidget.php
@@ -18,6 +18,7 @@ namespace Cake\View\Widget;
 
 use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;
+use DateTimeInterface;
 use InvalidArgumentException;
 
 /**
@@ -80,6 +81,10 @@ class YearWidget extends BasicWidget
 
         $data['min'] = (int)$data['min'];
         $data['max'] = (int)$data['max'];
+
+        if ($data['val'] instanceof DateTimeInterface) {
+            $data['val'] = $data['val']->format('Y');
+        }
 
         if (!empty($data['val'])) {
             $data['min'] = min((int)$data['val'], $data['min']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6296,6 +6296,27 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->year('published', [
+            'empty' => false,
+            'value' => new Date('2008-01-12'),
+            'min' => 2007,
+            'max' => 2009,
+        ]);
+        $expected = [
+            ['select' => ['name' => 'published']],
+            ['option' => ['value' => '2009']],
+            '2009',
+            '/option',
+            ['option' => ['value' => '2008', 'selected' => 'selected']],
+            '2008',
+            '/option',
+            ['option' => ['value' => '2007']],
+            '2007',
+            '/option',
+            '/select',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->year('published', [
             'empty' => 'Published on',
         ]);
         $this->assertStringContainsString('Published on', $result);


### PR DESCRIPTION
Handle DateTimeInterface objects by extracting the year out of them when
rendering a select box widget for year values.

Fixes #14169