### PR TITLE
Add getAccessible()

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -24,6 +24,7 @@ use JsonSerializable;
  * comply with.
  *
  * @property mixed $id Alias for commonly used primary key.
+ * @method bool[] getAccessible()
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable
 {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -107,7 +107,7 @@ trait EntityTrait
      * not defined in the map will take its value. For example, `'\*' => true`
      * means that any field not defined in the map will be accessible by default
      *
-     * @var array
+     * @var bool[]
      */
     protected $_accessible = ['*' => true];
 
@@ -1161,6 +1161,17 @@ trait EntityTrait
         }
 
         return $this;
+    }
+
+    /**
+     * Returns the raw accessible configuration for this entity.
+     * The `*` wildcard refers to all fields.
+     *
+     * @return bool[]
+     */
+    public function getAccessible(): array
+    {
+        return $this->_accessible;
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1393,11 +1393,30 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests accessible() method as a getter and setter
+     * Tests getAccessible() method
      *
      * @return void
      */
-    public function testAccessible()
+    public function testGetAccessible()
+    {
+        $entity = new Entity();
+        $entity->setAccess('*', false);
+        $entity->setAccess('bar', true);
+
+        $accessible = $entity->getAccessible();
+        $expected = [
+            '*' => false,
+            'bar' => true,
+        ];
+        $this->assertSame($expected, $accessible);
+    }
+
+    /**
+     * Tests isAccessible() and setAccess() methods
+     *
+     * @return void
+     */
+    public function testIsAccessible()
     {
         $entity = new Entity();
         $entity->setAccess('*', false);


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/14249

Is this missing getter OK to be added in 4.0? Or do we have to move it to 4.1?
It is fully BC as such.

We can also backport this to 3.x then afterwards.