### PR TITLE
#14226 - DateTimeWidget now accepts milliseconds. 

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -62,6 +62,7 @@ class DateTimeType extends BaseType
         'Y-m-d H:i:s',
         'Y-m-d\TH:i:s',
         'Y-m-d\TH:i:sP',
+        'Y-m-d\TH:i:s.v',
     ];
 
     /**


### PR DESCRIPTION
See ticket #14226.
The commit https://github.com/cakephp/cakephp/commit/c63778cbcc6baf5905e2b9454e77babd115057d0
introduced the milliseconds for fractional types. But it wasn't taking care of saving this format to the database.
