### PR TITLE
Change para method of HtmlHelper to accept $class as null

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -863,12 +863,12 @@ class HtmlHelper extends Helper
      *
      * - `escape` Whether or not the contents should be html_entity escaped.
      *
-     * @param string $class CSS class name of the p element.
+     * @param string|null $class CSS class name of the p element.
      * @param string|null $text String content that will appear inside the p element.
      * @param array $options Additional HTML attributes of the P tag
      * @return string The formatted P element
      */
-    public function para(string $class, ?string $text, array $options = []): string
+    public function para(?string $class, ?string $text, array $options = []): string
     {
         if (!empty($options['escape'])) {
             $text = h($text);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1888,8 +1888,12 @@ class HtmlHelperTest extends TestCase
      */
     public function testPara()
     {
-        $result = $this->Html->para('class-name', '');
+        $result = $this->Html->para('class-name', null);
         $expected = ['p' => ['class' => 'class-name']];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->para('class-name', '');
+        $expected = ['p' => ['class' => 'class-name'], '/p'];
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->para('class-name', 'text');
@@ -1902,6 +1906,14 @@ class HtmlHelperTest extends TestCase
 
         $result = $this->Html->para('class-name', 'text"', ['escape' => false]);
         $expected = ['p' => ['class' => 'class-name'], 'text"', '/p'];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->para(null, null);
+        $expected = ['p' => []];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->para(null, 'text');
+        $expected = ['p' => [], 'text', '/p'];
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
Closes #14225 

Simply change on the docblock, method signature and add a test case to cover the change.

But I'm wondering if the assertHtml has an issue or it's working as intended as the docblock of the method mentions his forgiven nature. As noted below the method appears to be ignoring the last closing tag when empty. It works fine comparing with any given tag. But it can't check if the returned html is properly closed.

```php
$result = $this->Html->para('class-name', null); // '<p class="class-name">'
$expected = ['p' => ['class' => 'class-name']]; // the result doesn't have a closing tag
$this->assertHtml($expected, $result); //true
```
```php
$result = $this->Html->para('class-name', ''); //'<p class="class-name"></p>'
$expected = ['p' => ['class' => 'class-name']]; //missing the closing p tag
$this->assertHtml($expected, $result); //true
```