### PR TITLE
4.1 - Use junction association bindingKey instead of target primaryKey

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -312,10 +312,17 @@ class BelongsToMany extends Association
     {
         $junctionAlias = $junction->getAlias();
         $sAlias = $source->getAlias();
+        $tAlias = $target->getAlias();
+
+        $targetBindingKey = null;
+        if ($junction->hasAssociation($tAlias)) {
+            $targetBindingKey = $junction->getAssociation($tAlias)->getBindingKey();
+        }
 
         if (!$target->hasAssociation($junctionAlias)) {
             $target->hasMany($junctionAlias, [
                 'targetTable' => $junction,
+                'bindingKey' => $targetBindingKey,
                 'foreignKey' => $this->getTargetForeignKey(),
                 'strategy' => $this->_strategy,
             ]);
@@ -350,9 +357,17 @@ class BelongsToMany extends Association
     protected function _generateSourceAssociations(Table $junction, Table $source): void
     {
         $junctionAlias = $junction->getAlias();
+        $sAlias = $source->getAlias();
+
+        $sourceBindingKey = null;
+        if ($junction->hasAssociation($sAlias)) {
+            $sourceBindingKey = $junction->getAssociation($sAlias)->getBindingKey();
+        }
+
         if (!$source->hasAssociation($junctionAlias)) {
             $source->hasMany($junctionAlias, [
                 'targetTable' => $junction,
+                'bindingKey' => $sourceBindingKey,
                 'foreignKey' => $this->getForeignKey(),
                 'strategy' => $this->_strategy,
             ]);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -753,7 +753,7 @@ class BelongsToMany extends Association
         $belongsTo = $junction->getAssociation($target->getAlias());
         $foreignKey = (array)$this->getForeignKey();
         $assocForeignKey = (array)$belongsTo->getForeignKey();
-        $targetPrimaryKey = (array)$target->getPrimaryKey();
+        $targetBindingKey = (array)$belongsTo->getBindingKey();
         $bindingKey = (array)$this->getBindingKey();
         $jointProperty = $this->_junctionProperty;
         $junctionRegistryAlias = $junction->getRegistryAlias();
@@ -764,7 +764,7 @@ class BelongsToMany extends Association
                 $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionRegistryAlias]);
             }
             $sourceKeys = array_combine($foreignKey, $sourceEntity->extract($bindingKey));
-            $targetKeys = array_combine($assocForeignKey, $e->extract($targetPrimaryKey));
+            $targetKeys = array_combine($assocForeignKey, $e->extract($targetBindingKey));
 
             $changedKeys = (
                 $sourceKeys !== $joint->extract($foreignKey) ||

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -183,6 +183,9 @@ class BelongsToManyTest extends TestCase
         $this->assertSame($assoc->getStrategy(), $this->tag->getAssociation('Articles')->getStrategy());
         $this->assertSame($assoc->getStrategy(), $this->tag->getAssociation('ArticlesTags')->getStrategy());
         $this->assertSame($assoc->getStrategy(), $this->article->getAssociation('ArticlesTags')->getStrategy());
+
+        $this->assertSame($this->article->getPrimaryKey(), $junction->getAssociation('Articles')->getBindingKey());
+        $this->assertSame($this->tag->getPrimaryKey(), $junction->getAssociation('Tags')->getBindingKey());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1422,4 +1422,77 @@ class BelongsToManyTest extends TestCase
         // The inner join on special_tags excludes the results.
         $this->assertSame(0, $query->count());
     }
+
+    /**
+     * Test custom binding key for target table association
+     *
+     * @return void
+     */
+    public function testCustomTargetBindingKeyContain()
+    {
+        $this->getTableLocator()->get('ArticlesTags')
+            ->belongsTo('SpecialTags', [
+                'bindingKey' => 'tag_id',
+                'foreignKey' => 'tag_id',
+            ]);
+
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('SpecialTags', [
+            'through' => 'ArticlesTags',
+            'targetForeignKey' => 'tag_id',
+        ]);
+
+        $results = $table->find()
+            ->contain('SpecialTags', function ($query) {
+                return $query->order(['SpecialTags.tag_id']);
+            })
+            ->where(['id' => 2])
+            ->toArray();
+
+        $this->assertCount(1, $results);
+        $this->assertCount(2, $results[0]->special_tags);
+
+        $this->assertSame(2, $results[0]->special_tags[0]->id);
+        $this->assertSame(1, $results[0]->special_tags[0]->tag_id);
+
+        $this->assertSame(1, $results[0]->special_tags[1]->id);
+        $this->assertSame(3, $results[0]->special_tags[1]->tag_id);
+    }
+
+    /**
+     * Test custom binding key for target table association
+     *
+     * @return void
+     */
+    public function testCustomTargetBindingKeyLink()
+    {
+        $this->getTableLocator()->get('ArticlesTags')
+            ->belongsTo('SpecialTags', [
+                'bindingKey' => 'tag_id',
+                'foreignKey' => 'tag_id',
+            ]);
+
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsToMany('SpecialTags', [
+            'through' => 'ArticlesTags',
+            'targetForeignKey' => 'tag_id',
+        ]);
+
+        $specialTag = $table->SpecialTags->newEntity([
+            'article_id' => 2,
+            'tag_id' => 2,
+        ]);
+        $table->SpecialTags->save($specialTag);
+
+        $article = $table->get(2);
+        $this->assertTrue($table->SpecialTags->link($article, [$specialTag]));
+
+        $results = $table->find()
+            ->contain('SpecialTags')
+            ->where(['id' => 2])
+            ->toArray();
+
+        $this->assertCount(1, $results);
+        $this->assertCount(3, $results[0]->special_tags);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/12061
Fixes https://github.com/cakephp/cakephp/issues/12238

This allows a BelongsToMany association to use a different bindingKey than the primaryKey for the table.  The default value for the bindingKey is the primary key of the target table.