### PR TITLE
Fix string[] types in docblocks.

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -39,7 +39,7 @@ class Hash
      *
      * @param array|\ArrayAccess $data Array of data or object implementing
      *   \ArrayAccess interface to operate on.
-     * @param string|int|array|null $path The path being searched for. Either a dot
+     * @param string|int|string[]|null $path The path being searched for. Either a dot
      *   separated string, or an array of path segments.
      * @param mixed $default The return value when the path does not exist
      * @throws \InvalidArgumentException
@@ -355,7 +355,7 @@ class Hash
      *
      * @param string $op The operation to do.
      * @param array $data The data to operate on.
-     * @param array $path The path to work on.
+     * @param string[] $path The path to work on.
      * @param mixed $values The values to insert when doing inserts.
      * @return array data.
      */
@@ -461,8 +461,8 @@ class Hash
      * following the path specified in `$groupPath`.
      *
      * @param array $data Array from where to extract keys and values
-     * @param string|array $keyPath A dot-separated string.
-     * @param string|array|null $valuePath A dot-separated string.
+     * @param string|string[] $keyPath A dot-separated string.
+     * @param string|string[]|null $valuePath A dot-separated string.
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::combine
@@ -543,7 +543,7 @@ class Hash
      * The `$format` string can use any format options that `vsprintf()` and `sprintf()` do.
      *
      * @param array $data Source array from which to extract the data
-     * @param array $paths An array containing one or more Hash::extract()-style key paths
+     * @param string[] $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
      * @return string[]|null An array of strings extracted from `$path` and formatted with `$format`
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::format

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -323,7 +323,7 @@ class EntityContext implements ContextInterface
      * primary key column is guessed out of the provided $path array
      *
      * @param mixed $values The list from which to extract primary keys from
-     * @param array $path Each one of the parts in a path for a field name
+     * @param string[] $path Each one of the parts in a path for a field name
      * @return array|null
      */
     protected function _extractMultiple($values, array $path): ?array


### PR DESCRIPTION
Arent those also all string[] here?