### PR TITLE
Add ConsoleFormatter for Debugger::exportVar()

### DIFF
--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -185,7 +185,6 @@ class ConsoleFormatter implements FormatterInterface
                 $this->style('punct', ' {}');
         }
 
-        /** @var \Cake\Error\Debug\ClassNode $var */
         $out = $this->style('punct', 'object(') .
             $this->style('class', $var->getValue()) .
             $this->style('punct', ') id:') .

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -83,7 +83,7 @@ class ConsoleFormatter implements FormatterInterface
     {
         $code = $this->styles[$style];
 
-        return "\033[{$code};m{$text}\033[0m";
+        return "\033[{$code}m{$text}\033[0m";
     }
 
     /**

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -1,0 +1,219 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error\Debug;
+
+use RuntimeException;
+
+/**
+ * A Debugger formatter for generating output with ANSI escape codes
+ */
+class ConsoleFormatter implements FormatterInterface
+{
+    /**
+     * text colors used in colored output.
+     *
+     * @var array
+     */
+    protected $styles = [
+        // bold yellow
+        'const' => '1;33',
+        // green
+        'string' => '0;32',
+        // bold blue
+        'number' => '1;34',
+        // cyan
+        'class' => '0;36',
+        // grey
+        'punct' => '0;8',
+        // black
+        'property' => '0;30',
+        // magenta
+        'visibility' => '0;35',
+        // red
+        'special' => '0;31',
+    ];
+
+    /**
+     * Check if the current environment supports ANSI output.
+     *
+     * @return bool
+     */
+    public static function environmentMatches(): bool
+    {
+        if (PHP_SAPI !== 'cli') {
+            return false;
+        }
+        // NO_COLOR in environment means no color.
+        if (env('NO_COLOR')) {
+            return false;
+        }
+        // Windows environment checks
+        if (DIRECTORY_SEPARATOR === '\\' &&
+            (!(bool)env('ANSICON') || env('ConEmuANSI') !== 'ON')
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Style text with ANSI escape codes.
+     *
+     * @param string $style The style name to use.
+     * @param string $text The text to style.
+     * @return string The styled output.
+     */
+    protected function style(string $style, string $text): string
+    {
+        $code = $this->styles[$style];
+
+        return "\033[{$code};m{$text}\033[0m";
+    }
+
+    /**
+     * Convert a tree of NodeInterface objects into a plain text string.
+     *
+     * @param \Cake\Error\Debug\NodeInterface $node The node tree to dump.
+     * @return string
+     */
+    public function dump(NodeInterface $node): string
+    {
+        $indent = 0;
+
+        return $this->_export($node, $indent);
+    }
+
+    /**
+     * Convert a tree of NodeInterface objects into a plain text string.
+     *
+     * @param \Cake\Error\Debug\NodeInterface $var The node tree to dump.
+     * @param int $indent The current indentation level.
+     * @return string
+     */
+    protected function _export(NodeInterface $var, int $indent): string
+    {
+        if ($var instanceof ScalarNode) {
+            switch ($var->getType()) {
+                case 'bool':
+                    return $this->style('const', $var->getValue() ? 'true' : 'false');
+                case 'null':
+                    return $this->style('const', 'null');
+                case 'string':
+                    return $this->style('string', "'" . (string)$var->getValue() . "'");
+                case 'int':
+                case 'float':
+                    return $this->style('visibility', "({$var->getType()})") .
+                        ' ' . $this->style('number', "{$var->getValue()}");
+                default:
+                    return "({$var->getType()}) {$var->getValue()}";
+            }
+        }
+        if ($var instanceof ArrayNode) {
+            return $this->_array($var, $indent + 1);
+        }
+        if ($var instanceof ClassNode || $var instanceof ReferenceNode) {
+            return $this->_object($var, $indent + 1);
+        }
+        if ($var instanceof SpecialNode) {
+            return $this->style('special', (string)$var->getValue());
+        }
+        throw new RuntimeException('Unknown node received ' . get_class($var));
+    }
+
+    /**
+     * Export an array type object
+     *
+     * @param \Cake\Error\Debug\ArrayNode $var The array to export.
+     * @param int $indent The current indentation level.
+     * @return string Exported array.
+     */
+    protected function _array(ArrayNode $var, int $indent): string
+    {
+        $out = $this->style('punct', '[');
+        $break = "\n" . str_repeat("  ", $indent);
+        $end = "\n" . str_repeat("  ", $indent - 1);
+        $vars = [];
+
+        $arrow = $this->style('punct', ' => ');
+        foreach ($var->getChildren() as $item) {
+            $val = $item->getValue();
+            $vars[] = $break . $this->_export($item->getKey(), $indent) . $arrow . $this->_export($val, $indent);
+        }
+
+        $close = $this->style('punct', ']');
+        if (count($vars)) {
+            return $out . implode($this->style('punct', ','), $vars) . $end . $close;
+        }
+
+        return $out . $close;
+    }
+
+    /**
+     * Handles object to string conversion.
+     *
+     * @param \Cake\Error\Debug\ClassNode|\Cake\Error\Debug\ReferenceNode $var Object to convert.
+     * @param int $indent Current indentation level.
+     * @return string
+     * @see \Cake\Error\Debugger::exportVar()
+     */
+    protected function _object($var, int $indent): string
+    {
+        $out = '';
+        $props = [];
+
+        if ($var instanceof ReferenceNode) {
+            return $this->style('punct', 'object(') .
+                $this->style('class', $var->getValue()) .
+                $this->style('punct', ') id:') .
+                $this->style('number', (string)$var->getId()) .
+                $this->style('punct', ' {}');
+        }
+
+        /** @var \Cake\Error\Debug\ClassNode $var */
+        $out = $this->style('punct', 'object(') .
+            $this->style('class', $var->getValue()) .
+            $this->style('punct', ') id:') .
+            $this->style('number', (string)$var->getId()) .
+            $this->style('punct', ' {');
+
+        $break = "\n" . str_repeat("  ", $indent);
+        $end = "\n" . str_repeat("  ", $indent - 1) . $this->style('punct', '}');
+
+        $arrow = $this->style('punct', ' => ');
+        foreach ($var->getChildren() as $property) {
+            $visibility = $property->getVisibility();
+            $name = $property->getName();
+            if ($visibility && $visibility !== 'public') {
+                $props[] = $this->style('visibility', $visibility) .
+                    ' ' .
+                    $this->style('property', $name) .
+                    $arrow .
+                    $this->_export($property->getValue(), $indent);
+            } else {
+                $props[] = $this->style('property', $name) .
+                    $arrow .
+                    $this->_export($property->getValue(), $indent);
+            }
+        }
+        if (count($props)) {
+            return $out . $break . implode($break, $props) . $end;
+        }
+
+        return $out . $this->style('punct', '}');
+    }
+}

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -62,7 +62,8 @@ class ConsoleFormatter implements FormatterInterface
             return false;
         }
         // Windows environment checks
-        if (DIRECTORY_SEPARATOR === '\\' &&
+        if (
+            DIRECTORY_SEPARATOR === '\\' &&
             (!(bool)env('ANSICON') || env('ConEmuANSI') !== 'ON')
         ) {
             return false;

--- a/src/Error/Debug/FormatterInterface.php
+++ b/src/Error/Debug/FormatterInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error\Debug;
+
+/**
+ * Interface for formatters used by Debugger::exportVar()
+ */
+interface FormatterInterface
+{
+    /**
+     * Convert a tree of NodeInterface objects into a plain text string.
+     *
+     * @param \Cake\Error\Debug\NodeInterface $node The node tree to dump.
+     * @return string
+     */
+    public function dump(NodeInterface $node): string;
+}

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -24,7 +24,7 @@ use RuntimeException;
  * Provides backwards compatible output with the historical output of
  * `Debugger::exportVar()`
  */
-class TextFormatter
+class TextFormatter implements FormatterInterface
 {
     /**
      * Convert a tree of NodeInterface objects into a plain text string.

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -114,7 +114,6 @@ class TextFormatter implements FormatterInterface
             return "object({$var->getValue()}) id:{$var->getId()} {}";
         }
 
-        /** @var \Cake\Error\Debug\ClassNode $var */
         $out .= "object({$var->getValue()}) id:{$var->getId()} {";
         $break = "\n" . str_repeat("  ", $indent);
         $end = "\n" . str_repeat("  ", $indent - 1) . '}';

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -53,10 +53,10 @@ class ConsoleFormatterTest extends TestCase
         $formatter = new ConsoleFormatter();
         $result = $formatter->dump($node);
 
-        $this->assertStringContainsString("\033[1;33;m", $result, 'Should contain yellow code');
-        $this->assertStringContainsString("\033[0;32;m", $result, 'Should contain green code');
-        $this->assertStringContainsString("\033[1;34;m", $result, 'Should contain blue code');
-        $this->assertStringContainsString("\033[0;36;m", $result, 'Should contain cyan code');
+        $this->assertStringContainsString("\033[1;33m", $result, 'Should contain yellow code');
+        $this->assertStringContainsString("\033[0;32m", $result, 'Should contain green code');
+        $this->assertStringContainsString("\033[1;34m", $result, 'Should contain blue code');
+        $this->assertStringContainsString("\033[0;36m", $result, 'Should contain cyan code');
         $expected = <<<TEXT
 object(MyObject) id:1 {
   stringProp => 'value'

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Error\Debug;
 
-use Cake\Error\Debug\ConsoleFormatter;
 use Cake\Error\Debug\ArrayItemNode;
 use Cake\Error\Debug\ArrayNode;
 use Cake\Error\Debug\ClassNode;
+use Cake\Error\Debug\ConsoleFormatter;
 use Cake\Error\Debug\PropertyNode;
 use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Error\Debug;
+
+use Cake\Error\Debug\ConsoleFormatter;
+use Cake\Error\Debug\ArrayItemNode;
+use Cake\Error\Debug\ArrayNode;
+use Cake\Error\Debug\ClassNode;
+use Cake\Error\Debug\PropertyNode;
+use Cake\Error\Debug\ReferenceNode;
+use Cake\Error\Debug\ScalarNode;
+use Cake\Error\Debug\SpecialNode;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ConsoleFormatterTest
+ */
+class ConsoleFormatterTest extends TestCase
+{
+    /**
+     * Test dumping a graph that contains all possible nodes.
+     *
+     * @return void
+     */
+    public function testDump()
+    {
+        $node = new ClassNode('MyObject', 1);
+        $node->addProperty(new PropertyNode('stringProp', 'public', new ScalarNode('string', 'value')));
+        $node->addProperty(new PropertyNode('intProp', 'protected', new ScalarNode('int', 1)));
+        $node->addProperty(new PropertyNode('floatProp', 'protected', new ScalarNode('float', 1.1)));
+        $node->addProperty(new PropertyNode('boolProp', 'protected', new ScalarNode('bool', true)));
+        $node->addProperty(new PropertyNode('nullProp', 'private', new ScalarNode('null', null)));
+        $arrayNode = new ArrayNode([
+            new ArrayItemNode(new ScalarNode('string', ''), new SpecialNode('too much')),
+            new ArrayItemNode(new ScalarNode('int', 1), new ReferenceNode('MyObject', 1)),
+        ]);
+        $node->addProperty(new PropertyNode('arrayProp', 'public', $arrayNode));
+
+        $formatter = new ConsoleFormatter();
+        $result = $formatter->dump($node);
+
+        $this->assertStringContainsString("\033[1;33;m", $result, 'Should contain yellow code');
+        $this->assertStringContainsString("\033[0;32;m", $result, 'Should contain green code');
+        $this->assertStringContainsString("\033[1;34;m", $result, 'Should contain blue code');
+        $this->assertStringContainsString("\033[0;36;m", $result, 'Should contain cyan code');
+        $expected = <<<TEXT
+object(MyObject) id:1 {
+  stringProp => 'value'
+  protected intProp => (int) 1
+  protected floatProp => (float) 1.1
+  protected boolProp => true
+  private nullProp => null
+  arrayProp => [
+    '' => too much,
+    (int) 1 => object(MyObject) id:1 {}
+  ]
+}
+TEXT;
+        $noescape = preg_replace('/\\033\[\d\;\d+\;m([^\\\\]+)\\033\[0m/', '$1', $expected);
+        $this->assertEquals($expected, $noescape);
+    }
+}

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Error;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
@@ -41,11 +40,6 @@ class DebuggerTest extends TestCase
     protected $restoreError = false;
 
     /**
-     * @var string|null
-     */
-    protected $restoreFormatter = null;
-
-    /**
      * setUp method
      *
      * @return void
@@ -56,8 +50,6 @@ class DebuggerTest extends TestCase
         Configure::write('debug', true);
         Log::drop('stderr');
         Log::drop('stdout');
-        $this->restoreFormatter = Debugger::configInstance('exportFormatter');
-        Debugger::configInstance('exportFormatter', TextFormatter::class);
     }
 
     /**
@@ -71,7 +63,6 @@ class DebuggerTest extends TestCase
         if ($this->restoreError) {
             restore_error_handler();
         }
-        Debugger::configInstance('exportFormatter', $this->restoreFormatter);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Error;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
+use Cake\Error\Debug\TextFormatter;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use stdClass;
@@ -34,7 +35,15 @@ use TestApp\Error\Thing\SecurityThing;
  */
 class DebuggerTest extends TestCase
 {
-    protected $_restoreError = false;
+    /**
+     * @var bool
+     */
+    protected $restoreError = false;
+
+    /**
+     * @var string|null
+     */
+    protected $restoreFormatter = null;
 
     /**
      * setUp method
@@ -47,6 +56,8 @@ class DebuggerTest extends TestCase
         Configure::write('debug', true);
         Log::drop('stderr');
         Log::drop('stdout');
+        $this->restoreFormatter = Debugger::configInstance('exportFormatter');
+        Debugger::configInstance('exportFormatter', TextFormatter::class);
     }
 
     /**
@@ -57,9 +68,10 @@ class DebuggerTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        if ($this->_restoreError) {
+        if ($this->restoreError) {
             restore_error_handler();
         }
+        Debugger::configInstance('exportFormatter', $this->restoreFormatter);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -578,6 +578,8 @@ TEXT;
     public function testGetInstance()
     {
         $result = Debugger::getInstance();
+        $exporter = $result->getConfig('exportFormatter');
+
         $this->assertInstanceOf(Debugger::class, $result);
 
         $result = Debugger::getInstance(TestDebugger::class);
@@ -588,6 +590,7 @@ TEXT;
 
         $result = Debugger::getInstance(Debugger::class);
         $this->assertInstanceOf(Debugger::class, $result);
+        $result->setConfig('exportFormatter', $exporter);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -18,8 +18,8 @@ namespace Cake\Test\TestCase\Error;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Error\Debugger;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\Debugger;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use stdClass;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,8 +17,8 @@ use Cake\Cache\Cache;
 use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error\Debugger;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\Debugger;
 use Cake\Log\Log;
 use Cake\Utility\Security;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,8 @@ use Cake\Cache\Cache;
 use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
+use Cake\Error\Debugger;
+use Cake\Error\Debug\TextFormatter;
 use Cake\Log\Log;
 use Cake\Utility\Security;
 
@@ -129,6 +131,7 @@ Log::setConfig([
 
 Chronos::setTestNow(Chronos::now());
 Security::setSalt('a-long-but-not-random-value');
+Debugger::configInstance('exportFormatter', TextFormatter::class);
 
 ini_set('intl.default_locale', 'en_US');
 ini_set('session.gc_divisor', '1');


### PR DESCRIPTION
This formatter adds ANSI escape code formatted output for use in console environments. I've not gone deep into 256 color land as I wanted to maximize compatibility. This also adds methods to Debugger to autoselect the formatter or users will be able to use `Debugger::configInstance()` to choose their preferred output format.

I chose to mostly duplicate the code in `TextFormatter` as I didn't want to clutter that class up with no-op `style()` calls. I'm also not confident in what a good abstraction would be or if its even useful. I hope to know more once I've implemented the HTML formatter.
