### PR TITLE
Add assertions to check session key presence

### DIFF
--- a/src/TestSuite/Constraint/Session/SessionEquals.php
+++ b/src/TestSuite/Constraint/Session/SessionEquals.php
@@ -15,9 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Constraint\Session;
 
-use Cake\Http\Session;
 use Cake\Utility\Hash;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
 
 /**

--- a/src/TestSuite/Constraint/Session/SessionHasKey.php
+++ b/src/TestSuite/Constraint/Session/SessionHasKey.php
@@ -33,7 +33,6 @@ class SessionHasKey extends Constraint
     /**
      * Constructor
      *
-     * @param array|null $session Session
      * @param string $path Session Path
      */
     public function __construct(string $path)

--- a/src/TestSuite/Constraint/Session/SessionHasKey.php
+++ b/src/TestSuite/Constraint/Session/SessionHasKey.php
@@ -10,22 +10,20 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @since         3.7.0
+ * @since         4.1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\TestSuite\Constraint\Session;
 
-use Cake\Http\Session;
 use Cake\Utility\Hash;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
 
 /**
- * SessionEquals
+ * SessionHasKey
  *
  * @internal
  */
-class SessionEquals extends Constraint
+class SessionHasKey extends Constraint
 {
     /**
      * @var string
@@ -35,6 +33,7 @@ class SessionEquals extends Constraint
     /**
      * Constructor
      *
+     * @param array|null $session Session
      * @param string $path Session Path
      */
     public function __construct(string $path)
@@ -53,7 +52,7 @@ class SessionEquals extends Constraint
         // Server::run calls Session::close at the end of the request.
         // Which means, that we cannot use Session object here to access the session data.
         // Call to Session::read will start new session (and will erase the data).
-        return Hash::get($_SESSION, $this->path) === $other;
+        return Hash::check($_SESSION, $this->path) === true;
     }
 
     /**
@@ -63,6 +62,6 @@ class SessionEquals extends Constraint
      */
     public function toString(): string
     {
-        return sprintf('is in session path \'%s\'', $this->path);
+        return "is a path present in the session";
     }
 }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -50,6 +50,7 @@ use Cake\TestSuite\Constraint\Response\StatusOk;
 use Cake\TestSuite\Constraint\Response\StatusSuccess;
 use Cake\TestSuite\Constraint\Session\FlashParamEquals;
 use Cake\TestSuite\Constraint\Session\SessionEquals;
+use Cake\TestSuite\Constraint\Session\SessionHasKey;
 use Cake\TestSuite\Constraint\View\LayoutFileEquals;
 use Cake\TestSuite\Constraint\View\TemplateFileEquals;
 use Cake\TestSuite\Stub\TestExceptionRenderer;
@@ -1099,7 +1100,33 @@ trait IntegrationTestTrait
     public function assertSession($expected, string $path, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($expected, new SessionEquals($this->_requestSession, $path), $verboseMessage);
+        $this->assertThat($expected, new SessionEquals($path), $verboseMessage);
+    }
+
+    /**
+     * Asserts session key exists.
+     *
+     * @param string $path The session data path. Uses Hash::get() compatible notation.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertSessionHasKey(string $path, string $message = ''): void
+    {
+        $verboseMessage = $this->extractVerboseMessage($message);
+        $this->assertThat($path, new SessionHasKey($path), $verboseMessage);
+    }
+
+    /**
+     * Asserts a session key does not exist.
+     *
+     * @param string $path The session data path. Uses Hash::get() compatible notation.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertSessionNotHasKey(string $path, string $message = ''): void
+    {
+        $verboseMessage = $this->extractVerboseMessage($message);
+        $this->assertThat($path, $this->logicalNot(new SessionHasKey($path)), $verboseMessage);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1501,7 +1501,11 @@ class IntegrationTestTraitTest extends TestCase
             'assertResponseRegExp' => ['assertResponseRegExp', 'Failed asserting that `/test/` PCRE pattern found in response body.', '/posts/index/error', '/test/'],
             'assertResponseSuccess' => ['assertResponseSuccess', 'Failed asserting that 404 is between 200 and 308.', '/posts/missing'],
             'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action PostsController::missing() could not be found, or is not accessible."', '/posts/missing'],
+
             'assertSession' => ['assertSession', 'Failed asserting that \'test\' is in session path \'Missing.path\'.', '/posts/index', 'test', 'Missing.path'],
+            'assertSessionHasKey' => ['assertSessionHasKey', 'Failed asserting that \'Missing.path\' is a path present in the session.', '/posts/index', 'Missing.path'],
+            'assertSessionNotHasKey' => ['assertSessionNotHasKey', 'Failed asserting that \'Flash.flash\' is not a path present in the session.', '/posts/index', 'Flash.flash'],
+
             'assertTemplate' => ['assertTemplate', 'Failed asserting that \'custom_template\' equals template file `' . $templateDir . 'Posts' . DS . 'index.php`.', '/posts/index', 'custom_template'],
             'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'custom_template'],
             'assertFlashMessage' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'flash\' message.', '/posts/index', 'missing'],


### PR DESCRIPTION
Add assertion methods to check for a session path existing and not existing. With the session being closed at the end of each simulated request testing session key presence is harder than it was in 3.x

Refs #14270