### PR TITLE
Fix #14432 Case insensitive stored procedure

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -380,7 +380,7 @@ trait SqlserverDialectTrait
      */
     public function disableForeignKeySQL()
     {
-        return 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"';
+        return 'EXEC sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"';
     }
 
     /**
@@ -388,6 +388,6 @@ trait SqlserverDialectTrait
      */
     public function enableForeignKeySQL()
     {
-        return 'EXEC sp_msforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"';
+        return 'EXEC sp_MSforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"';
     }
 }


### PR DESCRIPTION
Fix #14432 Case insensitive stored procedure call fail on SQLServer 2014 (12.0.5579)