### PR TITLE
Fix division by 0 when configuring Cache with probability of 0

### DIFF
--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -93,7 +93,7 @@ class CacheRegistry extends ObjectRegistry
         }
 
         $config = $instance->getConfig();
-        if (isset($config['probability']) && time() % $config['probability'] === 0) {
+        if (!empty($config['probability']) && time() % $config['probability'] === 0) {
             $instance->gc();
         }
 

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -69,6 +69,28 @@ class CacheTest extends TestCase
     }
 
     /**
+     * Tests creating Cache with 0 probability
+     *
+     * @return void
+     */
+    public function testCacheEngineZeroProbability()
+    {
+        Cache::setConfig('tests', [
+            'engine' => 'File',
+            'path' => CACHE,
+            'prefix' => 'test_',
+            'probability' => 0,
+        ]);
+
+        $engine = Cache::engine('tests');
+        $this->assertNotNull($engine);
+        $probability = $engine->getConfig('probability');
+        $this->assertSame(0, $probability);
+
+        Cache::drop('tests');
+    }
+
+    /**
      * tests Cache::engine() fallback
      *
      * @return void


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/14338.

The cache probability was removed in 4.0. No port required.