### PR TITLE
Debug a var when you user REST api methodology

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -142,7 +142,13 @@ if (!function_exists('dd')) {
             'line' => $trace[0]['line'],
             'file' => $trace[0]['file'],
         ];
-
+        
+        $origin = substr($_SERVER['HTTP_REFERER'], 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
+        $headers = ['authorization', 'content-type', 'api-token'];
+        header('Access-Control-Allow-Credentials: true');
+        header('Access-Control-Allow-Headers: '.implode($headers, ' '));
+        header('Access-Control-Allow-Origin:'.str_replace('\/', '', $origin));
+        
         Debugger::printVar($var, $location, $showHtml);
         die(1);
     }

--- a/src/basics.php
+++ b/src/basics.php
@@ -144,7 +144,8 @@ if (!function_exists('dd')) {
         ];
 
         if (PHP_SAPI !== 'cli') {
-            $origin = substr($_SERVER['HTTP_REFERER'], 0, strlen($_SERVER['HTTP_REFERER'] - 1));
+            $referer = env('HTTP_SERVER', '');
+            $origin = substr($referer, 0, (strlen($referer) - 1));
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');
             header(sprintf('Access-Control-Allow-Headers: %s', implode(' ', $headers)));

--- a/src/basics.php
+++ b/src/basics.php
@@ -144,7 +144,7 @@ if (!function_exists('dd')) {
         ];
 
         if (PHP_SAPI !== 'cli') {
-            $origin = substr($_SERVER['HTTP_REFERER'], 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
+            $origin = substr($_SERVER['HTTP_REFERER'], 0, strlen($_SERVER['HTTP_REFERER'] - 1));
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');
             header(sprintf('Access-Control-Allow-Headers: %s', implode(' ', $headers)));

--- a/src/basics.php
+++ b/src/basics.php
@@ -142,13 +142,15 @@ if (!function_exists('dd')) {
             'line' => $trace[0]['line'],
             'file' => $trace[0]['file'],
         ];
-        
-        $origin = substr($_SERVER['HTTP_REFERER'], 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
-        $headers = ['authorization', 'content-type', 'api-token'];
-        header('Access-Control-Allow-Credentials: true');
-        header('Access-Control-Allow-Headers: '.implode($headers, ' '));
-        header('Access-Control-Allow-Origin:'.str_replace('\/', '', $origin));
-        
+
+        if (PHP_SAPI !== 'cli') {
+            $origin = substr(env('HTTP_REFERER'), 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
+            $headers = ['authorization', 'content-type', 'api-token'];
+            header('Access-Control-Allow-Credentials: true');
+            header('Access-Control-Allow-Headers: '.implode($headers, ' '));
+            header('Access-Control-Allow-Origin:'.str_replace('\/', '', $origin));
+        }
+
         Debugger::printVar($var, $location, $showHtml);
         die(1);
     }

--- a/src/basics.php
+++ b/src/basics.php
@@ -144,7 +144,7 @@ if (!function_exists('dd')) {
         ];
 
         if (PHP_SAPI !== 'cli') {
-            $referer = env('HTTP_SERVER', '');
+            $referer = env('HTTP_REFERER', '');
             $origin = substr($referer, 0, (strlen($referer) - 1));
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');

--- a/src/basics.php
+++ b/src/basics.php
@@ -143,8 +143,11 @@ if (!function_exists('dd')) {
             'file' => $trace[0]['file'],
         ];
 
-        if (PHP_SAPI !== 'cli') {
-            $referer = env('HTTP_REFERER') ?? '';
+       if (
+            PHP_SAPI !== 'cli'
+            && $_SERVER['HTTP_REFERER']
+        ) {
+            $referer = $_SERVER['HTTP_REFERER'];
             $origin = substr($referer, 0, strlen($referer) - 1);
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');

--- a/src/basics.php
+++ b/src/basics.php
@@ -144,11 +144,11 @@ if (!function_exists('dd')) {
         ];
 
         if (PHP_SAPI !== 'cli') {
-            $origin = substr(env('HTTP_REFERER'), 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
+            $origin = substr($_SERVER['HTTP_REFERER'], 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');
-            header('Access-Control-Allow-Headers: '.implode($headers, ' '));
-            header('Access-Control-Allow-Origin:'.str_replace('\/', '', $origin));
+            header(sprintf('Access-Control-Allow-Headers: %s', implode($headers, ' ')));
+            header(sprintf('Access-Control-Allow-Origin: %s', $origin));
         }
 
         Debugger::printVar($var, $location, $showHtml);

--- a/src/basics.php
+++ b/src/basics.php
@@ -147,7 +147,7 @@ if (!function_exists('dd')) {
             $origin = substr($_SERVER['HTTP_REFERER'], 0, (strlen($_SERVER['HTTP_REFERER']) - 1));
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');
-            header(sprintf('Access-Control-Allow-Headers: %s', implode($headers, ' ')));
+            header(sprintf('Access-Control-Allow-Headers: %s', implode(' ', $headers)));
             header(sprintf('Access-Control-Allow-Origin: %s', $origin));
         }
 

--- a/src/basics.php
+++ b/src/basics.php
@@ -144,8 +144,8 @@ if (!function_exists('dd')) {
         ];
 
         if (PHP_SAPI !== 'cli') {
-            $referer = env('HTTP_REFERER', '');
-            $origin = substr($referer, 0, (strlen($referer) - 1));
+            $referer = env('HTTP_REFERER') ?? '';
+            $origin = substr($referer, 0, strlen($referer) - 1);
             $headers = ['authorization', 'content-type', 'api-token'];
             header('Access-Control-Allow-Credentials: true');
             header(sprintf('Access-Control-Allow-Headers: %s', implode(' ', $headers)));


### PR DESCRIPTION
This improve a lot when you simple die debug on api.

In most case you need to die and debug a var when you user REST api methodology, actually the entire response stream is ignored, now, this simple make die with some headers to test vars.
