### PR TITLE
Add timestamptimezone mapping to FormHelper and DateTimeWidget

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -72,6 +72,7 @@ class FormHelper extends Helper
             'datetimefractional' => 'datetime',
             'timestamp' => 'datetime',
             'timestampfractional' => 'datetime',
+            'timestamptimezone' => 'datetime',
             'date' => 'date',
             'time' => 'time',
             'year' => 'year',

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -145,6 +145,7 @@ class DateTimeWidget extends BasicWidget
         $fractionalTypes = [
             TableSchema::TYPE_DATETIME_FRACTIONAL,
             TableSchema::TYPE_TIMESTAMP_FRACTIONAL,
+            TableSchema::TYPE_TIMESTAMP_TIMEZONE,
         ];
 
         if (in_array($dbType, $fractionalTypes, true)) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7424,17 +7424,32 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Provides fractional schema types
+     *
+     * @return array
+     */
+    public function fractionalTypeProvider()
+    {
+        return [
+            ['datetimefractional'],
+            ['timestampfractional'],
+            ['timestamptimezone'],
+        ];
+    }
+
+    /**
      * testDateTimeWithFractional method
      *
      * Test that datetime() works with datetimefractional.
      *
      * @return void
+     * @dataProvider fractionalTypeProvider
      */
-    public function testDateTimeWithFractional()
+    public function testDateTimeWithFractional(string $type)
     {
         $this->Form->create([
             'schema' => [
-                'created' => ['type' => 'datetimefractional'],
+                'created' => ['type' => $type],
             ],
         ]);
         $result = $this->Form->datetime('created', [
@@ -7458,12 +7473,13 @@ class FormHelperTest extends TestCase
      * Test that control() works with datetimefractional.
      *
      * @return void
+     * @dataProvider fractionalTypeProvider
      */
-    public function testControlWithFractional()
+    public function testControlWithFractional(string $type)
     {
         $this->Form->create([
             'schema' => [
-                'created' => ['type' => 'datetimefractional'],
+                'created' => ['type' => $type],
             ],
         ]);
         $result = $this->Form->control('created', [


### PR DESCRIPTION
The timezonetimestamp type needs to be handled as a fractional type.