### PR TITLE
Fix EagerLoader loading optional association with leftJoinWith and contain

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -832,6 +832,9 @@ class EagerLoader
             foreach ($collectKeys as $nestKey => $parts) {
                 if ($parts[2] === true) {
                     // Missed joins will have null in the results.
+                    if (!array_key_exists($parts[1][0], $result)) {
+                        continue;
+                    }
                     // Assign empty array to avoid not found association when optional.
                     if (empty($keys[$nestKey][$parts[0]]) && !isset($result[$parts[1][0]])) {
                         $keys[$nestKey][$parts[0]] = [];
@@ -850,7 +853,6 @@ class EagerLoader
                 $keys[$nestKey][$parts[0]][implode(';', $collected)] = $collected;
             }
         }
-
         $statement->rewind();
 
         return $keys;

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -830,13 +830,15 @@ class EagerLoader
         $keys = [];
         foreach (($statement->fetchAll('assoc') ?: []) as $result) {
             foreach ($collectKeys as $nestKey => $parts) {
-                // Missed joins will have null in the results.
-                if ($parts[2] === true && !isset($result[$parts[1][0]])) {
-                    continue;
-                }
                 if ($parts[2] === true) {
-                    $value = $result[$parts[1][0]];
-                    $keys[$nestKey][$parts[0]][$value] = $value;
+                    // Missed joins will have null in the results.
+                    // Assign empty array to avoid not found association when optional.
+                    if (empty($keys[$nestKey][$parts[0]]) && !isset($result[$parts[1][0]])) {
+                        $keys[$nestKey][$parts[0]] = [];
+                    } else {
+                        $value = $result[$parts[1][0]];
+                        $keys[$nestKey][$parts[0]][$value] = $value;
+                    }
                     continue;
                 }
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -836,8 +836,10 @@ class EagerLoader
                         continue;
                     }
                     // Assign empty array to avoid not found association when optional.
-                    if (empty($keys[$nestKey][$parts[0]]) && !isset($result[$parts[1][0]])) {
-                        $keys[$nestKey][$parts[0]] = [];
+                    if (!isset($result[$parts[1][0]])) {
+                        if (!isset($keys[$nestKey][$parts[0]])) {
+                            $keys[$nestKey][$parts[0]] = [];
+                        }
                     } else {
                         $value = $result[$parts[1][0]];
                         $keys[$nestKey][$parts[0]][$value] = $value;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3417,7 +3417,8 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function testLeftJoinWithAndContainOnOptionalAssociation() {
+    public function testLeftJoinWithAndContainOnOptionalAssociation()
+    {
         $table = $this->getTableLocator()->get('Articles', ['table' => 'articles']);
         $table->belongsTo('Authors');
         $newArticle = $table->newEntity([
@@ -3452,8 +3453,8 @@ class QueryTest extends TestCase
                 'published' => 'Y',
                 'author' => [
                     'id' => 3,
-                    'name' => 'larry'
-                ]
+                    'name' => 'larry',
+                ],
             ],
             [
                 'id' => 3,
@@ -3463,8 +3464,8 @@ class QueryTest extends TestCase
                 'published' => 'Y',
                 'author' => [
                     'id' => 1,
-                    'name' => 'mariano'
-                ]
+                    'name' => 'mariano',
+                ],
             ],
             [
                 'id' => 4,
@@ -3472,8 +3473,8 @@ class QueryTest extends TestCase
                 'title' => 'Fourth Article',
                 'body' => 'Fourth Article Body',
                 'published' => 'N',
-                'author' => null
-            ]
+                'author' => null,
+            ],
         ];
         $this->assertEquals($expected, $results->toList());
         $table->deleteAll([]);
@@ -3496,8 +3497,8 @@ class QueryTest extends TestCase
                 'title' => 'Fourth Article',
                 'body' => 'Fourth Article Body',
                 'published' => 'N',
-                'author' => null
-            ]
+                'author' => null,
+            ],
         ];
         $this->assertEquals($expected, $results->toList());
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3413,6 +3413,104 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test leftJoinWith and contain on optional association
+     *
+     * @return void
+     */
+    public function testLeftJoinWithAndContainOnOptionalAssociation() {
+        $table = $this->getTableLocator()->get('Articles', ['table' => 'articles']);
+        $table->belongsTo('Authors');
+        $newArticle = $table->newEntity([
+            'title' => 'Fourth Article',
+            'body' => 'Fourth Article Body',
+            'published' => 'N',
+        ]);
+        $table->save($newArticle);
+        $results = $table
+            ->find()
+            ->disableHydration()
+            ->contain('Authors')
+            ->leftJoinWith('Authors')
+            ->all();
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+                'title' => 'First Article',
+                'body' => 'First Article Body',
+                'published' => 'Y',
+                'author' => [
+                    'id' => 1,
+                    'name' => 'mariano',
+                ],
+            ],
+            [
+                'id' => 2,
+                'author_id' => 3,
+                'title' => 'Second Article',
+                'body' => 'Second Article Body',
+                'published' => 'Y',
+                'author' => [
+                    'id' => 3,
+                    'name' => 'larry'
+                ]
+            ],
+            [
+                'id' => 3,
+                'author_id' => 1,
+                'title' => 'Third Article',
+                'body' => 'Third Article Body',
+                'published' => 'Y',
+                'author' => [
+                    'id' => 1,
+                    'name' => 'mariano'
+                ]
+            ],
+            [
+                'id' => 4,
+                'author_id' => null,
+                'title' => 'Fourth Article',
+                'body' => 'Fourth Article Body',
+                'published' => 'N',
+                'author' => null
+            ]
+        ];
+        $this->assertEquals($expected, $results->toList());
+        $table->deleteAll([]);
+        $newArticle = $table->newEntity([
+            'title' => 'Fourth Article',
+            'body' => 'Fourth Article Body',
+            'published' => 'N',
+        ]);
+        $table->save($newArticle);
+        $results = $table
+            ->find()
+            ->disableHydration()
+            ->contain('Authors')
+            ->leftJoinWith('Authors')
+            ->all();
+        $expected = [
+            [
+                'id' => 5,
+                'author_id' => null,
+                'title' => 'Fourth Article',
+                'body' => 'Fourth Article Body',
+                'published' => 'N',
+                'author' => null
+            ]
+        ];
+        $this->assertEquals($expected, $results->toList());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Tags association is not defined on Articles');
+        $table
+            ->find()
+            ->disableHydration()
+            ->contain('Tags')
+            ->leftJoinWith('Tags')
+            ->all();
+    }
+
+    /**
      * Tests innerJoinWith()
      *
      * @return void

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3477,22 +3477,16 @@ class QueryTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $results->toList());
-        $table->deleteAll([]);
-        $newArticle = $table->newEntity([
-            'title' => 'Fourth Article',
-            'body' => 'Fourth Article Body',
-            'published' => 'N',
-        ]);
-        $table->save($newArticle);
         $results = $table
             ->find()
             ->disableHydration()
             ->contain('Authors')
             ->leftJoinWith('Authors')
+            ->where(['Articles.author_id is' => null])
             ->all();
         $expected = [
             [
-                'id' => 5,
+                'id' => 4,
                 'author_id' => null,
                 'title' => 'Fourth Article',
                 'body' => 'Fourth Article Body',


### PR DESCRIPTION
Solves #14281 

It seems to work.

I added a test on ORM/QueryTest.php to check:
- If it works when there's some results with the associated filled and some not (this already worked as intended).
- If it works when all the results have a null associate (this was the case that needed a fix).
- If the table doesn't have an association (the exception that was thrown before).

I really don't know if it is on the right place and if it is a good enough test.