### PR TITLE
4.1 - Return previous app namespace

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -869,11 +869,14 @@ abstract class TestCase extends BaseTestCase
      * Set the app namespace
      *
      * @param string $appNamespace The app namespace, defaults to "TestApp".
-     * @return void
+     * @return string|null The previous app namespace or null if not set.
      */
-    public static function setAppNamespace(string $appNamespace = 'TestApp'): void
+    public static function setAppNamespace(string $appNamespace = 'TestApp'): ?string
     {
+        $previous = Configure::read('App.namespace');
         Configure::write('App.namespace', $appNamespace);
+
+        return $previous;
     }
 
     /**

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Core\Configure;
 use Cake\Http\MiddlewareQueue;
 use Cake\TestSuite\TestCase;
 use TestApp\Middleware\DumbMiddleware;
@@ -36,8 +35,7 @@ class MiddlewareQueueTest extends TestCase
     {
         parent::setUp();
 
-        $this->appNamespace = Configure::read('App.namespace');
-        static::setAppNamespace();
+        $this->previousNamespace = static::setAppNamespace('TestApp');
     }
 
     /**
@@ -48,7 +46,7 @@ class MiddlewareQueueTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        static::setAppNamespace($this->appNamespace);
+        static::setAppNamespace($this->previousNamespace);
     }
 
     public function testConstructorAddingMiddleware()


### PR DESCRIPTION
Easy access to previous app namespace without having to directly query the configure that's being wrapped here.