### PR TITLE
Improve ErrorLogger for PHP errors

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -345,7 +345,7 @@ abstract class BaseErrorHandler
     /**
      * Get exception logger.
      *
-     * @return \Cake\Error\ErrorLogger
+     * @return \Cake\Error\ErrorLoggerInterface
      */
     public function getLogger()
     {
@@ -363,7 +363,6 @@ abstract class BaseErrorHandler
             }
             $this->logger = $logger;
         }
-
 
         return $this->logger;
     }

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -54,7 +54,7 @@ abstract class BaseErrorHandler
     /**
      * Exception logger instance.
      *
-     * @var \Cake\Error\ErrorLogger|null
+     * @var \Cake\Error\ErrorLoggerInterface|null
      */
     protected $logger;
 
@@ -309,21 +309,17 @@ abstract class BaseErrorHandler
             $data['file'],
             $data['line']
         );
+        $context = [];
         if (!empty($this->_config['trace'])) {
             /** @var string $trace */
-            $trace = Debugger::trace([
+            $context['trace'] = Debugger::trace([
                 'start' => 1,
                 'format' => 'log',
             ]);
-
-            $request = Router::getRequest();
-            if ($request) {
-                $message .= $this->getLogger()->getRequestContext($request);
-            }
-            $message .= "\nTrace:\n" . $trace . "\n";
+            $context['request'] = Router::getRequest();
         }
 
-        return $this->getLogger()->logMessage($level, $message);
+        return $this->getLogger()->logMessage($level, $message, $context);
     }
 
     /**

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -359,7 +359,7 @@ abstract class BaseErrorHandler
 
                 $interface = ErrorLoggerInterface::class;
                 $type = getTypeName($logger);
-                throw new RuntimeException("Cannot create logger. {$type} does not implement {$interface}");
+                throw new RuntimeException("Cannot create logger. `{$type}` does not implement `{$interface}`.");
             }
             $this->logger = $logger;
         }

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -55,15 +55,15 @@ class ErrorLogger implements ErrorLoggerInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function logMessage(int $level, string $message): bool
+    public function logMessage($level, string $message): bool
     {
         return Log::write($level, $message);
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function log(Throwable $exception, ?ServerRequestInterface $request = null): bool
     {

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -26,7 +26,7 @@ use Throwable;
 /**
  * Log errors and unhandled exceptions to `Cake\Log\Log`
  */
-class ErrorLogger
+class ErrorLogger implements ErrorLoggerInterface
 {
     use InstanceConfigTrait;
 
@@ -55,11 +55,15 @@ class ErrorLogger
     }
 
     /**
-     * Generate the error log message.
-     *
-     * @param \Throwable $exception The exception to log a message for.
-     * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
-     * @return bool
+     * @inheritdoc
+     */
+    public function logMessage(int $level, string $message): bool
+    {
+        return Log::write($level, $message);
+    }
+
+    /**
+     * @inheritdoc
      */
     public function log(Throwable $exception, ?ServerRequestInterface $request = null): bool
     {

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -57,8 +57,15 @@ class ErrorLogger implements ErrorLoggerInterface
     /**
      * @inheritDoc
      */
-    public function logMessage($level, string $message): bool
+    public function logMessage($level, string $message, array $context = []): bool
     {
+        if (!empty($context['request'])) {
+            $message .= $this->getRequestContext($context['request']);
+        }
+        if (!empty($context['trace'])) {
+            $message .= "\nTrace:\n" . $context['trace'] . "\n";
+        }
+
         return Log::write($level, $message);
     }
 

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Error;
 
 use Psr\Http\Message\ServerRequestInterface;
-use \Throwable;
+use Throwable;
 
 /**
  * Interface for error logging handlers.
@@ -42,9 +42,9 @@ interface ErrorLoggerInterface
     /**
      * Log a an error message to the error logger.
      *
-     * @param int $level The logging level
+     * @param string|int $level The logging level
      * @param string $message The message to be logged.
      * @return bool
      */
-    public function logMessage(int $level, string $message): bool;
+    public function logMessage($level, string $message): bool;
 }

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -44,7 +44,8 @@ interface ErrorLoggerInterface
      *
      * @param string|int $level The logging level
      * @param string $message The message to be logged.
+     * @param array $context Context.
      * @return bool
      */
-    public function logMessage($level, string $message): bool;
+    public function logMessage($level, string $message, array $context = []): bool;
 }

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error;
+
+use Psr\Http\Message\ServerRequestInterface;
+use \Throwable;
+
+/**
+ * Interface for error logging handlers.
+ *
+ * Used by the ErrorHandlerMiddleware and global
+ * error handlers to log exceptions and errors.
+ */
+interface ErrorLoggerInterface
+{
+    /**
+     * Log an error for an exception with optional request context.
+     *
+     * @param \Throwable $exception The exception to log a message for.
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
+     * @return bool
+     */
+    public function log(
+        Throwable $exception,
+        ?ServerRequestInterface $request = null
+    ): bool;
+
+    /**
+     * Log a an error message to the error logger.
+     *
+     * @param int $level The logging level
+     * @param string $message The message to be logged.
+     * @return bool
+     */
+    public function logMessage(int $level, string $message): bool;
+}

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Error;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Error\ErrorHandler;
+use Cake\Error\ErrorLoggerInterface;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\MissingControllerException;
 use Cake\Http\Exception\NotFoundException;
@@ -233,7 +234,7 @@ class ErrorHandlerTest extends TestCase
         $messages = $this->logger->read();
         $this->assertRegExp('/^(notice|debug)/', $messages[0]);
         $this->assertStringContainsString(
-            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 5) . ']' . "\n\n",
+            'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 5) . ']',
             $messages[0]
         );
     }
@@ -508,5 +509,33 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals($expected, $new, 'memory limit did not get increased.');
 
         ini_set('memory_limit', $initial);
+    }
+
+    /**
+     * Test getting a logger
+     *
+     * @return void
+     */
+    public function testGetLogger()
+    {
+        $errorHandler = new TestErrorHandler(['key' => 'value', 'log' => true]);
+        $logger = $errorHandler->getLogger();
+
+        $this->assertInstanceOf(ErrorLoggerInterface::class, $logger);
+        $this->assertEquals('value', $logger->getConfig('key'), 'config should be forwarded.');
+        $this->assertSame($logger, $errorHandler->getLogger());
+    }
+
+    /**
+     * Test getting a logger
+     *
+     * @return void
+     */
+    public function testGetLoggerInvalid()
+    {
+        $errorHandler = new TestErrorHandler(['errorLogger' => \stdClass::class]);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot create logger');
+        $errorHandler->getLogger();
     }
 }


### PR DESCRIPTION
I was integrating an error tracking service with a CakePHP application and had hoped to be able to replace the `errorLogger` with a different implementation that forwarded errors to the remote service and then also logged to syslog.

This was challenging because exceptions are logged by the ErrorLogger but PHP errors are logged via the ErrorHandler. This change unifies logging to always be done in the ErrorLogger and adds an interface so we don't have to be lucky when implementing custom error loggers.
