### PR TITLE
Add urlArray() convenience function.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
+            "src/Routing/functions.php",
             "src/Utility/bootstrap.php"
         ]
     },

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -29,8 +29,12 @@ if (!function_exists('urlArray')) {
      */
     function urlArray(string $path, array $params = []): array
     {
-        $array = Router::parseRoutePath($path);
+        $url = Router::parseRoutePath($path);
+        $url += [
+            'plugin' => false,
+            'prefix' => false,
+        ];
 
-        return $array + $params;
+        return $url + $params;
     }
 }

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Routing\Router;
+
+if (!function_exists('urlArray')) {
+    /**
+     * Returns an array URL from a route path string.
+     *
+     * @param string $path Route path.
+     * @param array $params An array specifying any additional parameters.
+     *   Can be also any special parameters supported by `Router::url()`.
+     * @return array URL
+     * @see \Cake\Routing\Router::pathUrl()
+     */
+    function urlArray(string $path, array $params = []): array
+    {
+        $array = Router::parseRoutePath($path);
+
+        return $array + $params;
+    }
+}

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2270,6 +2270,39 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Tests that convenience wrapper urlArray() works as the internal
+     * Router::parseRoutePath() does.
+     *
+     * @return void
+     */
+    public function testUrlArray(): void
+    {
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+        ];
+        $this->assertSame($expected, urlArray('Bookmarks::view'));
+
+        $expected = [
+            'prefix' => 'admin',
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+        ];
+        $this->assertSame($expected, urlArray('Admin/Bookmarks::view'));
+
+        $expected = [
+            'plugin' => 'Vendor/Cms',
+            'prefix' => 'management/admin',
+            'controller' => 'Articles',
+            'action' => 'view',
+            3,
+            '?' => ['query' => 'string'],
+        ];
+        $params = [3, '?' => ['query' => 'string']];
+        $this->assertSame($expected, urlArray('Vendor/Cms.Management/Admin/Articles::view', $params));
+    }
+
+    /**
      * Test url() works with patterns on :action
      *
      * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2280,19 +2280,22 @@ class RouterTest extends TestCase
         $expected = [
             'controller' => 'Bookmarks',
             'action' => 'view',
+            'plugin' => false,
+            'prefix' => false,
         ];
         $this->assertSame($expected, urlArray('Bookmarks::view'));
 
         $expected = [
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'Bookmarks',
             'action' => 'view',
+            'plugin' => false,
         ];
         $this->assertSame($expected, urlArray('Admin/Bookmarks::view'));
 
         $expected = [
             'plugin' => 'Vendor/Cms',
-            'prefix' => 'management/admin',
+            'prefix' => 'Management/Admin',
             'controller' => 'Articles',
             'action' => 'view',
             3,


### PR DESCRIPTION
An idea of what was discussed in https://github.com/cakephp/cakephp/issues/14494

### Functionality
This works nicely if we expect the inflection of https://github.com/cakephp/cakephp/pull/14496 to be gone.

I tested it with e.g.

```php
    public function index()
    {
        $this->Flash->success('Test redirect');

        $url = urlArray('DatabaseLog.Admin/DatabaseLog::index');

        return $this->redirect($url);
    }
```

Questions:
- Should this be the _path only still? Or do we want this conversion to happen here right away?
- Is the method name clear and speaking enough, while still being not too long and verbose? 

---

### Usability

With the directive of 
```
    expectedArguments(
        \urlArray(),
        0,
        argumentsSet('routePaths')
    );
```
I got the desired autocomplete now for all URL relevant configs and methods this way:

![url_array](https://user-images.githubusercontent.com/39854/80154037-0c4f6900-85bf-11ea-8788-202b6c10ffad.png)
=> https://github.com/dereuromark/cakephp-ide-helper/pull/195