### PR TITLE
Fix docblock and revert missing iterable annotation.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -950,7 +950,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Get the associations collection for this table.
      *
-     * @return \Cake\ORM\AssociationCollection The collection of association objects.
+     * @return \Cake\ORM\AssociationCollection|\Cake\ORM\Association[] The collection of association objects.
      */
     public function associations(): AssociationCollection
     {


### PR DESCRIPTION
Can we please have this useful annotation back?

I had now several times the requirement of unnessarily needing to inline annotate the basic looping over the collection:
```php
/** @var \Cake\ORM\Association[] $associations */
$associations = $modelInstance->associations();
foreach ($associations as $association) {
	$relationType = $association->type();
```

With the proper docblock typehinting restored for the iterable behavior, this is then clear by itself.
And it is valid as the primary type still dictates this as object.