### PR TITLE
Rewrite note for getQuery() and getData().

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1333,7 +1333,7 @@ class ServerRequest implements ServerRequestInterface
      * ### PSR-7 Alternative
      *
      * ```
-     * $value = Hash::get($request->getQueryParams(), 'Post.id', null);
+     * $value = Hash::get($request->getQueryParams(), 'Post.id');
      * ```
      *
      * @param string|null $name The name or dotted path to the query param or null to read all.
@@ -1368,6 +1368,15 @@ class ServerRequest implements ServerRequestInterface
      * ```
      *
      * When reading values you will get `null` for keys/values that do not exist.
+     *
+     * Developers are encouraged to use getParsedBody() if they need the whole data array,
+     * as it is PSR-7 compliant, and this method is not. Using Hash::get() you can also get single params.
+     *
+     * ### PSR-7 Alternative
+     *
+     * ```
+     * $value = Hash::get($request->getParsedBody(), 'Post.id');
+     * ```
      *
      * @param string|null $name Dot separated name of the value to read. Or null to read all data.
      * @param mixed $default The default data.

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1327,8 +1327,8 @@ class ServerRequest implements ServerRequestInterface
     /**
      * Read a specific query value or dotted path.
      *
-     * Developers are encouraged to use getQueryParams() when possible as it is PSR-7 compliant, and this method
-     * is not.
+     * Developers are encouraged to use getQueryParams() if they need the whole query array,
+     * as it is PSR-7 compliant, and this method is not. Using Hash::get() you can also get single params.
      *
      * ### PSR-7 Alternative
      *


### PR DESCRIPTION
People are a bit scared from the original way this is written as they fear the getQuery() or getData() might go away.
I don't think the convenience wrapper should ever go away for the specific params to retrieve.

We could, however, deprecate the "whole params" way in favor of the PSR method.
That would also clean up the signature.
But if we do that, we should also consider doing that for getData() to getParsedBody() to be in sync.