### PR TITLE
Backport new 4.next afterMarshal event to 3.next

### DIFF
--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -260,6 +260,7 @@ class Behavior implements EventListenerInterface
     {
         $eventMap = [
             'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.afterMarshal' => 'afterMarshal',
             'Model.beforeFind' => 'beforeFind',
             'Model.beforeSave' => 'beforeSave',
             'Model.afterSave' => 'afterSave',

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -222,6 +222,7 @@ class Marshaller
         }
 
         $entity->setErrors($errors);
+        $this->dispatchAfterMarshal($entity, $data, $options);
 
         return $entity;
     }
@@ -606,6 +607,7 @@ class Marshaller
                     $entity->setDirty($field, $value->isDirty());
                 }
             }
+            $this->dispatchAfterMarshal($entity, $data, $options);
 
             return $entity;
         }
@@ -619,6 +621,7 @@ class Marshaller
                 $entity->setDirty($field, $properties[$field]->isDirty());
             }
         }
+        $this->dispatchAfterMarshal($entity, $data, $options);
 
         return $entity;
     }
@@ -858,5 +861,20 @@ class Marshaller
         }
 
         return $records;
+    }
+
+    /**
+     * dispatch Model.afterMarshal event.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity that was marshaled.
+     * @param array $data readOnly $data to use.
+     * @param array $options List of options that are readOnly.
+     * @return void
+     */
+    protected function dispatchAfterMarshal(EntityInterface $entity, array $data, array $options)
+    {
+        $data = new ArrayObject($data);
+        $options = new ArrayObject($options);
+        $this->_table->dispatchEvent('Model.afterMarshal', compact('entity', 'data', 'options'));
     }
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2970,6 +2970,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * The conventional method map is:
      *
      * - Model.beforeMarshal => beforeMarshal
+     * - Model.afterMarshal => afterMarshal
      * - Model.buildValidator => buildValidator
      * - Model.beforeFind => beforeFind
      * - Model.beforeSave => beforeSave
@@ -2987,6 +2988,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $eventMap = [
             'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.afterMarshal' => 'afterMarshal',
             'Model.buildValidator' => 'buildValidator',
             'Model.beforeFind' => 'beforeFind',
             'Model.beforeSave' => 'beforeSave',


### PR DESCRIPTION
Backport new 4.next afterMarshal event ( https://github.com/cakephp/cakephp/pull/14383 ) to 3.next
Further closes feature gap moving from 3.9 to 4.1 as upgrade path.


Takes care of https://github.com/cakephp/cakephp/issues/13493#issuecomment-610488608
