### PR TITLE
Issue #14254 - accounting for human input in decimal validation and w…

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -783,6 +783,14 @@ class Validation
         $decimalPoint = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupingSep = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
+        // There are two types of non-breaking spaces - we inject a space to account for human input
+        if($groupingSep == "\xc2\xa0" || $groupingSep == "\xe2\x80\xaf") {
+            $check = str_replace([' ', $groupingSep, $decimalPoint], ['', '', '.'], $check);
+        }
+        else {
+            $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], $check);
+        }
+
         $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], $check);
 
         return static::_check($check, $regex);

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -784,10 +784,9 @@ class Validation
         $groupingSep = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
         // There are two types of non-breaking spaces - we inject a space to account for human input
-        if($groupingSep == "\xc2\xa0" || $groupingSep == "\xe2\x80\xaf") {
+        if ($groupingSep == "\xc2\xa0" || $groupingSep == "\xe2\x80\xaf") {
             $check = str_replace([' ', $groupingSep, $decimalPoint], ['', '', '.'], $check);
-        }
-        else {
+        } else {
             $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], $check);
         }
 


### PR DESCRIPTION
Accounting for human input when validating decimals - some locales use non-breaking spaces (whitespace) as separators - and user inputs a normal space. That has to be artificially injected into the `str_replace()` call - otherwise it will "never" validate as it is trying to replace "the wrong whitespace". 