### PR TITLE
Add missing version infos

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -20,6 +20,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\App;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Filesystem;
 use Cake\Utility\Inflector;
@@ -624,7 +625,7 @@ class I18nExtractCommand extends Command
             $overwriteAll = true;
         }
         foreach ($this->_storage as $domain => $sentences) {
-            $output = $this->_writeHeader();
+            $output = $this->_writeHeader($domain);
             $headerLength = strlen($output);
             foreach ($sentences as $sentence => $header) {
                 $output .= $header . $sentence;
@@ -670,9 +671,11 @@ class I18nExtractCommand extends Command
     /**
      * Build the translation template header
      *
+     * @param string $domain Domain
+     *
      * @return string Translation template header
      */
-    protected function _writeHeader(): string
+    protected function _writeHeader(string $domain): string
     {
         $output = "# LANGUAGE translation of CakePHP Application\n";
         $output .= "# Copyright YEAR NAME <EMAIL@ADDRESS>\n";
@@ -680,7 +683,7 @@ class I18nExtractCommand extends Command
         $output .= "#, fuzzy\n";
         $output .= "msgid \"\"\n";
         $output .= "msgstr \"\"\n";
-        $output .= "\"Project-Id-Version: PROJECT VERSION\\n\"\n";
+        $output .= "\"Project-Id-Version: " . ($domain === 'cake' ? 'CakePHP ' . Configure::version() : 'PROJECT VERSION') . "\\n\"\n";
         $output .= '"POT-Creation-Date: ' . date('Y-m-d H:iO') . "\\n\"\n";
         $output .= "\"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\\n\"\n";
         $output .= "\"Last-Translator: NAME <EMAIL@ADDRESS>\\n\"\n";

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -672,18 +672,19 @@ class I18nExtractCommand extends Command
      * Build the translation template header
      *
      * @param string $domain Domain
-     *
      * @return string Translation template header
      */
     protected function _writeHeader(string $domain): string
     {
+        $projectIdVersion = $domain === 'cake' ? 'CakePHP ' . Configure::version() : 'PROJECT VERSION';
+
         $output = "# LANGUAGE translation of CakePHP Application\n";
         $output .= "# Copyright YEAR NAME <EMAIL@ADDRESS>\n";
         $output .= "#\n";
         $output .= "#, fuzzy\n";
         $output .= "msgid \"\"\n";
         $output .= "msgstr \"\"\n";
-        $output .= "\"Project-Id-Version: " . ($domain === 'cake' ? 'CakePHP ' . Configure::version() : 'PROJECT VERSION') . "\\n\"\n";
+        $output .= "\"Project-Id-Version: " . $projectIdVersion . "\\n\"\n";
         $output .= '"POT-Creation-Date: ' . date('Y-m-d H:iO') . "\\n\"\n";
         $output .= "\"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\\n\"\n";
         $output .= "\"Last-Translator: NAME <EMAIL@ADDRESS>\\n\"\n";


### PR DESCRIPTION
Refs https://github.com/cakephp/localized/pull/203

with this the `cake` domain itself and thus

    "Project-Id-Version: PROJECT VERSION\n"

becomes

    "Project-Id-Version: CakePHP 4.0.6\n"

right away, as this also makes more sense IMO for the cake domain.
As here I am not sure why the id version should need to be filled.

Or should we put this info somewhere else inside that file? So that you know from when this was extracted.

According to gettext docs:

> Project-Id-Version
This is the name and version of the package. Fill it in if it has not already been filled in by xgettext.