### PR TITLE
Bring docblock of dateAdd() in line with 4.x

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -203,8 +203,8 @@ class FunctionsBuilder
     /**
      * Add the time unit to the date expression
      *
-     * @param string $expression Expression to obtain the date part from.
-     * @param string $value Value to be added. Use negative to subtract.
+     * @param string|\Cake\Database\ExpressionInterface $expression Expression to obtain the date part from.
+     * @param string|int $value Value to be added. Use negative to subtract.
      * @param string $unit Unit of the value e.g. hour or day.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -43,7 +43,7 @@ class FunctionsBuilder
      * argument.
      *
      * @param string $name name of the function to build
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @param string $return The return type for the function
      * @return \Cake\Database\Expression\FunctionExpression
@@ -72,7 +72,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a call to SQL SUM function.
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -89,7 +89,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a call to SQL AVG function.
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -101,7 +101,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a call to SQL MAX function.
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -113,7 +113,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a call to SQL MIN function.
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -125,7 +125,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a call to SQL COUNT function.
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -175,7 +175,7 @@ class FunctionsBuilder
      * Returns the specified date part from the SQL expression.
      *
      * @param string $part Part of the date to return.
-     * @param string $expression Expression to obtain the date part from.
+     * @param string|\Cake\Database\ExpressionInterface $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -188,7 +188,7 @@ class FunctionsBuilder
      * Returns the specified date part from the SQL expression.
      *
      * @param string $part Part of the date to return.
-     * @param string $expression Expression to obtain the date part from.
+     * @param string|\Cake\Database\ExpressionInterface $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -225,7 +225,7 @@ class FunctionsBuilder
      * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
      * 1 - Sunday, 2 - Monday, 3 - Tuesday...
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -238,7 +238,7 @@ class FunctionsBuilder
      * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
      * 1 - Sunday, 2 - Monday, 3 - Tuesday...
      *
-     * @param mixed $expression the function argument
+     * @param string|\Cake\Database\ExpressionInterface $expression the function argument
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */


### PR DESCRIPTION
This PR updates the documentation of `FunctionsBuilder::dateAdd()` to indicate that both `string` and `\Cake\Database\ExpressionInterface` are acceptable types for the first argument, and both `string` and `int` for the second argument.  This brings the documentation for 3.x in line with what is currently in 4.x for the same method.