### PR TITLE
4.next path url

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -309,14 +309,14 @@ class HtmlHelper extends Helper
      *   over value of `escape`)
      * - `confirm` JavaScript confirmation message.
      *
-     * @param string|array $title The content to be wrapped by `<a>` tags.
-     *   Can be an array if $url is null. If $url is null, $title will be used as both the URL and title.
+     * @param string $title The content to be wrapped by `<a>` tags.
      * @param string $path Cake-relative route path.
      * @param array $options Array of options and HTML attributes.
      * @return string An `<a />` element.
+     * @see \Cake\Routing\Router::pathUrl()
      * @link https://book.cakephp.org/3/en/views/helpers/html.html#creating-links
      */
-    public function linkFromPath($title, string $path, array $options = []): string
+    public function linkFromPath(string $title, string $path, array $options = []): string
     {
         return $this->link($title, ['_path' => $path], $options);
     }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -311,14 +311,16 @@ class HtmlHelper extends Helper
      *
      * @param string $title The content to be wrapped by `<a>` tags.
      * @param string $path Cake-relative route path.
+     * @param array $params An array specifying any additional parameters.
+     *   Can be also any special parameters supported by `Router::url()`.
      * @param array $options Array of options and HTML attributes.
      * @return string An `<a />` element.
      * @see \Cake\Routing\Router::pathUrl()
      * @link https://book.cakephp.org/3/en/views/helpers/html.html#creating-links
      */
-    public function linkFromPath(string $title, string $path, array $options = []): string
+    public function linkFromPath(string $title, string $path, array $params = [], array $options = []): string
     {
-        return $this->link($title, ['_path' => $path], $options);
+        return $this->link($title, ['_path' => $path] + $params, $options);
     }
 
     /**

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -300,6 +300,28 @@ class HtmlHelper extends Helper
     }
 
     /**
+     * Creates an HTML link from route path string.
+     *
+     * ### Options
+     *
+     * - `escape` Set to false to disable escaping of title and attributes.
+     * - `escapeTitle` Set to false to disable escaping of title. Takes precedence
+     *   over value of `escape`)
+     * - `confirm` JavaScript confirmation message.
+     *
+     * @param string|array $title The content to be wrapped by `<a>` tags.
+     *   Can be an array if $url is null. If $url is null, $title will be used as both the URL and title.
+     * @param string $path Cake-relative route path.
+     * @param array $options Array of options and HTML attributes.
+     * @return string An `<a />` element.
+     * @link https://book.cakephp.org/3/en/views/helpers/html.html#creating-links
+     */
+    public function linkFromPath($title, string $path, array $options = []): string
+    {
+        return $this->link($title, ['_path' => $path], $options);
+    }
+
+    /**
      * Creates a link element for CSS stylesheets.
      *
      * ### Usage

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -69,10 +69,11 @@ class UrlHelper extends Helper
      * @param string $path Cake-relative route path.
      * @param array $options Array of options.
      * @return string Full translated URL with base path.
+     * @see \Cake\Routing\Router::pathUrl()
      */
     public function buildFromPath(string $path, array $options = []): string
     {
-        return $this->build($path, $options);
+        return $this->build(['_path' => $path], $options);
     }
 
     /**

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -67,13 +67,15 @@ class UrlHelper extends Helper
      * - `fullBase`: If true, the full base URL will be prepended to the result
      *
      * @param string $path Cake-relative route path.
+     * @param array $params An array specifying any additional parameters.
+     *   Can be also any special parameters supported by `Router::url()`.
      * @param array $options Array of options.
      * @return string Full translated URL with base path.
      * @see \Cake\Routing\Router::pathUrl()
      */
-    public function buildFromPath(string $path, array $options = []): string
+    public function buildFromPath(string $path, array $params = [], array $options = []): string
     {
-        return $this->build(['_path' => $path], $options);
+        return $this->build(['_path' => $path] + $params, $options);
     }
 
     /**

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -58,6 +58,24 @@ class UrlHelper extends Helper
     }
 
     /**
+     * Returns a URL from a route path string.
+     *
+     * ### Options:
+     *
+     * - `escape`: If false, the URL will be returned unescaped, do only use if it is manually
+     *    escaped afterwards before being displayed.
+     * - `fullBase`: If true, the full base URL will be prepended to the result
+     *
+     * @param string $path Cake-relative route path.
+     * @param array $options Array of options.
+     * @return string Full translated URL with base path.
+     */
+    public function buildFromPath(string $path, array $options = []): string
+    {
+        return $this->build($path, $options);
+    }
+
+    /**
      * Generates URL for given image file.
      *
      * Depending on options passed provides full URL with domain name. Also calls

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -341,8 +341,12 @@ class HtmlHelperTest extends TestCase
      */
     public function testLinkFromPath(): void
     {
-        $expected = '<a href="/articles">Home</a>';
         $result = $this->Html->linkFromPath('Home', 'Articles::index');
+        $expected = '<a href="/articles">Home</a>';
+        $this->assertSame($result, $expected);
+
+        $result = $this->Html->linkFromPath('Home', 'Articles::view', [3]);
+        $expected = '<a href="/articles/view/3">Home</a>';
         $this->assertSame($result, $expected);
     }
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -20,10 +20,12 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Filesystem;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\HtmlHelper;
+use Cake\View\View;
 
 /**
  * HtmlHelperTest class
@@ -73,7 +75,7 @@ class HtmlHelperTest extends TestCase
         Router::reload();
         Router::setRequest($request);
 
-        $this->View = $this->getMockBuilder('Cake\View\View')
+        $this->View = $this->getMockBuilder(View::class)
             ->setMethods(['append'])
             ->setConstructorArgs([$request])
             ->getMock();
@@ -84,7 +86,7 @@ class HtmlHelperTest extends TestCase
         Configure::write('Asset.timestamp', false);
 
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->fallbacks();
+            $routes->fallbacks(DashedRoute::class);
         });
     }
 
@@ -332,6 +334,16 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->link('Home', '/', ['fullBase' => false]);
         $expected = ['a' => ['href' => '/'], 'Home', '/a'];
         $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testLinkFromPath(): void
+    {
+        $expected = '<a href="/articles">Home</a>';
+        $result = $this->Html->linkFromPath('Home', 'Articles::index');
+        $this->assertSame($result, $expected);
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -168,8 +168,12 @@ class UrlHelperTest extends TestCase
      */
     public function testBuildFromPath(): void
     {
+        $result = $this->Helper->buildFromPath('Articles::index');
         $expected = '/articles';
-        $result = Router::pathUrl('Articles::index');
+        $this->assertSame($result, $expected);
+
+        $result = $this->Helper->buildFromPath('Articles::view', [3]);
+        $expected = '/articles/view/3';
         $this->assertSame($result, $expected);
     }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -58,7 +59,7 @@ class UrlHelperTest extends TestCase
         static::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->fallbacks();
+            $routes->fallbacks(DashedRoute::class);
         });
     }
 
@@ -160,6 +161,16 @@ class UrlHelperTest extends TestCase
             ],
         ], ['escape' => false]);
         $this->assertSame('/posts/view?k=v&1=2&param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildFromPath(): void
+    {
+        $expected = '/articles';
+        $result = Router::pathUrl('Articles::index');
+        $this->assertSame($result, $expected);
     }
 
     /**


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/13605

Uses https://github.com/dereuromark/cakephp-ide-helper/pull/191#issuecomment-616225774 to have template support for new route path strings.

Currently, Router::pathUrl() works fine already, but it has like 1% usage inside most apps.
The other 99% are inside the templates, and there having the chance to leverage those now as autocompletable strings is really a game changer.

See
![ide_url](https://user-images.githubusercontent.com/39854/79700168-24a84680-8294-11ea-950a-42a7ac57be69.png)
and
![ide_html](https://user-images.githubusercontent.com/39854/79700221-7f41a280-8294-11ea-896d-b5e72a9a2f47.png)

The overhead here is minimal, but the benefit of having this more strict syntactic sugar wrapper and the full IDE support behind it makes coding/developing 10x as fast, especially if you need to re-use similar actions a lot, and if those happen to be plugins or prefixed even more so.