### PR TITLE
Start MySQL service on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
+    - name: Setup MySQL
+      if: matrix.db-type == 'mysql'
+      run: |
+        sudo service mysql start
+
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1


### PR DESCRIPTION
Starting March 3rd, 2020, the Ubuntu virtual environments will no longer start the MySQL service automatically.

https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/

`4.next` will need a `if-else` to start MySQL as service or Docker.