### PR TITLE
Move request method marshalling into ServerRequestFactory.

### DIFF
--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -123,7 +123,12 @@ class DigestAuthenticate extends BasicAuthenticate
         $password = $user[$field];
         unset($user[$field]);
 
-        $hash = $this->generateResponseHash($digest, $password, (string)$request->getEnv('ORIGINAL_REQUEST_METHOD'));
+        $requestMethod = $request->getEnv('ORIGINAL_REQUEST_METHOD') ?: $request->getMethod();
+        $hash = $this->generateResponseHash(
+            $digest,
+            $password,
+            (string)$requestMethod
+        );
         if (hash_equals($hash, $digest['response'])) {
             return $user;
         }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -253,6 +253,10 @@ class ServerRequest implements ServerRequestInterface
             ]);
         }
 
+        if (empty($config['environment']['REQUEST_METHOD'])) {
+            $config['environment']['REQUEST_METHOD'] = 'GET';
+        }
+
         $this->_environment = $config['environment'];
         $this->cookies = $config['cookies'];
 
@@ -289,49 +293,11 @@ class ServerRequest implements ServerRequestInterface
         }
         $this->stream = $stream;
 
-        $this->data = $this->_processPost($config['post']);
+        $this->data = $config['post'];
         $this->uploadedFiles = $config['files'];
         $this->query = $this->_processGet($config['query'], $querystr);
         $this->params = $config['params'];
         $this->session = $config['session'];
-    }
-
-    /**
-     * Sets the REQUEST_METHOD environment variable based on the simulated _method
-     * HTTP override value. The 'ORIGINAL_REQUEST_METHOD' is also preserved, if you
-     * want the read the non-simulated HTTP method the client used.
-     *
-     * @param mixed $data Array of post data.
-     * @return mixed
-     */
-    protected function _processPost($data)
-    {
-        $method = $this->getEnv('REQUEST_METHOD');
-        $override = false;
-
-        if (
-            in_array($method, ['PUT', 'DELETE', 'PATCH'], true) &&
-            strpos((string)$this->contentType(), 'application/x-www-form-urlencoded') === 0
-        ) {
-            $data = $this->input();
-            parse_str($data, $data);
-        }
-        if ($this->hasHeader('X-Http-Method-Override')) {
-            $data['_method'] = $this->getHeaderLine('X-Http-Method-Override');
-            $override = true;
-        }
-        $this->_environment['ORIGINAL_REQUEST_METHOD'] = $method;
-        if (isset($data['_method'])) {
-            $this->_environment['REQUEST_METHOD'] = $data['_method'];
-            unset($data['_method']);
-            $override = true;
-        }
-
-        if ($override && !in_array($this->_environment['REQUEST_METHOD'], ['PUT', 'POST', 'DELETE', 'PATCH'], true)) {
-            $data = [];
-        }
-
-        return $data;
     }
 
     /**

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -62,9 +62,6 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
     ): ServerRequest {
         $server = normalizeServer($server ?: $_SERVER);
         $uri = static::createUri($server);
-        $data = static::processFiles($files ?: $_FILES, $parsedBody ?: $_POST);
-        $files = $data['files'];
-        $parsedBody = $data['parsedBody'];
 
         /** @psalm-suppress NoInterfaceProperties */
         $sessionConfig = (array)Configure::read('Session') + [
@@ -77,29 +74,82 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
         $request = new ServerRequest([
             'environment' => $server,
             'uri' => $uri,
-            'files' => $files,
             'cookies' => $cookies ?: $_COOKIE,
             'query' => $query ?: $_GET,
-            'post' => $parsedBody,
             'webroot' => $uri->webroot,
             'base' => $uri->base,
             'session' => $session,
+            'input' => $server['CAKE_PHP_INPUT'] ?? null,
         ]);
 
+        $request = static::marshalBodyAndRequestMethod($parsedBody ?? $_POST, $request);
+        $request = static::marshalFiles($files ?? $_FILES, $request);
+
         return $request;
+    }
+
+    /**
+     * Sets the REQUEST_METHOD environment variable based on the simulated _method
+     * HTTP override value. The 'ORIGINAL_REQUEST_METHOD' is also preserved, if you
+     * want the read the non-simulated HTTP method the client used.
+     *
+     * Request body of content type "application/x-www-form-urlencoded" is parsed
+     * into array for PUT/PATCH/DELETE requests.
+     *
+     * @param array $parsedBody Parsed body.
+     * @param \Cake\Http\ServerRequest $request Request instance.
+     * @return \Cake\Http\ServerRequest
+     */
+    protected static function marshalBodyAndRequestMethod(array $parsedBody, ServerRequest $request): ServerRequest
+    {
+        $method = $request->getMethod();
+        $override = false;
+
+        if (
+            in_array($method, ['PUT', 'DELETE', 'PATCH'], true) &&
+            strpos((string)$request->contentType(), 'application/x-www-form-urlencoded') === 0
+        ) {
+            $data = (string)$request->getBody();
+            parse_str($data, $parsedBody);
+        }
+        if ($request->hasHeader('X-Http-Method-Override')) {
+            $parsedBody['_method'] = $request->getHeaderLine('X-Http-Method-Override');
+            $override = true;
+        }
+
+        $request = $request->withEnv('ORIGINAL_REQUEST_METHOD', $method);
+        if (isset($parsedBody['_method'])) {
+            $request = $request->withEnv('REQUEST_METHOD', $parsedBody['_method']);
+            unset($parsedBody['_method']);
+            $override = true;
+        }
+
+        if (
+            $override &&
+            !in_array($request->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH'], true)
+        ) {
+            $parsedBody = [];
+        }
+
+        return $request->withParsedBody($parsedBody);
     }
 
     /**
      * Process uploaded files and move things onto the parsed body.
      *
      * @param array $files Files array for normalization and merging in parsed body.
-     * @param array $parsedBody Parsed body to merge files onto.
-     * @return array
-     * @psalm-return array{files: array, parsedBody: array}
+     * @param \Cake\Http\ServerRequest $request Request instance.
+     * @return \Cake\Http\ServerRequest
      */
-    protected static function processFiles(array $files, array $parsedBody): array
+    protected static function marshalFiles(array $files, ServerRequest $request): ServerRequest
     {
         $files = normalizeUploadedFiles($files);
+        $request = $request->withUploadedFiles($files);
+
+        $parsedBody = $request->getParsedBody();
+        if (!is_array($parsedBody)) {
+            return $request;
+        }
 
         if (Configure::read('App.uploadedFilesAsObjects', true)) {
             $parsedBody = Hash::merge($parsedBody, $files);
@@ -122,7 +172,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             }
         }
 
-        return ['files' => $files, 'parsedBody' => $parsedBody];
+        return $request->withParsedBody($parsedBody);
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -294,6 +294,127 @@ class ServerRequestFactoryTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testFormUrlEncodedBodyParsing()
+    {
+        $data = [
+            'Article' => ['title'],
+        ];
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'PUT',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
+            'CAKE_PHP_INPUT' => 'Article[]=title',
+        ]);
+        $this->assertEquals($data, $request->getData());
+
+        $data = ['one' => 1, 'two' => 'three'];
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'PUT',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
+            'CAKE_PHP_INPUT' => 'one=1&two=three',
+        ]);
+        $this->assertEquals($data, $request->getData());
+
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'DELETE',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
+            'CAKE_PHP_INPUT' => 'Article[title]=Testing&action=update',
+        ]);
+        $expected = [
+            'Article' => ['title' => 'Testing'],
+            'action' => 'update',
+        ];
+        $this->assertEquals($expected, $request->getData());
+
+        $data = [
+            'Article' => ['title'],
+            'Tag' => ['Tag' => [1, 2]],
+        ];
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'PATCH',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
+            'CAKE_PHP_INPUT' => 'Article[]=title&Tag[Tag][]=1&Tag[Tag][]=2',
+        ]);
+        $this->assertEquals($data, $request->getData());
+    }
+
+    /**
+     * Test method overrides coming in from POST data.
+     *
+     * @return void
+     */
+    public function testMethodOverrides()
+    {
+        $post = ['_method' => 'POST'];
+        $request = ServerRequestFactory::fromGlobals([], [], $post);
+        $this->assertSame('POST', $request->getEnv('REQUEST_METHOD'));
+
+        $post = ['_method' => 'DELETE'];
+        $request = ServerRequestFactory::fromGlobals([], [], $post);
+        $this->assertSame('DELETE', $request->getEnv('REQUEST_METHOD'));
+
+        $request = ServerRequestFactory::fromGlobals(['HTTP_X_HTTP_METHOD_OVERRIDE' => 'PUT']);
+        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_METHOD' => 'POST'],
+            [],
+            ['_method' => 'PUT']
+        );
+        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
+        $this->assertSame('POST', $request->getEnv('ORIGINAL_REQUEST_METHOD'));
+    }
+
+    /**
+     * Test getServerParams
+     *
+     * @return void
+     */
+    public function testGetServerParams()
+    {
+        $vars = [
+            'REQUEST_METHOD' => 'PUT',
+            'HTTPS' => 'on',
+        ];
+
+        $request = ServerRequestFactory::fromGlobals($vars);
+        $expected = $vars + [
+            'CONTENT_TYPE' => null,
+            'HTTP_CONTENT_TYPE' => null,
+            'ORIGINAL_REQUEST_METHOD' => 'PUT',
+        ];
+        $this->assertSame($expected, $request->getServerParams());
+    }
+
+    /**
+     * Tests that overriding the method to GET will clean all request
+     * data, to better simulate a GET request.
+     *
+     * @return void
+     */
+    public function testMethodOverrideEmptyParsedBody()
+    {
+        $body = ['_method' => 'GET', 'foo' => 'bar'];
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_METHOD' => 'POST'],
+            [],
+            $body
+        );
+        $this->assertEmpty($request->getParsedBody());
+
+        $request = ServerRequestFactory::fromGlobals(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'HTTP_X_HTTP_METHOD_OVERRIDE' => 'GET',
+            ],
+            [],
+            ['foo' => 'bar']
+        );
+        $this->assertEmpty($request->getParsedBody());
+    }
+
+    /**
      * Tests the default file upload merging behavior.
      *
      * @return void

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -272,62 +272,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test parsing PUT data into the object.
-     *
-     * @return void
-     */
-    public function testPutParsing()
-    {
-        $data = [
-            'Article' => ['title'],
-        ];
-        $request = new ServerRequest([
-            'input' => 'Article[]=title',
-            'environment' => [
-                'REQUEST_METHOD' => 'PUT',
-                'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
-            ],
-        ]);
-        $this->assertEquals($data, $request->getData());
-
-        $data = ['one' => 1, 'two' => 'three'];
-        $request = new ServerRequest([
-            'input' => 'one=1&two=three',
-            'environment' => [
-                'REQUEST_METHOD' => 'PUT',
-                'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
-            ],
-        ]);
-        $this->assertEquals($data, $request->getData());
-
-        $request = new ServerRequest([
-            'input' => 'Article[title]=Testing&action=update',
-            'environment' => [
-                'REQUEST_METHOD' => 'DELETE',
-                'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
-            ],
-        ]);
-        $expected = [
-            'Article' => ['title' => 'Testing'],
-            'action' => 'update',
-        ];
-        $this->assertEquals($expected, $request->getData());
-
-        $data = [
-            'Article' => ['title'],
-            'Tag' => ['Tag' => [1, 2]],
-        ];
-        $request = new ServerRequest([
-            'input' => 'Article[]=title&Tag[Tag][]=1&Tag[Tag][]=2',
-            'environment' => [
-                'REQUEST_METHOD' => 'PATCH',
-                'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=UTF-8',
-            ],
-        ]);
-        $this->assertEquals($data, $request->getData());
-    }
-
-    /**
      * Test parsing json PUT data into the object.
      *
      * @return void
@@ -459,32 +403,6 @@ class ServerRequestTest extends TestCase
         $this->expectExceptionMessage('Invalid file at \'user.avatar\'');
         $request = new ServerRequest();
         $request->withUploadedFiles(['user' => ['avatar' => 'not a file']]);
-    }
-
-    /**
-     * Test method overrides coming in from POST data.
-     *
-     * @return void
-     */
-    public function testMethodOverrides()
-    {
-        $post = ['_method' => 'POST'];
-        $request = new ServerRequest(compact('post'));
-        $this->assertSame('POST', $request->getEnv('REQUEST_METHOD'));
-
-        $post = ['_method' => 'DELETE'];
-        $request = new ServerRequest(compact('post'));
-        $this->assertSame('DELETE', $request->getEnv('REQUEST_METHOD'));
-
-        $request = new ServerRequest(['environment' => ['HTTP_X_HTTP_METHOD_OVERRIDE' => 'PUT']]);
-        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
-
-        $request = new ServerRequest([
-            'environment' => ['REQUEST_METHOD' => 'POST'],
-            'post' => ['_method' => 'PUT'],
-        ]);
-        $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
-        $this->assertSame('POST', $request->getEnv('ORIGINAL_REQUEST_METHOD'));
     }
 
     /**
@@ -2197,29 +2115,6 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test getServerParams
-     *
-     * @return void
-     */
-    public function testGetServerParams()
-    {
-        $vars = [
-            'REQUEST_METHOD' => 'PUT',
-            'HTTPS' => 'on',
-        ];
-
-        $request = new ServerRequest([
-            'environment' => $vars,
-        ]);
-        $expected = $vars + [
-            'CONTENT_TYPE' => null,
-            'HTTP_CONTENT_TYPE' => null,
-            'ORIGINAL_REQUEST_METHOD' => 'PUT',
-        ];
-        $this->assertSame($expected, $request->getServerParams());
-    }
-
-    /**
      * Test using param()
      *
      * @return void
@@ -2790,32 +2685,6 @@ XML;
         $_SERVER['CONTENT_TYPE'] = 'application/xml';
         $request = ServerRequestFactory::fromGlobals();
         $this->assertSame('application/xml', $request->contentType(), 'prefer non http header.');
-    }
-
-    /**
-     * Tests that overriding the method to GET will clean all request
-     * data, to better simulate a GET request.
-     *
-     * @return void
-     */
-    public function testMethodOverrideEmptyData()
-    {
-        $post = ['_method' => 'GET', 'foo' => 'bar'];
-        $request = new ServerRequest([
-            'post' => $post,
-            'environment' => ['REQUEST_METHOD' => 'POST'],
-        ]);
-        $this->assertEmpty($request->getData());
-
-        $post = ['_method' => 'GET', 'foo' => 'bar'];
-        $request = new ServerRequest([
-            'post' => ['foo' => 'bar'],
-            'environment' => [
-                'REQUEST_METHOD' => 'POST',
-                'HTTP_X_HTTP_METHOD_OVERRIDE' => 'GET',
-            ],
-        ]);
-        $this->assertEmpty($request->getData());
     }
 
     /**


### PR DESCRIPTION
Parsing of "application/x-www-form-urlencoded" content type for PUT/PATCH/DELETE
methods is also moved to the factory class.

Refs #14213