### PR TITLE
Updated inheritDoc comments to follow formatting standard.

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -73,9 +73,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function filter(?callable $c = null): CollectionInterface
     {
@@ -89,9 +87,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function reject(callable $c): CollectionInterface
     {
@@ -143,9 +139,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function map(callable $c): CollectionInterface
     {
@@ -654,9 +648,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function insert(string $path, $values): CollectionInterface
     {
@@ -692,9 +684,7 @@ trait CollectionTrait
     }
 
     /**
-     * Return array which should be serialized to JSON.
-     *
-     * @return array
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {
@@ -724,9 +714,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function buffered(): CollectionInterface
     {
@@ -734,9 +722,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\CollectionInterface
+     * @inheritDoc
      */
     public function listNested($dir = 'desc', $nestingKey = 'children'): CollectionInterface
     {
@@ -764,9 +750,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Cake\Collection\Iterator\StoppableIterator
+     * @inheritDoc
      */
     public function stopWhen($condition): CollectionInterface
     {
@@ -910,6 +894,9 @@ trait CollectionTrait
     /**
      * {@inheritDoc}
      *
+     * @param callable|null $operation A callable that allows you to customize the product result.
+     * @param callable|null $filter A filtering callback that must return true for a result to be part
+     *   of the final results.
      * @return \Cake\Collection\CollectionInterface
      * @throws \LogicException
      */
@@ -992,9 +979,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return int
+     * @inheritDoc
      */
     public function count(): int
     {
@@ -1008,9 +993,7 @@ trait CollectionTrait
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return int
+     * @inheritDoc
      */
     public function countKeys(): int
     {

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -76,12 +76,7 @@ class ExtractIterator extends Collection
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * We perform here some strictness analysis so that the
-     * iterator logic is bypassed entirely.
-     *
-     * @return \Traversable
+     * @inheritDoc
      */
     public function unwrap(): Traversable
     {

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -60,12 +60,7 @@ class FilterIterator extends Collection
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * We perform here some strictness analysis so that the
-     * iterator logic is bypassed entirely.
-     *
-     * @return \Traversable
+     * @inheritDoc
      */
     public function unwrap(): Traversable
     {

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -73,12 +73,7 @@ class ReplaceIterator extends Collection
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * We perform here some strictness analysis so that the
-     * iterator logic is bypassed entirely.
-     *
-     * @return \Traversable
+     * @inheritDoc
      */
     public function unwrap(): Traversable
     {

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -84,12 +84,7 @@ class StoppableIterator extends Collection
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * We perform here some strictness analysis so that the
-     * iterator logic is bypassed entirely.
-     *
-     * @return \Traversable
+     * @inheritDoc
      */
     public function unwrap(): Traversable
     {

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -41,7 +41,7 @@ abstract class BaseCommand implements CommandInterface
     protected $name = 'cake unknown';
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function setName(string $name)
     {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -682,15 +682,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * ### Example:
-     *
-     * ```
-     * $connection->transactional(function ($connection) {
-     *   $connection->newQuery()->delete('users')->execute();
-     * });
-     * ```
+     * @inheritDoc
      */
     public function transactional(callable $callback)
     {
@@ -730,15 +722,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * ### Example:
-     *
-     * ```
-     * $connection->disableConstraints(function ($connection) {
-     *   $connection->newQuery()->delete('users')->execute();
-     * });
-     * ```
+     * @inheritDoc
      */
     public function disableConstraints(callable $callback)
     {

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -59,7 +59,7 @@ class CachedCollection implements CollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function listTables(): array
     {
@@ -67,7 +67,7 @@ class CachedCollection implements CollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function describe(string $name, array $options = []): TableSchemaInterface
     {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -241,6 +241,10 @@ class SqliteSchema extends BaseSchema
      * stable, and the names for constraints will not match those used to create
      * the table. This is a limitation in Sqlite's metadata features.
      *
+     * @param \Cake\Database\Schema\TableSchema $schema The table object to append
+     *    an index or constraint to.
+     * @param array $row The row data from `describeIndexSql`.
+     * @return void
      */
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
@@ -308,6 +312,9 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
+     * @param string $name The name of the column.
+     * @return string SQL fragment.
      * @throws \Cake\Database\Exception when the column type is unknown
      */
     public function columnSql(TableSchema $schema, string $name): string
@@ -444,6 +451,9 @@ class SqliteSchema extends BaseSchema
      * Note integer primary keys will return ''. This is intentional as Sqlite requires
      * that integer primary keys be defined in the column definition.
      *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
+     * @param string $name The name of the column.
+     * @return string SQL fragment.
      */
     public function constraintSql(TableSchema $schema, string $name): string
     {
@@ -495,6 +505,9 @@ class SqliteSchema extends BaseSchema
      *
      * SQLite can not properly handle adding a constraint to an existing table.
      * This method is no-op
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
+     * @return array SQL fragment.
      */
     public function addConstraintSql(TableSchema $schema): array
     {
@@ -506,6 +519,9 @@ class SqliteSchema extends BaseSchema
      *
      * SQLite can not properly handle dropping a constraint to an existing table.
      * This method is no-op
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
+     * @return array SQL fragment.
      */
     public function dropConstraintSql(TableSchema $schema): array
     {

--- a/src/Database/Statement/MysqlStatement.php
+++ b/src/Database/Statement/MysqlStatement.php
@@ -28,7 +28,7 @@ class MysqlStatement extends PDOStatement
     use BufferResultsTrait;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      */
     public function execute(?array $params = null): bool

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -26,7 +26,7 @@ class SqliteStatement extends StatementDecorator
     use BufferResultsTrait;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      */
     public function execute(?array $params = null): bool

--- a/src/Database/Statement/SqlserverStatement.php
+++ b/src/Database/Statement/SqlserverStatement.php
@@ -26,10 +26,15 @@ use PDO;
 class SqlserverStatement extends PDOStatement
 {
     /**
+     * {@inheritDoc}
+     *
      * The SQL Server PDO driver requires that binary parameters be bound with the SQLSRV_ENCODING_BINARY attribute.
      * This overrides the PDOStatement::bindValue method in order to bind binary columns using the required attribute.
      *
-     * {@inheritDoc}
+     * @param string|int $column name or param position to be bound
+     * @param mixed $value The value to bind to variable in query
+     * @param string|int|null $type PDO type or name of configured Type class
+     * @return void
      */
     public function bindValue($column, $value, $type = 'string'): void
     {

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -71,9 +71,7 @@ class BoolType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -187,6 +187,8 @@ class DateTimeType extends BaseType
     /**
      * {@inheritDoc}
      *
+     * @param mixed $value Value to be converted to PHP equivalent
+     * @param \Cake\Database\DriverInterface $driver Object from which database preferences and configuration will be extracted
      * @return \DateTimeInterface|null
      */
     public function toPHP($value, DriverInterface $driver)
@@ -241,9 +243,7 @@ class DateTimeType extends BaseType
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver)
     {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -245,7 +245,7 @@ class DateTimeType extends BaseType
     /**
      * @inheritDoc
      */
-    public function manyToPHP(array $values, array $fields, DriverInterface $driver)
+    public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {
         foreach ($fields as $field) {
             if (!isset($values[$field])) {

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -77,7 +77,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Convert numeric values to strings representing decimal.
+     * {@inheritDoc}
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
@@ -93,9 +93,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -60,7 +60,7 @@ class FloatType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Convert float values to PHP integers
+     * {@inheritDoc}
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
@@ -77,9 +77,7 @@ class FloatType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -63,7 +63,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Convert integer values to PHP integers
+     * {@inheritDoc}
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
@@ -79,9 +79,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -49,7 +49,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Convert string values to PHP arrays.
+     * {@inheritDoc}
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
@@ -65,9 +65,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return array
+     * @inheritDoc
      */
     public function manyToPHP(array $values, array $fields, DriverInterface $driver): array
     {

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -80,6 +80,14 @@ interface ConnectionInterface extends LoggerAwareInterface
      *
      * The callback will receive the connection instance as its first argument.
      *
+     * ### Example:
+     *
+     * ```
+     * $connection->transactional(function ($connection) {
+     *   $connection->newQuery()->delete('users')->execute();
+     * });
+     * ```
+     *
      * @param callable $transaction The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
@@ -91,6 +99,14 @@ interface ConnectionInterface extends LoggerAwareInterface
      * Run an operation with constraints disabled.
      *
      * Constraints should be re-enabled after the callback succeeds/fails.
+     *
+     * ### Example:
+     *
+     * ```
+     * $connection->disableConstraints(function ($connection) {
+     *   $connection->newQuery()->delete('users')->execute();
+     * });
+     * ```
      *
      * @param callable $operation The callback to execute within a transaction.
      * @return mixed The return value of the callback.

--- a/src/Http/CallbackStream.php
+++ b/src/Http/CallbackStream.php
@@ -34,7 +34,7 @@ use Laminas\Diactoros\CallbackStream as BaseCallbackStream;
 class CallbackStream extends BaseCallbackStream
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @return string
      */

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -241,7 +241,7 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @return int The status code.
      */
@@ -251,7 +251,7 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param int $code The status code to set.
      * @param string $reasonPhrase The status reason phrase.
@@ -267,7 +267,7 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @return string The current reason phrase.
      */

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -182,9 +182,7 @@ class BelongsTo extends Association
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Closure
+     * @inheritDoc
      */
     public function eagerLoader(array $options): Closure
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -511,9 +511,7 @@ class BelongsToMany extends Association
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Closure
+     * @inheritDoc
      */
     public function eagerLoader(array $options): Closure
     {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -653,9 +653,7 @@ class HasMany extends Association
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Closure
+     * @inheritDoc
      */
     public function eagerLoader(array $options): Closure
     {

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -125,9 +125,7 @@ class HasOne extends Association
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return \Closure
+     * @inheritDoc
      */
     public function eagerLoader(array $options): Closure
     {

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -55,7 +55,7 @@ class SelectWithPivotLoader extends SelectLoader
     protected $junctionConditions;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      */
     public function __construct(array $options)

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -393,7 +393,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
     {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -214,11 +214,16 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Add in `_translations` marshalling handlers. You can disable marshalling
      * of translations by setting `'translations' => false` in the options
      * provided to `Table::newEntity()` or `Table::patchEntity()`.
      *
-     * {@inheritDoc}
+     * @param \Cake\ORM\Marshaller $marshaller The marhshaller of the table the behavior is attached to.
+     * @param array $map The property map being built.
+     * @param array $options The options array used in the marshalling call.
+     * @return array A map of `[property => callable]` of additional properties to marshal.
      */
     public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
     {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -872,6 +872,8 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Returns the COUNT(*) for the query. If the query has not been
      * modified, and the count has already been performed the cached
      * value is returned
+     *
+     * @return int
      */
     public function count(): int
     {
@@ -1033,6 +1035,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Cake\Datasource\ResultSetInterface
      * @throws \RuntimeException if this method is called on a non-select Query.
      */
     public function all(): ResultSetInterface
@@ -1181,9 +1184,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see \Cake\ORM\Table::find()
+     * @inheritDoc
      */
     public function find(string $finder, array $options = [])
     {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1460,8 +1460,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * $article = $articles->get(1, ['contain' => ['Users', 'Comments']]);
      * ```
      *
+     * @param mixed $primaryKey primary key value to find
+     * @param array $options options accepted by `Table::find()`
+     * @return \Cake\Datasource\EntityInterface
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException if the record with such id
+     * could not be found
      * @throws \Cake\Datasource\Exception\InvalidPrimaryKeyException When $primaryKey has an
      *      incorrect number of elements.
+     * @see \Cake\Datasource\RepositoryInterface::find()
      * @psalm-suppress InvalidReturnType
      */
     public function get($primaryKey, array $options = []): EntityInterface
@@ -1792,8 +1798,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * $articles->save($entity, ['associated' => false]);
      * ```
      *
-     * @param \Cake\Datasource\EntityInterface $entity
-     * @param array|\ArrayAccess|\Cake\ORM\SaveOptionsBuilder $options
+     * @param \Cake\Datasource\EntityInterface $entity the entity to be saved
+     * @param array|\ArrayAccess|\Cake\ORM\SaveOptionsBuilder $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface|false
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction is aborted in the afterSave event.
      */
@@ -2235,6 +2241,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * for the duration of the callbacks, this allows listeners to modify
      * the options used in the delete operation.
      *
+     * @param \Cake\Datasource\EntityInterface $entity The entity to remove.
+     * @param array|\ArrayAccess $options The options for the delete.
+     * @return bool success
      */
     public function delete(EntityInterface $entity, $options = []): bool
     {
@@ -2670,6 +2679,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
+     *
+     * @param array $data The data to build an entity with.
+     * @param array $options A list of options for the object hydration.
+     * @return \Cake\Datasource\EntityInterface
      */
     public function newEntity(array $data, array $options = []): EntityInterface
     {
@@ -2708,6 +2721,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
+     *
+     * @param array $data The data to build an entity with.
+     * @param array $options A list of options for the objects hydration.
+     * @return \Cake\Datasource\EntityInterface[] An array of hydrated records.
      */
     public function newEntities(array $data, array $options = []): array
     {
@@ -2762,6 +2779,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * presently has an identical value, the setter will not be called, and the
      * property will not be marked as dirty. This is an optimization to prevent unnecessary field
      * updates when persisting entities.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
+     * data merged in
+     * @param array $data key value list of fields to be merged into the entity
+     * @param array $options A list of options for the object hydration.
+     * @return \Cake\Datasource\EntityInterface
      */
     public function patchEntity(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
@@ -2797,6 +2820,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
+     *
+     * @param \Cake\Datasource\EntityInterface[]|\Traversable $entities the entities that will get the
+     * data merged in
+     * @param array $data list of arrays to be merged into the entities
+     * @param array $options A list of options for the objects hydration.
+     * @return \Cake\Datasource\EntityInterface[]
      */
     public function patchEntities(iterable $entities, array $data, array $options = []): array
     {

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 class OrdersFixture extends TestFixture
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public $table = 'orders';
 

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 class ProductsFixture extends TestFixture
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public $table = 'products';
 

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -13,7 +13,7 @@ use TestApp\Controller\TestAppsErrorController;
 class TestAppsExceptionRenderer extends ExceptionRenderer
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function _getController(): Controller
     {


### PR DESCRIPTION
This updates a couple formatting issues:

- Docblocks that want to just inherit must use `@inheritDoc`
- Docblocks that want to extend the comment must start with `{@inheritDoc}` on a single line.
- `inheritdoc` is updated to `inheritDoc`
- All `@param` and `@return` tags must be valid when extending docblock with `{@inheritDoc}`