### PR TITLE
Reset default Debugger output format in unit test

### DIFF
--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -270,6 +270,8 @@ class DebuggerTest extends TestCase
         $result = ob_get_clean();
         $this->assertStringContainsString('Notice: I eated an error', $result);
         $this->assertStringContainsString('DebuggerTest.php', $result);
+
+        Debugger::setOutputFormat('js');
     }
 
     /**


### PR DESCRIPTION
If you run ErrorHandler tests after DebuggerTest, it will fail due to the callback formatting.