### PR TITLE
Update dump colors to align with cake docs

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -1,30 +1,26 @@
 <style type="text/css">
 .cake-debug {
+  --color-bg: #ECECE9;
+  --color-highlight-bg: #fcf8e3;
+
+  --color-orange: #c44f24;
+  --color-green: #0b6125;
+  --color-violet: #a71d5d;
+  --color-blue: #4070a0;
+  --color-grey: #5f5f5f;
+
+  --color-dark-grey: #222;
+  --color-cyan: #234aa0;
+  --color-red: #d33c44;
+
+  --indent: 20px;
+
   font-family: monospace;
   background: var(--color-bg);
   padding: 5px;
   line-height: 16px;
   font-size: 14px;
   margin-bottom: 10px;
-
-  /*
-  Colours based on solarized scheme
-  https://ethanschoonover.com/solarized/
-  */
-  --color-bg: #fdf6e3;
-  --color-highlight-bg: #eee8d5;
-
-  --color-grey: #586e75;
-  --color-dark-grey: #073642;
-  --color-cyan: #2aa198;
-  --color-blue: #268bd2;
-  --color-green: #859900;
-  --color-orange: #cb4b16;
-  --color-yellow: #b58900;
-  --color-violet: #6c71c4;
-  --color-red: #dc322f;
-
-  --indent: 20px;
 }
 .cake-debug:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
Instead of introducing another palette, reuse the colours used to highlight code in the CakePHP documentation.

![Screen Shot 2020-02-22 at 09 41 53](https://user-images.githubusercontent.com/24086/75094319-f9d19880-5557-11ea-8158-13f6dbe818fa.png)

