### PR TITLE
Fix HasMany::_saveTarget method assign property to wrong entity

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -21,6 +21,7 @@ use Cake\Collection\Collection;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\InvalidPropertyInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectLoader;
 use Cake\ORM\Query;
@@ -197,9 +198,10 @@ class HasMany extends Association
      * target entity, and the parent entity.
      * @param \Cake\Datasource\EntityInterface $parentEntity The source entity containing the target
      * entities to be saved.
-     * @param array $entities list of entities to persist in target table and to
-     * link to the parent entity
+     * @param \Cake\Datasource\EntityInterface[]|\Cake\Datasource\InvalidPropertyInterface[] $entities list of entities
+     * to persist in target table and to link to the parent entity
      * @param array $options list of options accepted by `Table::save()`.
+     *
      * @return bool `true` on success, `false` otherwise.
      */
     protected function _saveTarget(
@@ -231,8 +233,12 @@ class HasMany extends Association
             }
 
             if (!empty($options['atomic'])) {
-                $original[$k]->setErrors($entity->getErrors());
-                $original[$k]->setInvalid($entity->getInvalid());
+                if ($original[$k] instanceof EntityInterface && $entity instanceof EntityInterface) {
+                    $original[$k]->setErrors($entity->getErrors());
+                }
+                if ($original[$k] instanceof InvalidPropertyInterface && $entity instanceof InvalidPropertyInterface) {
+                    $original[$k]->setInvalid($entity->getInvalid());
+                }
 
                 return false;
             }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -232,6 +232,7 @@ class HasMany extends Association
 
             if (!empty($options['atomic'])) {
                 $original[$k]->setErrors($entity->getErrors());
+                $original[$k]->setInvalid($entity->getInvalid());
                 return false;
             }
         }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -233,6 +233,7 @@ class HasMany extends Association
             if (!empty($options['atomic'])) {
                 $original[$k]->setErrors($entity->getErrors());
                 $original[$k]->setInvalid($entity->getInvalid());
+
                 return false;
             }
         }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -232,8 +232,6 @@ class HasMany extends Association
 
             if (!empty($options['atomic'])) {
                 $original[$k]->setErrors($entity->getErrors());
-                $entity->set($this->getProperty(), $original);
-
                 return false;
             }
         }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -964,7 +964,8 @@ class HasManyTest extends TestCase
      *
      * @return void
      */
-    public function testSaveAssociatedWithFailedRuleOnAssociated() {
+    public function testSaveAssociatedWithFailedRuleOnAssociated()
+    {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('Comments');
         $comments = $this->getTableLocator()->get('Comments');
@@ -980,7 +981,7 @@ class HasManyTest extends TestCase
                     'comment' => 'That is true!',
                 ],
                 [
-                    'user_id' => 999,// This rule will fail because the user doesn't exist
+                    'user_id' => 999, // This rule will fail because the user doesn't exist
                     'comment' => 'Of course',
                 ],
             ],

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -45,6 +45,7 @@ class HasManyTest extends TestCase
         'core.Comments',
         'core.Articles',
         'core.Authors',
+        'core.Users',
         'core.ArticlesTags',
         'core.Tags',
     ];
@@ -955,6 +956,47 @@ class HasManyTest extends TestCase
             'contain' => ['Comments'],
         ]);
         $this->assertEmpty($entity->get('comments'));
+    }
+
+    /**
+     * Test that the associated entities are not saved when there's any rule
+     * that fail on them and the errors are correctly set on the original entity.
+     *
+     * @return void
+     */
+    public function testSaveAssociatedWithFailedRuleOnAssociated() {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->hasMany('Comments');
+        $comments = $this->getTableLocator()->get('Comments');
+        $comments->belongsTo('Users');
+        $rules = $comments->rulesChecker();
+        $rules->add($rules->existsIn('user_id', 'Users'));
+        $article = $articles->newEntity([
+            'title' => 'Bakeries are sky rocketing',
+            'body' => 'All because of cake',
+            'comments' => [
+                [
+                    'user_id' => 1,
+                    'comment' => 'That is true!',
+                ],
+                [
+                    'user_id' => 999,// This rule will fail because the user doesn't exist
+                    'comment' => 'Of course',
+                ],
+            ],
+        ], ['associated' => ['Comments']]);
+        $this->assertFalse($article->hasErrors());
+        $this->assertFalse($articles->save($article, ['associated' => ['Comments']]));
+        $this->assertTrue($article->hasErrors());
+        $this->assertFalse($article->comments[0]->hasErrors());
+        $this->assertTrue($article->comments[1]->hasErrors());
+        $this->assertNotEmpty($article->comments[1]->getErrors());
+        $expected = [
+            'user_id' => [
+                '_existsIn' => __('This value does not exist'),
+            ],
+        ];
+        $this->assertEquals($expected, $article->comments[1]->getErrors());
     }
 
     /**


### PR DESCRIPTION
Fixes #14303 

- Simple removal of the unnecessary set of property on entity.
- Add test case to cover it.
- Set _invalid content of original entity according to the value of the cloned one.

There's a reason for the getInvalid()/setInvalid() is not part of the EntityInterface?