### PR TITLE
Test to show a bug when using a custom event implementation

### DIFF
--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -15,10 +15,94 @@
 namespace Cake\Test\TestCase\Event;
 
 use Cake\Event\Event;
+use Cake\Event\EventInterface;
 use Cake\Event\EventList;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+
+/**
+ * TestEvent
+ */
+class TestEvent implements EventInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSubject()
+    {
+        // TODO: Implement getSubject() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function stopPropagation()
+    {
+        // TODO: Implement stopPropagation() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isStopped()
+    {
+        // TODO: Implement isStopped() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResult()
+    {
+        // TODO: Implement getResult() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setResult($value = null)
+    {
+        // TODO: Implement setResult() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData($key = null)
+    {
+        // TODO: Implement getData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setData($key, $value = null)
+    {
+        // TODO: Implement setData() method.
+    }
+}
 
 /**
  * Mock class used to test event dispatching
@@ -94,6 +178,19 @@ class CustomTestEventListenerInterface extends EventTestListener implements Even
  */
 class EventManagerTest extends TestCase
 {
+
+    /**
+     * @return void
+     */
+    public function testCustomEventImplementation()
+    {
+        $event = new TestEvent('fake.event');
+        $listener = new CustomTestEventListenerInterface();
+
+        $manager = new EventManager();
+        $manager->on($listener);
+        $manager->dispatch($event);
+    }
 
     /**
      * Tests the attach() method for a single event key in multiple queues


### PR DESCRIPTION
This test shows a problem with the type hint of _callListener() in the EventManager when using a custom event implementation. The current implementation is this:

> protected function _callListener(callable $listener, **Event** $event)

and by using Event and not EventInterface, it will fail when using a custom event class. It needs to be changed to this:

> protected function _callListener(callable $listener, **EventInterface** $event)

Also there is yet another bug:

```php
EventManager::instance()->on($event->getName(), [$this, $handlerMethod]);
```

Will cause a type error on the callable type hint. The line above is at least according to the documentation valid code. https://book.cakephp.org/3/en/core-libraries/events.html#interacting-with-existing-listeners

So to fix the we need to remove the callable and check for array or callable and throw an invalid argument exception if none of both matches and change Event to EventInterface.