### PR TITLE
Use error handler to supress `ReflectionType::__toString()` deprecation warnings on PHP 7.4

### DIFF
--- a/src/TestSuite/MockBuilder.php
+++ b/src/TestSuite/MockBuilder.php
@@ -30,12 +30,28 @@ class MockBuilder extends BaseMockBuilder
      */
     public function getMock()
     {
-        $errorLevel = error_reporting();
-        error_reporting(E_ALL ^ E_DEPRECATED);
+        static::setSupressedErrorHandler();
+
         try {
             return parent::getMock();
         } finally {
-            error_reporting($errorLevel);
+            restore_error_handler();
         }
+    }
+
+    /**
+     * Set error handler to supress `ReflectionType::__toString()` deprecation warning
+     *
+     * @return void
+     */
+    public static function setSupressedErrorHandler()
+    {
+        $previousHandler = set_error_handler(function ($code, $description, $file = null, $line = null, $context = null) use (&$previousHandler) {
+            if (($code & E_DEPRECATED) && ($description === 'Function ReflectionType::__toString() is deprecated')) {
+                return true;
+            }
+
+            return $previousHandler($code, $description, $file, $line, $context);
+        });
     }
 }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -750,8 +750,8 @@ abstract class TestCase extends BaseTestCase
         $callAutoload = true,
         $cloneArguments = false
     ) {
-        $errorLevel = error_reporting();
-        error_reporting(E_ALL ^ E_DEPRECATED);
+        MockBuilder::setSupressedErrorHandler();
+
         try {
             return parent::getMockClass(
                 $originalClassName,
@@ -764,7 +764,7 @@ abstract class TestCase extends BaseTestCase
                 $cloneArguments
             );
         } finally {
-            error_reporting($errorLevel);
+            restore_error_handler();
         }
     }
 
@@ -781,8 +781,8 @@ abstract class TestCase extends BaseTestCase
         $mockedMethods = [],
         $cloneArguments = false
     ) {
-        $errorLevel = error_reporting();
-        error_reporting(E_ALL ^ E_DEPRECATED);
+        MockBuilder::setSupressedErrorHandler();
+
         try {
             return parent::getMockForAbstractClass(
                 $originalClassName,
@@ -795,7 +795,7 @@ abstract class TestCase extends BaseTestCase
                 $cloneArguments
             );
         } finally {
-            error_reporting($errorLevel);
+            restore_error_handler();
         }
     }
 

--- a/tests/test_app/TestApp/Auth/CallCounterPasswordHasher.php
+++ b/tests/test_app/TestApp/Auth/CallCounterPasswordHasher.php
@@ -1,6 +1,4 @@
 <?php
-declare(strict_types=1);
-
 namespace TestApp\Auth;
 
 use Cake\Auth\AbstractPasswordHasher;


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/14326. As reported in the issue, `error_reporting()` level should be handled by error handler.

PHPUnit error handler [checks](https://github.com/sebastianbergmann/phpunit/blob/6.5.14/src/Util/ErrorHandler.php#L47-L49) current error level, so for simple tests previous solution was OK.

But in integration tests, CakePHP error handler is [registered](https://github.com/cakephp/cakephp/blob/3.8.10/src/Error/BaseErrorHandler.php#L78-L79), but it [doesn't check](https://github.com/cakephp/cakephp/blob/3.8.10/src/Error/BaseErrorHandler.php#L78-L79) active error level. Full fix would be to check active error level like PHPUnit error handler does, but it is not completely BC safe.

So instead of temporary changing error level, temporary set custom error handler to catch and skip only specific `ReflectionType::__toString()` deprecation warning. I've tested it with fresh app skeleton and there is now no warning.
