### PR TITLE
4.next - Add Collapse to HTML debug output

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -127,6 +127,11 @@ function createCollapsibles(nodes) {
       node.dataset.hidden = true;
     }
 
+    // Don't show toggles for empty arrays/objects
+    if (node.childNodes.length == 0) {
+      return;
+    }
+
     var collapser = doc.createElement('a');
     collapser.classList.add('cake-dbg-collapse');
     collapser.dataset.open = !node.dataset.hidden;
@@ -152,7 +157,6 @@ function createCollapsibles(nodes) {
 function attachRefEvents(nodes) {
   nodes.forEach(function (container) {
     var refLinks = container.querySelectorAll('.cake-dbg-ref');
-    console.log(refLinks);
     refLinks.forEach(function (ref) {
       ref.addEventListener('click', function (event) {
         event.preventDefault();

--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -32,6 +32,28 @@ nesting works.
 .cake-dbg-array-items {
   display: block;
 }
+/** Collapser state **/
+.cake-dbg-array-items.cake-dbg-hidden,
+.cake-dbg-object-props.cake-dbg-hidden {
+  display: none;
+}
+.cake-dbg-collapse-open:before,
+.cake-dbg-collapse-close:before {
+  content: "\25b8";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  font-size: 12px;
+  line-height: 12px;
+  background: hsla(0, 0%, 50%, 0.2);
+  padding: 4px 2px 4px 6px;
+  border-radius: 3px;
+  color: var(--color-blue);
+}
+.cake-dbg-collapse-open:before {
+  content: "\25be";
+}
+
 .cake-dbg-prop,
 .cake-dbg-array-item {
   display: block;
@@ -70,3 +92,37 @@ nesting works.
   font-style: italic;
 }
 </style>
+<script type="text/javascript">
+(function (win, doc) {
+
+function initialize() {
+  createCollapsibles(doc.querySelectorAll('.cake-dbg-array-items'));
+  createCollapsibles(doc.querySelectorAll('.cake-dbg-object-props'));
+}
+
+function createCollapsibles(nodes) {
+  nodes.forEach(function (node) {
+    // Hide the childnode container
+    node.classList.add('cake-dbg-hidden');
+
+    var collapser = doc.createElement('a');
+    collapser.classList.add('cake-dbg-collapse-close');
+    collapser.setAttribute('href', '#')
+    collapser.setAttribute('title', 'Toggle items');
+
+    // Add open/close behavior
+    collapser.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      node.classList.toggle('cake-dbg-hidden');
+      collapser.classList.toggle('cake-dbg-collapse-close');
+      collapser.classList.toggle('cake-dbg-collapse-open');
+    });
+
+    node.parentNode.insertBefore(collapser, node);
+  });
+}
+
+doc.addEventListener('DOMContentLoaded', initialize);
+}(window, document))
+</script>

--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -5,6 +5,7 @@
   padding: 5px;
   line-height: 16px;
   font-size: 14px;
+  margin-bottom: 10px;
 
   /*
   Colours based on solarized scheme
@@ -24,6 +25,9 @@
   --color-red: #dc322f;
 
   --indent: 20px;
+}
+.cake-debug:last-child {
+  margin-bottom: 0;
 }
 .cake-debug > span {
   display: block;

--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -3,12 +3,16 @@
   font-family: monospace;
   background: var(--color-bg);
   padding: 5px;
+  line-height: 16px;
+  font-size: 14px;
 
   /*
   Colours based on solarized scheme
   https://ethanschoonover.com/solarized/
   */
   --color-bg: #fdf6e3;
+  --color-highlight-bg: #eee8d5;
+
   --color-grey: #586e75;
   --color-dark-grey: #073642;
   --color-cyan: #2aa198;
@@ -24,6 +28,11 @@
 .cake-dbg-object {
   display: inline;
 }
+.cake-dbg-object[data-highlighted=true],
+.cake-dbg-object[data-highlighted=true] samp {
+  background: var(--color-highlight-bg);
+}
+
 /*
 Array item container and each items are blocks so
 nesting works.
@@ -32,32 +41,32 @@ nesting works.
 .cake-dbg-array-items {
   display: block;
 }
-/** Collapser state **/
-.cake-dbg-array-items.cake-dbg-hidden,
-.cake-dbg-object-props.cake-dbg-hidden {
+.cake-dbg-prop,
+.cake-dbg-array-item {
+  display: block;
+  padding-left: var(--indent);
+  min-height: 18px;
+}
+
+/** Collapser buttons **/
+[data-hidden=true] {
   display: none;
 }
-.cake-dbg-collapse-open:before,
-.cake-dbg-collapse-close:before {
+.cake-dbg-collapse:before {
   content: "\25b8";
   display: inline-block;
-  width: 12px;
-  height: 12px;
-  font-size: 12px;
-  line-height: 12px;
+  width: 10px;
+  height: 10px;
+  font-size: 13px;
+  line-height: 10px;
   background: hsla(0, 0%, 50%, 0.2);
   padding: 4px 2px 4px 6px;
   border-radius: 3px;
   color: var(--color-blue);
 }
-.cake-dbg-collapse-open:before {
+.cake-dbg-collapse[data-open=true]:before {
   content: "\25be";
-}
-
-.cake-dbg-prop,
-.cake-dbg-array-item {
-  display: block;
-  padding-left: var(--indent);
+  padding: 4px 3px 4px 5px;
 }
 
 /* Textual elements */
@@ -98,15 +107,23 @@ nesting works.
 function initialize() {
   createCollapsibles(doc.querySelectorAll('.cake-dbg-array-items'));
   createCollapsibles(doc.querySelectorAll('.cake-dbg-object-props'));
+  attachRefEvents(doc.querySelectorAll('.cake-dbg'));
 }
 
+/**
+ * Create collapse toggles and attach events
+ */
 function createCollapsibles(nodes) {
   nodes.forEach(function (node) {
-    // Hide the childnode container
-    node.classList.add('cake-dbg-hidden');
+    // Hide the childnode container if it is not
+    // a direct parent of the container.
+    if (!node.parentNode.parentNode.classList.contains('cake-dbg')) {
+      node.dataset.hidden = true;
+    }
 
     var collapser = doc.createElement('a');
-    collapser.classList.add('cake-dbg-collapse-close');
+    collapser.classList.add('cake-dbg-collapse');
+    collapser.dataset.open = !node.dataset.hidden;
     collapser.setAttribute('href', '#')
     collapser.setAttribute('title', 'Toggle items');
 
@@ -114,13 +131,59 @@ function createCollapsibles(nodes) {
     collapser.addEventListener('click', function (event) {
       event.preventDefault();
       event.stopPropagation();
-      node.classList.toggle('cake-dbg-hidden');
-      collapser.classList.toggle('cake-dbg-collapse-close');
-      collapser.classList.toggle('cake-dbg-collapse-open');
+      node.dataset.hidden = node.dataset.hidden === 'true' ? 'false' : 'true';
+      collapser.dataset.open = collapser.dataset.open === 'true' ? 'false' : 'true';
     });
 
     node.parentNode.insertBefore(collapser, node);
   });
+}
+
+/**
+ * When ref links are clicked open the path to that
+ * element and highlight the reference
+ */
+function attachRefEvents(nodes) {
+  nodes.forEach(function (container) {
+    var refLinks = container.querySelectorAll('.cake-dbg-ref');
+    console.log(refLinks);
+    refLinks.forEach(function (ref) {
+      ref.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        var target = document.getElementById(ref.getAttribute('href').substr(1));
+        openPath(container, target);
+      });
+    });
+  });
+}
+
+function openPath(container, target) {
+  // Open the target element
+  var expander = target.querySelector('.cake-dbg-collapse');
+  if (expander.dataset.open === 'false') {
+    expander.click();
+  }
+  container.querySelectorAll('.cake-dbg-object').forEach(function (el) {
+    el.dataset.highlighted = 'false';
+  })
+  target.dataset.highlighted = 'true';
+
+  var current = target;
+  // Traverse up the tree opening all closed containers.
+  while (true) {
+    var parent = current.parentNode;
+    if (parent == container) {
+      break;
+    }
+    if (parent.classList.contains('cake-dbg-object') || parent.classList.contains('cake-dbg-array')) {
+      expander = parent.querySelector('.cake-dbg-collapse');
+      if (expander.dataset.open === 'false') {
+        expander.click();
+      }
+    }
+    current = parent;
+  }
 }
 
 doc.addEventListener('DOMContentLoaded', initialize);

--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -1,5 +1,5 @@
 <style type="text/css">
-.cake-dbg {
+.cake-debug {
   font-family: monospace;
   background: var(--color-bg);
   padding: 5px;
@@ -25,6 +25,12 @@
 
   --indent: 20px;
 }
+.cake-debug > span {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--color-dark-grey);
+}
+
 .cake-dbg-object {
   display: inline;
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -88,12 +88,12 @@ class Debugger
             'code' => '',
             'context' => '',
             'links' => [],
-            'escapeContext' => true,
+            'escapeContext' => false,
         ],
         'html' => [
             'trace' => '<pre class="cake-error trace"><b>Trace</b> <p>{:trace}</p></pre>',
             'context' => '<pre class="cake-error context"><b>Context</b> <p>{:context}</p></pre>',
-            'escapeContext' => true,
+            'escapeContext' => false,
         ],
         'txt' => [
             'error' => "{:error}: {:code} :: {:description} on line {:line} of {:path}\n{:info}",
@@ -157,7 +157,7 @@ class Debugger
 
         $this->_templates['js']['links'] = $links;
 
-        $this->_templates['js']['context'] = '<pre id="{:id}-context" class="cake-context" ';
+        $this->_templates['js']['context'] = '<pre id="{:id}-context" class="cake-context cake-debug" ';
         $this->_templates['js']['context'] .= 'style="display: none;">{:context}</pre>';
 
         $this->_templates['js']['code'] = '<pre id="{:id}-code" class="cake-code-dump" ';
@@ -167,7 +167,7 @@ class Debugger
         $e .= '[<b>{:path}</b>, line <b>{:line}]</b></pre>';
         $this->_templates['html']['error'] = $e;
 
-        $this->_templates['html']['context'] = '<pre class="cake-context"><b>Context</b> ';
+        $this->_templates['html']['context'] = '<pre class="cake-context cake-debug"><b>Context</b> ';
         $this->_templates['html']['context'] .= '<p>{:context}</p></pre>';
     }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -88,12 +88,12 @@ class Debugger
             'code' => '',
             'context' => '',
             'links' => [],
-            'escapeContext' => false,
+            'escapeContext' => true,
         ],
         'html' => [
             'trace' => '<pre class="cake-error trace"><b>Trace</b> <p>{:trace}</p></pre>',
             'context' => '<pre class="cake-error context"><b>Context</b> <p>{:context}</p></pre>',
-            'escapeContext' => false,
+            'escapeContext' => true,
         ],
         'txt' => [
             'error' => "{:error}: {:code} :: {:description} on line {:line} of {:path}\n{:info}",
@@ -846,7 +846,6 @@ class Debugger
         }
 
         if (!empty($tpl['escapeContext'])) {
-            $context = h($context);
             $data['description'] = h($data['description']);
         }
 

--- a/templates/element/exception_stack_trace.php
+++ b/templates/element/exception_stack_trace.php
@@ -55,8 +55,11 @@ foreach ($trace as $i => $stack):
         <?php endforeach; ?>
         </table>
 
-        <div id="stack-args-<?= $i ?>" style="display: none;">
-            <pre><?= h(implode("\n", $params)) ?></pre>
+        <div id="stack-args-<?= $i ?>" class="cake-debug" style="display: none;">
+            <h4>Arguments</h4>
+            <?php foreach ($params as $param): ?>
+                <div class="cake-debug"><?= $param ?></div>
+            <?php endforeach; ?>
         </div>
     </div>
 <?php endforeach; ?>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -139,10 +139,11 @@ use Cake\Error\Debugger;
     .stack-frame {
         background: #e5e5e5;
         padding: 10px;
-        margin-bottom: 5px;
+        margin-bottom: 10px;
     }
     .stack-frame:last-child {
         border-bottom: none;
+        margin-bottom: 0;
     }
     .stack-frame a {
         display: block;
@@ -211,7 +212,7 @@ use Cake\Error\Debugger;
 
     .code-excerpt {
         width: 100%;
-        margin: 10px 0;
+        margin: 10px 0 0 0;
         background: #fefefe;
     }
     .code-highlight {
@@ -231,6 +232,9 @@ use Cake\Error\Debugger;
     }
     .excerpt-number:after {
         content: attr(data-number);
+    }
+    .cake-debug {
+        margin-top: 10px;
     }
 
     table {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -705,14 +705,7 @@ EXPECTED;
         $value = '<div>this-is-a-test</div>';
         Debugger::printVar($value, ['file' => __FILE__, 'line' => __LINE__], true);
         $result = ob_get_clean();
-        $expectedHtml = <<<EXPECTED
-<div class="cake-debug-output cake-debug" style="direction:ltr">
-<span><strong>%s</strong> (line <strong>%d</strong>)</span>
-<div class="cake-dbg"><span class="cake-dbg-string">&#039;&lt;div&gt;this-is-a-test&lt;/div&gt;&#039;</span></div>
-</div>
-EXPECTED;
-        $expected = sprintf($expectedHtml, Debugger::trimPath(__FILE__), __LINE__ - 8);
-        $this->assertEquals($expected, $result);
+        $this->assertStringContainsString('&#039;&lt;div&gt;this-is-a-test&lt;/div&gt;&#039;', $result);
 
         ob_start();
         Debugger::printVar('<div>this-is-a-test</div>', ['file' => __FILE__, 'line' => __LINE__], true);


### PR DESCRIPTION
* Add collapse/open controls to HTML debug output.
* When ref links are clicked the path to the source element is opened.
* Referenced objects are highlighted when a ref link is clicked.

### Screenshot

![Screen Shot 2020-02-01 at 15 25 28](https://user-images.githubusercontent.com/24086/73598526-67654880-4507-11ea-95ab-c3fefb09c349.png)
