### PR TITLE
Add Redirect exception support

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -20,8 +20,10 @@ use Cake\Core\App;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRenderer;
+use Cake\Http\Exception\RedirectException;
 use Cake\Http\Response;
 use InvalidArgumentException;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -116,6 +118,8 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     {
         try {
             return $handler->handle($request);
+        } catch (RedirectException $exception) {
+            return $this->handleRedirect($exception);
         } catch (Throwable $exception) {
             return $this->handleException($exception, $request);
         }
@@ -142,6 +146,21 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         }
 
         return $response;
+    }
+
+    /**
+     * Convert a redirect exception into a response.
+     *
+     * @param \Cake\Http\Exception\RedirectException $exception The exception to handle
+     * @return \Psr\Http\Message\ResponseInterface Response created from the redirect.
+     */
+    public function handleRedirect(RedirectException $exception): ResponseInterface
+    {
+        return new RedirectResponse(
+            $exception->getMessage(),
+            $exception->getCode(),
+            $exception->getHeaders()
+        );
     }
 
     /**

--- a/src/Http/Exception/RedirectException.php
+++ b/src/Http/Exception/RedirectException.php
@@ -33,7 +33,6 @@ use Cake\Core\Exception\Exception;
  */
 class RedirectException extends Exception
 {
-
     /**
      * Headers to include in the response.
      *

--- a/src/Http/Exception/RedirectException.php
+++ b/src/Http/Exception/RedirectException.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Exception;
+
+use Cake\Core\Exception\Exception;
+
+/**
+ * An exception subclass used by routing and application code to
+ * trigger a redirect.
+ *
+ * The URL and status code are provided as constructor arguments.
+ *
+ * ```
+ * throw new RedirectException('http://example.com/some/path', 301);
+ * ```
+ *
+ * Additional headers can also be provided in the constructor, or
+ * using the addHeaders() method.
+ */
+class RedirectException extends Exception
+{
+
+    /**
+     * Headers to include in the response.
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * Constructor
+     *
+     * @param string $target The URL to redirect to.
+     * @param int $code The exception code that will be used as a HTTP status code
+     * @param array $headers The headers that should be sent in the unauthorized challenge response.
+     */
+    public function __construct(string $target, int $code = 302, array $headers = [])
+    {
+        parent::__construct($target, $code);
+        $this->addHeaders($headers);
+    }
+
+    /**
+     * Add headers to be included in the response generated from this exception
+     *
+     * @param array $headers An array of `header => value` to append to the exception.
+     *  If a header already exists, the new values will be appended to the existing ones.
+     * @return $this
+     */
+    public function addHeaders(array $headers)
+    {
+        foreach ($headers as $key => $value) {
+            $this->headers[$key][] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a header from the exception.
+     *
+     * @param string $key The header to remove.
+     * @return $this
+     */
+    public function removeHeader(string $key)
+    {
+        unset($this->headers[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Get the headers from the exception.
+     *
+     * @return array
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+}

--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -27,6 +27,9 @@ use Cake\Core\Exception\Exception;
  * ```
  * throw new RedirectException('http://example.com/some/path', 301);
  * ```
+ *
+ * If you need a more general purpose redirect exception use
+ * Cake\Http\Exception\RedirectException instead of this class.
  */
 class RedirectException extends Exception
 {

--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -30,6 +30,8 @@ use Cake\Core\Exception\Exception;
  *
  * If you need a more general purpose redirect exception use
  * Cake\Http\Exception\RedirectException instead of this class.
+ *
+ * @deprecated 4.1.0 Use Cake\Http\Exception\RedirectException instead.
  */
 class RedirectException extends Exception
 {

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -18,9 +18,10 @@ namespace Cake\Routing\Middleware;
 
 use Cake\Cache\Cache;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Http\Exception\RedirectException;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
-use Cake\Routing\Exception\RedirectException;
+use Cake\Routing\Exception\RedirectException as DeprecatedRedirectException;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
@@ -146,6 +147,11 @@ class RoutingMiddleware implements MiddlewareInterface
                 Router::setRequest($request);
             }
         } catch (RedirectException $e) {
+            return new RedirectResponse(
+                $e->getMessage(),
+                (int)$e->getCode()
+            );
+        } catch (DeprecatedRedirectException $e) {
             return new RedirectResponse(
                 $e->getMessage(),
                 (int)$e->getCode()

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Route;
 
-use Cake\Routing\Exception\RedirectException;
+use Cake\Http\Exception\RedirectException;
 use Cake\Routing\Router;
 
 /**
@@ -59,7 +59,7 @@ class RedirectRoute extends Route
      * @param string $url The URL to parse.
      * @param string $method The HTTP method being used.
      * @return array|null Null on failure. An exception is raised on a successful match. Array return type is unused.
-     * @throws \Cake\Routing\Exception\RedirectException An exception is raised on successful match.
+     * @throws \Cake\Http\Exception\RedirectException An exception is raised on successful match.
      *   This is used to halt route matching and signal to the middleware that a redirect should happen.
      */
     public function parse(string $url, string $method = ''): ?array

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -160,7 +160,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertEquals(302, $result->getStatusCode());
-        $this->assertEmpty('' . $result->getBody());
+        $this->assertEmpty((string)$result->getBody());
         $expected = [
             'location' => ['http://example.org/login'],
         ];

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Routing\Route;
 
+use Cake\Http\Exception\RedirectException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Route\RedirectRoute;
 use Cake\Routing\Router;
@@ -70,7 +71,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseSimple()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/posts');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/home', ['controller' => 'posts']);
@@ -84,7 +85,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseRedirectOption()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/posts');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/home', ['redirect' => ['controller' => 'posts']]);
@@ -98,7 +99,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseArray()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/posts');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/home', ['controller' => 'posts', 'action' => 'index']);
@@ -112,7 +113,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseAbsolute()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://google.com');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/google', ['redirect' => 'http://google.com']);
@@ -126,7 +127,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseStatusCode()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/posts/view');
         $this->expectExceptionCode(302);
         $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['status' => 302]);
@@ -140,7 +141,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParsePersist()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/posts/view/2');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['persist' => true]);
@@ -160,7 +161,7 @@ class RedirectRouteTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/basedir/posts/view/2');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['persist' => true]);
@@ -174,7 +175,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParsePersistStringUrl()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/test');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/posts/*', ['redirect' => '/test'], ['persist' => true]);
@@ -188,7 +189,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParsePersistPassedArgs()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/tags/add/passme');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'tags', 'action' => 'add'], ['persist' => true]);
@@ -202,7 +203,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseNoPersistPassedArgs()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/tags/add');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'tags', 'action' => 'add']);
@@ -216,7 +217,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParsePersistPatterns()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/tags/add');
         $this->expectExceptionCode(301);
         $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
@@ -230,7 +231,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParsePersistMatchesAnotherRoute()
     {
-        $this->expectException(\Cake\Routing\Exception\RedirectException::class);
+        $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/nl/preferred_controllers');
         $this->expectExceptionCode(301);
         Router::connect('/:lang/preferred_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);


### PR DESCRIPTION
An alternative to #14384. I've added a new RedirectException class that isn't coupled to Routing package and is integrated with the ErrorHandlerMiddleware which enables any middleware/controller/component to raise a RedirectException and get the intended effect.
