### PR TITLE
Fix exceptions not raised when disableErrorHandlerMiddleware() is used.

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -131,9 +131,10 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     public function handleException(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
         $errorHandler = $this->getErrorHandler();
+        $renderer = $errorHandler->getRenderer($exception, $request);
 
         try {
-            $response = $errorHandler->getRenderer($exception, $request)->render();
+            $response = $renderer->render();
             $errorHandler->logException($exception, $request);
         } catch (Throwable $internalException) {
             $errorHandler->logException($internalException, $request);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1360,18 +1360,18 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/posts/get');
         $this->assertFileResponse('foo');
     }
-
     /**
-     * Test disabling the error handler middleware.
+     * Test disabling the error handler middleware with exceptions
+     * in controllers.
      *
      * @return void
      */
     public function testDisableErrorHandlerMiddleware()
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/foo" could not be found.');
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('oh no!');
         $this->disableErrorHandlerMiddleware();
-        $this->get('/foo');
+        $this->get('/posts/throw_exception');
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1360,6 +1360,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/posts/get');
         $this->assertFileResponse('foo');
     }
+
     /**
      * Test disabling the error handler middleware with exceptions
      * in controllers.

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -18,7 +18,6 @@ namespace TestApp;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\Configure;
-use Cake\Error\ExceptionRenderer;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -18,6 +18,8 @@ namespace TestApp;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\Configure;
+use Cake\Error\ExceptionRenderer;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -66,6 +68,7 @@ class Application extends BaseApplication
 
             return $res->withHeader('X-Middleware', 'true');
         });
+        $middleware->add(new ErrorHandlerMiddleware(Configure::read('Error', [])));
         $middleware->add(new RoutingMiddleware($this));
 
         return $middleware;


### PR DESCRIPTION
Fix the test to actually hit the code paths we are interested in as they
weren't before.

Fixes #14237