### PR TITLE
4.1 - Deprecate DateTimeType::setTimezone()

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -157,6 +157,7 @@ class DateTimeType extends BaseType
      *
      * @param string|\DateTimeZone|null $timezone Database timezone.
      * @return $this
+     * @deprecated 4.1.0 Use `setDatabaseTimezone()` instead.
      */
     public function setTimezone($timezone)
     {


### PR DESCRIPTION
This was renamed to `setDatabaseTimezone()` for clarity in 4.0.0 release.
