### PR TITLE
Improve error message when driver cannot connect to database.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -230,15 +230,24 @@ class Connection implements ConnectionInterface
     /**
      * Connects to the configured database.
      *
-     * @throws \Cake\Database\Exception\MissingConnectionException if credentials are invalid.
+     * @throws \Cake\Database\Exception\MissingConnectionException If database connection could not be established.
      * @return bool true, if the connection was already established or the attempt was successful.
      */
     public function connect(): bool
     {
         try {
             return $this->_driver->connect();
+        } catch (MissingConnectionException $e) {
+            throw $e;
         } catch (Throwable $e) {
-            throw new MissingConnectionException(['reason' => $e->getMessage()], null, $e);
+            throw new MissingConnectionException(
+                [
+                    'driver' => App::shortName(get_class($this->_driver), 'Database/Driver'),
+                    'reason' => $e->getMessage(),
+                ],
+                null,
+                $e
+            );
         }
     }
 

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -30,6 +30,7 @@ interface DriverInterface
     /**
      * Establishes a connection to the database server.
      *
+     * @throws \Cake\Database\Exception\MissingConnectionException If database connection could not be established.
      * @return bool True on success, false on failure.
      */
     public function connect(): bool;

--- a/src/Database/Exception/MissingConnectionException.php
+++ b/src/Database/Exception/MissingConnectionException.php
@@ -26,5 +26,5 @@ class MissingConnectionException extends Exception
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Connection to database could not be established: %s';
+    protected $_messageTemplate = 'Connection to %s could not be established: %s';
 }

--- a/templates/Error/missing_connection.php
+++ b/templates/Error/missing_connection.php
@@ -17,15 +17,7 @@ $this->layout = 'dev_error';
 $this->assign('templateName', 'missing_connection.php');
 $this->assign('title', 'Missing Database Connection');
 
-
-$this->start('subheading'); ?>
-A Database connection using was missing or unable to connect.
-<br>
-<?php
-if (isset($reason)):
-    echo sprintf('The database server returned this error: %s', h($reason));
-endif;
-$this->end();
+$this->assign('subheading', h($message));
 
 $this->start('file');
 echo $this->element('auto_table_warning');

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database;
 
 use Cake\Cache\Engine\NullEngine;
 use Cake\Collection\Collection;
+use Cake\Core\App;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
@@ -210,7 +211,13 @@ class ConnectionTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertStringStartsWith('Connection to database could not be established:', $e->getMessage());
+        $this->assertStringStartsWith(
+            sprintf(
+                'Connection to %s could not be established:',
+                App::shortName(get_class($connection->getDriver()), 'Database/Driver')
+            ),
+            $e->getMessage()
+        );
         $this->assertInstanceOf('PDOException', $e->getPrevious());
     }
 


### PR DESCRIPTION
There are various places where Driver::connect() is called directly and not through Connection::connect().
So making Driver::connect() itself deal with PDOException allows showing a better error message.

Refs #14307

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
