### PR TITLE
Deprecate false/string for FormHelper::create() to ease upgrade pain.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -397,7 +397,7 @@ class FormHelper extends Helper
      *
      * @param mixed $context The context for which the form is being defined.
      *   Can be a ContextInterface instance, ORM entity, ORM resultset, or an
-     *   array of meta data. You can use false or null to make a context-less form.
+     *   array of meta data. You can use null to make a context-less form.
      * @param array $options An array of html attributes and options.
      * @return string An formatted opening FORM tag.
      * @link https://book.cakephp.org/3/en/views/helpers/form.html#Cake\View\Helper\FormHelper::create
@@ -405,6 +405,10 @@ class FormHelper extends Helper
     public function create($context = null, array $options = [])
     {
         $append = '';
+
+        if (is_bool($context) || is_string($context)) {
+            deprecationWarning('Using `string` or `bool` for $context is deprecated, use `null` to make a context-less form.');
+        }
 
         if ($context instanceof ContextInterface) {
             $this->context($context);
@@ -1883,7 +1887,7 @@ class FormHelper extends Helper
             $formOptions = $options['form'] + $formOptions;
             unset($options['form']);
         }
-        $out = $this->create(false, $formOptions);
+        $out = $this->create(null, $formOptions);
         if (isset($options['data']) && is_array($options['data'])) {
             foreach (Hash::flatten($options['data']) as $key => $value) {
                 $out .= $this->hidden($key, ['value' => $value]);

--- a/tests/test_app/TestApp/Template/Posts/cache_form.ctp
+++ b/tests/test_app/TestApp/Template/Posts/cache_form.ctp
@@ -1,5 +1,5 @@
 <div class="users form">
-    <?= $this->Form->create(false); ?>
+    <?= $this->Form->create(); ?>
         <fieldset>
             <legend><?= __('Add User'); ?></legend>
         </fieldset>


### PR DESCRIPTION
Takes care of https://github.com/cakephp/cakephp/issues/13493#issuecomment-570640461