### PR TITLE
Fix ConsoleInput::read() exception when false was returned by readline() or fgets()

### DIFF
--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -55,20 +55,26 @@ class ConsoleInput
     /**
      * Read a value from the stream
      *
-     * @return string The value of the stream
+     * @return string|null The value of the stream. Null on EOF.
      */
-    public function read(): string
+    public function read(): ?string
     {
         if ($this->_canReadline) {
+            /** @var string|false $line */
             $line = readline('');
-            if (strlen($line) > 0) {
+
+            if ($line !== false && strlen($line) > 0) {
                 readline_add_history($line);
             }
-
-            return $line;
+        } else {
+            $line = fgets($this->_input);
         }
 
-        return (string)fgets($this->_input);
+        if ($line === false) {
+            return null;
+        }
+
+        return $line;
     }
 
     /**

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -489,7 +489,7 @@ class ConsoleIo
         $this->_out->write('<question>' . $prompt . "</question>$optionsText\n$defaultText> ", 0);
         $result = $this->_in->read();
 
-        $result = $result !== null ? trim($result) : '';
+        $result = $result === null ?  '' : trim($result);
         if ($default !== null && $result === '') {
             return $default;
         }

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -489,7 +489,7 @@ class ConsoleIo
         $this->_out->write('<question>' . $prompt . "</question>$optionsText\n$defaultText> ", 0);
         $result = $this->_in->read();
 
-        $result = $result === null ?  '' : trim($result);
+        $result = $result === null ? '' : trim($result);
         if ($default !== null && $result === '') {
             return $default;
         }

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -489,7 +489,7 @@ class ConsoleIo
         $this->_out->write('<question>' . $prompt . "</question>$optionsText\n$defaultText> ", 0);
         $result = $this->_in->read();
 
-        $result = trim($result);
+        $result = $result !== null ? trim($result) : '';
         if ($default !== null && $result === '') {
             return $default;
         }


### PR DESCRIPTION
Solves #14350 

Make `ConsoleInput::read()` return null when false is returned by the calls to ```readline()``` or ```fgets()```.

I'm not sure how to test this, btw.