### PR TITLE
Re-enable retrieval of model alias per controller.

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -129,10 +129,13 @@ trait ModelAwareTrait
         if ($modelType === null) {
             $modelType = $this->getModelType();
         }
-
         if ($modelClass === null) {
             $modelClass = $this->modelClass;
         }
+        if (empty($modelClass)) {
+            throw new UnexpectedValueException('Default modelClass is empty');
+        }
+
         $alias = $this->getModelAlias($modelClass, $modelType);
 
         if (isset($this->{$alias})) {

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -73,8 +73,8 @@ trait ModelAwareTrait
     }
 
     /**
-     * @param string|null $modelClass
-     * @param string|null $modelType
+     * @param string|null $modelClass Name of model class to load. Defaults to $this->modelClass.
+     * @param string|null $modelType The type of repository to load. Defaults to the modelType() value.
      * @throws \UnexpectedValueException If $modelClass argument is not provided
      *   and ModelAwareTrait::$modelClass property value is empty.
      * @return string
@@ -130,14 +130,13 @@ trait ModelAwareTrait
             $modelType = $this->getModelType();
         }
 
+        if ($modelClass === null) {
+            $modelClass = $this->modelClass;
+        }
         $alias = $this->getModelAlias($modelClass, $modelType);
 
         if (isset($this->{$alias})) {
             return $this->{$alias};
-        }
-
-        if ($modelClass === null) {
-            $modelClass = $this->modelClass;
         }
 
         $options = [];

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -37,7 +37,20 @@ class ModelAwareTraitTest extends TestCase
         $this->assertNull($stub->getModelClass());
 
         $stub->setProps('StubArticles');
-        $this->assertEquals('StubArticles', $stub->getModelClass());
+        $this->assertSame('StubArticles', $stub->getModelClass());
+        $this->assertSame('StubArticles', $stub->getModelAlias());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetModelAlias()
+    {
+        $stub = new Stub();
+        $stub->setProps('Foo.Bar');
+
+        $this->assertSame('Foo.Bar', $stub->getModelClass());
+        $this->assertSame('Bar', $stub->getModelAlias());
     }
 
     /**


### PR DESCRIPTION
When upgrading a plugin one faces the challenge of accessing the now protected class property.
In this case $modelClass and the resulting alias per controller

```php
// Inside component
$modelName = $this->Controller->modelClass;
		
list(, $modelName) = pluginSplit($modelName);
$this->setConfig('modelName', $modelName);
if (!$this->Controller->{$modelName}->behaviors()->has('...')) {
	$this->Controller->{$modelName}->behaviors()->load('...', $this->_config);
}
```

With this suggested change this would be able again
```php
$modelName = $this->Controller->getModelAlias();

$this->setConfig('modelName', $modelName);
if (!$this->Controller->{$modelName}->behaviors()->has('...')) {
	$this->Controller->{$modelName}->behaviors()->load('...', $this->_config);
}
```
Or other generic operations done by a generic component assisting:
```php
$modelName = $this->Controller->getModelAlias();
if ($this->Controller->{$modelName}->do()) {
	...
}
```

Or are there better alternatives?

Force reading the field with reflection is an option but sounds like a less clean approach.