### PR TITLE
Always use / in fallback layout title

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -918,7 +918,7 @@ class View implements EventDispatcherInterface
 
         $title = $this->Blocks->get('title');
         if ($title === '') {
-            $title = Inflector::humanize($this->templatePath);
+            $title = Inflector::humanize(str_replace(DIRECTORY_SEPARATOR, '/', $this->templatePath));
             $this->Blocks->set('title', $title);
         }
 


### PR DESCRIPTION
When layout has no `title` set, generated title for prefixed route is like `Admin\Users` on Windows, `Admin/Users` elsewhere. Normalize to always use `/`.