### PR TITLE
Improve missing template errors

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -203,7 +203,7 @@ abstract class Cell implements EventDispatcherInterface
                 $attributes = $e->getAttributes();
                 throw new MissingCellTemplateException(
                     $name,
-                    basename($attributes['file']),
+                    $attributes['file'],
                     $attributes['paths'],
                     null,
                     $e

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -60,11 +60,11 @@ class MissingTemplateException extends Exception
      */
     public function formatMessage(): string
     {
-        $message = "{$this->type} file '{$this->file}' could not be found.";
+        $message = "{$this->type} file `{$this->file}` could not be found.";
         if ($this->paths) {
             $message .= "\n\nThe following paths were searched:\n\n";
             foreach ($this->paths as $path) {
-                $message .= "- {$path}\n";
+                $message .= "- `{$path}{$this->file}`\n";
             }
         }
 

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -109,30 +109,30 @@ class ExceptionsTest extends TestCase
     {
         $previous = new Exception();
 
-        $error = new MissingTemplateException('view.ctp', ['path/a', 'path/b'], 100, $previous);
-        $this->assertStringContainsString("Template file 'view.ctp' could not be found", $error->getMessage());
-        $this->assertStringContainsString('- path/a', $error->getMessage());
+        $error = new MissingTemplateException('view.ctp', ['path/a/', 'path/b/'], 100, $previous);
+        $this->assertStringContainsString("Template file `view.ctp` could not be found", $error->getMessage());
+        $this->assertStringContainsString('- `path/a/view.ctp`', $error->getMessage());
         $this->assertSame($previous, $error->getPrevious());
         $this->assertSame(100, $error->getCode());
         $attributes = $error->getAttributes();
         $this->assertArrayHasKey('file', $attributes);
         $this->assertArrayHasKey('paths', $attributes);
 
-        $error = new MissingLayoutException('default.ctp', ['path/a', 'path/b'], 100, $previous);
-        $this->assertStringContainsString("Layout file 'default.ctp' could not be found", $error->getMessage());
-        $this->assertStringContainsString('- path/a', $error->getMessage());
+        $error = new MissingLayoutException('default.ctp', ['path/a/', 'path/b/'], 100, $previous);
+        $this->assertStringContainsString("Layout file `default.ctp` could not be found", $error->getMessage());
+        $this->assertStringContainsString('- `path/a/default.ctp`', $error->getMessage());
         $this->assertSame($previous, $error->getPrevious());
         $this->assertSame(100, $error->getCode());
 
-        $error = new MissingElementException('view.ctp', ['path/a', 'path/b'], 100, $previous);
-        $this->assertStringContainsString("Element file 'view.ctp' could not be found", $error->getMessage());
-        $this->assertStringContainsString('- path/a', $error->getMessage());
+        $error = new MissingElementException('view.ctp', ['path/a/', 'path/b/'], 100, $previous);
+        $this->assertStringContainsString("Element file `view.ctp` could not be found", $error->getMessage());
+        $this->assertStringContainsString('- `path/a/view.ctp`', $error->getMessage());
         $this->assertSame($previous, $error->getPrevious());
         $this->assertSame(100, $error->getCode());
 
-        $error = new MissingCellTemplateException('Articles', 'view.ctp', ['path/a', 'path/b'], 100, $previous);
-        $this->assertStringContainsString("Cell template file 'view.ctp' could not be found", $error->getMessage());
-        $this->assertStringContainsString('- path/a', $error->getMessage());
+        $error = new MissingCellTemplateException('Articles', 'view.ctp', ['path/a/', 'path/b/'], 100, $previous);
+        $this->assertStringContainsString("Cell template file `view.ctp` could not be found", $error->getMessage());
+        $this->assertStringContainsString('- `path/a/view.ctp`', $error->getMessage());
         $this->assertSame($previous, $error->getPrevious());
         $this->assertSame(100, $error->getCode());
         $attributes = $error->getAttributes();

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -211,7 +211,10 @@ class CellTest extends TestCase
 
         $this->assertNotNull($e);
         $message = $e->getMessage();
-        $this->assertStringContainsString("Cell template file 'foo_bar.php' could not be found.", $message);
+        $this->assertStringContainsString(
+            str_replace(DS, '/', "Cell template file `cell/Articles/foo_bar.php` could not be found."),
+            $message
+        );
         $this->assertStringContainsString('The following paths', $message);
         $this->assertStringContainsString(ROOT . DS . 'templates', $message);
         $this->assertInstanceOf(MissingTemplateException::class, $e->getPrevious());

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -212,7 +212,7 @@ class CellTest extends TestCase
         $this->assertNotNull($e);
         $message = $e->getMessage();
         $this->assertStringContainsString(
-            str_replace(DS, '/', "Cell template file `cell/Articles/foo_bar.php` could not be found."),
+            str_replace('/', DS, "Cell template file `cell/Articles/foo_bar.php` could not be found."),
             $message
         );
         $this->assertStringContainsString('The following paths', $message);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -577,9 +577,9 @@ class ViewTest extends TestCase
     public function testMissingTemplate()
     {
         $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
-        $this->expectExceptionMessage("Template file 'does_not_exist' could not be found");
+        $this->expectExceptionMessage("Template file `does_not_exist.php` could not be found");
         $this->expectExceptionMessage('The following paths were searched');
-        $this->expectExceptionMessage('- ' . ROOT . DS . 'templates');
+        $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'does_not_exist.php`');
         $viewOptions = ['plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages',
@@ -599,9 +599,9 @@ class ViewTest extends TestCase
     public function testMissingLayout()
     {
         $this->expectException(\Cake\View\Exception\MissingLayoutException::class);
-        $this->expectExceptionMessage("Layout file 'whatever' could not be found");
+        $this->expectExceptionMessage("Layout file `whatever.php` could not be found");
         $this->expectExceptionMessage('The following paths were searched');
-        $this->expectExceptionMessage('- ' . ROOT . DS . 'templates' . DS . 'layout');
+        $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'layout' . DS . 'whatever.php`');
         $viewOptions = ['plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages',
@@ -700,7 +700,7 @@ class ViewTest extends TestCase
     public function testElementMissing()
     {
         $this->expectException(\Cake\View\Exception\MissingElementException::class);
-        $this->expectExceptionMessage("Element file 'non_existent_element' could not be found");
+        $this->expectExceptionMessage("Element file `non_existent_element.php` could not be found");
 
         $this->View->element('non_existent_element');
     }
@@ -713,7 +713,7 @@ class ViewTest extends TestCase
     public function testElementMissingPluginElement()
     {
         $this->expectException(\Cake\View\Exception\MissingElementException::class);
-        $this->expectExceptionMessage("Element file 'TestPlugin.nope' could not be found");
+        $this->expectExceptionMessage("Element file `TestPlugin.nope.php` could not be found");
 
         $this->View->element('TestPlugin.nope');
     }


### PR DESCRIPTION
Refactor path generation for layouts and elements so that we can include the full path of each attempt. I've switched to using generators to try and optimize how much memory path lookups take.

Fixes #14230
