### PR TITLE
Move "url" config processing into separate method.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -258,7 +258,7 @@ class ServerRequest implements ServerRequestInterface
 
         if (isset($config['uri'])) {
             if (!$config['uri'] instanceof UriInterface) {
-                throw new Exception('The `uri` key must be an instanceof Psr\Http\Message\UriInterface.');
+                throw new Exception('The `uri` key must be an instance of ' . UriInterface::class);
             }
             $uri = $config['uri'];
         } else {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -285,7 +285,7 @@ class ServerRequest implements ServerRequestInterface
 
         $this->data = $config['post'];
         $this->uploadedFiles = $config['files'];
-        $this->query = $this->_processGet($config['query']);
+        $this->query = $config['query'];
         $this->params = $config['params'];
         $this->session = $config['session'];
     }
@@ -314,20 +314,6 @@ class ServerRequest implements ServerRequestInterface
         $config['environment']['REQUEST_URI'] = $config['url'];
 
         return $config;
-    }
-
-    /**
-     * Process the GET parameters and move things into the object.
-     *
-     * @param array $query The array to which the parsed keys/values are being added.
-     * @return array An array containing the parsed query string as keys/values.
-     */
-    protected function _processGet(array $query): array
-    {
-        $unsetUrl = str_replace(['.', ' '], '_', urldecode($this->uri->getPath()));
-        unset($query[$unsetUrl], $query[$this->base . $unsetUrl]);
-
-        return $query;
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -18,6 +18,7 @@ namespace Cake\Http;
 
 use BadMethodCallException;
 use Cake\Core\Configure;
+use Cake\Core\Exception\Exception;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
@@ -243,10 +244,6 @@ class ServerRequest implements ServerRequestInterface
      */
     protected function _setConfig(array $config): void
     {
-        if (strlen($config['url']) > 1 && $config['url'][0] === '/') {
-            $config['url'] = substr($config['url'], 1);
-        }
-
         if (empty($config['session'])) {
             $config['session'] = new Session([
                 'cookiePath' => $config['base'],
@@ -257,28 +254,21 @@ class ServerRequest implements ServerRequestInterface
             $config['environment']['REQUEST_METHOD'] = 'GET';
         }
 
-        $this->_environment = $config['environment'];
         $this->cookies = $config['cookies'];
 
-        if (isset($config['uri']) && $config['uri'] instanceof UriInterface) {
+        if (isset($config['uri'])) {
+            if (!$config['uri'] instanceof UriInterface) {
+                throw new Exception('The `uri` key must be an instanceof Psr\Http\Message\UriInterface.');
+            }
             $uri = $config['uri'];
         } else {
+            if ($config['url'] !== '') {
+                $config = $this->processUrlOption($config);
+            }
             $uri = ServerRequestFactory::createUri($config['environment']);
         }
 
-        // Extract a query string from config[url] if present.
-        // This is required for backwards compatibility and keeping
-        // UriInterface implementations happy.
-        $querystr = '';
-        if (strpos($config['url'], '?') !== false) {
-            [$config['url'], $querystr] = explode('?', $config['url']);
-        }
-        if (strlen($config['url'])) {
-            $uri = $uri->withPath('/' . $config['url']);
-        }
-        if (strlen($querystr)) {
-            $uri = $uri->withQuery($querystr);
-        }
+        $this->_environment = $config['environment'];
 
         $this->uri = $uri;
         $this->base = $config['base'];
@@ -295,26 +285,47 @@ class ServerRequest implements ServerRequestInterface
 
         $this->data = $config['post'];
         $this->uploadedFiles = $config['files'];
-        $this->query = $this->_processGet($config['query'], $querystr);
+        $this->query = $this->_processGet($config['query']);
         $this->params = $config['params'];
         $this->session = $config['session'];
+    }
+
+    /**
+     * Set environment vars based on `url` option to facilitate UriInterface instance generation.
+     *
+     * `query` option is also updated based on URL's querystring.
+     *
+     * @param array $config Config array.
+     * @return array Update config.
+     */
+    protected function processUrlOption(array $config): array
+    {
+        if ($config['url'][0] !== '/') {
+            $config['url'] = '/' . $config['url'];
+        }
+
+        if (strpos($config['url'], '?') !== false) {
+            [$config['url'], $config['environment']['QUERY_STRING']] = explode('?', $config['url']);
+
+            parse_str($config['environment']['QUERY_STRING'], $queryArgs);
+            $config['query'] += $queryArgs;
+        }
+
+        $config['environment']['REQUEST_URI'] = $config['url'];
+
+        return $config;
     }
 
     /**
      * Process the GET parameters and move things into the object.
      *
      * @param array $query The array to which the parsed keys/values are being added.
-     * @param string $queryString A query string from the URL if provided
      * @return array An array containing the parsed query string as keys/values.
      */
-    protected function _processGet(array $query, string $queryString = ''): array
+    protected function _processGet(array $query): array
     {
         $unsetUrl = str_replace(['.', ' '], '_', urldecode($this->uri->getPath()));
         unset($query[$unsetUrl], $query[$this->base . $unsetUrl]);
-        if (strlen($queryString)) {
-            parse_str($queryString, $queryArgs);
-            $query += $queryArgs;
-        }
 
         return $query;
     }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1569,7 +1569,6 @@ class ServerRequestTest extends TestCase
     public function testGetParamsWithDot()
     {
         $_GET = [];
-        $_GET['/posts/index/add_add'] = '';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
@@ -1577,7 +1576,6 @@ class ServerRequestTest extends TestCase
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
-        $_GET['/cake_dev/posts/index/add_add'] = '';
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/index/add.add';
         $request = ServerRequestFactory::fromGlobals();
@@ -1593,7 +1591,6 @@ class ServerRequestTest extends TestCase
     public function testGetParamWithUrlencodedElement()
     {
         $_GET = [];
-        $_GET['/posts/add/∂∂'] = '';
         $_SERVER['PHP_SELF'] = '/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
@@ -1601,7 +1598,6 @@ class ServerRequestTest extends TestCase
         $this->assertEquals([], $request->getQueryParams());
 
         $_GET = [];
-        $_GET['/cake_dev/posts/add/∂∂'] = '';
         $_SERVER['PHP_SELF'] = '/cake_dev/webroot/index.php';
         $_SERVER['REQUEST_URI'] = '/cake_dev/posts/add/%E2%88%82%E2%88%82';
         $request = ServerRequestFactory::fromGlobals();
@@ -1708,7 +1704,6 @@ class ServerRequestTest extends TestCase
                         'dir' => 'TestApp',
                         'webroot' => 'webroot',
                     ],
-                    'GET' => ['/posts/add' => ''],
                     'SERVER' => [
                         'SCRIPT_NAME' => '/site/index.php',
                         'PATH_TRANSLATED' => 'C:\\Inetpub\\wwwroot',
@@ -1962,13 +1957,11 @@ class ServerRequestTest extends TestCase
                         'dir' => 'TestApp',
                         'webroot' => 'webroot',
                     ],
-                    'GET' => ['/posts/add' => ''],
                     'SERVER' => [
                         'SERVER_NAME' => 'localhost',
                         'DOCUMENT_ROOT' => '/Library/WebServer/Documents/site/webroot',
                         'SCRIPT_FILENAME' => '/Library/WebServer/Documents/site/webroot/index.php',
                         'SCRIPT_NAME' => '/index.php',
-                        'QUERY_STRING' => '/posts/add&',
                         'PHP_SELF' => '/index.php',
                         'PATH_INFO' => null,
                         'REQUEST_URI' => '/posts/add',
@@ -1990,13 +1983,11 @@ class ServerRequestTest extends TestCase
                         'dir' => 'app',
                         'webroot' => 'webroot',
                     ],
-                    'GET' => ['/site/posts/add' => ''],
                     'SERVER' => [
                         'SERVER_NAME' => 'localhost',
                         'DOCUMENT_ROOT' => '/Library/WebServer/Documents',
                         'SCRIPT_FILENAME' => '/Library/WebServer/Documents/site/App/webroot/index.php',
                         'SCRIPT_NAME' => '/site/app/webroot/index.php',
-                        'QUERY_STRING' => '/site/posts/add&',
                         'PHP_SELF' => '/site/webroot/index.php',
                         'PATH_INFO' => null,
                         'REQUEST_URI' => '/site/posts/add',


### PR DESCRIPTION
Refs #14213

Generating the `UriInterface` instance and populating to `$query` property from the `url` option is something that needs to be retained for convenience. There are lot of tests which using the `url` option. 