### PR TITLE
Fix Debugger::exportVar() not handling typed properties

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -633,10 +633,21 @@ class Debugger
             foreach ($filters as $filter => $visibility) {
                 $reflectionProperties = $ref->getProperties($filter);
                 foreach ($reflectionProperties as $reflectionProperty) {
+                    $value = null;
                     $reflectionProperty->setAccessible(true);
-                    $property = $reflectionProperty->getValue($var);
 
-                    $value = static::_export($property, $depth - 1, $indent);
+                    if (
+                        method_exists($reflectionProperty, 'isInitialized') &&
+                        !$reflectionProperty->isInitialized($var)
+                    ) {
+                        $value = '[uninitialized]';
+                    }
+
+                    if ($value === null) {
+                        $property = $reflectionProperty->getValue($var);
+                        $value = static::_export($property, $depth - 1, $indent);
+                    }
+
                     $key = $reflectionProperty->name;
                     $props[] = sprintf(
                         '[%s] %s => %s',

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -412,6 +412,7 @@ TEXT;
     {
         $this->skipIf(version_compare(PHP_VERSION, '7.4.0', '<'), 'typed properties require PHP7.4');
         // This is gross but was simpler than adding a fixture file.
+        // phpcs:ignore
         eval('class MyClass { private string $field; }');
         $obj = new \MyClass();
         $out = Debugger::exportVar($obj);

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -408,6 +408,16 @@ TEXT;
         $this->assertTextEquals('unknown', $result);
     }
 
+    public function testExportVarTypedProperty()
+    {
+        $this->skipIf(version_compare(PHP_VERSION, '7.4.0', '<'), 'typed properties require PHP7.4');
+        // This is gross but was simpler than adding a fixture file.
+        eval('class MyClass { private string $field; }');
+        $obj = new \MyClass();
+        $out = Debugger::exportVar($obj);
+        $this->assertTextContains('field => [uninitialized]', $out);
+    }
+
     /**
      * Test exporting various kinds of false.
      *


### PR DESCRIPTION
Ensure typed properties are initialized before reading their values.

Fixes #14488