### PR TITLE
[4.next] Add table() convenience function for CakePHP REPL

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -17,9 +17,6 @@ declare(strict_types=1);
 
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
-use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
-use Psy\Shell as PsyShell;
 
 define('SECOND', 1);
 define('MINUTE', 60);
@@ -63,7 +60,6 @@ if (!function_exists('debug')) {
 
         return $var;
     }
-
 }
 
 if (!function_exists('stackTrace')) {
@@ -92,50 +88,6 @@ if (!function_exists('stackTrace')) {
         /** @var string $trace */
         $trace = Debugger::trace($options);
         echo $trace;
-    }
-
-}
-
-if (!function_exists('breakpoint')) {
-    /**
-     * Command to return the eval-able code to startup PsySH in interactive debugger
-     * Works the same way as eval(\Psy\sh());
-     * psy/psysh must be loaded in your project
-     *
-     * @link http://psysh.org/
-     * ```
-     * eval(breakpoint());
-     * ```
-     * @return string|null
-     */
-    function breakpoint(): ?string
-    {
-        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && class_exists(PsyShell::class)) {
-            return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
-        }
-        trigger_error(
-            'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
-            E_USER_WARNING
-        );
-
-        return null;
-    }
-}
-
-if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
-    /**
-     * REPL convenience function to load a table
-     *
-     * Do **NOT** use this function in your app or plugin code,
-     * it is meant only for use in the CakePHP interactive console (REPL).
-     *
-     * @param string $alias The alias name you want to get.
-     * @param array $options The options you want to build the table with.
-     * @return \Cake\ORM\Table
-     */
-    function table(string $alias, array $options = []): Table
-    {
-        return TableRegistry::getTableLocator()->get($alias, $options);
     }
 }
 

--- a/src/basics.php
+++ b/src/basics.php
@@ -126,6 +126,9 @@ if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) 
     /**
      * REPL convenience function to load a table
      *
+     * Do **NOT** use this function in your app or plugin code,
+     * it is meant only for use in the CakePHP interactive console (REPL).
+     *
      * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the table with.
      * @return \Cake\ORM\Table

--- a/src/basics.php
+++ b/src/basics.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Psy\Shell as PsyShell;
 
 define('SECOND', 1);
@@ -117,6 +119,20 @@ if (!function_exists('breakpoint')) {
         );
 
         return null;
+    }
+}
+
+if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
+    /**
+     * REPL convenience function to load a table
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the table with.
+     * @return \Cake\ORM\Table
+     */
+    function table(string $alias, array $options = []): Table
+    {
+        return TableRegistry::getTableLocator()->get($alias, $options);
     }
 }
 

--- a/src/repl_functions.php
+++ b/src/repl_functions.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.2.9
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Psy\Shell as PsyShell;
+
+if (!function_exists('breakpoint')) {
+    /**
+     * Command to return the eval-able code to startup PsySH in interactive debugger
+     * Works the same way as eval(\Psy\sh());
+     * psy/psysh must be loaded in your project
+     *
+     * @link http://psysh.org/
+     * ```
+     * eval(breakpoint());
+     * ```
+     * @return string|null
+     */
+    function breakpoint(): ?string
+    {
+        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && class_exists(PsyShell::class)) {
+            return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
+        }
+        trigger_error(
+            'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
+            E_USER_WARNING
+        );
+
+        return null;
+    }
+}
+
+if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
+    /**
+     * REPL convenience function to load a table
+     *
+     * Do **NOT** use this function in your app or plugin code,
+     * it is meant only for use in the CakePHP interactive console (REPL).
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the table with.
+     * @return \Cake\ORM\Table
+     */
+    function table(string $alias, array $options = []): Table
+    {
+        return TableRegistry::getTableLocator()->get($alias, $options);
+    }
+}

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -22,6 +22,7 @@ use Cake\Collection\Collection;
 use Cake\Error\Debugger;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
 require_once CAKE . 'basics.php';
@@ -425,6 +426,17 @@ EXPECTED;
         [$r, $expected] = [stackTrace($opts), \Cake\Error\Debugger::trace($opts)];
         $result = ob_get_clean();
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Tests the table() function returns a table object
+     *
+     * @return void
+     */
+    public function testTable()
+    {
+        $table = \table('Table');
+        $this->assertInstanceOf(Table::class, $table);
     }
 
     /**

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -22,13 +22,12 @@ use Cake\Collection\Collection;
 use Cake\Error\Debugger;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
-use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
 require_once CAKE . 'basics.php';
 
 /**
- * BasicsTest class
+ * Basic functions tests
  */
 class BasicsTest extends TestCase
 {
@@ -426,17 +425,6 @@ EXPECTED;
         [$r, $expected] = [stackTrace($opts), \Cake\Error\Debugger::trace($opts)];
         $result = ob_get_clean();
         $this->assertSame($expected, $result);
-    }
-
-    /**
-     * Tests the table() function returns a table object
-     *
-     * @return void
-     */
-    public function testTable()
-    {
-        $table = \table('Table');
-        $this->assertInstanceOf(Table::class, $table);
     }
 
     /**

--- a/tests/TestCase/ReplFunctionsTest.php
+++ b/tests/TestCase/ReplFunctionsTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BasicsTest file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase;
+
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+require_once CAKE . 'repl_functions.php';
+
+/**
+ * REPL functions tests
+ */
+class ReplFunctionsTest extends TestCase
+{
+    /**
+     * Tests the table() function returns a table object
+     *
+     * @return void
+     */
+    public function testTable()
+    {
+        $table = \table('Table');
+        $this->assertInstanceOf(Table::class, $table);
+    }
+}


### PR DESCRIPTION
This adds the ``table()`` convenience function for the [CakePHP REPL](https://book.cakephp.org/4/en/console-commands/repl.html).

Instead of needing to do ``Cake\ORM\TableRegistry::getTableLocator()->get('TableName')`` to fetch a table in the CakePHP REPL

````
bin/cake console

>>> $articles = Cake\ORM\TableRegistry::getTableLocator()->get('Articles');
// object(Cake\ORM\Table)(
//
// )
>>> $articles->find()->all();
````

One can do ``table('TableName')``

````
bin/cake console

>>> $articles = table('Articles');
// object(Cake\ORM\Table)(
//
// )
>>> $articles->find()->all();
````

I tried to conditionally define the new function when the Psy shell class is available, but this makes it impossible test it, as this class does not seem to be available during tests.

```` php
if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && class_exists('\Psy\Shell')) {
````

This was inspired by @steinkel's CakePHP training session.