### PR TITLE
Add slug() to TextHelper

### DIFF
--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -396,6 +396,32 @@ class TextHelper extends Helper
     }
 
     /**
+     * Returns a string with all spaces converted to dashes (by default),
+     * characters transliterated to ASCII characters, and non word characters removed.
+     *
+     * ### Options:
+     *
+     * - `replacement`: Replacement string. Default '-'.
+     * - `transliteratorId`: A valid transliterator id string.
+     *   If `null` (default) the transliterator (identifier) set via
+     *   `Text::setTransliteratorId()` or `Text::setTransliterator()` will be used.
+     *   If `false` no transliteration will be done, only non words will be removed.
+     * - `preserve`: Specific non-word character to preserve. Default `null`.
+     *   For e.g. this option can be set to '.' to generate clean file names.
+     *
+     * @param string $string the string you want to slug
+     * @param array|string $options If string it will be use as replacement character
+     *   or an array of options.
+     * @return string
+     * @see \Cake\Utility\Text::setTransliterator()
+     * @see \Cake\Utility\setTransliteratorId()
+     */
+    public function slug(string $string, $options = []): string
+    {
+        return $this->_engine->slug($string, $options);
+    }
+
+    /**
      * Event listeners.
      *
      * @return array

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -414,7 +414,7 @@ class TextHelper extends Helper
      *   or an array of options.
      * @return string
      * @see \Cake\Utility\Text::setTransliterator()
-     * @see \Cake\Utility\setTransliteratorId()
+     * @see \Cake\Utility\Text::setTransliteratorId()
      */
     public function slug(string $string, $options = []): string
     {

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1752,7 +1752,10 @@ HTML;
         $this->assertSame($expected, $result);
     }
 
-    public function slugInputProvider()
+    /**
+     * @return array
+     */
+    public function slugInputProvider(): array
     {
         return [
             [

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -634,4 +634,36 @@ TEXT;
         $result = $this->Text->autoParagraph(null);
         $this->assertTextEquals($expected, $result);
     }
+
+    /**
+     * testSlug method
+     *
+     * @param string $string String
+     * @param array $options Options
+     * @param String $expected Expected string
+     * @return void
+     * @dataProvider slugInputProvider
+     */
+    public function testSlug($string, $options, $expected)
+    {
+        $result = $this->Text->slug($string, $options);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function slugInputProvider(): array
+    {
+        return [
+            [
+                'Foo Bar: Not just for breakfast any-more', [],
+                'Foo-Bar-Not-just-for-breakfast-any-more',
+            ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => false],
+                'FooBarNotjustforbreakfastanymore',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
In the view templates once is forced to use the static access

    echo \Cake\Utility\Text::slug($name)

where needed - formerly known as Inflector::slug().

If we had the helper delegating to this (new) method as well, we could  do

    echo $this->Text->slug($name);

Any objections?