### PR TITLE
Fix routes check not handling invalid input

### DIFF
--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -90,6 +90,7 @@ class RoutesCheckCommand extends Command
         )
         ->addArgument('url', [
             'help' => 'The URL to check.',
+            'required' => true,
         ]);
 
         return $parser;

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -108,7 +108,6 @@ class RoutesCommandTest extends TestCase
         $this->assertErrorEmpty();
     }
 
-
     /**
      * Ensure routes check with no input
      *

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -108,6 +108,19 @@ class RoutesCommandTest extends TestCase
         $this->assertErrorEmpty();
     }
 
+
+    /**
+     * Ensure routes check with no input
+     *
+     * @return void
+     */
+    public function testCheckNoInput()
+    {
+        $this->exec('routes check');
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('`url` argument is required');
+    }
+
     /**
      * Test checking an existing route.
      *


### PR DESCRIPTION
Make the positional argument required so we don't get errors downstream.

Fixes #14438
