### PR TITLE
Forward port changes from #13848 from 3.9 to 4.1

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -534,7 +534,7 @@ class Hash
             return [];
         }
 
-        return array_combine($keys === null ? range(0, count($vals) - 1) : $keys, $vals);
+        return array_combine($keys ?? range(0, count($vals) - 1), $vals);
     }
 
     /**

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -461,7 +461,7 @@ class Hash
      * following the path specified in `$groupPath`.
      *
      * @param array $data Array from where to extract keys and values
-     * @param string|array $keyPath A dot-separated string.
+     * @param string|array|null $keyPath A dot-separated string. If null the output will be numerically indexed.
      * @param string|array|null $valuePath A dot-separated string.
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
@@ -478,11 +478,13 @@ class Hash
             $format = array_shift($keyPath);
             /** @var array $keys */
             $keys = static::format($data, $keyPath, $format);
+        } elseif ($keyPath === null) {
+            $keys = $keyPath;
         } else {
             /** @var array $keys */
             $keys = static::extract($data, $keyPath);
         }
-        if (empty($keys)) {
+        if ($keyPath !== null && empty($keys)) {
             return [];
         }
 
@@ -496,10 +498,10 @@ class Hash
             $vals = static::extract($data, $valuePath);
         }
         if (empty($vals)) {
-            $vals = array_fill(0, count($keys), null);
+            $vals = array_fill(0, $keys === null ? count($data) : count($keys), null);
         }
 
-        if (count($keys) !== count($vals)) {
+        if (is_array($keys) && count($keys) !== count($vals)) {
             throw new RuntimeException(
                 'Hash::combine() needs an equal number of keys + values.'
             );
@@ -508,7 +510,7 @@ class Hash
         if ($groupPath !== null) {
             $group = static::extract($data, $groupPath);
             if (!empty($group)) {
-                $c = count($keys);
+                $c = is_array($keys) ? count($keys) : count($vals);
                 $out = [];
                 for ($i = 0; $i < $c; $i++) {
                     if (!isset($group[$i])) {
@@ -518,7 +520,11 @@ class Hash
                         /** @psalm-suppress PossiblyNullArrayOffset */
                         $out[$group[$i]] = [];
                     }
-                    $out[$group[$i]][$keys[$i]] = $vals[$i];
+                    if ($keys === null) {
+                        $out[$group[$i]][] = $vals[$i];
+                    } else {
+                        $out[$group[$i]][$keys[$i]] = $vals[$i];
+                    }
                 }
 
                 return $out;
@@ -528,7 +534,7 @@ class Hash
             return [];
         }
 
-        return array_combine($keys, $vals);
+        return array_combine($keys === null ? range(0, count($vals) - 1) : $keys, $vals);
     }
 
     /**

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -2310,6 +2310,41 @@ class HashTest extends TestCase
     }
 
     /**
+     * test combine() with null key path.
+     *
+     * @return void
+     */
+    public function testCombineWithNullKeyPath()
+    {
+        $result = Hash::combine([], null, '{n}.User.Data');
+        $this->assertEmpty($result);
+
+        $a = static::userData();
+
+        $result = Hash::combine($a, null);
+        $expected = [0 => null, 1 => null, 2 => null];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.non-existant');
+        $expected = [0 => null, 1 => null, 2 => null];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data');
+        $expected = [
+            0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+            1 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
+            2 => ['user' => 'gwoo', 'name' => 'The Gwoo']];
+        $this->assertEquals($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name');
+        $expected = [
+            0 => 'Mariano Iglesias',
+            1 => 'Larry E. Masters',
+            2 => 'The Gwoo'];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test combine() giving errors on key/value length mismatches.
      *
      * @return void
@@ -2360,6 +2395,18 @@ class HashTest extends TestCase
         ];
         $this->assertSame($expected, $result);
 
+        $result = Hash::combine($a, null, '{n}.User.Data', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+            ],
+            2 => [
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
             1 => [
@@ -2371,6 +2418,18 @@ class HashTest extends TestCase
             ],
         ];
         $this->assertSame($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => 'Mariano Iglesias',
+                1 => 'The Gwoo'
+            ],
+            2 => [
+                0 => 'Larry E. Masters'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data', '{n}.User.group_id');
         $expected = [
@@ -2384,6 +2443,18 @@ class HashTest extends TestCase
         ];
         $this->assertSame($expected, $result);
 
+        $result = Hash::combine($a, null, '{n}.User.Data', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+            ],
+            2 => [
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.name', '{n}.User.group_id');
         $expected = [
             1 => [
@@ -2393,6 +2464,18 @@ class HashTest extends TestCase
             2 => [
                 14 => 'Larry E. Masters',
             ],
+        ];
+        $this->assertSame($expected, $result);
+
+        $result = Hash::combine($a, null, '{n}.User.Data.name', '{n}.User.group_id');
+        $expected = [
+            1 => [
+                0 => 'Mariano Iglesias',
+                1 => 'The Gwoo'
+            ],
+            2 => [
+                0 => 'Larry E. Masters'
+            ]
         ];
         $this->assertSame($expected, $result);
     }
@@ -2422,6 +2505,23 @@ class HashTest extends TestCase
             ],
         ];
         $this->assertSame($expected, $result);
+
+        $result = Hash::combine(
+            $a,
+            null,
+            ['%1$s: %2$s', '{n}.User.Data.user', '{n}.User.Data.name'],
+            '{n}.User.group_id'
+        );
+        $expected = [
+            1 => [
+                0 => 'mariano.iglesias: Mariano Iglesias',
+                1 => 'gwoo: The Gwoo'
+            ],
+            2 => [
+                0 => 'phpnut: Larry E. Masters'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
 
         $result = Hash::combine(
             $a,

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -2399,11 +2399,11 @@ class HashTest extends TestCase
         $expected = [
             1 => [
                 0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
-                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo'],
             ],
             2 => [
-                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
-            ]
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
+            ],
         ];
         $this->assertEquals($expected, $result);
 
@@ -2423,11 +2423,11 @@ class HashTest extends TestCase
         $expected = [
             1 => [
                 0 => 'Mariano Iglesias',
-                1 => 'The Gwoo'
+                1 => 'The Gwoo',
             ],
             2 => [
-                0 => 'Larry E. Masters'
-            ]
+                0 => 'Larry E. Masters',
+            ],
         ];
         $this->assertEquals($expected, $result);
 
@@ -2447,11 +2447,11 @@ class HashTest extends TestCase
         $expected = [
             1 => [
                 0 => ['user' => 'mariano.iglesias', 'name' => 'Mariano Iglesias'],
-                1 => ['user' => 'gwoo', 'name' => 'The Gwoo']
+                1 => ['user' => 'gwoo', 'name' => 'The Gwoo'],
             ],
             2 => [
-                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters']
-            ]
+                0 => ['user' => 'phpnut', 'name' => 'Larry E. Masters'],
+            ],
         ];
         $this->assertEquals($expected, $result);
 
@@ -2471,11 +2471,11 @@ class HashTest extends TestCase
         $expected = [
             1 => [
                 0 => 'Mariano Iglesias',
-                1 => 'The Gwoo'
+                1 => 'The Gwoo',
             ],
             2 => [
-                0 => 'Larry E. Masters'
-            ]
+                0 => 'Larry E. Masters',
+            ],
         ];
         $this->assertSame($expected, $result);
     }
@@ -2515,11 +2515,11 @@ class HashTest extends TestCase
         $expected = [
             1 => [
                 0 => 'mariano.iglesias: Mariano Iglesias',
-                1 => 'gwoo: The Gwoo'
+                1 => 'gwoo: The Gwoo',
             ],
             2 => [
-                0 => 'phpnut: Larry E. Masters'
-            ]
+                0 => 'phpnut: Larry E. Masters',
+            ],
         ];
         $this->assertEquals($expected, $result);
 


### PR DESCRIPTION
Allow $keyPath to be null which results in a numerically indexed output.
