### PR TITLE
Fixed spacing for reference assignment

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -614,7 +614,7 @@ trait CollectionTrait
             $row[$nestingKey] = [];
             $id = $idPath($row, $key);
             $parentId = $parentPath($row, $key);
-            $parents[$id] =& $row;
+            $parents[$id] = &$row;
             $mapReduce->emitIntermediate($id, $parentId);
         };
 
@@ -635,7 +635,7 @@ trait CollectionTrait
 
             $children = [];
             foreach ($values as $id) {
-                $children[] =& $parents[$id];
+                $children[] = &$parents[$id];
             }
             $parents[$key][$nestingKey] = $children;
         };

--- a/src/Collection/Iterator/InsertIterator.php
+++ b/src/Collection/Iterator/InsertIterator.php
@@ -109,12 +109,12 @@ class InsertIterator extends Collection
             return $row;
         }
 
-        $pointer =& $row;
+        $pointer = &$row;
         foreach ($this->_path as $step) {
             if (!isset($pointer[$step])) {
                 return $row;
             }
-            $pointer =& $pointer[$step];
+            $pointer = &$pointer[$step];
         }
 
         $pointer[$this->_target] = $this->_values->current();

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -599,8 +599,8 @@ class Shell
         if (empty($this->{$name}) && in_array($name, $this->taskNames, true)) {
             $properties = $this->_taskMap[$name];
             $this->{$name} = $this->Tasks->load($properties['class'], $properties['config']);
-            $this->{$name}->args =& $this->args;
-            $this->{$name}->params =& $this->params;
+            $this->{$name}->args = &$this->args;
+            $this->{$name}->params = &$this->params;
             $this->{$name}->initialize();
             $this->{$name}->loadTasks();
         }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -257,7 +257,7 @@ trait InstanceConfigTrait
             return;
         }
 
-        $update =& $this->_config;
+        $update = &$this->_config;
         $stack = explode('.', $key);
 
         foreach ($stack as $k) {
@@ -269,7 +269,7 @@ trait InstanceConfigTrait
                 $update[$k] = [];
             }
 
-            $update =& $update[$k];
+            $update = &$update[$k];
         }
 
         $update = $value;
@@ -290,7 +290,7 @@ trait InstanceConfigTrait
             return;
         }
 
-        $update =& $this->_config;
+        $update = &$this->_config;
         $stack = explode('.', $key);
         $length = count($stack);
 
@@ -308,7 +308,7 @@ trait InstanceConfigTrait
                 break;
             }
 
-            $update =& $update[$k];
+            $update = &$update[$k];
         }
     }
 }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -597,7 +597,7 @@ class QueryExpression implements ExpressionInterface, Countable
     {
         $parts = [];
         foreach ($this->_conditions as $k => $c) {
-            $key =& $k;
+            $key = &$k;
             $part = $callable($c, $key);
             if ($part !== null) {
                 $parts[$key] = $part;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -281,7 +281,7 @@ trait EntityTrait
         $method = static::_accessor($field, 'get');
 
         if (isset($this->_fields[$field])) {
-            $value =& $this->_fields[$field];
+            $value = &$this->_fields[$field];
         }
 
         if ($method) {

--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -33,7 +33,7 @@ trait AssociationsNormalizerTrait
     {
         $result = [];
         foreach ((array)$associations as $table => $options) {
-            $pointer =& $result;
+            $pointer = &$result;
 
             if (is_int($table)) {
                 $table = $options;
@@ -49,14 +49,14 @@ trait AssociationsNormalizerTrait
             $table = array_pop($path);
             $first = array_shift($path);
             $pointer += [$first => []];
-            $pointer =& $pointer[$first];
+            $pointer = &$pointer[$first];
             $pointer += ['associated' => []];
 
             foreach ($path as $t) {
                 $pointer += ['associated' => []];
                 $pointer['associated'] += [$t => []];
                 $pointer['associated'][$t] += ['associated' => []];
-                $pointer =& $pointer['associated'][$t];
+                $pointer = &$pointer['associated'][$t];
             }
 
             $pointer['associated'] += [$table => []];

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -252,14 +252,14 @@ class EagerLoader
         $assocs = explode('.', $assoc);
         $last = array_pop($assocs);
         $containments = [];
-        $pointer =& $containments;
+        $pointer = &$containments;
         $opts = ['matching' => true] + $options;
         /** @psalm-suppress InvalidArrayOffset */
         unset($opts['negateMatch']);
 
         foreach ($assocs as $name) {
             $pointer[$name] = $opts;
-            $pointer =& $pointer[$name];
+            $pointer = &$pointer[$name];
         }
 
         $pointer[$last] = ['queryBuilder' => $builder, 'matching' => true] + $options;
@@ -337,7 +337,7 @@ class EagerLoader
         $result = $original;
 
         foreach ((array)$associations as $table => $options) {
-            $pointer =& $result;
+            $pointer = &$result;
             if (is_int($table)) {
                 $table = $options;
                 $options = [];
@@ -359,7 +359,7 @@ class EagerLoader
                 $table = array_pop($path);
                 foreach ($path as $t) {
                     $pointer += [$t => []];
-                    $pointer =& $pointer[$t];
+                    $pointer = &$pointer[$t];
                 }
             }
 

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -361,7 +361,7 @@ class Hash
      */
     protected static function _simpleOp(string $op, array $data, array $path, $values = null): array
     {
-        $_list =& $data;
+        $_list = &$data;
 
         $count = count($path);
         $last = $count - 1;
@@ -375,7 +375,7 @@ class Hash
                 if (!isset($_list[$key])) {
                     $_list[$key] = [];
                 }
-                $_list =& $_list[$key];
+                $_list = &$_list[$key];
                 if (!is_array($_list)) {
                     $_list = [];
                 }
@@ -390,7 +390,7 @@ class Hash
                 if (!isset($_list[$key])) {
                     return $data;
                 }
-                $_list =& $_list[$key];
+                $_list = &$_list[$key];
             }
         }
 
@@ -1239,9 +1239,9 @@ class Hash
                 $idMap[$id] = array_merge($result, [$options['children'] => []]);
             }
             if (!$parentId || !in_array($parentId, $ids)) {
-                $return[] =& $idMap[$id];
+                $return[] = &$idMap[$id];
             } else {
-                $idMap[$parentId][$options['children']][] =& $idMap[$id];
+                $idMap[$parentId][$options['children']][] = &$idMap[$id];
             }
         }
 


### PR DESCRIPTION
Languages with heavy use of references tend to put the operator directly before the variable not directly next to the assignment operator.

This is easier to read for most people.