### PR TITLE
Remove use of deprecated File and Folder classes from tests

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -143,8 +143,8 @@ class Filesystem
             $success = @file_put_contents($filename, $content, LOCK_EX);
         }
 
-        if (!$success) {
-            throw new Exception(sprintf('Failed dumping content to file "%s"', $dir));
+        if ($success === false) {
+            throw new Exception(sprintf('Failed dumping content to file `%s`', $dir));
         }
 
         if (!$exists) {

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -18,7 +18,7 @@ namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 
@@ -78,8 +78,8 @@ class ConsoleIoTest extends TestCase
     {
         parent::tearDown();
         if (is_dir(TMP . 'shell_test')) {
-            $folder = new Folder(TMP . 'shell_test');
-            $folder->delete();
+            $fs = new Filesystem();
+            $fs->deleteDir(TMP . 'shell_test');
         }
     }
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -20,7 +20,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Exception\StopException;
 use Cake\Console\Shell;
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\TestSuite\TestCase;
 use RuntimeException;
 use TestApp\Shell\MergeShell;
@@ -64,6 +64,11 @@ class ShellTest extends TestCase
     protected $io;
 
     /**
+     * @var \Cake\Filesystem\Filesystem
+     */
+    protected $fs;
+
+    /**
      * setUp method
      *
      * @return void
@@ -77,9 +82,10 @@ class ShellTest extends TestCase
             ->getMock();
         $this->Shell = new ShellTestShell($this->io, $this->getTableLocator());
 
+        $this->fs = new Filesystem();
+
         if (is_dir(TMP . 'shell_test')) {
-            $Folder = new Folder(TMP . 'shell_test');
-            $Folder->delete();
+            $this->fs->deleteDir(TMP . 'shell_test');
         }
     }
 
@@ -490,7 +496,7 @@ class ShellTest extends TestCase
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         $contents = "<?php{$eol}echo 'test';${eol}\$te = 'st';{$eol}";
 
@@ -517,7 +523,7 @@ class ShellTest extends TestCase
         touch($file);
         $this->assertFileExists($file);
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         $contents = "<?php{$eol}echo 'test';${eol}\$te = 'st';{$eol}";
         $this->Shell->interactive = false;
@@ -535,7 +541,7 @@ class ShellTest extends TestCase
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         $this->io->expects($this->once())
             ->method('askChoice')
@@ -561,7 +567,7 @@ class ShellTest extends TestCase
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         $this->io->expects($this->once())
             ->method('askChoice')
@@ -588,7 +594,7 @@ class ShellTest extends TestCase
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         touch($file);
         $this->assertFileExists($file);
@@ -616,7 +622,7 @@ class ShellTest extends TestCase
             $path . DS . 'file3.php' => 'My third content',
         ];
 
-        new Folder($path, true);
+        $this->fs->mkdir($path);
 
         $this->io->expects($this->once())
             ->method('askChoice')

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -69,6 +69,10 @@ class FilesystemTest extends TestCase
 
         $this->fs->dumpFile($path, 'bar');
         $this->assertEquals(file_get_contents($path), 'bar');
+
+        $path = $this->vfsPath . DS . 'empty.txt';
+        $this->fs->dumpFile($path, '');
+        $this->assertSame(file_get_contents($path), '');
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestSuiteTest.php
+++ b/tests/TestCase/TestSuite/TestSuiteTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Filesystem\Folder;
+use Cake\Filesystem\Filesystem;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -74,11 +74,13 @@ class TestSuiteTest extends TestCase
     {
         $this->skipIf(!is_writable(TMP), 'Cant addTestDirectoryRecursiveWithHidden unless the tmp folder is writable.');
 
-        $Folder = new Folder(TMP . 'MyTestFolder', true, 0777);
-        mkdir($Folder->path . DS . '.svn', 0777, true);
-        touch($Folder->path . DS . '.svn/InHiddenFolderTest.php');
-        touch($Folder->path . DS . 'NotHiddenTest.php');
-        touch($Folder->path . DS . '.HiddenTest.php');
+        $path = TMP . 'MyTestFolder';
+        $fs = new Filesystem();
+        $fs->mkdir($path);
+        mkdir($path . DS . '.svn', 0777, true);
+        touch($path . DS . '.svn/InHiddenFolderTest.php');
+        touch($path . DS . 'NotHiddenTest.php');
+        touch($path . DS . '.HiddenTest.php');
 
         $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
             ->setMethods(['addTestFile'])
@@ -87,9 +89,9 @@ class TestSuiteTest extends TestCase
             ->expects($this->exactly(1))
             ->method('addTestFile');
 
-        $suite->addTestDirectoryRecursive($Folder->pwd());
+        $suite->addTestDirectoryRecursive($path);
 
-        $Folder->delete();
+        $fs->deleteDir($path);
     }
 
     /**
@@ -101,10 +103,12 @@ class TestSuiteTest extends TestCase
     {
         $this->skipIf(!is_writable(TMP), 'Cant addTestDirectoryRecursiveWithNonPhp unless the tmp folder is writable.');
 
-        $Folder = new Folder(TMP . 'MyTestFolder', true, 0777);
-        touch($Folder->path . DS . 'BackupTest.php~');
-        touch($Folder->path . DS . 'SomeNotesTest.txt');
-        touch($Folder->path . DS . 'NotHiddenTest.php');
+        $path = TMP . 'MyTestFolder';
+        $fs = new Filesystem();
+        $fs->mkdir($path);
+        touch($path . DS . 'BackupTest.php~');
+        touch($path . DS . 'SomeNotesTest.txt');
+        touch($path . DS . 'NotHiddenTest.php');
 
         $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
             ->setMethods(['addTestFile'])
@@ -113,8 +117,8 @@ class TestSuiteTest extends TestCase
             ->expects($this->exactly(1))
             ->method('addTestFile');
 
-        $suite->addTestDirectoryRecursive($Folder->pwd());
+        $suite->addTestDirectoryRecursive($path);
 
-        $Folder->delete();
+        $fs->deleteDir($path);
     }
 }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Validation;
 
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
-use Cake\Filesystem\File;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
@@ -2684,9 +2683,6 @@ class ValidationTest extends TestCase
     public function testMimeType()
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
-        $File = new File($image, false);
-
-        $this->skipIf(!$File->mime(), 'Cannot determine mimeType');
 
         $this->assertTrue(Validation::mimeType($image, ['image/gif']));
         $this->assertTrue(Validation::mimeType(['tmp_name' => $image], ['image/gif']));
@@ -2706,9 +2702,6 @@ class ValidationTest extends TestCase
     public function testMimeTypeCaseInsensitive()
     {
         $algol68 = CORE_TESTS . 'Fixture/sample.a68';
-        $File = new File($algol68, false);
-
-        $this->skipIf($File->mime() != 'text/x-Algol68', 'Cannot determine text/x-Algol68 mimeType');
 
         $this->assertTrue(Validation::mimeType($algol68, ['text/x-Algol68']));
         $this->assertTrue(Validation::mimeType($algol68, ['text/x-algol68']));
@@ -2743,8 +2736,6 @@ class ValidationTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $image = CORE_TESTS . 'invalid-file.png';
-        $File = new File($image, false);
-        $this->skipIf($File->mime(), 'mimeType can be determined, no Exception will be thrown');
         Validation::mimeType($image, ['image/gif']);
     }
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -18,7 +18,7 @@ namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Filesystem\File;
+use Cake\Filesystem\Filesystem;
 use Cake\Http\ServerRequest;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
@@ -518,7 +518,8 @@ class HtmlHelperTest extends TestCase
         $this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
 
         $testfile = WWW_ROOT . 'test_theme/img/__cake_test_image.gif';
-        $File = new File($testfile, true);
+        $fs = new Filesystem();
+        $fs->dumpFile($testfile, '');
 
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', true);
@@ -544,7 +545,9 @@ class HtmlHelperTest extends TestCase
             'alt' => '',
         ]];
         $this->assertHtml($expected, $result);
-        $File->delete();
+
+        // phpcs:ignore
+        @unlink($testfile);
     }
 
     /**
@@ -1135,8 +1138,9 @@ class HtmlHelperTest extends TestCase
     {
         $this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
 
-        $testfile = WWW_ROOT . '/test_theme/js/__test_js.js';
-        $File = new File($testfile, true);
+        $testfile = WWW_ROOT . 'test_theme/js/__test_js.js';
+        $fs = new Filesystem();
+        $fs->dumpFile($testfile, '');
 
         $request = Router::getRequest()->withAttribute('webroot', '/');
         Router::setRequest($request);
@@ -1146,7 +1150,9 @@ class HtmlHelperTest extends TestCase
             'script' => ['src' => '/test_theme/js/__test_js.js'],
         ];
         $this->assertHtml($expected, $result);
-        $File->delete();
+
+        // phpcs:ignore
+        @unlink($testfile);
     }
 
     /**


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
