### PR TITLE
Don't convert Entity data if instance of ArrayAccess

### DIFF
--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -33,13 +33,13 @@ interface EventDispatcherInterface
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param array $data Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface;
+    public function dispatchEvent(string $name, array $data = [], ?object $subject = null): EventInterface;
 
     /**
      * Sets the Cake\Event\EventManager manager instance for this object.

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -75,13 +75,13 @@ trait EventDispatcherTrait
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param array $data Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface
+    public function dispatchEvent(string $name, array $data = [], ?object $subject = null): EventInterface
     {
         if ($subject === null) {
             $subject = $this;

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -24,6 +24,7 @@ use ArrayObject;
 use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * Tests the Cake\Event\Event class functionality
@@ -100,10 +101,21 @@ class EventTest extends TestCase
     {
         $data = new ArrayObject(['some' => 'data']);
         $event = new Event('fake.event', $this, $data);
-        $this->assertEquals(['some' => 'data'], $event->getData());
+        $this->assertEquals($data, $event->getData());
 
         $this->assertSame('data', $event->getData('some'));
         $this->assertNull($event->getData('undef'));
+    }
+
+    /**
+     * Tests using non-array event data throws exception.
+     *
+     * @return void
+     */
+    public function testInvalidEventData()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $event = new Event('fake.event', $this, new \stdClass());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/14482

Issues:

- Event::setData() will operate on the ArrayAccess instance

  Should we create a copy?

- IterateAggregate might provide a valid array conversion. 

  Not sure if we care about ArrayObject.
  