### PR TITLE
Fix examples around prefix casing

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -291,7 +291,7 @@ class RouteBuilder
      * Admin prefix:
      *
      * ```
-     * Router::prefix('admin', function ($routes) {
+     * Router::prefix('Admin', function ($routes) {
      *   $routes->resources('Articles');
      * });
      * ```
@@ -821,8 +821,8 @@ class RouteBuilder
      * for $params argument:
      *
      * ```
-     * $route->prefix('api', function($route) {
-     *     $route->prefix('v10', ['path' => '/v1.0'], function($route) {
+     * $route->prefix('Api', function($route) {
+     *     $route->prefix('V10', ['path' => '/v1.0'], function($route) {
      *         // Translates to `Controller\Api\V10\` namespace
      *     });
      * });

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -831,14 +831,14 @@ class Router
      * relevant prefix information.
      *
      * The path parameter is used to generate the routing parameter name.
-     * For example a path of `admin` would result in `'prefix' => 'admin'` being
+     * For example a path of `admin` would result in `'prefix' => 'Admin'` being
      * applied to all connected routes.
      *
      * The prefix name will be inflected to the dasherized version to create
      * the routing path. If you want a custom path name, use the `path` option.
      *
      * You can re-open a prefix as many times as necessary, as well as nest prefixes.
-     * Nested prefixes will result in prefix values like `admin/api` which translates
+     * Nested prefixes will result in prefix values like `Admin/Api` which translates
      * to the `Controller\Admin\Api\` namespace.
      *
      * @param string $name The prefix name to use.

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -463,7 +463,7 @@ class RouteBuilderTest extends TestCase
     public function testPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', ['param' => 'value'], function ($r) {
+        $res = $routes->prefix('admin', ['param' => 'value'], function (RouteBuilder $r) {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
@@ -480,7 +480,7 @@ class RouteBuilderTest extends TestCase
     public function testPrefixWithNoParams()
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', function ($r) {
+        $res = $routes->prefix('admin', function (RouteBuilder $r) {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
@@ -497,7 +497,7 @@ class RouteBuilderTest extends TestCase
     public function testNestedPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
-        $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function ($r) {
+        $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function (RouteBuilder $r) {
             $this->assertSame('/admin/api', $r->path());
             $this->assertEquals(['prefix' => 'admin/Api'], $r->params());
             $this->assertSame('api:', $r->namePrefix());
@@ -512,14 +512,14 @@ class RouteBuilderTest extends TestCase
      */
     public function testPathWithDotInPrefix()
     {
-        $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
-        $res = $routes->prefix('api', function ($r) {
-            $r->prefix('v10', ['path' => '/v1.0'], function ($r2) {
+        $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'Admin']);
+        $res = $routes->prefix('Api', function (RouteBuilder $r) {
+            $r->prefix('v10', ['path' => '/v1.0'], function (RouteBuilder $r2) {
                 $this->assertSame('/admin/api/v1.0', $r2->path());
-                $this->assertEquals(['prefix' => 'admin/Api/V10'], $r2->params());
-                $r2->prefix('b1', ['path' => '/beta.1'], function ($r3) {
+                $this->assertEquals(['prefix' => 'Admin/Api/V10'], $r2->params());
+                $r2->prefix('b1', ['path' => '/beta.1'], function (RouteBuilder $r3) {
                     $this->assertSame('/admin/api/v1.0/beta.1', $r3->path());
-                    $this->assertEquals(['prefix' => 'admin/Api/V10/B1'], $r3->params());
+                    $this->assertEquals(['prefix' => 'Admin/Api/V10/B1'], $r3->params());
                 });
             });
         });
@@ -534,7 +534,7 @@ class RouteBuilderTest extends TestCase
     public function testNestedPlugin()
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
-        $res = $routes->plugin('Contacts', function ($r) {
+        $res = $routes->plugin('Contacts', function (RouteBuilder $r) {
             $this->assertSame('/b/contacts', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
 
@@ -556,7 +556,7 @@ class RouteBuilderTest extends TestCase
     public function testNestedPluginPathOption()
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
-        $routes->plugin('Contacts', ['path' => '/people'], function ($r) {
+        $routes->plugin('Contacts', ['path' => '/people'], function (RouteBuilder $r) {
             $this->assertSame('/b/people', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
         });


### PR DESCRIPTION
I found a few misleading examples

- refs https://github.com/cakephp/cakephp/issues/14282

Still wont fix router->connect() issues around casing though.