### PR TITLE
Fix ISO8601 validation from Validator

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -541,6 +541,9 @@ class Validation
         if (is_object($check)) {
             return false;
         }
+        if (is_array($dateFormat) && count($dateFormat) === 1) {
+            $dateFormat = reset($dateFormat);
+        }
         if ($dateFormat === static::DATETIME_ISO8601 && !static::iso8601($check)) {
             return false;
         }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2489,11 +2489,14 @@ class ValidatorTest extends TestCase
      *
      * @return void
      */
-    public function testDateTime()
+    public function testDateTime(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'dateTime', ['ymd'], [['ymd']], 'datetime');
         $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
+
+        $validator = (new Validator())->dateTime('thedate', ['iso8601']);
+        $this->assertEmpty($validator->validate(['thedate' => '2020-05-01T12:34:56Z']));
     }
 
     /**


### PR DESCRIPTION
When using the `dateTime()` proxy method in `Validator` with a date format of `[iso8601]`, the validation does not pass, even with a valid value.  A small addition to the test case has been provided to prove the problem, and a non-invasive solution has been implemented.
