### PR TITLE
Added float type annotation to TIME_START define

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -15,7 +15,10 @@
 
 use Cake\Routing\Router;
 
-define('TIME_START', microtime(true));
+/**
+ * @var float
+ */
+define('TIME_START', (float)microtime(true));
 
 require CAKE . 'basics.php';
 


### PR DESCRIPTION
This sets the type to float instead of mixed from microtime() for static analyzers.
