### PR TITLE
Alias PHPUnit MockBuilder separately

### DIFF
--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -15,6 +15,9 @@ if (class_exists('PHPUnit_Runner_Version')) {
         class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
         class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
         class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
-        class_alias('PHPUnit_Framework_MockObject_MockBuilder', 'PHPUnit\Framework\MockObject\MockBuilder');
     }
+}
+
+if (!class_exists('PHPUnit\Framework\MockObject\MockBuilder')) {
+    class_alias('PHPUnit_Framework_MockObject_MockBuilder', 'PHPUnit\Framework\MockObject\MockBuilder');
 }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/14443

`MockBuilder` is in separate package from PHPUnit, handle their aliases separately.

https://github.com/cakephp/cakephp/blob/3.8.11/tests/phpunit_aliases.php expects either both `phpunit/phpunit` and `phpunit/phpunit-mock-objects` classes are namespaced or underscored, but in some versions they are mixed.

PHPUnit 5.7 (underscored) requires `"phpunit/phpunit-mock-objects": "^3.2"` (underscored),
PHPUnit 6.0-6.4 (namespaces) requires `"phpunit/phpunit-mock-objects": "^4.0"` (underscored),
PHPUnit 6.5 (namespaces) requires `"phpunit/phpunit-mock-objects": "^5.0"` (namespaces).

Another option would be to change constraint
```diff
-"phpunit/phpunit": "^5.7.14|^6.0"
+"phpunit/phpunit": "^5.7.14|^6.5"
```
