### PR TITLE
Allow whitespace grouping separators in decimal values.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -751,7 +751,12 @@ class Validation
         $decimalPoint = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupingSep = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
-        $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], (string)$check);
+        // There are two types of non-breaking spaces - we inject a space to account for human input
+        if ($groupingSep == "\xc2\xa0" || $groupingSep == "\xe2\x80\xaf") {
+            $check = str_replace([' ', $groupingSep, $decimalPoint], ['', '', '.'], (string)$check);
+        } else {
+            $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], (string)$check);
+        }
 
         return static::_check($check, $regex);
     }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2034,11 +2034,14 @@ class ValidationTest extends TestCase
         $this->skipIf(DS === '\\', 'The locale is not supported in Windows and affects other tests.');
         $this->skipIf(Locale::setDefault('da_DK') === false, "The Danish locale isn't available.");
 
-        $this->assertTrue(Validation::decimal(1.54), '1.54 should be considered a valid float');
-        $this->assertTrue(Validation::decimal('1.54'), '"1.54" should be considered a valid float');
+        $this->assertTrue(Validation::decimal(1.54), '1.54 should be considered a valid decimal');
+        $this->assertTrue(Validation::decimal('1.54'), '"1.54" should be considered a valid decimal');
 
-        $this->assertTrue(Validation::decimal(12345.67), '12345.67 should be considered a valid float');
-        $this->assertTrue(Validation::decimal('12,345.67'), '"12,345.67" should be considered a valid float');
+        $this->assertTrue(Validation::decimal(12345.67), '12345.67 should be considered a valid decimal');
+        $this->assertTrue(Validation::decimal('12,345.67'), '"12,345.67" should be considered a valid decimal');
+
+        $this->skipIf(Locale::setDefault('pl_PL') === false, "The Polish locale isn't available.");
+        $this->assertTrue(Validation::decimal('1 200,99'), 'should be considered a valid decimal');
     }
 
     /**


### PR DESCRIPTION
Backport fixes from #14256 - accounting for human input in decimal validation and whitespace grouping separators to 4.x.