### PR TITLE
3.8 - Include file and line information in ErrorHandler

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -172,9 +172,11 @@ class ErrorHandler extends BaseErrorHandler
         // Disable trace for internal errors.
         $this->_options['trace'] = false;
         $message = sprintf(
-            "[%s] %s\n%s", // Keeping same message format
+            "[%s] %s (%s:%s)\n%s", // Keeping same message format
             get_class($exception),
             $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine(),
             $exception->getTraceAsString()
         );
         trigger_error($message, E_USER_ERROR);


### PR DESCRIPTION
Related: #13717

Before:
`2020-02-21 11:03:13 Error: Fatal Error (256): [ParseError] syntax error, unexpected ','`

After:
`2020-02-21 10:51:34 Error: Fatal Error (256): [ParseError] syntax error, unexpected ',' (/home/rachman/sites/api.test/config/routes.php:114)`
