### PR TITLE
Fix typehint for iterables.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.8.5@e6ec5fa22a7b9e61670a24d07b3119aff80dcd89">
+<files psalm-version="3.9.5@0cfe565d0afbcd31eadcc281b9017b5692911661">
   <file src="src/Command/CompletionCommand.php">
     <DeprecatedClass occurrences="1">
       <code>\Cake\Console\Shell</code>
     </DeprecatedClass>
   </file>
   <file src="src/Console/CommandCollection.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass occurrences="5">
+      <code>(\Cake\Console\Shell|\Cake\Console\CommandInterface|class-string)[]</code>
       <code>string|\Cake\Console\Shell|\Cake\Console\CommandInterface</code>
+      <code>Shell::class</code>
+      <code>class-string|\Cake\Console\Shell|\Cake\Console\CommandInterface</code>
+      <code>\Traversable&lt;string, \Cake\Console\Shell|\Cake\Console\CommandInterface|class-string&gt;</code>
     </DeprecatedClass>
   </file>
   <file src="src/Console/CommandFactoryInterface.php">

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -125,9 +125,9 @@ class MapReduce implements IteratorAggregate
      * Returns an iterator with the end result of running the Map and Reduce
      * phases on the original data
      *
-     * @return \ArrayIterator
+     * @return \Traversable
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         if (!$this->_executed) {
             $this->_execute();

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -58,7 +58,9 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $commands = $this->commands->getIterator();
-        $commands->ksort();
+        if ($commands instanceof ArrayIterator) {
+            $commands->ksort();
+        }
 
         if ($args->getOption('xml')) {
             $this->asXml($io, $commands);
@@ -75,10 +77,10 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      * Output text.
      *
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @param \ArrayIterator $commands The command collection to output.
+     * @param iterable $commands The command collection to output.
      * @return void
      */
-    protected function asText(ConsoleIo $io, ArrayIterator $commands): void
+    protected function asText(ConsoleIo $io, iterable $commands): void
     {
         $invert = [];
         foreach ($commands as $name => $class) {
@@ -182,10 +184,10 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      * Output as XML
      *
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @param \ArrayIterator $commands The command collection to output
+     * @param iterable $commands The command collection to output
      * @return void
      */
-    protected function asXml(ConsoleIo $io, ArrayIterator $commands): void
+    protected function asXml(ConsoleIo $io, iterable $commands): void
     {
         $shells = new SimpleXMLElement('<shells></shells>');
         foreach ($commands as $name => $class) {

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -20,6 +20,7 @@ use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * Collection for Commands.
@@ -34,6 +35,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * Command list
      *
      * @var array
+     * @psalm-var (\Cake\Console\Shell|\Cake\Console\CommandInterface|class-string)[]
      */
     protected $commands = [];
 
@@ -60,7 +62,6 @@ class CommandCollection implements IteratorAggregate, Countable
      */
     public function add(string $name, $command)
     {
-        /** @psalm-suppress DeprecatedClass */
         if (!is_subclass_of($command, Shell::class) && !is_subclass_of($command, CommandInterface::class)) {
             $class = is_string($command) ? $command : get_class($command);
             throw new InvalidArgumentException(sprintf(
@@ -125,8 +126,9 @@ class CommandCollection implements IteratorAggregate, Countable
      * Get the target for a command.
      *
      * @param string $name The named shell.
-     * @return string|\Cake\Console\CommandInterface Either the command class or an instance.
+     * @return string|\Cake\Console\Shell|\Cake\Console\CommandInterface Either the command class or an instance.
      * @throws \InvalidArgumentException when unknown commands are fetched.
+     * @psalm-return class-string|\Cake\Console\Shell|\Cake\Console\CommandInterface
      */
     public function get(string $name)
     {
@@ -140,9 +142,10 @@ class CommandCollection implements IteratorAggregate, Countable
     /**
      * Implementation of IteratorAggregate.
      *
-     * @return \ArrayIterator
+     * @return \Traversable
+     * @psalm-return \Traversable<string, \Cake\Console\Shell|\Cake\Console\CommandInterface|class-string>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->commands);
     }

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -22,6 +22,7 @@ use Cake\Event\EventListenerInterface;
 use Countable;
 use IteratorAggregate;
 use RuntimeException;
+use Traversable;
 
 /**
  * Acts as a registry/factory for objects.
@@ -375,10 +376,10 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     /**
      * Returns an array iterator.
      *
-     * @return \ArrayIterator
-     * @psalm-return \ArrayIterator<string, TObject>
+     * @return \Traversable
+     * @psalm-return \Traversable<string, TObject>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_loaded);
     }

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -25,6 +25,7 @@ use IteratorAggregate;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Traversable;
 
 /**
  * Cookie Collection
@@ -209,9 +210,10 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Gets the iterator
      *
-     * @return \ArrayIterator
+     * @return \Cake\Http\Cookie\CookieInterface[]
+     * @psalm-return \Traversable<string, \Cake\Http\Cookie\CookieInterface>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->cookies);
     }

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -223,7 +223,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
         if ($filter === null) {
             $filter = DateTimeZone::ALL;
         }
-        $identifiers = DateTimeZone::listIdentifiers($filter, (string)$country);
+        $identifiers = DateTimeZone::listIdentifiers($filter, (string)$country) ?: [];
 
         if ($regex) {
             foreach ($identifiers as $key => $tz) {

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -303,7 +303,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
         if ($filter === null) {
             $filter = DateTimeZone::ALL;
         }
-        $identifiers = DateTimeZone::listIdentifiers($filter, (string)$country);
+        $identifiers = DateTimeZone::listIdentifiers($filter, (string)$country) ?: [];
 
         if ($regex) {
             foreach ($identifiers as $key => $tz) {

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -22,6 +22,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Locator\LocatorInterface;
 use InvalidArgumentException;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * A container/collection for association classes.
@@ -378,9 +379,10 @@ class AssociationCollection implements IteratorAggregate
     /**
      * Allow looping through the associations
      *
-     * @return \ArrayIterator
+     * @return \Cake\ORM\Association[]
+     * @psalm-return \Traversable<string, \Cake\ORM\Association>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_items);
     }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -106,7 +106,7 @@ class ValidationRule
      *   new record
      * - data: The full data that was passed to the validation process
      * - field: The name of the field that is being processed
-     * @return bool|string
+     * @return bool|string|array
      * @throws \InvalidArgumentException when the supplied rule is not a valid
      * callable for the configured scope
      */

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -20,6 +20,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * ValidationSet object. Holds all validation rules for a field and exposes
@@ -214,9 +215,10 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns an iterator for each of the rules to be applied
      *
-     * @return \ArrayIterator
+     * @return \Cake\Validation\ValidationRule[]
+     * @psalm-return \Traversable<string, \Cake\Validation\ValidationRule>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_rules);
     }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -22,6 +22,7 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Psr\Http\Message\UploadedFileInterface;
+use Traversable;
 
 /**
  * Validator object encapsulates all methods related to data validations for a model
@@ -125,7 +126,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Holds the ValidationSet objects array
      *
-     * @var array
+     * @var \Cake\Validation\ValidationSet[]
+     * @psalm-var array<string, \Cake\Validation\ValidationSet>
      */
     protected $_fields = [];
 
@@ -397,9 +399,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     {
         if (!$rules instanceof ValidationSet) {
             $set = new ValidationSet();
-            foreach ((array)$rules as $name => $rule) {
+            foreach ($rules as $name => $rule) {
                 $set->add($name, $rule);
             }
+            $rules = $set;
         }
         $this->_fields[$field] = $rules;
     }
@@ -418,9 +421,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns an iterator for each of the fields to be validated
      *
-     * @return \ArrayIterator
+     * @return \Cake\Validation\ValidationSet[]
+     * @psalm-return \Traversable<string, \Cake\Validation\ValidationSet>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_fields);
     }


### PR DESCRIPTION
Improve docblock types to help static analyzers and IDEs detect the type of item returned by iterables.

https://blog.jetbrains.com/phpstorm/2016/06/phpstorm-2016-2-eap-162-844/

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
