### PR TITLE
add afterMarshal event

### DIFF
--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -266,6 +266,7 @@ class Behavior implements EventListenerInterface
     {
         $eventMap = [
             'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.afterMarshal' => 'afterMarshal',
             'Model.beforeFind' => 'beforeFind',
             'Model.beforeSave' => 'beforeSave',
             'Model.afterSave' => 'afterSave',

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -600,6 +600,7 @@ class Marshaller
                     $entity->setDirty($field, $value->isDirty());
                 }
             }
+            $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
 
             return $entity;
         }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -861,7 +861,7 @@ class Marshaller
         return $records;
     }
 
-     /**
+    /**
      * dispatch Model.afterMarshal event.
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity that was marshaled.

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -232,7 +232,7 @@ class Marshaller
         }
 
         $entity->setErrors($errors);
-        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
+        $this->dispatchAfterMarshal($entity, $data, $options);
 
         return $entity;
     }
@@ -600,7 +600,7 @@ class Marshaller
                     $entity->setDirty($field, $value->isDirty());
                 }
             }
-            $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
+            $this->dispatchAfterMarshal($entity, $data, $options);
 
             return $entity;
         }
@@ -614,7 +614,7 @@ class Marshaller
                 $entity->setDirty($field, $properties[$field]->isDirty());
             }
         }
-        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
+        $this->dispatchAfterMarshal($entity, $data, $options);
 
         return $entity;
     }
@@ -859,5 +859,20 @@ class Marshaller
         }
 
         return $records;
+    }
+
+     /**
+     * dispatch Model.afterMarshal event.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity that was marshaled.
+     * @param array $data readOnly $data to use.
+     * @param array $options List of options that are readOnly.
+     * @return void
+     */
+    protected function dispatchAfterMarshal(EntityInterface $entity, array $data, array $options = []): void
+    {
+        $data = new ArrayObject($data);
+        $options = new ArrayObject($options);
+        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity', 'data', 'options'));
     }
 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -232,6 +232,7 @@ class Marshaller
         }
 
         $entity->setErrors($errors);
+        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
 
         return $entity;
     }
@@ -612,6 +613,7 @@ class Marshaller
                 $entity->setDirty($field, $properties[$field]->isDirty());
             }
         }
+        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity'));
 
         return $entity;
     }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2884,6 +2884,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * The conventional method map is:
      *
      * - Model.beforeMarshal => beforeMarshal
+     * - Model.afterMarshal => afterMarshal
      * - Model.buildValidator => buildValidator
      * - Model.beforeFind => beforeFind
      * - Model.beforeSave => beforeSave
@@ -2901,6 +2902,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $eventMap = [
             'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.afterMarshal' => 'afterMarshal',
             'Model.buildValidator' => 'buildValidator',
             'Model.beforeFind' => 'beforeFind',
             'Model.beforeSave' => 'beforeSave',

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3242,6 +3242,105 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test Model.afterMarshal event.
+     *
+     * @return void
+     */
+    public function testAfterMarshalEvent()
+    {
+        $data = [
+            'title' => 'original title',
+            'body' => 'original content',
+            'user' => [
+                'name' => 'Robert',
+                'username' => 'rob',
+            ],
+        ];
+
+        $marshall = new Marshaller($this->articles);
+
+        $this->articles->getEventManager()->on(
+            'Model.afterMarshal',
+            function ($e, $entity, $data, $options) {
+                $this->assertInstanceOf('Cake\ORM\Entity', $entity);
+                $this->assertArrayHasKey('validate', $options);
+                $this->assertFalse($options['isMerge']);
+
+                $data['title'] = 'Modified title';
+                $data['user']['username'] = 'robert';
+                $options['associated'] = ['Users'];
+
+                $entity->body = 'Modified body';
+            }
+        );
+
+        $entity = $marshall->one($data);
+
+        $this->assertSame('original title', $entity->title, '$data is immutable');
+        $this->assertSame('Modified body', $entity->body);
+        // both $options and $data are unchangeable
+        $this->assertIsArray($entity->user, '$options[\'associated\'] is ignored');
+        $this->assertSame('Robert', $entity->user['name']);
+        $this->assertSame('rob', $entity->user['username']);
+    }
+
+    /**
+     * Test Model.afterMarshal event on patchEntity.
+     * when $options['fields'] is set and is empty
+     *
+     * @return void
+     */
+    public function testAfterMarshalEventOnPatchEntity()
+    {
+        $data = [
+            'title' => 'original title',
+            'body' => 'original content',
+            'user' => [
+                'name' => 'Robert',
+                'username' => 'rob',
+            ],
+        ];
+
+        $marshall = new Marshaller($this->articles);
+
+        $this->articles->getEventManager()->on(
+            'Model.afterMarshal',
+            function ($e, $entity, $data, $options) {
+                $this->assertInstanceOf('Cake\ORM\Entity', $entity);
+                $this->assertArrayHasKey('validate', $options);
+                $this->assertTrue($options['isMerge']);
+
+                $data['title'] = 'Modified title';
+                $data['user']['username'] = 'robert';
+                $options['associated'] = ['Users'];
+
+                $entity->body = 'options[fields] is empty';
+                if (isset($options['fields'])) {
+                    $entity->body = 'options[fields] is set';
+                }
+            }
+        );
+
+        //test when $options['fields'] is empty
+        $entity = $this->articles->newEmptyEntity();
+        $result = $marshall->merge($entity, $data, []);
+
+        $this->assertSame('original title', $entity->title, '$data is immutable');
+        $this->assertSame('options[fields] is empty', $entity->body);
+        // both $options and $data are unchangeable
+        $this->assertIsArray($entity->user, '$options[\'associated\'] is ignored');
+        $this->assertSame('Robert', $entity->user['name']);
+        $this->assertSame('rob', $entity->user['username']);
+
+        //test when $options['fields'] is set
+        $entity = $this->articles->newEmptyEntity();
+        $result = $marshall->merge($entity, $data, ['fields' => ['title', 'body']]);
+
+        $this->assertSame('original title', $entity->title, '$data is immutable');
+        $this->assertSame('options[fields] is set', $entity->body);
+    }
+
+    /**
      * Tests that patching an association resulting in no changes, will
      * not mark the parent entity as dirty
      *


### PR DESCRIPTION
how to use ?
```php
//model
use Cake\Datasource\EntityInterface;
use Cake\Event\EventInterface;

public function afterMarshal(EventInterface $event, EntityInterface $entity)
{
    //
}
```

why we need to this ?
for validation (set error) and manipulate  the result after `patchEntity()` there not any hook for this

other options ??
- buildValidator

works well but it suitable  for manipulate fields separately not several fields together and impossible to conditionally mark them as invalid/error 

- beforeRules
- afterRules

too late for manipulate entity because if there was an error on entity 
even `save()` and these callbacks/events  will not call/trigger

