### PR TITLE
Add methods to support editor links

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -765,3 +765,7 @@ parameters:
 			count: 1
 			path: src/basics.php
 
+		-
+			message: "#^Result of \\&\\& is always false.$#"
+			count: 1
+			path: src/Error/Debugger.php

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -115,10 +115,12 @@ class Debugger
      * @var array
      */
     protected $editors = [
-        'sublime' => 'subl://open?url=file://{file}&line={line}',
-        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
-        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
+        'atom' => 'atom://core/open/file?filename={file}&line={line}',
         'emacs' => 'emacs://open?url=file://{file}&line={line}',
+        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
+        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
+        'sublime' => 'subl://open?url=file://{file}&line={line}',
+        'textmate' => 'txmt://open?url=file://{file}&line={line}',
         'vscode' => 'vscode://file/{file}:{line}',
     ];
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -115,7 +115,7 @@ class Debugger
      * @var array
      */
     protected $editors = [
-        'sublime'  => 'subl://open?url=file://{file}&line={line}',
+        'sublime' => 'subl://open?url=file://{file}&line={line}',
         'phpstorm' => 'phpstorm://open?file={file}&line={line}',
         'macvim' => 'mvim://open/?url=file://{file}&line={line}',
         'emacs' => 'emacs://open?url=file://{file}&line={line}',
@@ -311,6 +311,7 @@ class Debugger
         if (is_string($template)) {
             return str_replace(['{file}', '{line}'], [$file, $line], $template);
         }
+
         return $template($file, $line);
     }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -34,6 +34,7 @@ use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Cake\Utility\Text;
+use Closure;
 use Exception;
 use InvalidArgumentException;
 use ReflectionObject;
@@ -61,6 +62,7 @@ class Debugger
     protected $_defaultConfig = [
         'outputMask' => [],
         'exportFormatter' => null,
+        'editor' => 'phpstorm',
     ];
 
     /**
@@ -105,6 +107,19 @@ class Debugger
             'trace' => "Trace:\n{:trace}\n",
             'context' => "Context:\n{:context}\n",
         ],
+    ];
+
+    /**
+     * A map of editors to their link templates.
+     *
+     * @var array
+     */
+    protected $editors = [
+        'sublime'  => 'subl://open?url=file://{file}&line={line}',
+        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
+        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
+        'emacs' => 'emacs://open?url=file://{file}&line={line}',
+        'vscode' => 'vscode://file/{file}:{line}',
     ];
 
     /**
@@ -238,6 +253,65 @@ class Debugger
     public static function setOutputMask(array $value, bool $merge = true): void
     {
         static::configInstance('outputMask', $value, $merge);
+    }
+
+    /**
+     * Add an editor link format
+     *
+     * Template strings can use the `{file}` and `{line}` placeholders.
+     * Closures templates must return a string, and accept two parameters:
+     * The file and line.
+     *
+     * @param string $name The name of the editor.
+     * @param string|\Closure $template The string template or closure
+     * @return void
+     */
+    public static function addEditor(string $name, $template): void
+    {
+        $instance = static::getInstance();
+        if (!is_string($template) && !($template instanceof Closure)) {
+            $type = getTypeName($template);
+            throw new RuntimeException("Invalid editor type of `{$type}`. Expected string or Closure.");
+        }
+        $instance->editors[$name] = $template;
+    }
+
+    /**
+     * Choose the editor link style you want to use.
+     *
+     * @param string $name The editor name.
+     * @return void
+     */
+    public static function setEditor(string $name): void
+    {
+        $instance = static::getInstance();
+        if (!isset($instance->editors[$name])) {
+            $known = implode(', ', array_keys($instance->editors));
+            throw new RuntimeException("Unknown editor `{$name}`. Known editors are {$known}");
+        }
+        $instance->setConfig('editor', $name);
+    }
+
+    /**
+     * Get a formatted URL for the active editor.
+     *
+     * @param string $file The file to create a link for.
+     * @param int $line The line number to create a link for.
+     * @return string The formatted URL.
+     */
+    public static function editorUrl(string $file, int $line): string
+    {
+        $instance = static::getInstance();
+        $editor = $instance->getConfig('editor');
+        if (!isset($instance->editors[$editor])) {
+            throw new RuntimeException("Cannot format editor URL `{$editor}` is not a known editor.");
+        }
+
+        $template = $instance->editors[$editor];
+        if (is_string($template)) {
+            return str_replace(['{file}', '{line}'], [$file, $line], $template);
+        }
+        return $template($file, $line);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -21,6 +21,7 @@ use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 use stdClass;
 use TestApp\Error\TestDebugger;
 use TestApp\Error\Thing\DebuggableThing;
@@ -776,5 +777,68 @@ EXPECTED;
             "Some <code>code</code> to &lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;<br />\nmore",
             $output
         );
+    }
+
+    /**
+     * test adding invalid editor
+     *
+     * @return void
+     */
+    public function testAddEditorInvalid()
+    {
+        $this->expectException(RuntimeException::class);
+        Debugger::addEditor('nope', ['invalid']);
+    }
+
+    /**
+     * test choosing an unknown editor
+     *
+     * @return void
+     */
+    public function testSetEditorInvalid()
+    {
+        $this->expectException(RuntimeException::class);
+        Debugger::setEditor('nope');
+    }
+
+    /**
+     * test choosing a default editor
+     *
+     * @return void
+     */
+    public function testSetEditorPredefined()
+    {
+        Debugger::setEditor('phpstorm');
+        Debugger::setEditor('macvim');
+        Debugger::setEditor('sublime');
+        Debugger::setEditor('emacs');
+        // No exceptions raised.
+        $this->assertTrue(true);
+    }
+
+    /**
+     * test using a valid editor.
+     *
+     * @return void
+     */
+    public function testEditorUrlValid()
+    {
+        Debugger::addEditor('open', 'open://{file}:{line}');
+        Debugger::setEditor('open');
+        $this->assertSame('open://test.php:123', Debugger::editorUrl('test.php', 123));
+    }
+
+    /**
+     * test using a valid editor.
+     *
+     * @return void
+     */
+    public function testEditorUrlClosure()
+    {
+        Debugger::addEditor('open', function (string $file, int $line) {
+            return "${file}/${line}";
+        });
+        Debugger::setEditor('open');
+        $this->assertSame('test.php/123', Debugger::editorUrl('test.php', 123));
     }
 }


### PR DESCRIPTION
This adds methods to Debugger that will help generate editor links in error pages. I'll be updating the error pages in a separate pull request.

### Questions

* Are there other editors that we should include?
* Suggestions on where the editor links should be added in the error page?
