### PR TITLE
Generate milliseconds for datetime-local inputs only if "step" is decimal.

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -59,7 +59,7 @@ class DateTimeWidget extends BasicWidget
      * @var string[]
      */
     protected $formatMap = [
-        'datetime-local' => 'Y-m-d\TH:i:s.v',
+        'datetime-local' => 'Y-m-d\TH:i:s',
         'date' => 'Y-m-d',
         'time' => 'H:i:s',
         'month' => 'Y-m',
@@ -192,7 +192,15 @@ class DateTimeWidget extends BasicWidget
             $dateTime = $dateTime->setTimezone($timezone);
         }
 
-        return $dateTime->format($this->formatMap[$options['type']]);
+        $format = $this->formatMap[$options['type']];
+        if (
+            $options['type'] === 'datetime-local' &&
+            strpos((string)$options['step'], '.') !== false
+        ) {
+            $format = $format . '.v';
+        }
+
+        return $dateTime->format($format);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3433,7 +3433,7 @@ class FormHelperTest extends TestCase
                 'name' => 'prueba',
                 'id' => 'prueba',
                 'type' => 'datetime-local',
-                'value' => '2019-09-27T02:52:43.000',
+                'value' => '2019-09-27T02:52:43',
                 'step' => '1',
             ],
             '/div',
@@ -6083,7 +6083,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'date',
-                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}\.\d{3}/',
+                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}/',
                 'step' => '1',
             ],
         ];
@@ -6157,7 +6157,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'updated',
-                'value' => '2009-06-01T11:15:30.000',
+                'value' => '2009-06-01T11:15:30',
                 'step' => '1',
             ],
         ];
@@ -6170,7 +6170,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'updated',
-                'value' => '2009-06-01T11:15:30.000',
+                'value' => '2009-06-01T11:15:30',
                 'step' => '1',
             ],
         ];
@@ -7415,7 +7415,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => 'created',
-                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}\.\d{3}/',
+                'value' => 'preg:/' . date('Y-m-d') . 'T\d{2}:\d{2}:\d{2}/',
                 'step' => '1',
             ],
         ];

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -106,7 +106,7 @@ class DateTimeWidgetTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => '',
-                'value' => '2014-01-20T12:30:45.000',
+                'value' => '2014-01-20T12:30:45',
                 'step' => '1',
             ],
         ];
@@ -128,7 +128,7 @@ class DateTimeWidgetTest extends TestCase
             'input' => [
                 'type' => 'datetime-local',
                 'name' => '',
-                'value' => '2019-02-03T15:30:00.000',
+                'value' => '2019-02-03T15:30:00',
                 'step' => '1',
             ],
         ];


### PR DESCRIPTION
Fixes #14226

Alternative to #14236