### PR TITLE
[2.x] php-7.4-compact: replace deprecated curly brace offset access

### DIFF
--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -388,7 +388,7 @@ class ModelTask extends BakeTask {
 		sort($options);
 		$default = 1;
 		foreach ($options as $option) {
-			if ($option{0} !== '_') {
+			if ($option[0] !== '_') {
 				$choices[$default] = $option;
 				$default++;
 			}

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -237,7 +237,7 @@ class UpgradeShell extends AppShell {
 		foreach ($helpers as $helper) {
 			$helper = preg_replace('/Helper$/', '', $helper);
 			$oldHelper = $helper;
-			$oldHelper{0} = strtolower($oldHelper{0});
+			$oldHelper[0] = strtolower($oldHelper[0]);
 			$patterns[] = array(
 				"\${$oldHelper} to \$this->{$helper}",
 				"/\\\${$oldHelper}->/",

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -620,8 +620,8 @@ class ConsoleOptionParser {
 		if (substr($name, 0, 2) === '--') {
 			return isset($this->_options[substr($name, 2)]);
 		}
-		if ($name{0} === '-' && $name{1} !== '-') {
-			return isset($this->_shortOptions[$name{1}]);
+		if ($name[0] === '-' && $name[1] !== '-') {
+			return isset($this->_shortOptions[$name[1]]);
 		}
 		return false;
 	}

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -306,7 +306,7 @@ class ContainableBehavior extends ModelBehavior {
 				if (!$optionKey && is_string($key) && preg_match('/^[a-z(]/', $key) && (!isset($Model->{$key}) || !is_object($Model->{$key}))) {
 					$option = 'fields';
 					$val = array($key);
-					if ($key{0} === '(') {
+					if ($key[0] === '(') {
 						$val = preg_split('/\s*,\s*/', substr($key, 1, -1));
 					} elseif (preg_match('/ASC|DESC$/', $key)) {
 						$option = 'order';

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -190,7 +190,7 @@ class Permission extends AppModel {
 				$actions = array('_' . $actions);
 			}
 			foreach ($actions as $action) {
-				if ($action{0} !== '_') {
+				if ($action[0] !== '_') {
 					$action = '_' . $action;
 				}
 				if (!in_array($action, $permKeys, true)) {

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -589,7 +589,7 @@ class HttpSocket extends CakeSocket {
 			if (is_array($port)) {
 				$port = $port[0];
 			}
-			if ($url{0} === '/') {
+			if ($url[0] === '/') {
 				$url = $this->config['request']['uri']['host'] . ':' . $port . $url;
 			}
 			if (!preg_match('/^.+:\/\/|\*|^\//', $url)) {

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -401,7 +401,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 				$tags = (string)$tags;
 			}
 			$i++;
-			if (is_string($tags) && $tags{0} === '<') {
+			if (is_string($tags) && $tags[0] === '<') {
 				$tags = array(substr($tags, 1) => array());
 			} elseif (is_string($tags)) {
 				$tagsTrimmed = preg_replace('/\s+/m', '', $tags);

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -520,7 +520,7 @@ class Folder {
 		foreach ($iterator as $itemPath => $fsIterator) {
 			if ($skipHidden) {
 				$subPathName = $fsIterator->getSubPathname();
-				if ($subPathName{0} === '.' || strpos($subPathName, DS . '.') !== false) {
+				if ($subPathName[0] === '.' || strpos($subPathName, DS . '.') !== false) {
 					continue;
 				}
 			}

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -72,7 +72,7 @@ class Sanitize {
 		$db = ConnectionManager::getDataSource($connection);
 		$string = $db->value($string, 'string');
 		$start = 1;
-		if ($string{0} === 'N') {
+		if ($string[0] === 'N') {
 			$start = 2;
 		}
 

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -500,7 +500,7 @@ class Set {
 
 			$val = $data[$key];
 
-			if ($op === '=' && $expected && $expected{0} === '/') {
+			if ($op === '=' && $expected && $expected[0] === '/') {
 				return preg_match($expected, $val);
 			}
 			if ($op === '=' && $val != $expected) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2060,7 +2060,7 @@ class FormHelper extends AppHelper {
 			$tag = $this->Html->useTag('submitimage', $caption, $options);
 		} elseif ($isImage) {
 			unset($options['type']);
-			if ($caption{0} !== '/') {
+			if ($caption[0] !== '/') {
 				$url = $this->webroot(Configure::read('App.imageBaseUrl') . $caption);
 			} else {
 				$url = $this->webroot(trim($caption, '/'));

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -196,7 +196,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 		$length = strlen($string);
 		$return = '';
 		for ($i = 0; $i < $length; ++$i) {
-			$ord = ord($string{$i});
+			$ord = ord($string[$i]);
 			switch (true) {
 				case $ord == 0x08:
 					$return .= '\b';
@@ -216,10 +216,10 @@ abstract class JsBaseEngineHelper extends AppHelper {
 				case $ord == 0x22:
 				case $ord == 0x2F:
 				case $ord == 0x5C:
-					$return .= '\\' . $string{$i};
+					$return .= '\\' . $string[$i];
 					break;
 				case (($ord >= 0x20) && ($ord <= 0x7F)):
-					$return .= $string{$i};
+					$return .= $string[$i];
 					break;
 				case (($ord & 0xE0) == 0xC0):
 					if ($i + 1 >= $length) {
@@ -227,7 +227,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 						$return .= '?';
 						break;
 					}
-					$charbits = $string{$i} . $string{$i + 1};
+					$charbits = $string[$i] . $string[$i + 1];
 					$char = Multibyte::utf8($charbits);
 					$return .= sprintf('\u%04s', dechex($char[0]));
 					$i += 1;
@@ -238,7 +238,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 						$return .= '?';
 						break;
 					}
-					$charbits = $string{$i} . $string{$i + 1} . $string{$i + 2};
+					$charbits = $string[$i] . $string[$i + 1] . $string[$i + 2];
 					$char = Multibyte::utf8($charbits);
 					$return .= sprintf('\u%04s', dechex($char[0]));
 					$i += 2;
@@ -249,7 +249,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 						$return .= '?';
 						break;
 					}
-					$charbits = $string{$i} . $string{$i + 1} . $string{$i + 2} . $string{$i + 3};
+					$charbits = $string[$i] . $string[$i + 1] . $string[$i + 2] . $string[$i + 3];
 					$char = Multibyte::utf8($charbits);
 					$return .= sprintf('\u%04s', dechex($char[0]));
 					$i += 3;
@@ -260,7 +260,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 						$return .= '?';
 						break;
 					}
-					$charbits = $string{$i} . $string{$i + 1} . $string{$i + 2} . $string{$i + 3} . $string{$i + 4};
+					$charbits = $string[$i] . $string[$i + 1] . $string[$i + 2] . $string[$i + 3] . $string[$i + 4];
 					$char = Multibyte::utf8($charbits);
 					$return .= sprintf('\u%04s', dechex($char[0]));
 					$i += 4;
@@ -271,7 +271,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 						$return .= '?';
 						break;
 					}
-					$charbits = $string{$i} . $string{$i + 1} . $string{$i + 2} . $string{$i + 3} . $string{$i + 4} . $string{$i + 5};
+					$charbits = $string[$i] . $string[$i + 1] . $string[$i + 2] . $string[$i + 3] . $string[$i + 4] . $string[$i + 5];
 					$char = Multibyte::utf8($charbits);
 					$return .= sprintf('\u%04s', dechex($char[0]));
 					$i += 5;


### PR DESCRIPTION
Per https://wiki.php.net/rfc/deprecate_curly_braces_array_access and https://www.php.net/manual/en/migration74.deprecated.php
>  The array and string offset access syntax using curly braces is deprecated. Use $var[$idx] instead of $var{$idx}.

In a codebase I still have to maintain on 2.x (moving off is still work in progress), I recently discovered this:
> `2020-03-20 20:15:04 Notice: Array and string offset access syntax with curly braces is deprecated in [/project/app/Vendor/cakephp/cakephp/lib/Cake/Model/Behavior/ContainableBehavior.php, line 309]`

The project I experience this is mixed with other code parts which require this error level, i.e. I can't change that.

Full stacktrace:
```
ErrorException: Array and string offset access syntax with curly braces is deprecated
#20 /project/app/Vendor/cakephp/cakephp/lib/Cake/Model/Behavior/ContainableBehavior.php(309): handleError
#19 /project/app/Vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php(34): handleError
#18 /project/app/Vendor/cakephp/cakephp/lib/Cake/Core/App.php(547): include
#17 /project/app/Vendor/cakephp/cakephp/lib/Cake/Core/App.php(547): load
#16 /project/app/Vendor/cakephp/cakephp/lib/Cake/Core/App.php(0): spl_autoload_call
#15 [Anonymous function](0): class_exists
#14 /project/app/Vendor/cakephp/cakephp/lib/Cake/Model/BehaviorCollection.php(120): load
#13 /project/app/Vendor/cakephp/cakephp/lib/Cake/Model/BehaviorCollection.php(66): init
#12 /project/app/Vendor/cakephp/cakephp/lib/Cake/Model/Model.php(781): __construct
#11 /project/app/Vendor/cakephp/cakephp/lib/Cake/Model/Model.php(0): newInstance
#10 /project/app/Vendor/cakephp/cakephp/lib/Cake/Utility/ClassRegistry.php(169): init
#9 /project/app/Vendor/cakephp/cakephp/lib/Cake/Console/Shell.php(316): loadModel
#8 /project/app/Vendor/cakephp/cakephp/lib/Cake/Console/Shell.php(269): _loadModels
#7 /project/app/Vendor/cakephp/cakephp/lib/Cake/Console/Shell.php(228): initialize
#6 /project/app/Console/Command/AppShell.php(90): initialize
#5 /project/app/Console/Command/AppShell.php(26): perform
#4 lib/Resque/Job.php(199): perform
#3 lib/Resque/Worker.php(278): perform
#2 lib/Resque/Worker.php(241): work
#1 bin/resque(109): startWorker
#0 bin/resque(100): null
```

However I figured this was not the only place; it is currently the only one triggered in this project. Therefore I set out to fix all of them.
I did fix this with PhpStorms "Reports the usages of curly brace syntax for accessing array elements and string offsets."-intention.

Thanks for considering