### PR TITLE
2.x: Fix argument order for implode method

### DIFF
--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -265,7 +265,7 @@ class ConsoleOutput {
 				$styleInfo[] = static::$_options[$option];
 			}
 		}
-		return "\033[" . implode($styleInfo, ';') . 'm' . $matches['text'] . "\033[0m";
+		return "\033[" . implode(';', $styleInfo) . 'm' . $matches['text'] . "\033[0m";
 	}
 
 /**


### PR DESCRIPTION
Different order is deprecated and will cause fatal error in PHP8

> implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it is deprecated not to use the documented order of arguments.

– https://www.php.net/manual/en/function.implode.php