### PR TITLE
Allow changing log date format

### DIFF
--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -37,6 +37,7 @@ abstract class BaseLog extends AbstractLogger
     protected $_defaultConfig = [
         'levels' => [],
         'scopes' => [],
+        'dateFormat' => 'Y-m-d H:i:s',
     ];
 
     /**

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -161,11 +161,13 @@ abstract class BaseLog extends AbstractLogger
     }
 
     /**
-     * Get the date.
+     * Returns date formatted according to given `dateFormat` option format.
+     *
+     * This function affects `FileLog` or` ConsoleLog` datetime information format.
      *
      * @return string
      */
-    protected function _date()
+    protected function _getFormattedDate()
     {
         return date($this->_config['dateFormat']);
     }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -159,4 +159,14 @@ abstract class BaseLog extends AbstractLogger
 
         return str_replace(array_keys($replacements), $replacements, $message);
     }
+
+    /**
+     * Get the date.
+     *
+     * @return string
+     */
+    protected function _date()
+    {
+        return date($this->_config['date_format']);
+    }
 }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -167,6 +167,6 @@ abstract class BaseLog extends AbstractLogger
      */
     protected function _date()
     {
-        return date($this->_config['date_format']);
+        return date($this->_config['dateFormat']);
     }
 }

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -34,6 +34,7 @@ class ConsoleLog extends BaseLog
         'levels' => null,
         'scopes' => [],
         'outputAs' => null,
+        'date_format' => 'Y-m-d H:i:s',
     ];
 
     /**
@@ -52,6 +53,7 @@ class ConsoleLog extends BaseLog
      * - `scopes` string or array, scopes the engine is interested in
      * - `stream` the path to save logs on.
      * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
+     * - `date_format` php date() format.
      *
      * @param array $config Options for the FileLog, see above.
      * @throws \InvalidArgumentException
@@ -86,7 +88,7 @@ class ConsoleLog extends BaseLog
     public function log($level, $message, array $context = [])
     {
         $message = $this->_format($message, $context);
-        $output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message;
+        $output = $this->_date() . ' ' . ucfirst($level) . ': ' . $message;
 
         $this->_output->write(sprintf('<%s>%s</%s>', $level, $output, $level));
     }

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -34,7 +34,7 @@ class ConsoleLog extends BaseLog
         'levels' => null,
         'scopes' => [],
         'outputAs' => null,
-        'date_format' => 'Y-m-d H:i:s',
+        'dateFormat' => 'Y-m-d H:i:s',
     ];
 
     /**
@@ -53,7 +53,7 @@ class ConsoleLog extends BaseLog
      * - `scopes` string or array, scopes the engine is interested in
      * - `stream` the path to save logs on.
      * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
-     * - `date_format` php date() format.
+     * - `dateFormat` php date() format.
      *
      * @param array $config Options for the FileLog, see above.
      * @throws \InvalidArgumentException

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -88,7 +88,7 @@ class ConsoleLog extends BaseLog
     public function log($level, $message, array $context = [])
     {
         $message = $this->_format($message, $context);
-        $output = $this->_date() . ' ' . ucfirst($level) . ': ' . $message;
+        $output = $this->_getFormattedDate() . ' ' . ucfirst($level) . ': ' . $message;
 
         $this->_output->write(sprintf('<%s>%s</%s>', $level, $output, $level));
     }

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -53,7 +53,7 @@ class ConsoleLog extends BaseLog
      * - `scopes` string or array, scopes the engine is interested in
      * - `stream` the path to save logs on.
      * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
-     * - `dateFormat` php date() format.
+     * - `dateFormat` PHP date() format.
      *
      * @param array $config Options for the FileLog, see above.
      * @throws \InvalidArgumentException

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -40,7 +40,7 @@ class FileLog extends BaseLog
      *   If value is 0, old versions are removed rather then rotated.
      * - `mask` A mask is applied when log files are created. Left empty no chmod
      *   is made.
-     * - `date_format` php date() format.
+     * - `dateFormat` php date() format.
      *
      * @var array
      */
@@ -53,7 +53,7 @@ class FileLog extends BaseLog
         'rotate' => 10,
         'size' => 10485760, // 10MB
         'mask' => null,
-        'date_format' => 'Y-m-d H:i:s',
+        'dateFormat' => 'Y-m-d H:i:s',
     ];
 
     /**

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -40,7 +40,7 @@ class FileLog extends BaseLog
      *   If value is 0, old versions are removed rather then rotated.
      * - `mask` A mask is applied when log files are created. Left empty no chmod
      *   is made.
-     * - `dateFormat` php date() format.
+     * - `dateFormat` PHP date() format.
      *
      * @var array
      */

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -119,7 +119,7 @@ class FileLog extends BaseLog
     public function log($level, $message, array $context = []): void
     {
         $message = $this->_format($message, $context);
-        $output = $this->_date() . ' ' . ucfirst($level) . ': ' . $message . "\n";
+        $output = $this->_getFormattedDate() . ' ' . ucfirst($level) . ': ' . $message . "\n";
         $filename = $this->_getFilename($level);
         if ($this->_size) {
             $this->_rotateFile($filename);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -40,6 +40,7 @@ class FileLog extends BaseLog
      *   If value is 0, old versions are removed rather then rotated.
      * - `mask` A mask is applied when log files are created. Left empty no chmod
      *   is made.
+     * - `date_format` php date() format.
      *
      * @var array
      */
@@ -52,6 +53,7 @@ class FileLog extends BaseLog
         'rotate' => 10,
         'size' => 10485760, // 10MB
         'mask' => null,
+        'date_format' => 'Y-m-d H:i:s',
     ];
 
     /**
@@ -117,7 +119,7 @@ class FileLog extends BaseLog
     public function log($level, $message, array $context = []): void
     {
         $message = $this->_format($message, $context);
-        $output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
+        $output = $this->_date() . ' ' . ucfirst($level) . ': ' . $message . "\n";
         $filename = $this->_getFilename($level);
         if ($this->_size) {
             $this->_rotateFile($filename);

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -57,7 +57,7 @@ class ConsoleLogTest extends TestCase
         $fh = fopen($filename, 'r');
         $line = fgets($fh);
         $this->assertStringContainsString('Error: oh noes', $line);
-        $this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: oh noes/', $line);
+        $this->assertRegExp('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: oh noes/', $line);
     }
 
     /**
@@ -93,6 +93,6 @@ class ConsoleLogTest extends TestCase
         $log->log('error', 'oh noes');
         $fh = fopen($filename, 'r');
         $line = fgets($fh);
-        $this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Error: oh noes/', $line);
+        $this->assertRegExp('/2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Error: oh noes/', $line);
     }
 }

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -57,6 +57,7 @@ class ConsoleLogTest extends TestCase
         $fh = fopen($filename, 'r');
         $line = fgets($fh);
         $this->assertStringContainsString('Error: oh noes', $line);
+        $this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: oh noes/', $line);
     }
 
     /**
@@ -75,5 +76,23 @@ class ConsoleLogTest extends TestCase
             'outputAs' => ConsoleOutput::RAW,
         ]);
         $this->assertEquals(ConsoleOutput::RAW, $log->getConfig('outputAs'));
+    }
+
+    /**
+     * test dateFormat option
+     *
+     * @return void
+     */
+    public function testDateFormat()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
+        $log = new ConsoleLog([
+            'stream' => $filename,
+            'dateFormat' => 'c',
+        ]);
+        $log->log('error', 'oh noes');
+        $fh = fopen($filename, 'r');
+        $line = fgets($fh);
+        $this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Error: oh noes/', $line);
     }
 }

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -198,4 +198,23 @@ class FileLogTest extends TestCase
             unlink($file);
         }
     }
+
+    /**
+     * test log date_format
+     *
+     * @return void
+     */
+    public function testDateFormat()
+    {
+        $this->_deleteLogs(LOGS);
+
+        // original 'Y-m-d H:i:s' format test was testLogFileWriting() method
+
+        // 'c': ISO 8601 date (added in PHP 5)
+        $log = new FileLog(['path' => LOGS, 'date_format' => 'c']);
+        $log->log('warning', 'Test warning');
+
+        $result = file_get_contents(LOGS . 'error.log');
+        $this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Warning: Test warning/', $result);
+    }
 }

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -200,7 +200,7 @@ class FileLogTest extends TestCase
     }
 
     /**
-     * test log dateFormat option
+     * test dateFormat option
      *
      * @return void
      */

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -200,7 +200,7 @@ class FileLogTest extends TestCase
     }
 
     /**
-     * test log date_format
+     * test log dateFormat option
      *
      * @return void
      */
@@ -211,7 +211,7 @@ class FileLogTest extends TestCase
         // original 'Y-m-d H:i:s' format test was testLogFileWriting() method
 
         // 'c': ISO 8601 date (added in PHP 5)
-        $log = new FileLog(['path' => LOGS, 'date_format' => 'c']);
+        $log = new FileLog(['path' => LOGS, 'dateFormat' => 'c']);
         $log->log('warning', 'Test warning');
 
         $result = file_get_contents(LOGS . 'error.log');


### PR DESCRIPTION
# Allow changing log date format

Allow changing log date format for LogEngine  provided by CakePHP.
no change default date format. (compatible changes)

I understand that it is possible to change the date format using monolog.
https://book.cakephp.org/4/en/core-libraries/logging.html#using-monolog

But I'm satisfied with the log engine provided by CakePHP, except that I can't change the date format.

Because the Application TimeZone and the OS TimeZone may be different, it will be confusing if the date has no TimeZone information.
