### PR TITLE
Fix unload command removing too much content.

### DIFF
--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -70,7 +70,8 @@ class PluginUnloadCommand extends Command
      */
     protected function modifyApplication(string $app, string $plugin): bool
     {
-        $finder = "@\\\$this\-\>addPlugin\(\s*'$plugin'(.|.\n|)+\);+@";
+        $finder = "/\s*\\\$this\-\>addPlugin\(\s*['\"]{$plugin}['\"](\s*,[\s\\n]*\[(\\n.*|.*){0,5}\][\\n\s]*)?\);/m";
+        // $finder = "@\\\$this\-\>addPlugin\(\s*'$plugin'(.|.\n|)+\);+@";
 
         $content = file_get_contents($app);
         $newContent = preg_replace($finder, '', $content);

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -71,7 +71,6 @@ class PluginUnloadCommand extends Command
     protected function modifyApplication(string $app, string $plugin): bool
     {
         $finder = "/\s*\\\$this\-\>addPlugin\(\s*['\"]{$plugin}['\"](\s*,[\s\\n]*\[(\\n.*|.*){0,5}\][\\n\s]*)?\);/m";
-        // $finder = "@\\\$this\-\>addPlugin\(\s*'$plugin'(.|.\n|)+\);+@";
 
         $content = file_get_contents($app);
         $newContent = preg_replace($finder, '', $content);

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -70,7 +70,16 @@ class PluginUnloadCommand extends Command
      */
     protected function modifyApplication(string $app, string $plugin): bool
     {
-        $finder = "/\s*\\\$this\-\>addPlugin\(\s*['\"]{$plugin}['\"](\s*,[\s\\n]*\[(\\n.*|.*){0,5}\][\\n\s]*)?\);/m";
+        $plugin = preg_quote($plugin, '/');
+        $finder = "/
+            # whitespace and addPlugin call
+            \s*\\\$this\-\>addPlugin\(
+            # plugin name in quotes of any kind
+            \s*['\"]{$plugin}['\"]
+            # method arguments assuming a literal array with multiline args
+            (\s*,[\s\\n]*\[(\\n.*|.*){0,5}\][\\n\s]*)?
+            # closing paren of method
+            \);/mx";
 
         $content = file_get_contents($app);
         $newContent = preg_replace($finder, '', $content);

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -76,10 +76,6 @@ class PluginUnloadCommandTest extends TestCase
         $plugin2 = "\$this->addPlugin('TestPluginTwo', ['bootstrap' => false, 'routes' => false]);";
         $this->addPluginToApp($plugin1);
         $this->addPluginToApp($plugin2);
-
-        $contents = file_get_contents($this->app);
-        $this->assertStringContainsString($plugin1, $contents);
-
         $this->exec('plugin unload TestPlugin');
 
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -87,6 +83,26 @@ class PluginUnloadCommandTest extends TestCase
 
         $this->assertStringNotContainsString($plugin1, $contents);
         $this->assertStringContainsString($plugin2, $contents);
+    }
+
+    /**
+     * test removing the first plugin leaves the second behind.
+     *
+     * @return void
+     */
+    public function testUnloadFirstPlugin()
+    {
+        $plugin1 = "\$this->addPlugin('TestPlugin');";
+        $plugin2 = "\$this->addPlugin('TestPluginTwo');";
+        $this->addPluginToApp($plugin1);
+        $this->addPluginToApp($plugin2);
+        $this->exec('plugin unload TestPluginTwo');
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $contents = file_get_contents($this->app);
+
+        $this->assertStringNotContainsString($plugin2, $contents);
+        $this->assertStringContainsString($plugin1, $contents);
     }
 
     /**
@@ -176,7 +192,7 @@ class PluginUnloadCommandTest extends TestCase
     protected function addPluginToApp($insert)
     {
         $contents = file_get_contents($this->app);
-        $contents = preg_replace('/(function bootstrap\(\)(?:\s*)\:(?:\s*)void(?:\s+)\{)/m', '$1' . $insert, $contents);
+        $contents = preg_replace('/(function bootstrap\(\)(?:\s*)\:(?:\s*)void(?:\s+)\{)/m', "\$1\n        " . $insert, $contents);
         file_put_contents($this->app, $contents);
     }
 }

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -93,10 +93,10 @@ class PluginUnloadCommandTest extends TestCase
     public function testUnloadFirstPlugin()
     {
         $plugin1 = "\$this->addPlugin('TestPlugin');";
-        $plugin2 = "\$this->addPlugin('TestPluginTwo');";
+        $plugin2 = "\$this->addPlugin('Vendor/TestPluginTwo');";
         $this->addPluginToApp($plugin1);
         $this->addPluginToApp($plugin2);
-        $this->exec('plugin unload TestPluginTwo');
+        $this->exec('plugin unload Vendor/TestPluginTwo');
 
         $this->assertExitCode(Command::CODE_SUCCESS);
         $contents = file_get_contents($this->app);


### PR DESCRIPTION
The previous regex would include all plugins that followed the named plugin. The new pattern is a bit more deliberate about the structure of the parameters to unload.

Fixes #14414
Fixes #14415
