### PR TITLE
AJAX Flash Header support (if AJAX HTTP request contains "X-Get-Flash: yes")

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -73,7 +73,7 @@ class FlashComponent extends Component
             return null;
         }
 
-        $flash = $session->read("Flash.$key");
+        $flash = $session->read("Flash");
         if (!is_array($flash)) {
             throw new UnexpectedValueException('Value for Flash setting must be an array');
         }
@@ -81,11 +81,17 @@ class FlashComponent extends Component
 
 		$array = [];
 		foreach ($flash as $key => $stack) {
+            if (!is_array($stack)) {
+                throw new UnexpectedValueException(sprintf(
+                    'Value for flash setting key "%s" must be an array.',
+                    $key
+                ));
+            }
 			foreach ($stack as $message) {
 				$array[$key][] = [
-					'message' => $message['message'],
-					'type' => $message['type'],
-					'params' => $message['params'],
+					'message' => $message['message'] ?? null,
+					'type' => $message['type'] ?? null,
+					'params' => $message['params'] ?? null,
 				];
 			}
 		}

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Event\Event;
+use Cake\Event\EventInterface;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Session;
 use Cake\Utility\Inflector;
@@ -47,27 +47,30 @@ class FlashComponent extends Component
         'duplicate' => true,
     ];
 
-	/**
-	 * Called after the Controller::beforeRender(), after the view class is loaded, and before the
-	 * Controller::render()
-	 *
-	 * @param \Cake\Event\Event $event
-	 * @return \Cake\Http\Response|null
-	 */
-	public function beforeRender(Event $event) {
-		/** @var \Cake\Controller\Controller $controller */
-		$controller = $event->getSubject();
+    /**
+     * Called after the Controller::beforeRender(), after the view class is loaded, and before the
+     * Controller::render()
+     *
+     * @param EventInterface $event Event.
+     * @return \Cake\Http\Response|null
+     */
+    public function beforeRender(EventInterface $event)
+    {
+        /** @var \Cake\Controller\Controller $controller */
+        $controller = $event->getSubject();
 
         if (!$controller->getRequest()->is('ajax')) {
-			return null;
-		}
+            return null;
+        }
 
-        if (!in_array('yes', array_map( // case insensitive
-			'strtolower',
-			$controller->getRequest()->getHeader('X-Get-Flash')
-		), true)) {
-			return null;
-		}
+        if (
+            !in_array('yes', array_map( // case insensitive
+                'strtolower',
+                $controller->getRequest()->getHeader('X-Get-Flash')
+            ), true)
+        ) {
+            return null;
+        }
 
         $session = $controller->getRequest()->getSession();
 
@@ -81,28 +84,28 @@ class FlashComponent extends Component
         }
         $session->delete('Flash');
 
-		$array = [];
-		foreach ($flash as $key => $stack) {
+        $array = [];
+        foreach ($flash as $key => $stack) {
             if (!is_array($stack)) {
                 throw new UnexpectedValueException(sprintf(
                     'Value for flash setting key "%s" must be an array.',
                     $key
                 ));
             }
-			foreach ($stack as $message) {
-				$array[$key][] = [
-					'message' => $message['message'] ?? null,
-					'type' => $message['type'] ?? null,
-					'params' => $message['params'] ?? null,
-				];
-			}
-		}
+            foreach ($stack as $message) {
+                $array[$key][] = [
+                    'message' => $message['message'] ?? null,
+                    'type' => $message['type'] ?? null,
+                    'params' => $message['params'] ?? null,
+                ];
+            }
+        }
 
-		// The header can be processed by the client side JavaScript to display flash messages
-		$this->getController()->setResponse($controller->getResponse()->withHeader('X-Flash', json_encode($array)));
+        // The header can be processed by the client side JavaScript to display flash messages
+        $this->getController()->setResponse($controller->getResponse()->withHeader('X-Flash', json_encode($array)));
 
-		return null;
-	}
+        return null;
+    }
 
     /**
      * Used to set a session variable that can be used to output messages in the view.

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -22,7 +22,7 @@ use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Session;
 use Cake\Utility\Inflector;
 use Exception;
-use http\Exception\UnexpectedValueException;
+use UnexpectedValueException;
 
 /**
  * The CakePHP FlashComponent provides a way for you to write a flash variable

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -52,7 +52,7 @@ class FlashComponent extends Component
      * Called after the Controller::beforeRender(), after the view class is loaded, and before the
      * Controller::render()
      *
-     * @param EventInterface $event Event.
+     * @param \Cake\Event\EventInterface $event Event.
      * @return \Cake\Http\Response|null
      */
     public function beforeRender(EventInterface $event)

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Event\Event;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Session;
 use Cake\Utility\Inflector;
@@ -40,6 +41,7 @@ class FlashComponent extends Component
     protected $_defaultConfig = [
         'key' => 'flash',
         'element' => 'default',
+        'type' => 'default',
         'params' => [],
         'clear' => false,
         'duplicate' => true,
@@ -162,6 +164,7 @@ class FlashComponent extends Component
         $messages[] = [
             'message' => $message,
             'key' => $options['key'],
+            'type' => $options['type'],
             'element' => $options['element'],
             'params' => $options['params'],
         ];
@@ -199,7 +202,7 @@ class FlashComponent extends Component
             throw new InternalErrorException('Flash message missing.');
         }
 
-        $options = ['element' => $element];
+        $options = ['element' => $element, 'type' => $name];
 
         if (!empty($args[1])) {
             if (!empty($args[1]['plugin'])) {

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -22,6 +22,7 @@ use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Session;
 use Cake\Utility\Inflector;
 use Exception;
+use http\Exception\UnexpectedValueException;
 
 /**
  * The CakePHP FlashComponent provides a way for you to write a flash variable

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -328,7 +328,8 @@ class FlashComponentTest extends TestCase
     /**
      * @return void
      */
-    public function testAjax() {
+    public function testAjax()
+    {
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
         $this->Controller->getRequest()->getSession()->write('Foo', 'bar');
 


### PR DESCRIPTION
At times, it would be useful if flash messages could also be sent with AJAX responses. These would need to be handled client side with javascript notifying the user of the message.