### PR TITLE
Add locale path into BasePlugin config.

### DIFF
--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -198,6 +198,10 @@ class App
             /** @psalm-suppress PossiblyNullArgument */
             return [Plugin::templatePath($plugin)];
         }
+        if ($type === 'locales') {
+            /** @psalm-suppress PossiblyNullArgument */
+            return [Plugin::localePath($plugin)];
+        }
 
         deprecationWarning(
             'App::path() is deprecated for class path.'

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -86,6 +86,13 @@ class BasePlugin implements PluginInterface
     protected $templatePath;
 
     /**
+     * The templates path for this plugin.
+     *
+     * @var string
+     */
+    protected $localePath;
+
+    /**
      * The name of this plugin
      *
      * @var string
@@ -194,6 +201,19 @@ class BasePlugin implements PluginInterface
         $path = $this->getPath();
 
         return $this->templatePath = $path . 'templates' . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLocalePath(): string
+    {
+        if ($this->localePath) {
+            return $this->localePath;
+        }
+        $path = $this->getPath();
+
+        return $this->templatePath = $path . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -65,7 +65,7 @@ class Plugin
      * Returns the filesystem path for plugin's folder containing config files.
      *
      * @param string $name name of the plugin in CamelCase format.
-     * @return string Path to the plugin folder container config files.
+     * @return string Path to the plugin folder containing config files.
      * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
      */
     public static function configPath(string $name): string
@@ -79,7 +79,7 @@ class Plugin
      * Returns the filesystem path for plugin's folder containing template files.
      *
      * @param string $name name of the plugin in CamelCase format.
-     * @return string Path to the plugin folder container config files.
+     * @return string Path to the plugin folder containing template files.
      * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
      */
     public static function templatePath(string $name): string
@@ -87,6 +87,20 @@ class Plugin
         $plugin = static::getCollection()->get($name);
 
         return $plugin->getTemplatePath();
+    }
+
+    /**
+     * Returns the filesystem path for plugin's folder containing locale files.
+     *
+     * @param string $name name of the plugin in CamelCase format.
+     * @return string Path to the plugin folder containing locale files.
+     * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
+     */
+    public static function localePath(string $name): string
+    {
+        $plugin = static::getCollection()->get($name);
+
+        return $plugin->getLocalePath();
     }
 
     /**

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -20,6 +20,8 @@ use Cake\Routing\RouteBuilder;
 
 /**
  * Plugin Interface
+ *
+ * @method string getLocalePath()
  */
 interface PluginInterface
 {


### PR DESCRIPTION
```
public static function path(string $type, ?string $plugin = null): array
```
Docblock states:
```
     * Used to read information stored path.
     *
     * The 1st character of $type argument should be lower cased and will return the
     * value of `App.paths.$type` config.
     *
     * Default types:
     * - plugins
     * - templates
     * - locales
```

locales here, however, are different from the others, the only one that doesn't properly work for plugins as 2nd arg:
```php
    $paths = App::path('locales'); // OK
    $paths = App::path('locales', $plugin); // broken
```

This fixes it for 4.1+.

We don't necessarily have to go full config here, we could also let the BasePlugin read by convention from the resources/locales/ folder without the check of the property.
But I figured it ain't that much overhead after all.