### PR TITLE
#14471 support pre 4.0.6 CSRF tokens

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -241,13 +241,17 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         $body = $request->getParsedBody();
         if (is_array($body) || $body instanceof ArrayAccess) {
             $post = Hash::get($body, $this->_config['field']);
-            if ($this->_compareToken($post, $cookie)) {
+            if (Security::constantEquals($post, $cookie)) {
+                return;
+            } else if ($this->_compareToken($post, $cookie)) {
                 return;
             }
         }
 
         $header = $request->getHeaderLine('X-CSRF-Token');
-        if ($this->_compareToken($header, $cookie)) {
+        if (Security::constantEquals($header, $cookie)) {
+            return;
+        } else if ($this->_compareToken($header, $cookie)) {
             return;
         }
 

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -241,9 +241,13 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         $body = $request->getParsedBody();
         if (is_array($body) || $body instanceof ArrayAccess) {
             $post = Hash::get($body, $this->_config['field']);
+            // Allow non-hardened tokens until 4.1.0
             if (Security::constantEquals($post, $cookie)) {
                 return;
-            } else if ($this->_compareToken($post, $cookie)) {
+            }
+            // Validates hardened tokens generated since 4.0.6
+            // The above check will circumvent this until 4.1.0
+            if ($this->_compareToken($post, $cookie)) {
                 return;
             }
         }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -262,6 +262,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
     /**
      * Test that tokens cannot be simple matches and must pass our hmac.
      *
+     * @deprecated 4.1.0 In 4.1.0 this scenario should start raising an exception.
      * @return void
      */
     public function testInvalidTokenIncorrectOrigin()
@@ -276,8 +277,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         $middleware = new CsrfProtectionMiddleware();
 
-        $this->expectException(InvalidCsrfTokenException::class);
-        $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $this->assertEmpty($response->getCookie('csrfToken'));
     }
 
     /**


### PR DESCRIPTION
See #14471 for details. This commit enables support for reading pre 4.0.6 CSRF tokens.