### PR TITLE
4.1 - Renamed TestApp I18nTable to CustomI18nTable

### DIFF
--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -25,7 +25,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use TestApp\Model\Entity\TranslateArticle;
-use TestApp\Model\Table\I18nTable;
+use TestApp\Model\Table\CustomI18nTable;
 
 /**
  * Translate behavior test case
@@ -84,15 +84,15 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
 
         $table->addBehavior('Translate', [
-            'translationTable' => I18nTable::class,
+            'translationTable' => CustomI18nTable::class,
             'fields' => ['title', 'body'],
         ]);
 
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals(I18nTable::class, $i18n->getName());
-        $this->assertInstanceOf(I18nTable::class, $i18n->getTarget());
+        $this->assertEquals(CustomI18nTable::class, $i18n->getName());
+        $this->assertInstanceOf(CustomI18nTable::class, $i18n->getTarget());
         $this->assertSame('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
         $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTable());
     }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -459,7 +459,7 @@ class TestCaseTest extends TestCase
     {
         static::setAppNamespace();
 
-        $I18n = $this->getMockForModel('I18n', ['save']);
+        $I18n = $this->getMockForModel('CustomI18n', ['save']);
         $this->assertSame('custom_i18n_table', $I18n->getTable());
 
         $Tags = $this->getMockForModel('Tags', ['save']);

--- a/tests/test_app/TestApp/Model/Table/CustomI18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/CustomI18nTable.php
@@ -16,9 +16,9 @@ namespace TestApp\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * I18n table class
+ * Custom I18n table class
  */
-class I18nTable extends Table
+class CustomI18nTable extends Table
 {
     public function initialize(array $config): void
     {


### PR DESCRIPTION
The `I18nTable` class should not be a custom test because it is the default translate table name for the translate behavior.

This causes issues if the `TestApp` app namespace is set for a test suite.