### PR TITLE
4.1 - Setup mysql8 for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
           - 5432/tcp
 
     steps:
+    - name: Setup mysql 8
+      if: matrix.db-type == 'mysql'
+      run: |
+        sudo service mysql stop
+        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password
+
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
@@ -58,10 +64,8 @@ jobs:
       env:
         REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       run: |
-        if [ ${{ matrix.db-type }} == 'mysql' ]; then mysql -u root -proot -e 'CREATE DATABASE cakephp_test;'; fi
-
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_DSN='sqlite:///:memory:'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_DSN='mysql://root:root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_DSN='mysql://root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_DSN='postgres://postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres'; fi
 
         if [[ ${{ matrix.php-version }} == '7.2' ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.db-type == 'mysql'
       run: |
         sudo service mysql stop
-        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
+        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --tmpfs /var/lib/mysql:rw --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
 
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
     - name: Setup mysql 8
-      if: matrix.db-type == 'mysql'
+      if: matrix.db-type == 'mysql' && matrix.php-version == '7.2'
       run: |
         sudo service mysql stop
-        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --tmpfs /var/lib/mysql:rw --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
+        docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root --tmpfs /var/lib/mysql:rw --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
 
     - uses: actions/checkout@v1
       with:
@@ -64,8 +64,10 @@ jobs:
       env:
         REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       run: |
+        if [ ${{ matrix.db-type }} == 'mysql' ]; then mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp;'; fi
+
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_DSN='sqlite:///:memory:'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_DSN='mysql://root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_DSN='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_DSN='postgres://postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres'; fi
 
         if [[ ${{ matrix.php-version }} == '7.2' ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.db-type == 'mysql'
       run: |
         sudo service mysql stop
-        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin
+        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
 
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.db-type == 'mysql'
       run: |
         sudo service mysql stop
-        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password
+        docker run --rm --name=mysqld -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=cakephp --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin
 
     - uses: actions/checkout@v1
       with:

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -119,16 +119,16 @@ class MysqlSchemaDialect extends SchemaDialect
 
         $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
         if (strpos($col, 'bigint') !== false || $col === 'bigint') {
-            return ['type' => TableSchema::TYPE_BIGINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_BIGINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if ($col === 'tinyint') {
-            return ['type' => TableSchema::TYPE_TINYINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_TINYINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if ($col === 'smallint') {
-            return ['type' => TableSchema::TYPE_SMALLINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_SMALLINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if (in_array($col, ['int', 'integer', 'mediumint'])) {
-            return ['type' => TableSchema::TYPE_INTEGER, 'length' => $length, 'unsigned' => $unsigned];
+            return ['type' => TableSchema::TYPE_INTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if ($col === 'char' && $length === 36) {
             return ['type' => TableSchema::TYPE_UUID, 'length' => null];
@@ -263,7 +263,8 @@ class MysqlSchemaDialect extends SchemaDialect
                 kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
                 AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
             )
-            WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? AND rc.TABLE_NAME = ?';
+            WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? AND rc.TABLE_NAME = ?
+            ORDER BY kcu.ORDINAL_POSITION ASC';
 
         return [$sql, [$config['database'], $tableName, $tableName]];
     }

--- a/tests/Fixture/MembersFixture.php
+++ b/tests/Fixture/MembersFixture.php
@@ -28,7 +28,7 @@ class MembersFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'group_count' => ['type' => 'integer'],
+        'section_count' => ['type' => 'integer'],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
@@ -38,6 +38,6 @@ class MembersFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['group_count' => 2],
+        ['section_count' => 2],
     ];
 }

--- a/tests/Fixture/SectionsFixture.php
+++ b/tests/Fixture/SectionsFixture.php
@@ -17,9 +17,9 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * GroupsMembersFixture
+ * SectionsFixture
  */
-class GroupsMembersFixture extends TestFixture
+class SectionsFixture extends TestFixture
 {
     /**
      * fields property
@@ -28,8 +28,7 @@ class GroupsMembersFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'group_id' => ['type' => 'integer'],
-        'member_id' => ['type' => 'integer'],
+        'title' => ['type' => 'string'],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
@@ -39,7 +38,7 @@ class GroupsMembersFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['group_id' => 1, 'member_id' => 1],
-        ['group_id' => 2, 'member_id' => 1],
+        ['title' => 'foo'],
+        ['title' => 'bar'],
     ];
 }

--- a/tests/Fixture/SectionsMembersFixture.php
+++ b/tests/Fixture/SectionsMembersFixture.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
+ * @since         3.0.2
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\Fixture;
@@ -17,10 +17,9 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * Class GroupsTranslationsFixture
- *
+ * SectionsMembersFixture
  */
-class GroupsTranslationsFixture extends TestFixture
+class SectionsMembersFixture extends TestFixture
 {
     /**
      * fields property
@@ -29,9 +28,9 @@ class GroupsTranslationsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'locale' => ['type' => 'string', 'null' => false],
-        'title' => ['type' => 'string'],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+        'section_id' => ['type' => 'integer'],
+        'member_id' => ['type' => 'integer'],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     /**
@@ -39,5 +38,8 @@ class GroupsTranslationsFixture extends TestFixture
      *
      * @var array
      */
-    public $records = [];
+    public $records = [
+        ['section_id' => 1, 'member_id' => 1],
+        ['section_id' => 2, 'member_id' => 1],
+    ];
 }

--- a/tests/Fixture/SectionsTranslationsFixture.php
+++ b/tests/Fixture/SectionsTranslationsFixture.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.0.2
+ * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\Fixture;
@@ -17,9 +17,10 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * GroupsFixture
+ * Class SectionsTranslationsFixture
+ *
  */
-class GroupsFixture extends TestFixture
+class SectionsTranslationsFixture extends TestFixture
 {
     /**
      * fields property
@@ -28,8 +29,9 @@ class GroupsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
         'title' => ['type' => 'string'],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
     ];
 
     /**
@@ -37,8 +39,5 @@ class GroupsFixture extends TestFixture
      *
      * @var array
      */
-    public $records = [
-        ['title' => 'foo'],
-        ['title' => 'bar'],
-    ];
+    public $records = [];
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -295,12 +295,12 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:50:00');
+        $time = new \DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $result = $query
             ->select(['title', 'comment' => 'c.comment'])
             ->from('articles')
-            ->join(['table' => 'comments', 'alias' => 'c', 'conditions' => ['created <=' => $time]], $types)
+            ->join(['table' => 'comments', 'alias' => 'c', 'conditions' => ['created' => $time]], $types)
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'comment' => 'First Comment for First Article'], $result->fetch('assoc'));
         $result->closeCursor();
@@ -468,7 +468,7 @@ class QueryTest extends TestCase
             ->from('authors')
             ->innerJoin('comments', function ($exp, $q) use ($query, $types) {
                 $this->assertSame($q, $query);
-                $exp->add(['created >' => new \DateTime('2007-03-18 10:45:23')], $types);
+                $exp->add(['created' => new \DateTime('2007-03-18 10:47:23')], $types);
 
                 return $exp;
             })

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -85,36 +85,36 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'boolean', 'length' => null],
             ],
             [
-                'TINYINT(2)',
-                ['type' => 'tinyinteger', 'length' => 2, 'unsigned' => false],
+                'TINYINT(1) UNSIGNED',
+                ['type' => 'boolean', 'length' => null],
             ],
             [
                 'TINYINT(3)',
-                ['type' => 'tinyinteger', 'length' => 3, 'unsigned' => false],
+                ['type' => 'tinyinteger', 'length' => null, 'unsigned' => false],
             ],
             [
                 'TINYINT(3) UNSIGNED',
-                ['type' => 'tinyinteger', 'length' => 3, 'unsigned' => true],
+                ['type' => 'tinyinteger', 'length' => null, 'unsigned' => true],
             ],
             [
                 'SMALLINT(4)',
-                ['type' => 'smallinteger', 'length' => 4, 'unsigned' => false],
+                ['type' => 'smallinteger', 'length' => null, 'unsigned' => false],
             ],
             [
                 'SMALLINT(4) UNSIGNED',
-                ['type' => 'smallinteger', 'length' => 4, 'unsigned' => true],
+                ['type' => 'smallinteger', 'length' => null, 'unsigned' => true],
             ],
             [
                 'INTEGER(11)',
-                ['type' => 'integer', 'length' => 11, 'unsigned' => false],
+                ['type' => 'integer', 'length' => null, 'unsigned' => false],
             ],
             [
                 'MEDIUMINT(11)',
-                ['type' => 'integer', 'length' => 11, 'unsigned' => false],
+                ['type' => 'integer', 'length' => null, 'unsigned' => false],
             ],
             [
                 'INTEGER(11) UNSIGNED',
-                ['type' => 'integer', 'length' => 11, 'unsigned' => true],
+                ['type' => 'integer', 'length' => null, 'unsigned' => true],
             ],
             [
                 'BIGINT',
@@ -267,7 +267,7 @@ class MysqlSchemaTest extends TestCase
 
         $table = <<<SQL
             CREATE TABLE schema_authors (
-                id INT(11) PRIMARY KEY AUTO_INCREMENT,
+                id INT PRIMARY KEY AUTO_INCREMENT,
                 name VARCHAR(50),
                 bio TEXT,
                 created DATETIME
@@ -280,7 +280,7 @@ SQL;
                 id BIGINT PRIMARY KEY AUTO_INCREMENT,
                 title VARCHAR(20) COMMENT 'A title',
                 body TEXT,
-                author_id INT(11) NOT NULL,
+                author_id INT NOT NULL,
                 published BOOLEAN DEFAULT 0,
                 allow_comments TINYINT(1) DEFAULT 0,
                 created DATETIME,
@@ -295,7 +295,7 @@ SQL;
         if ($connection->getDriver()->supportsNativeJson()) {
             $table = <<<SQL
                 CREATE TABLE schema_json (
-                    id INT(11) PRIMARY KEY AUTO_INCREMENT,
+                    id INT PRIMARY KEY AUTO_INCREMENT,
                     data JSON NOT NULL
                 )
 SQL;
@@ -340,7 +340,7 @@ SQL;
                 'null' => false,
                 'unsigned' => false,
                 'default' => null,
-                'length' => 20,
+                'length' => null,
                 'precision' => null,
                 'comment' => null,
                 'autoIncrement' => true,
@@ -368,7 +368,7 @@ SQL;
                 'null' => false,
                 'unsigned' => false,
                 'default' => null,
-                'length' => 11,
+                'length' => null,
                 'precision' => null,
                 'comment' => null,
                 'autoIncrement' => null,
@@ -490,7 +490,7 @@ SQL;
         $sql = <<<SQL
 CREATE TABLE `odd_primary_key` (
 `id` BIGINT UNSIGNED NOT NULL,
-`other_field` INTEGER(11) NOT NULL AUTO_INCREMENT,
+`other_field` INTEGER NOT NULL AUTO_INCREMENT,
 PRIMARY KEY (`id`),
 UNIQUE KEY `other_field` (`other_field`)
 )
@@ -510,7 +510,7 @@ SQL;
 
         $output = $table->createSql($connection);
         $this->assertStringContainsString('`id` BIGINT UNSIGNED NOT NULL,', $output[0]);
-        $this->assertStringContainsString('`other_field` INTEGER(11) NOT NULL AUTO_INCREMENT,', $output[0]);
+        $this->assertStringContainsString('`other_field` INTEGER NOT NULL AUTO_INCREMENT,', $output[0]);
     }
 
     /**
@@ -637,57 +637,57 @@ SQL;
             // Integers
             [
                 'post_id',
-                ['type' => 'tinyinteger', 'length' => 2],
-                '`post_id` TINYINT(2)',
+                ['type' => 'tinyinteger'],
+                '`post_id` TINYINT',
             ],
             [
                 'post_id',
-                ['type' => 'tinyinteger', 'length' => 2, 'unsigned' => true],
-                '`post_id` TINYINT(2) UNSIGNED',
+                ['type' => 'tinyinteger', 'unsigned' => true],
+                '`post_id` TINYINT UNSIGNED',
             ],
             [
                 'post_id',
-                ['type' => 'smallinteger', 'length' => 4],
-                '`post_id` SMALLINT(4)',
+                ['type' => 'smallinteger'],
+                '`post_id` SMALLINT',
             ],
             [
                 'post_id',
-                ['type' => 'smallinteger', 'length' => 4, 'unsigned' => true],
-                '`post_id` SMALLINT(4) UNSIGNED',
+                ['type' => 'smallinteger', 'unsigned' => true],
+                '`post_id` SMALLINT UNSIGNED',
             ],
             [
                 'post_id',
-                ['type' => 'integer', 'length' => 11],
-                '`post_id` INTEGER(11)',
+                ['type' => 'integer'],
+                '`post_id` INTEGER',
             ],
             [
                 'post_id',
-                ['type' => 'integer', 'length' => 11, 'unsigned' => true],
-                '`post_id` INTEGER(11) UNSIGNED',
+                ['type' => 'integer', 'unsigned' => true],
+                '`post_id` INTEGER UNSIGNED',
             ],
             [
                 'post_id',
-                ['type' => 'biginteger', 'length' => 20],
+                ['type' => 'biginteger'],
                 '`post_id` BIGINT',
             ],
             [
                 'post_id',
-                ['type' => 'biginteger', 'length' => 20, 'unsigned' => true],
+                ['type' => 'biginteger', 'unsigned' => true],
                 '`post_id` BIGINT UNSIGNED',
             ],
             [
                 'post_id',
-                ['type' => 'integer', 'length' => 20, 'autoIncrement' => true],
-                '`post_id` INTEGER(20) AUTO_INCREMENT',
+                ['type' => 'integer', 'autoIncrement' => true],
+                '`post_id` INTEGER AUTO_INCREMENT',
             ],
             [
                 'post_id',
-                ['type' => 'integer', 'length' => 20, 'null' => false, 'autoIncrement' => false],
-                '`post_id` INTEGER(20) NOT NULL',
+                ['type' => 'integer', 'null' => false, 'autoIncrement' => false],
+                '`post_id` INTEGER NOT NULL',
             ],
             [
                 'post_id',
-                ['type' => 'biginteger', 'length' => 20, 'autoIncrement' => true],
+                ['type' => 'biginteger', 'autoIncrement' => true],
                 '`post_id` BIGINT AUTO_INCREMENT',
             ],
             // Decimal

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -40,14 +40,14 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         'core.TagsTranslations',
         'core.ArticlesTags',
         'core.SpecialTags',
-        'core.Groups',
+        'core.Sections',
         'core.ArticlesTranslations',
         'core.ArticlesMoreTranslations',
         'core.AuthorsTranslations',
         'core.CommentsTranslations',
         'core.TagsShadowTranslations',
         'core.SpecialTagsTranslations',
-        'core.GroupsTranslations',
+        'core.SectionsTranslations',
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -40,7 +40,7 @@ class TranslateBehaviorTest extends TestCase
         'core.Articles',
         'core.ArticlesTags',
         'core.Authors',
-        'core.Groups',
+        'core.Sections',
         'core.SpecialTags',
         'core.Tags',
         'core.Comments',
@@ -1450,7 +1450,7 @@ class TranslateBehaviorTest extends TestCase
      */
     public function testSaveNewRecordWithOnlyTranslationsNotDefaultLocale()
     {
-        $table = $this->getTableLocator()->get('Groups');
+        $table = $this->getTableLocator()->get('Sections');
         $table->addBehavior('Translate', [
             'fields' => ['title'],
             'validator' => (new \Cake\Validation\Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2377,7 +2377,7 @@ class QueryTest extends TestCase
         };
         $query = $table->find()
             ->contain(['Articles' => $builder, 'Articles.Authors' => $builder])
-            ->order(['Articles.id' => 'ASC']);
+            ->order(['ArticlesTags.article_id' => 'ASC']);
 
         $query->formatResults(function ($results) {
             return $results->map(function ($row) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -60,8 +60,8 @@ class TableTest extends TestCase
         'core.Authors',
         'core.Categories',
         'core.Comments',
-        'core.Groups',
-        'core.GroupsMembers',
+        'core.Sections',
+        'core.SectionsMembers',
         'core.Members',
         'core.PolymorphicTagged',
         'core.SiteArticles',
@@ -606,19 +606,19 @@ class TableTest extends TestCase
      */
     public function testAssociationDotSyntax()
     {
-        $groups = $this->getTableLocator()->get('Groups');
+        $sections = $this->getTableLocator()->get('Sections');
         $members = $this->getTableLocator()->get('Members');
-        $groupsMembers = $this->getTableLocator()->get('GroupsMembers');
+        $sectionsMembers = $this->getTableLocator()->get('SectionsMembers');
 
-        $groups->belongsToMany('Members');
-        $groups->hasMany('GroupsMembers');
-        $groupsMembers->belongsTo('Members');
-        $members->belongsToMany('Groups');
+        $sections->belongsToMany('Members');
+        $sections->hasMany('SectionsMembers');
+        $sectionsMembers->belongsTo('Members');
+        $members->belongsToMany('Sections');
 
-        $association = $groups->getAssociation('GroupsMembers.Members.Groups');
+        $association = $sections->getAssociation('SectionsMembers.Members.Sections');
         $this->assertInstanceOf(BelongsToMany::class, $association);
         $this->assertSame(
-            $groups->getAssociation('GroupsMembers')->getAssociation('Members')->getAssociation('Groups'),
+            $sections->getAssociation('SectionsMembers')->getAssociation('Members')->getAssociation('Sections'),
             $association
         );
     }
@@ -632,7 +632,7 @@ class TableTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->getTableLocator()->get('Groups')->getAssociation('FooBar');
+        $this->getTableLocator()->get('Sections')->getAssociation('FooBar');
     }
 
     /**
@@ -3079,28 +3079,30 @@ class TableTest extends TestCase
      */
     public function testDeleteAssociationsCascadingCallbacksOrder()
     {
-        $groups = $this->getTableLocator()->get('Groups');
+        $sections = $this->getTableLocator()->get('Sections');
         $members = $this->getTableLocator()->get('Members');
-        $groupsMembers = $this->getTableLocator()->get('GroupsMembers');
+        $sectionsMembers = $this->getTableLocator()->get('SectionsMembers');
 
-        $groups->belongsToMany('Members');
-        $groups->hasMany('GroupsMembers', [
+        $sections->belongsToMany('Members', [
+            'joinTable' => 'sections_members',
+        ]);
+        $sections->hasMany('SectionsMembers', [
             'dependent' => true,
             'cascadeCallbacks' => true,
         ]);
-        $groupsMembers->belongsTo('Members');
-        $groupsMembers->addBehavior('CounterCache', [
-            'Members' => ['group_count'],
+        $sectionsMembers->belongsTo('Members');
+        $sectionsMembers->addBehavior('CounterCache', [
+            'Members' => ['section_count'],
         ]);
 
         $member = $members->get(1);
-        $this->assertEquals(2, $member->group_count);
+        $this->assertEquals(2, $member->section_count);
 
-        $group = $groups->get(1);
-        $groups->delete($group);
+        $section = $sections->get(1);
+        $sections->delete($section);
 
         $member = $members->get(1);
-        $this->assertEquals(1, $member->group_count);
+        $this->assertEquals(1, $member->section_count);
     }
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -642,7 +642,7 @@ class EntityContextTest extends TestCase
             'user' => new Entity([
                 'username' => 'mark',
                 'fname' => 'Mark',
-                'groups' => [
+                'sections' => [
                     new Entity(['title' => 'PHP', 'id' => 1]),
                     new Entity(['title' => 'Javascript', 'id' => 2]),
                 ],
@@ -653,7 +653,7 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $result = $context->val('user.groups._ids');
+        $result = $context->val('user.sections._ids');
         $this->assertEquals([1, 2], $result);
     }
 
@@ -671,7 +671,7 @@ class EntityContextTest extends TestCase
             'user' => new Entity([
                 'username' => 'mark',
                 'fname' => 'Mark',
-                'groups' => [
+                'sections' => [
                     new Entity(['title' => 'PHP', 'thing' => 1]),
                     new Entity(['title' => 'Javascript', 'thing' => 4]),
                 ],
@@ -682,10 +682,10 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->getTableLocator()->get('Users')->belongsToMany('Groups');
-        $this->getTableLocator()->get('Groups')->setPrimaryKey('thing');
+        $this->getTableLocator()->get('Users')->belongsToMany('Sections');
+        $this->getTableLocator()->get('Sections')->setPrimaryKey('thing');
 
-        $result = $context->val('user.groups._ids');
+        $result = $context->val('user.sections._ids');
         $this->assertEquals([1, 4], $result);
     }
 


### PR DESCRIPTION
This switches github actions to mysql 8 via docker container.

- Ignored integer display widths except for `TINYINT(1)`
- Properly sorted foreign keys by declaration order when building schema
- Rename groups fixture as groups is now reserved keyword