### PR TITLE
Replaced deprecated expectExceptionMessageRegex

### DIFF
--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -83,7 +83,7 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabled()
     {
         $this->expectException(Deprecated::class);
-        $this->expectExceptionMessageRegExp('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
+        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away', 2);
@@ -97,7 +97,7 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabledDefaultFrame()
     {
         $this->expectException(Deprecated::class);
-        $this->expectExceptionMessageRegExp('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away');
@@ -123,7 +123,7 @@ class FunctionsTest extends TestCase
     public function testTriggerWarningEnabled()
     {
         $this->expectException(Warning::class);
-        $this->expectExceptionMessageRegExp('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             triggerWarning('This is going away');

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -480,7 +480,7 @@ class AssociationTest extends TestCase
     public function testPropertyNameClash()
     {
         $this->expectException(\PHPUnit\Framework\Error\Warning::class);
-        $this->expectExceptionMessageRegExp('/^Association property name "foo" clashes with field of same name of table "test"/');
+        $this->expectExceptionMessageMatches('/^Association property name "foo" clashes with field of same name of table "test"/');
         $this->source->setSchema(['foo' => ['type' => 'string']]);
         $this->assertSame('foo', $this->association->getProperty());
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1113,7 +1113,7 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithUrlFilterFailureClosure()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp(
+        $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: nope/'
         );
@@ -1142,7 +1142,7 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithUrlFilterFailureMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp(
+        $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: /'
         );

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -78,7 +78,7 @@ class SecurityTest extends TestCase
     public function testInvalidHashTypeException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/The hash type `doesnotexist` was not found. Available algorithms are: \w+/');
+        $this->expectExceptionMessageMatches('/The hash type `doesnotexist` was not found. Available algorithms are: \w+/');
 
         Security::hash('test', 'doesnotexist', false);
     }


### PR DESCRIPTION
Use expectExceptionMessageMatches instead.