### PR TITLE
Reduce travis cache size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ services:
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 php:


### PR DESCRIPTION
Caching just composer cache should be sufficient as all packages will load from cache.