### PR TITLE
Relay SMTP buffer in exception message.

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -465,7 +465,7 @@ class SmtpTransport extends AbstractTransport
                 $response .= $bytes;
             }
             if (substr($response, -2) !== "\r\n") {
-                throw new SocketException('SMTP timeout.');
+                throw new SocketException($response ?: 'SMTP timeout.');
             }
             $responseLines = explode("\r\n", rtrim($response, "\r\n"));
             $response = end($responseLines);

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -464,7 +464,9 @@ class SmtpTransport extends AbstractTransport
                 }
                 $response .= $bytes;
             }
+            // Catch empty or malformed responses.
             if (substr($response, -2) !== "\r\n") {
+                // Use response message or assume operation timed out.
                 throw new SocketException($response ?: 'SMTP timeout.');
             }
             $responseLines = explode("\r\n", rtrim($response, "\r\n"));


### PR DESCRIPTION
On Windows, the "\r\n" was not included in the error message as required by the spec which was causing the default "SMTP timeout" message to be passed to SocketException instead of the actual error.

This PR will use the default message only if the response is empty, otherwise passing the raw message.

Closes #14228 
