### PR TITLE
removal of Throwables through _sendRequest from get(), post(), patch(), put(), delete, head(), & options()

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -17,7 +17,6 @@ namespace Cake\TestSuite;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Database\Exception as DatabaseException;
 use Cake\Error\ExceptionRenderer;
 use Cake\Event\EventInterface;
 use Cake\Form\FormProtector;
@@ -60,7 +59,6 @@ use Cake\Utility\Text;
 use Exception;
 use Laminas\Diactoros\Uri;
 use LogicException;
-use PHPUnit\Framework\Error\Error as PhpUnitError;
 use Throwable;
 
 /**
@@ -501,9 +499,9 @@ trait IntegrationTestTrait
             }
             $this->_response = $response;
             $this->_exception = null;
-        } catch (PhpUnitError $e) {
+        } catch (\PHPUnit\Framework\Error\Error $e) {
             $this->_exception = $e;
-        } catch (DatabaseException $e) {
+        } catch (\Cake\Database\Exception $e) {
             $this->_exception = $e;
         } catch (LogicException $e) {
             $this->_exception = $e;
@@ -559,7 +557,7 @@ trait IntegrationTestTrait
      *
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
-     * @param \Throwable|\LogicException|DatabaseException|PhpUnitError|null $exception Exception to handle.
+     * @param \Throwable|\LogicException|\Cake\Database\Exception|\PHPUnit\Framework\Error\Error|null $exception Exception to handle.
      * @return void
      */
     protected function _handleError($exception): void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -107,7 +107,7 @@ trait IntegrationTestTrait
     /**
      * The exception being thrown if the case.
      *
-     * @var \Throwable|null
+     * @var Throwable|null
      */
     protected $_exception;
 
@@ -567,7 +567,7 @@ trait IntegrationTestTrait
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
      *
-     * @param \Throwable|\LogicException|\LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
+     * @param Throwable|LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
      * @return void
      */
     protected function _handleError($exception): void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -377,7 +377,6 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     *
      * @return void
      */
     public function get($url): void
@@ -394,7 +393,6 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
-     *
      * @return void
      */
     public function post($url, $data = []): void
@@ -411,7 +409,6 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
-     *
      * @return void
      */
     public function patch($url, $data = []): void
@@ -428,7 +425,6 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
-     *
      * @return void
      */
     public function put($url, $data = []): void
@@ -444,7 +440,6 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     *
      * @return void
      */
     public function delete($url): void
@@ -460,7 +455,6 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     *
      * @return void
      */
     public function head($url): void
@@ -476,7 +470,6 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
-     *
      * @return void
      */
     public function options($url): void
@@ -492,7 +485,6 @@ trait IntegrationTestTrait
      * @param string|array $url The URL
      * @param string $method The HTTP method
      * @param string|array $data The request data.
-     *
      * @return void
      */
     protected function _sendRequest($url, $method, $data = []): void
@@ -508,6 +500,7 @@ trait IntegrationTestTrait
                 $this->_requestSession->write('Flash', $this->_flashMessages);
             }
             $this->_response = $response;
+            $this->_exception = null;
         } catch (PhpUnitError $e) {
             $this->_exception = $e;
         } catch (DatabaseException $e) {
@@ -566,8 +559,7 @@ trait IntegrationTestTrait
      *
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
-     *
-     * @param \Throwable|\LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
+     * @param \Throwable|\LogicException|DatabaseException|PhpUnitError|null $exception Exception to handle.
      * @return void
      */
     protected function _handleError($exception): void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -377,8 +377,8 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function get($url): void
     {
@@ -394,8 +394,8 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function post($url, $data = []): void
     {
@@ -411,8 +411,8 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function patch($url, $data = []): void
     {
@@ -428,8 +428,8 @@ trait IntegrationTestTrait
      *
      * @param string|array $url The URL to request.
      * @param string|array $data The data for the request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function put($url, $data = []): void
     {
@@ -444,8 +444,8 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function delete($url): void
     {
@@ -460,8 +460,8 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function head($url): void
     {
@@ -476,8 +476,8 @@ trait IntegrationTestTrait
      * response.
      *
      * @param string|array $url The URL to request.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     public function options($url): void
     {
@@ -492,8 +492,8 @@ trait IntegrationTestTrait
      * @param string|array $url The URL
      * @param string $method The HTTP method
      * @param string|array $data The request data.
+     *
      * @return void
-     * @throws \PHPUnit\Framework\Error\Error|\Throwable
      */
     protected function _sendRequest($url, $method, $data = []): void
     {
@@ -509,16 +509,17 @@ trait IntegrationTestTrait
             }
             $this->_response = $response;
         } catch (PhpUnitError $e) {
-            throw $e;
+            $this->_exception = $e;
         } catch (DatabaseException $e) {
-            throw $e;
+            $this->_exception = $e;
         } catch (LogicException $e) {
-            throw $e;
+            $this->_exception = $e;
         } catch (Throwable $e) {
             $this->_exception = $e;
-            // Simulate the global exception handler being invoked.
-            $this->_handleError($e);
         }
+
+        // Simulate the global exception handler being invoked.
+        $this->_handleError($this->_exception);
     }
 
     /**
@@ -566,10 +567,10 @@ trait IntegrationTestTrait
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
      *
-     * @param \Throwable $exception Exception to handle.
+     * @param \Throwable|\LogicException|\LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
      * @return void
      */
-    protected function _handleError(Throwable $exception): void
+    protected function _handleError($exception): void
     {
         $class = Configure::read('Error.exceptionRenderer');
         if (empty($class) || !class_exists($class)) {

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -558,7 +558,7 @@ trait IntegrationTestTrait
      *
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
-     * 
+     *
      * @param \Throwable|\LogicException|\Cake\Database\Exception|\PHPUnit\Framework\Error\Error $exception Exception to handle.
      * @return void
      */

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -498,7 +498,6 @@ trait IntegrationTestTrait
                 $this->_requestSession->write('Flash', $this->_flashMessages);
             }
             $this->_response = $response;
-            $this->_exception = null;
         } catch (\PHPUnit\Framework\Error\Error $e) {
             $this->_exception = $e;
         } catch (\Cake\Database\Exception $e) {
@@ -510,7 +509,9 @@ trait IntegrationTestTrait
         }
 
         // Simulate the global exception handler being invoked.
-        $this->_handleError($this->_exception);
+        if ($this->_exception instanceof Throwable) {
+            $this->_handleError($this->_exception);
+        }
     }
 
     /**
@@ -557,7 +558,7 @@ trait IntegrationTestTrait
      *
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
-     * @param \Throwable|\LogicException|\Cake\Database\Exception|\PHPUnit\Framework\Error\Error|null $exception Exception to handle.
+     * @param \Throwable|\LogicException|\Cake\Database\Exception|\PHPUnit\Framework\Error\Error $exception Exception to handle.
      * @return void
      */
     protected function _handleError($exception): void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -107,7 +107,7 @@ trait IntegrationTestTrait
     /**
      * The exception being thrown if the case.
      *
-     * @var Throwable|null
+     * @var \Throwable|null
      */
     protected $_exception;
 
@@ -567,7 +567,7 @@ trait IntegrationTestTrait
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
      *
-     * @param Throwable|LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
+     * @param \Throwable|\LogicException|DatabaseException|PhpUnitError $exception Exception to handle.
      * @return void
      */
     protected function _handleError($exception): void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -558,6 +558,7 @@ trait IntegrationTestTrait
      *
      * This method will attempt to use the configured exception renderer.
      * If that class does not exist, the built-in renderer will be used.
+     * 
      * @param \Throwable|\LogicException|\Cake\Database\Exception|\PHPUnit\Framework\Error\Error $exception Exception to handle.
      * @return void
      */


### PR DESCRIPTION
IntegrationTestTrait removed all throwables from send request methods:

- get()
- post()
- patch()
- put()
- delet()
- head()
- options()

See discussion/issue at:
https://github.com/cakephp/cakephp/issues/14143