### PR TITLE
Fix poorly formatted multi-line errors

### DIFF
--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -264,7 +264,7 @@ use Cake\Error\Debugger;
             <span><?= Debugger::formatHtmlMessage($errorTitle) ?></span>
             <a>&#128203</a>
         </h1>
-        <?php if (strlen($errorDescription)): ?>
+        <?php if (strlen($errorDescription)) : ?>
             <span class="header-description"><?= Debugger::formatHtmlMessage($errorDescription) ?></span>
         <?php endif ?>
         <span class="header-type"><?= get_class($error) ?></span>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -59,6 +59,12 @@ use Cake\Error\Debugger;
     .header-title code {
         margin: 0 10px;
     }
+    .header-description {
+        display: block;
+        font-size: 18px;
+        line-height: 1.2;
+        margin-bottom: 16px;
+    }
     .header-type {
         display: block;
         font-size: 16px;
@@ -249,10 +255,18 @@ use Cake\Error\Debugger;
 </head>
 <body>
     <header>
+        <?php
+        $title = explode("\n", $this->fetch('title'));
+        $errorTitle = array_shift($title);
+        $errorDescription = implode("\n", $title);
+        ?>
         <h1 class="header-title">
-            <?= Debugger::formatHtmlMessage($this->fetch('title')) ?>
+            <span><?= Debugger::formatHtmlMessage($errorTitle) ?></span>
             <a>&#128203</a>
         </h1>
+        <?php if (strlen($errorDescription)): ?>
+            <span class="header-description"><?= Debugger::formatHtmlMessage($errorDescription) ?></span>
+        <?php endif ?>
         <span class="header-type"><?= get_class($error) ?></span>
     </header>
     <div class="error-content">

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -256,7 +256,7 @@ use Cake\Error\Debugger;
 <body>
     <header>
         <?php
-        $title = explode("\n", $this->fetch('title'));
+        $title = explode("\n", trim($this->fetch('title')));
         $errorTitle = array_shift($title);
         $errorDescription = implode("\n", $title);
         ?>


### PR DESCRIPTION
Add elements to fix flex layout and separate first line and subsequent lines so that we can have a more pleasing error layout.

Fixes #14510

### Multi-line
![Screen Shot 2020-04-28 at 22 57 23](https://user-images.githubusercontent.com/24086/80557198-1fd64780-89a4-11ea-8345-05dd5b08dbb6.png)

### Single line
![Screen Shot 2020-04-28 at 22 57 55](https://user-images.githubusercontent.com/24086/80557202-206ede00-89a4-11ea-99b9-2e9b2d7aa1fa.png)

