### PR TITLE
Adding two examples of how to use the accessibleFields option

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -160,6 +160,14 @@ class Marshaller
      * ]);
      * ```
      *
+     * ```
+     * $result = $marshaller->one($data, [
+     *   'associated' => [
+     *     'Tags' => ['accessibleFields' => ['*' => true]]
+     *   ]
+     * ]);
+     * ```
+     *
      * @param array $data The data to hydrate.
      * @param array $options List of options
      * @return \Cake\Datasource\EntityInterface

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2733,6 +2733,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * );
      * ```
      *
+     * ```
+     * $article = $this->Articles->patchEntity($article, $this->request->getData(), [
+     *   'associated' => [
+     *     'Tags' => ['accessibleFields' => ['*' => true]]
+     *   ]
+     * ]);
+     * ```
+     *
      * By default, the data is validated before being passed to the entity. In
      * the case of invalid fields, those will not be assigned to the entity.
      * The `validate` option can be used to disable validation on the passed data:


### PR DESCRIPTION
I added two examples to show how to set `accessibleFields` option of associated entities using `Table::patchEntity()`

Took me quite a while to figure this out! Many thanks to @ADmad 
