### PR TITLE
Add session access for IntegrationTest testing.

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -419,6 +419,10 @@ class Session
             return false;
         }
 
+        if ($name === null) {
+            return (bool)$_SESSION;
+        }
+
         return Hash::get($_SESSION, $name) !== null;
     }
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1300,7 +1300,7 @@ trait IntegrationTestTrait
     /**
      * @return \Cake\TestSuite\TestSession
      */
-    protected function getTestSession(): TestSession
+    protected function getSession(): TestSession
     {
         return new TestSession($_SESSION);
     }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1296,4 +1296,12 @@ trait IntegrationTestTrait
             PHP_EOL .
             $exception->getTraceAsString();
     }
+
+    /**
+     * @return \Cake\TestSuite\TestSession
+     */
+    protected function getTestSession(): TestSession
+    {
+        return new TestSession($_SESSION);
+    }
 }

--- a/src/TestSuite/TestSession.php
+++ b/src/TestSuite/TestSession.php
@@ -50,6 +50,10 @@ class TestSession
             return false;
         }
 
+        if ($name === null) {
+            return (bool)$this->session;
+        }
+
         return Hash::get($this->session, $name) !== null;
     }
 

--- a/src/TestSuite/TestSession.php
+++ b/src/TestSuite/TestSession.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * A class to contain and retain the session during integration testing.
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.5
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Utility\Hash;
+
+/**
+ * Read only access to the session during testing.
+ */
+class TestSession
+{
+    /**
+     * @var array|null
+     */
+    protected $session;
+
+    /**
+     * @param array|null $session Session data.
+     */
+    public function __construct(?array $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Returns true if given variable name is set in session.
+     *
+     * @param string|null $name Variable name to check for
+     * @return bool True if variable is there
+     */
+    public function check(?string $name = null): bool
+    {
+        if ($this->session === null) {
+            return false;
+        }
+
+        return Hash::get($this->session, $name) !== null;
+    }
+
+    /**
+     * Returns given session variable, or all of them, if no parameters given.
+     *
+     * @param string|null $name The name of the session variable (or a path as sent to Hash.extract)
+     * @return mixed The value of the session variable, null if session not available,
+     *   session not started, or provided name not found in the session.
+     */
+    public function read(?string $name = null)
+    {
+        if ($this->session === null) {
+            return null;
+        }
+
+        if ($name === null) {
+            return $this->session ?: [];
+        }
+
+        return Hash::get($this->session, $name);
+    }
+}

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -100,6 +100,7 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $session->write('SessionTestCase', 'value');
+        $this->assertTrue($session->check());
         $this->assertTrue($session->check('SessionTestCase'));
         $this->assertFalse($session->check('NotExistingSessionTestCase'));
         $this->assertFalse($session->check('Crazy.foo'));

--- a/tests/TestCase/TestSuite/TestSessionTest.php
+++ b/tests/TestCase/TestSuite/TestSessionTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         4.0.5
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\TestSuite\TestCase;
+use Cake\TestSuite\TestSession;
+
+class TestSessionTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    protected $sessionData;
+
+    /**
+     * @var \Cake\TestSuite\TestSession
+     */
+    protected $session;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionData = [
+            'root' => [
+                'sub' => [
+                    'subsub' => 'foo',
+                ],
+            ],
+        ];
+        $this->session = new TestSession($this->sessionData);
+    }
+
+    /**
+     * Tests read()
+     *
+     * @return void
+     */
+    public function testRead(): void
+    {
+        $result = $this->session->read();
+        $this->assertSame($this->sessionData, $result);
+
+        $result = $this->session->read('root.sub');
+        $this->assertSame(['subsub' => 'foo'], $result);
+    }
+
+    /**
+     * Tests check()
+     *
+     * @return void
+     */
+    public function testCheck(): void
+    {
+        $result = $this->session->check();
+        $this->assertTrue($result);
+
+        $result = $this->session->check('root.sub');
+        $this->assertTrue($result);
+
+        $result = $this->session->check('root.nonexistent');
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/14270 and https://github.com/cakephp/cakephp/issues/14398

Fixes the session testing regression introduced in cake 4.

Now, you can do this (again):
```php
	$this->post(['plugin' => 'TestHelper', 'controller' => 'TestFixtures', 'action' => 'generate'], $data);

	$this->assertResponseCode(302);

	$flash = $this->getTestSession()->read('Flash.flash');
	$flash = Hash::combine($flash, '{n}.element', '{n}.message');
	$this->assertTextContains('bake fixture MyCoolRecords -q -p Tools', $flash['flash/info']);
	$this->assertSame('MyCoolRecordsFixture generated.', $flash['flash/success']);
```

The wrapper is read only, thus it only exposes read() and check().
It is also protected as there is no need afaik to have public access from a third party location.

It seems like the Session itself doesn't have a readOrFail(), so I didn't add one here either.
This could be a follow up addition for both classes.
See https://github.com/dereuromark/cakephp-test-helper/commit/0a8eaf56b02d39c25293ac51d9b1591050a437ed#diff-74bfea6f6fb4add7746dde591fe332efR76-R83 as possible implementation idea.