### PR TITLE
Sync arguments with NumberHelper::precision and Number::precision

### DIFF
--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -88,13 +88,14 @@ class NumberHelper extends Helper
      *
      * @param float $number A floating point number.
      * @param int $precision The precision of the returned number.
+     * @param array $options Additional options.
      * @return string Formatted float.
      * @see \Cake\I18n\Number::precision()
      * @link https://book.cakephp.org/3/en/views/helpers/number.html#formatting-floating-point-numbers
      */
-    public function precision($number, $precision = 3)
+    public function precision($number, $precision = 3, array $options = [])
     {
-        return $this->_engine->precision($number, $precision);
+        return $this->_engine->precision($number, $precision, $options);
     }
 
     /**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -18,9 +18,11 @@ namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\I18n\Number;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\NumberHelper;
 use Cake\View\View;
+use ReflectionMethod;
 
 /**
  * NumberHelperTestObject class
@@ -92,7 +94,6 @@ class NumberHelperTest extends TestCase
             ['toPercentage'],
             ['currency'],
             ['format'],
-            ['addFormat'],
             ['formatDelta'],
             ['defaultCurrency'],
             ['ordinal'],
@@ -116,6 +117,21 @@ class NumberHelperTest extends TestCase
             ->method($method)
             ->with(12.3);
         $helper->{$method}(12.3, ['options']);
+    }
+
+    /**
+     * Test that number of argument of helper's proxy methods matches
+     * corresponding method of Number class.
+     *
+     * @dataProvider methodProvider
+     * @return void
+     */
+    public function testParameterCountMatch($method)
+    {
+        $numberMethod = new ReflectionMethod(Number::class, $method);
+        $helperMethod = new ReflectionMethod(NumberHelper::class, $method);
+
+        $this->assertSame($numberMethod->getNumberOfParameters(), $helperMethod->getNumberOfParameters());
     }
 
     /**


### PR DESCRIPTION
Backport changes from #14216 to 3.x