### PR TITLE
Fix CounterCacheBehavior::_processAssociation() to properly update count on null association

### DIFF
--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -280,8 +280,9 @@ class CounterCacheBehavior extends Behavior
      *
      * @return bool True if the count update should happen, false otherwise.
      */
-    protected function _shouldUpdateCount(array $conditions) {
-        return !empty(array_filter($conditions, function($value) {
+    protected function _shouldUpdateCount(array $conditions)
+    {
+        return !empty(array_filter($conditions, function ($value) {
             return $value !== null;
         }));
     }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -220,17 +220,12 @@ class CounterCacheBehavior extends Behavior
     ): void {
         $foreignKeys = (array)$assoc->getForeignKey();
         $countConditions = $entity->extract($foreignKeys);
-        $allNulls = true;
+
         foreach ($countConditions as $field => $value) {
             if ($value === null) {
                 $countConditions[$field . ' IS'] = $value;
                 unset($countConditions[$field]);
-            } else {
-                $allNulls = false;
             }
-        }
-        if ($allNulls) {
-            return;
         }
 
         $primaryKeys = (array)$assoc->getBindingKey();
@@ -254,16 +249,18 @@ class CounterCacheBehavior extends Behavior
                 continue;
             }
 
-            if ($config instanceof Closure) {
-                $count = $config($event, $entity, $this->_table, false);
-            } else {
-                $count = $this->_getCount($config, $countConditions);
-            }
-            if ($count !== false) {
-                $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
+            if ($this->_shouldUpdateCount($updateConditions)) {
+                if ($config instanceof Closure) {
+                    $count = $config($event, $entity, $this->_table, false);
+                } else {
+                    $count = $this->_getCount($config, $countConditions);
+                }
+                if ($count !== false) {
+                    $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
+                }
             }
 
-            if (isset($updateOriginalConditions)) {
+            if (isset($updateOriginalConditions) && $this->_shouldUpdateCount($updateOriginalConditions)) {
                 if ($config instanceof Closure) {
                     $count = $config($event, $entity, $this->_table, true);
                 } else {
@@ -274,6 +271,19 @@ class CounterCacheBehavior extends Behavior
                 }
             }
         }
+    }
+
+    /**
+     * Checks if the count should be updated given a set of conditions.
+     *
+     * @param array $conditions Conditions to update count.
+     *
+     * @return bool True if the count update should happen, false otherwise.
+     */
+    protected function _shouldUpdateCount(array $conditions) {
+        return !empty(array_filter($conditions, function($value) {
+            return $value !== null;
+        }));
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -285,6 +285,22 @@ class CounterCacheBehaviorTest extends TestCase
         $this->assertEquals(2, $user2->get('post_count'));
         $this->assertSame(0, $category1->get('post_count'));
         $this->assertEquals(3, $category2->get('post_count'));
+
+        $entity = $this->post->patchEntity($post, ['user_id' => null, 'category_id' => null]);
+        $this->post->save($entity);
+
+        $user2 = $this->_getUser(2);
+        $category2 = $this->_getCategory(2);
+        $this->assertEquals(1, $user2->get('post_count'));
+        $this->assertEquals(2, $category2->get('post_count'));
+
+        $entity = $this->post->patchEntity($post, ['user_id' => 2, 'category_id' => 2]);
+        $this->post->save($entity);
+
+        $user2 = $this->_getUser(2);
+        $category2 = $this->_getCategory(2);
+        $this->assertEquals(2, $user2->get('post_count'));
+        $this->assertEquals(3, $category2->get('post_count'));
     }
 
     /**


### PR DESCRIPTION
Solves #14362 

When new count were null the original count was not updated, because of the ```$allNulls``` condition that returned the without checking this out, and when the original count was null an exception was thrown because of the null conditions invalid build.

Removed the $allNulls return and added a method to simply verify if the conditions array has only null values before attempting to perform the update. It appears to be working fine, but I'm not sure if the ```array_filter``` is the best solution.

Added test case on testUpdate for these conditions.