### PR TITLE
Update TableLocator Interface to add more flexibility

### DIFF
--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -39,7 +39,7 @@ interface LocatorInterface
      *
      * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the table with.
-     * @return \Cake\ORM\Table
+     * @return \Cake\Datasource\RepositoryInterface
      */
     public function get($alias, array $options = []);
 


### PR DESCRIPTION
Resolves #14495

This change creates more flexibility in the interface by allowing custom Locator implementations such as the use-case shown in #12014

It should actually make no difference to the core framework code as `\Cake\ORM\Table` already implements `\Cake\Datasource\RepositoryInterface`.

The only downside I can think of, might be [the stand-alone ORM package](https://github.com/cakephp/orm), as I can't see the interface in there. 