### PR TITLE
Handle viewbuilder methods in EmailTrait

### DIFF
--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -73,7 +73,7 @@ class MailSentWith extends MailConstraintBase
     {
         $viewBuilderMethods = [
             'template', 'layout', 'helpers',
-            'theme', 
+            'theme',
         ];
         if (in_array($this->method, $viewBuilderMethods)) {
             return $email->viewBuilder()->{'get' . ucfirst($this->method)}();

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -48,7 +48,7 @@ class MailSentWith extends MailConstraintBase
     {
         $emails = $this->getEmails();
         foreach ($emails as $email) {
-            $value = $email->{'get' . ucfirst($this->method)}();
+            $value = $this->getValue($email);
             if (
                 in_array($this->method, ['to', 'cc', 'bcc', 'from'])
                 && array_key_exists($other, $value)
@@ -61,6 +61,25 @@ class MailSentWith extends MailConstraintBase
         }
 
         return false;
+    }
+
+    /**
+     * Read a value from the email
+     *
+     * @param \Cake\Mailer\Email $email The email to read properties from.
+     * @return mixed
+     */
+    protected function getValue($email)
+    {
+        $viewBuilderMethods = [
+            'template', 'layout', 'helpers',
+            'theme', 
+        ];
+        if (in_array($this->method, $viewBuilderMethods)) {
+            return $email->viewBuilder()->{'get' . ucfirst($this->method)}();
+        }
+
+        return $email->{'get' . ucfirst($this->method)}();
     }
 
     /**

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -75,7 +75,7 @@ class MailSentWith extends MailConstraintBase
             'template', 'layout', 'helpers',
             'theme',
         ];
-        if (in_array($this->method, $viewBuilderMethods)) {
+        if (in_array($this->method, $viewBuilderMethods, true)) {
             return $email->viewBuilder()->{'get' . ucfirst($this->method)}();
         }
 

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -71,10 +71,7 @@ class MailSentWith extends MailConstraintBase
      */
     protected function getValue($email)
     {
-        $viewBuilderMethods = [
-            'template', 'layout', 'helpers',
-            'theme',
-        ];
+        $viewBuilderMethods = ['template', 'layout', 'helpers', 'theme'];
         if (in_array($this->method, $viewBuilderMethods, true)) {
             return $email->viewBuilder()->{'get' . ucfirst($this->method)}();
         }

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -90,6 +90,9 @@ class EmailTraitTest extends TestCase
         $this->assertMailSentWith('cc@example.com', 'cc');
         $this->assertMailSentWith('bcc@example.com', 'bcc');
         $this->assertMailSentWith('cc2@example.com', 'cc');
+
+        $this->assertMailSentWith('default', 'template');
+        $this->assertMailSentWith('default', 'layout');
     }
 
     /**
@@ -231,11 +234,14 @@ class EmailTraitTest extends TestCase
             ->setEmailFormat(Email::MESSAGE_TEXT)
             ->send('text');
 
-        (new Email('alternate'))
+        $email = (new Email('alternate'))
             ->setTo('to2@example.com')
             ->setCc('cc2@example.com')
-            ->setEmailFormat(Email::MESSAGE_HTML)
-            ->send('html');
+            ->setEmailFormat(Email::MESSAGE_HTML);
+        $email->viewBuilder()
+            ->setTemplate('default')
+            ->setLayout('default');
+        $email->send('html');
 
         (new Email('alternate'))
             ->setTo(['to3@example.com' => null])


### PR DESCRIPTION
As a high-level API the `assertMailSentWith` method is more useful if the user doesn't have to worry too much with where properties are coming from.

Fixes #14078