### PR TITLE
4.next Allows to set single element inside form data

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -273,9 +273,9 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     /**
      * Saves a variable or an associative array of variables for use inside form data.
      *
-     * @param string|array $name A string or an array of data.
-     * @param mixed $value Value in case $name is a string (which then works as the key).
-     *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
+     * @param string|array $name The key to write, can be a dot notation value.
+     * Alternatively can be an array containing key(s) and value(s).
+     * @param mixed $value Value to set for var
      * @return $this
      */
     public function set($name, $value = null)

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -278,8 +278,8 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
      */
-	public function set($name, $value = null) 
-	{
+    public function set($name, $value = null)
+    {
         $write = $name;
         if (!is_array($name)) {
             $write = [$name => $value];
@@ -289,8 +289,8 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
             $this->_data = Hash::insert($this->_data, $key, $val);
         }
 
-		return $this;
-	}
+        return $this;
+    }
 
     /**
      * Set form data.

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -271,6 +271,28 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     }
 
     /**
+     * Saves a variable or an associative array of variables for use inside form data.
+     *
+     * @param string|array $name A string or an array of data.
+     * @param mixed $value Value in case $name is a string (which then works as the key).
+     *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
+     * @return $this
+     */
+	public function set($name, $value = null) 
+	{
+        $write = $name;
+        if (!is_array($name)) {
+            $write = [$name => $value];
+        }
+
+        foreach ($write as $key => $val) {
+            $this->_data = Hash::insert($this->_data, $key, $val);
+        }
+
+		return $this;
+	}
+
+    /**
      * Set form data.
      *
      * @param array $data Data array.

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -196,6 +196,49 @@ class FormTest extends TestCase
     }
 
     /**
+     * Test set() with one param.
+     *
+     * @return void
+     */
+    public function testSetOneParam()
+    {
+        $form = new Form();
+        $data = ['test' => 'val', 'foo' => 'bar'];
+        $form->set($data);
+        $this->assertEquals($data, $form->getData());
+
+        $update = ['test' => 'updated'];
+        $form->set($update);
+        $this->assertSame('updated', $form->getData()['test']);
+    }
+
+    /**
+     * test set() with 2 params
+     *
+     * @return void
+     */
+    public function testSetTwoParam()
+    {
+        $form = new Form();
+        $form->set('testing', 'value');
+        $this->assertEquals(['testing' => 'value'], $form->getData());
+    }
+
+    /**
+     * test chainable set()
+     *
+     * @return void
+     */
+    public function testSetChained()
+    {
+        $form = new Form();
+        $result = $form->set('testing', 'value')
+            ->set('foo', 'bar');
+        $this->assertSame($form, $result);
+        $this->assertEquals(['testing' => 'value', 'foo' => 'bar'], $form->getData());
+    }
+
+    /**
      * Test setting and getting form data.
      *
      * @return void


### PR DESCRIPTION
`public function Form::set()` - Saves a variable or an associative array of variables for use inside form data
Allows to set single element inside form data, similar to `Session::write()`, `Entity::set()` or `View::set()`

Replacement for https://github.com/cakephp/cakephp/pull/13850