### PR TITLE
Removed missing phpstan error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -674,8 +674,3 @@ parameters:
 			message: "#^Class Psy\\\\Shell not found\\.$#"
 			count: 1
 			path: src/basics.php
-
-		-
-			message: "#^Result of \\&\\& is always false.$#"
-			count: 1
-			path: src/Error/Debugger.php


### PR DESCRIPTION
phpstan throws an error that the warning doesn't exist in debugger.php.