### PR TITLE
4.next: Start MySQL service on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,17 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-    - name: Setup mysql 8
-      if: matrix.db-type == 'mysql' && matrix.php-version == '7.2'
+    - name: Setup MySQL
+      if: matrix.db-type == 'mysql'
       run: |
-        sudo service mysql stop
-        docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root --tmpfs /var/lib/mysql:rw --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
+        if [[ ${{ matrix.php-version }} == '7.2' ]]; then
+          sudo service mysql stop
+          # MySQL 8
+          docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root --tmpfs /var/lib/mysql:rw --network=host -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin --innodb-flush-method=O_DIRECT_NO_FSYNC
+        else
+          # MySQL 5.7
+          sudo service mysql start
+        fi
 
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
Starting March 3rd, 2020, the Ubuntu virtual environments will no longer start the MySQL service automatically.

https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/