### PR TITLE
addHelper() as chainable method, with IDE support.

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -302,6 +302,18 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
+     * Adds a helper to use.
+     *
+     * @param string $helper Helper to use.
+     * @return $this
+     * @since 4.1.0
+     */
+    public function addHelper(string $helper)
+    {
+        return $this->setHelpers([$helper]);
+    }
+
+    /**
      * Sets the helpers to use.
      *
      * @param array $helpers Helpers to use.

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -402,6 +402,9 @@ class ViewBuilderTest extends TestCase
         $this->assertEmpty($result);
     }
 
+    /**
+     * @return void
+     */
     public function testOptionSetGet()
     {
         $builder = new ViewBuilder();
@@ -416,8 +419,6 @@ class ViewBuilderTest extends TestCase
     }
 
     /**
-     * testDisableAutoLayout
-     *
      * @return void
      */
     public function testDisableAutoLayout()
@@ -427,5 +428,24 @@ class ViewBuilderTest extends TestCase
 
         $builder->disableAutoLayout();
         $this->assertFalse($builder->isAutoLayoutEnabled());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddHelperChained()
+    {
+        $builder = new ViewBuilder();
+        $builder->addHelper('Form')
+            ->addHelper('Time')
+            ->addHelper('Text');
+
+        $helpers = $builder->getHelpers();
+        $expected = [
+            'Form',
+            'Time',
+            'Text',
+        ];
+        $this->assertSame($expected, $helpers);
     }
 }


### PR DESCRIPTION
4.next version of https://github.com/cakephp/cakephp/pull/14435

You cannot always set all helpers via AppView and loadHelper() calls.
Sometimes you do it inside controller using view builder.
Currently, the array syntax has 0 autocomplete on the magic strings inside.

I propose to add a syntactic sugar that makes the IDE experience here way better, faster and cleaner coding. The merge overhead on a simple small list here should be irrelevant on that request level.

```php
// Before, no autocomplete :(
$this->viewBuilder()->setHelpers(['Tools.Format', 'Captcha.Captcha']);

// After, nice chaining with suggest/autocomplete
$this->viewBuilder()
	->addHelper('Tools.Format')
	->addHelper('Captcha.Captcha');
```

Makes it possible to have https://github.com/dereuromark/cakephp-ide-helper auto complete now. PR: https://github.com/dereuromark/cakephp-ide-helper/pull/180

See

![ide_autocomplete](https://user-images.githubusercontent.com/39854/79008512-d9888800-7b5d-11ea-9d16-739d1922cd29.png)

