### PR TITLE
Fix command runner mocking

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -108,7 +108,7 @@ trait ConsoleIntegrationTestTrait
         if ($this->_in === null) {
             $this->_in = new ConsoleInput($input);
         } elseif ($input) {
-            throw new RuntimeException('You can use $input only if $_in property is null and will be reset.');
+            throw new RuntimeException('You can use `$input` only if `$_in` property is null and will be reset.');
         }
 
         $args = $this->commandStringToArgs("cake $command");

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -29,6 +29,7 @@ use Cake\TestSuite\Constraint\Console\ExitCode;
 use Cake\TestSuite\Stub\ConsoleInput;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\Stub\MissingConsoleInputException;
+use RuntimeException;
 
 /**
  * A test case class intended to make integration tests of cake console commands
@@ -90,15 +91,25 @@ trait ConsoleIntegrationTestTrait
      *
      * @param string $command Command to run
      * @param array $input Input values to pass to an interactive shell
+     * @throws \Cake\TestSuite\Stub\MissingConsoleInputException
+     * @throws \RuntimeException
      * @return void
      */
     public function exec(string $command, array $input = []): void
     {
         $runner = $this->makeRunner();
 
-        $this->_out = new ConsoleOutput();
-        $this->_err = new ConsoleOutput();
-        $this->_in = new ConsoleInput($input);
+        if ($this->_out === null) {
+            $this->_out = new ConsoleOutput();
+        }
+        if ($this->_err === null) {
+            $this->_err = new ConsoleOutput();
+        }
+        if ($this->_in === null) {
+            $this->_in = new ConsoleInput($input);
+        } elseif ($input) {
+            throw new RuntimeException('You can use $input only if $_in property is null and will be reset.');
+        }
 
         $args = $this->commandStringToArgs("cake $command");
         $io = new ConsoleIo($this->_out, $this->_err, $this->_in);


### PR DESCRIPTION
Or is there a better way to resolve the issue of

> Cake\TestSuite\Stub\MissingConsoleInputException: There are no more input replies available. This is the 1st read operation, only 0 replies were set.
The provided replies are: 
The question asked was: <question>Does this table already contain records? If so, we need to create a nullable field.</question> (no/yes) 

for more complex scenarios than just a simple input (which would be the 2nd arg)?

With the fix this one could set up a custom mock here if needed:
```php
	$this->io = $this->getMockBuilder(ConsoleIo::class)->getMock();
	...
	$this->io->expects($this->once())->method('askChoice')->willReturn('yes');

	$this->exec('add_exposed_field Users');
	$this->assertExitCode(Command::CODE_SUCCESS);
```