### PR TITLE
Fix withStatus() overwriting content-type

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -478,7 +478,7 @@ class Response implements ResponseInterface
      * Formats the Content-Type header based on the configured contentType and charset
      * the charset will only be set in the header if the response is of type text/*
      *
-     * @param string|null $type The type to set.
+     * @param string $type The type to set.
      * @return void
      */
     protected function _setContentType(string $type): void

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -632,6 +632,7 @@ class Response implements ResponseInterface
         }
         $this->_reasonPhrase = $reasonPhrase;
 
+        // These status codes don't have bodies and can't have content-types.
         if (in_array($code, [304, 204], true)) {
             $this->_clearHeader('Content-Type');
         }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -362,14 +362,6 @@ class Response implements ResponseInterface
     protected $_status = 200;
 
     /**
-     * Content type to send. This can be an 'extension' that will be transformed using the $_mimetypes array
-     * or a complete mime-type
-     *
-     * @var string
-     */
-    protected $_contentType = 'text/html';
-
-    /**
      * File object for file to be read out as response
      *
      * @var \SplFileInfo|null
@@ -464,10 +456,11 @@ class Response implements ResponseInterface
             $options['charset'] = Configure::read('App.encoding');
         }
         $this->_charset = $options['charset'];
+        $type = 'text/html';
         if (isset($options['type'])) {
-            $this->_contentType = $this->resolveType($options['type']);
+            $type = $this->resolveType($options['type']);
         }
-        $this->_setContentType();
+        $this->_setContentType($type);
         $this->_cookies = new CookieCollection();
     }
 
@@ -485,9 +478,10 @@ class Response implements ResponseInterface
      * Formats the Content-Type header based on the configured contentType and charset
      * the charset will only be set in the header if the response is of type text/*
      *
+     * @param string|null $type The type to set.
      * @return void
      */
-    protected function _setContentType(): void
+    protected function _setContentType(string $type): void
     {
         if (in_array($this->_status, [304, 204], true)) {
             $this->_clearHeader('Content-Type');
@@ -502,17 +496,17 @@ class Response implements ResponseInterface
         if (
             $this->_charset &&
             (
-                strpos($this->_contentType, 'text/') === 0 ||
-                in_array($this->_contentType, $whitelist, true)
+                strpos($type, 'text/') === 0 ||
+                in_array($type, $whitelist, true)
             )
         ) {
             $charset = true;
         }
 
-        if ($charset) {
-            $this->_setHeader('Content-Type', "{$this->_contentType}; charset={$this->_charset}");
+        if ($charset && strpos($type, ';') === false) {
+            $this->_setHeader('Content-Type', "{$type}; charset={$this->_charset}");
         } else {
-            $this->_setHeader('Content-Type', (string)$this->_contentType);
+            $this->_setHeader('Content-Type', $type);
         }
     }
 
@@ -637,7 +631,10 @@ class Response implements ResponseInterface
             $reasonPhrase = $this->_statusCodes[$code];
         }
         $this->_reasonPhrase = $reasonPhrase;
-        $this->_setContentType();
+
+        if (in_array($code, [304, 204], true)) {
+            $this->_clearHeader('Content-Type');
+        }
     }
 
     /**
@@ -681,7 +678,12 @@ class Response implements ResponseInterface
      */
     public function getType(): string
     {
-        return $this->_contentType;
+        $header = $this->getHeaderLine('Content-Type');
+        if (strpos($header, ';') !== false) {
+            return explode(';', $header)[0];
+        }
+
+        return $header;
     }
 
     /**
@@ -697,8 +699,7 @@ class Response implements ResponseInterface
     {
         $mappedType = $this->resolveType($contentType);
         $new = clone $this;
-        $new->_contentType = $mappedType;
-        $new->_setContentType();
+        $new->_setContentType($mappedType);
 
         return $new;
     }
@@ -783,7 +784,7 @@ class Response implements ResponseInterface
     {
         $new = clone $this;
         $new->_charset = $charset;
-        $new->_setContentType();
+        $new->_setContentType($this->getType());
 
         return $new;
     }
@@ -1556,7 +1557,7 @@ class Response implements ResponseInterface
     {
         return [
             'status' => $this->_status,
-            'contentType' => $this->_contentType,
+            'contentType' => $this->getType(),
             'headers' => $this->headers,
             'file' => $this->_file,
             'fileRange' => $this->_fileRange,

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -180,10 +180,10 @@ class ResponseTest extends TestCase
             'Original object should not be modified'
         );
         $this->assertSame('application/pdf', $new->getHeaderLine('Content-Type'));
-        $this->assertSame(
-            'application/json',
-            $new->withType('json')->getHeaderLine('Content-Type')
-        );
+
+        $json = $new->withType('json');
+        $this->assertSame('application/json', $json->getHeaderLine('Content-Type'));
+        $this->assertSame('application/json', $json->getType());
     }
 
     /**
@@ -203,6 +203,11 @@ class ResponseTest extends TestCase
             'custom/stuff',
             $response->withType('custom/stuff')->getHeaderLine('Content-Type'),
             'Should allow arbitrary types'
+        );
+        $this->assertEquals(
+            'text/html; charset=UTF-8',
+            $response->withType('text/html; charset=UTF-8')->getHeaderLine('Content-Type'),
+            'Should allow charset types'
         );
     }
 
@@ -245,12 +250,45 @@ class ResponseTest extends TestCase
         $new = $response->withType('pdf')
             ->withStatus(204);
         $this->assertFalse($new->hasHeader('Content-Type'));
-        $this->assertSame(204, $new->getStatusCode());
+        $this->assertSame('', $new->getType());
+        $this->assertSame(204, $new->getStatusCode(), 'Status code should clear content-type');
 
         $response = new Response();
         $new = $response->withStatus(304)
             ->withType('pdf');
-        $this->assertFalse($new->hasHeader('Content-Type'));
+        $this->assertSame('', $new->getType());
+        $this->assertFalse(
+            $new->hasHeader('Content-Type'),
+            'Type should not be retained because of status code.'
+        );
+
+        $response = new Response();
+        $new = $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(204);
+        $this->assertFalse($new->hasHeader('Content-Type'), 'Should clear direct header');
+        $this->assertSame('', $new->getType());
+    }
+
+    /**
+     * Test that setting status codes doesn't overwrite content-type
+     *
+     * @return void
+     */
+    public function testWithStatusDoesNotChangeContentType()
+    {
+        $response = new Response();
+        $new = $response->withHeader('Content-Type', 'application/json')
+            ->withStatus(403);
+        $this->assertSame('application/json', $new->getHeaderLine('Content-Type'));
+        $this->assertSame(403, $new->getStatusCode());
+
+        $response = new Response();
+        $new = $response->withStatus(403)
+            ->withHeader('Content-Type', 'application/json');
+        $this->assertSame('application/json', $new->getHeaderLine('Content-Type'));
+        $this->assertSame(403, $new->getStatusCode());
+        $this->assertSame('application/json', $new->getType());
     }
 
     /**


### PR DESCRIPTION
The withStatus() method would use the `_contentType` property which can contain stale information if `withHeader()` is used to set the content-type. Instead of storing potentially divergent information we can make the content-type header authoritative and do type munging in getType().

While this could be a breaking change we make precious few promises around protected properties. This change should be backported to 3.x as well to resolve the same problem there.

Fixes #14211