### PR TITLE
Table::_saveMany() won't rollback if some entity fail to save

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2178,13 +2178,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         };
 
+        $failed = null;
         try {
-            $failed = $this->getConnection()
-                ->transactional(function () use ($entities, $options, &$isNew) {
+            $this->getConnection()
+                ->transactional(function () use ($entities, $options, &$isNew, &$failed) {
                     foreach ($entities as $key => $entity) {
                         $isNew[$key] = $entity->isNew();
                         if ($this->save($entity, $options) === false) {
-                            return $entity;
+                            $failed = $entity;
+
+                            return false;
                         }
                     }
                 });

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2178,6 +2178,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         };
 
+        /** @var \Cake\Datasource\EntityInterface|null $failed */
         $failed = null;
         try {
             $this->getConnection()

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2836,7 +2836,7 @@ class TableTest extends TestCase
         $result = $table->saveMany($entities);
 
         $this->assertFalse($result);
-        $this->assertEquals($expectedCount, $table->find()->count());
+        $this->assertSame($expectedCount, $table->find()->count());
         foreach ($entities as $entity) {
             $this->assertTrue($entity->isNew());
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2827,6 +2827,7 @@ class TableTest extends TestCase
     public function testSaveManyFailed()
     {
         $table = $this->getTableLocator()->get('authors');
+        $expectedCount = $table->find()->count();
         $entities = [
             new Entity(['name' => 'mark']),
             new Entity(['name' => 'jose']),
@@ -2835,6 +2836,7 @@ class TableTest extends TestCase
         $result = $table->saveMany($entities);
 
         $this->assertFalse($result);
+        $this->assertEquals($expectedCount, $table->find()->count());
         foreach ($entities as $entity) {
             $this->assertTrue($entity->isNew());
         }


### PR DESCRIPTION
Table::_saveMany() is not working properly, it won't rollback when there's a failed entity and if the fail happens after any save, i.e any entity beside the first, that entity will be saved on the database although the cleanup will remove the given ids and set them as new again.

I changed the testSaveManyFailed to check the count on the table to make sure that the rollback worked. I passed the $failed variable as reference for the Connection::transaction() callback, then it's possible to return false and rollback on the transaction and still have the failed entity for the thrown PersistenceFailedException.