### PR TITLE
Fix null values in Hash::get

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -61,7 +61,7 @@ class Hash {
 		}
 
 		foreach ($parts as $key) {
-			if (is_array($data) && isset($data[$key])) {
+			if (is_array($data) && array_key_exists($key, $data)) {
 				$data =& $data[$key];
 			} else {
 				return $default;


### PR DESCRIPTION
Did not work as described. The default value should be returned when the path does not exist according to the docs. Because of the use of isset it will also return the default value when the provided field holds null as value. Since already checked if its an array its better to use array_key_exists.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
