### PR TITLE
Remove invalid inflection

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -984,7 +984,7 @@ class Router
             $defaults['plugin'] = $matches['plugin'];
         }
         if ($matches['prefix'] !== '') {
-            $defaults['prefix'] = Inflector::underscore($matches['prefix']);
+            $defaults['prefix'] = $matches['prefix'];
         }
         $defaults['controller'] = $matches['controller'];
         $defaults['action'] = $matches['action'];

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -238,7 +238,7 @@ class RouteBuilderTest extends TestCase
         $expected = [
             'pass' => [],
             'plugin' => null,
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'Bookmarks',
             'action' => 'index',
             '_matchedRoute' => '/admin/bookmarks',
@@ -285,7 +285,7 @@ class RouteBuilderTest extends TestCase
         $expected = [
             'pass' => [],
             'plugin' => 'Vendor/Blog',
-            'prefix' => 'management/admin',
+            'prefix' => 'Management/Admin',
             'controller' => 'Articles',
             'action' => 'view',
             '_matchedRoute' => '/admin/blog/articles/view',

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2207,14 +2207,14 @@ class RouterTest extends TestCase
         $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view'));
 
         $expected = [
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'Bookmarks',
             'action' => 'view',
         ];
         $this->assertSame($expected, Router::parseRoutePath('Admin/Bookmarks::view'));
 
         $expected = [
-            'prefix' => 'long_prefix/back_end',
+            'prefix' => 'LongPrefix/BackEnd',
             'controller' => 'Bookmarks',
             'action' => 'view',
         ];
@@ -2229,7 +2229,7 @@ class RouterTest extends TestCase
 
         $expected = [
             'plugin' => 'Vendor/Cms',
-            'prefix' => 'management/admin',
+            'prefix' => 'Management/Admin',
             'controller' => 'Articles',
             'action' => 'view',
         ];
@@ -3089,7 +3089,7 @@ class RouterTest extends TestCase
         $result = Router::parseRequest($this->makeRequest('/admin/articles/view', 'GET'));
         $expected = [
             'pass' => [],
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'Articles',
             'action' => 'view',
             'plugin' => null,


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/14282 maybe

This seems to be a relict based on/off the prefixes being under_scored instead of CamelCase.

The issue is that the conversation here then creates a lowercase a for admin (or worse for multi words):

> Expects a CamelCasedInputString, and produces a lower_case_delimited_string

This is what Inflector::underscore() does internally

Not doing this takes away some of these route errors. And is also required for https://github.com/cakephp/cakephp/pull/14497 to work (and not ending up with the wrong inflections and thus not matching routes anymore).
