### PR TITLE
Add RedirectMiddleware

### DIFF
--- a/src/Routing/Middleware/RedirectMiddleware.php
+++ b/src/Routing/Middleware/RedirectMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Routing\Middleware;
+
+use Cake\Routing\Exception\RedirectException;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Ensures any RedirectException thrown is redirected.
+ */
+class RedirectMiddleware implements MiddlewareInterface
+{
+    /**
+     * Ensures any RedirectException thrown is redirected.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            $response = $handler->handle($request);
+
+        } catch (RedirectException $e) {
+            return new RedirectResponse(
+                $e->getMessage(),
+                (int)$e->getCode()
+            );
+        }
+
+        return $response;
+    }
+}

--- a/src/Routing/Middleware/RedirectMiddleware.php
+++ b/src/Routing/Middleware/RedirectMiddleware.php
@@ -39,7 +39,6 @@ class RedirectMiddleware implements MiddlewareInterface
     {
         try {
             $response = $handler->handle($request);
-
         } catch (RedirectException $e) {
             return new RedirectResponse(
                 $e->getMessage(),

--- a/tests/TestCase/Http/Middleware/RedirectMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RedirectMiddlewareTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Http\ServerRequest;
+use Cake\Routing\Exception\RedirectException;
+use Cake\Routing\Middleware\RedirectMiddleware;
+use Cake\TestSuite\TestCase;
+use TestApp\Http\TestRequestHandler;
+
+class RedirectMiddlewareTest extends TestCase
+{
+    /**
+     * Provides the request handler
+     *
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    protected function _getRequestHandler()
+    {
+        return new TestRequestHandler(function ($request) {
+            throw new RedirectException('/foo/bar?baz=1');
+        });
+    }
+
+    /**
+     * testInvoke
+     *
+     * @return void
+     */
+    public function testProcess()
+    {
+        $request = new ServerRequest();
+
+        $middleware = new RedirectMiddleware();
+
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $headers = $response->getHeaders();
+        $expected = [
+            'location' => [
+                '/foo/bar?baz=1'
+            ],
+        ];
+
+        $this->assertEquals($expected, $headers);
+    }
+}

--- a/tests/TestCase/Http/Middleware/RedirectMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RedirectMiddlewareTest.php
@@ -52,7 +52,7 @@ class RedirectMiddlewareTest extends TestCase
         $headers = $response->getHeaders();
         $expected = [
             'location' => [
-                '/foo/bar?baz=1'
+                '/foo/bar?baz=1',
             ],
         ];
 


### PR DESCRIPTION
In 3.x we could use a hack with $reponse->send() and exit(); to make redirects from within the components and alike.
In 4.x this is not possible anymore, a cleaner approach is using the RedirectException available already.

But there is a core Middleware missing for handling this.

I added one on project level as demo here:
https://github.com/dereuromark/cakephp-sandbox/commit/b4fb8635fd8ea6bef3ac057d2351b776dc083ea4

You can see how it can be used
https://sandbox.dereuromark.de/sandbox/search-examples/table?page=12 (200 OK)
But when you hit the next page usually, you get a hard exception
This is not very user-friendly, as often, just an item got deleted at the end and thus the page count is one less. So if userland code wants to easily implement a paginator that does this, such middleware is vital here.
https://sandbox.dereuromark.de/sandbox/search-examples/table?page=13 (302 redirect)
This one now redirects to the last page on its own.

With this change, it is easier inside apps to leverage the given exception now.
