### PR TITLE
3.9 - Fix Table::_saveMany() to properly rollback when one entity fail to save

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2282,13 +2282,17 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         };
 
+        /** @var \Cake\Datasource\EntityInterface|null $failed */
+        $failed = null;
         try {
-            $failed = $this->getConnection()
-                ->transactional(function () use ($entities, $options, &$isNew) {
+            $this->getConnection()
+                ->transactional(function () use ($entities, $options, &$isNew, &$failed) {
                     foreach ($entities as $key => $entity) {
                         $isNew[$key] = $entity->isNew();
                         if ($this->save($entity, $options) === false) {
-                            return $entity;
+                            $failed = $entity;
+
+                            return false;
                         }
                     }
                 });

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2813,6 +2813,7 @@ class TableTest extends TestCase
     public function testSaveManyFailed()
     {
         $table = $this->getTableLocator()->get('authors');
+        $expectedCount = $table->find()->count();
         $entities = [
             new Entity(['name' => 'mark']),
             new Entity(['name' => 'jose']),
@@ -2821,6 +2822,7 @@ class TableTest extends TestCase
         $result = $table->saveMany($entities);
 
         $this->assertFalse($result);
+        $this->assertSame($expectedCount, $table->find()->count());
         foreach ($entities as $entity) {
             $this->assertTrue($entity->isNew());
         }


### PR DESCRIPTION
Port changes from #14339 to 3.9 where they are applicable.
