### PR TITLE
Remove unused property.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -351,19 +351,9 @@ parameters:
 			path: src/I18n/Date.php
 
 		-
-			message: "#^Call to function is_subclass_of\\(\\) with class\\-string\\<static\\(Cake\\\\I18n\\\\Date\\)\\> and 'Cake\\\\\\\\Chronos\\\\\\\\Date' will always evaluate to false\\.$#"
-			count: 1
-			path: src/I18n/Date.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/I18n/Date.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: src/I18n/FrozenDate.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
@@ -376,11 +366,6 @@ parameters:
 			path: src/I18n/FrozenDate.php
 
 		-
-			message: "#^Call to function is_subclass_of\\(\\) with class\\-string\\<static\\(Cake\\\\I18n\\\\FrozenTime\\)\\> and 'Cake\\\\\\\\Chronos\\\\\\\\Date' will always evaluate to false\\.$#"
-			count: 1
-			path: src/I18n/FrozenTime.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/I18n/FrozenTime.php
@@ -389,11 +374,6 @@ parameters:
 			message: "#^Call to an undefined method Cake\\\\Chronos\\\\DifferenceFormatterInterface\\:\\:timeAgoInWords\\(\\)\\.$#"
 			count: 1
 			path: src/I18n/FrozenTime.php
-
-		-
-			message: "#^Call to function is_subclass_of\\(\\) with class\\-string\\<static\\(Cake\\\\I18n\\\\Time\\)\\> and 'Cake\\\\\\\\Chronos\\\\\\\\Date' will always evaluate to false\\.$#"
-			count: 1
-			path: src/I18n/Time.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
@@ -604,3 +584,4 @@ parameters:
 			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
 			count: 1
 			path: src/View/Helper/TimeHelper.php
+

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
-use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\DifferenceFormatterInterface;
-use Cake\Chronos\MutableDate;
 use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
@@ -47,13 +45,6 @@ trait DateFormatTrait
      * @var \IntlDateFormatter[]
      */
     protected static $_formatters = [];
-
-    /**
-     * Caches whether or not this class is a subclass of a Date or MutableDate
-     *
-     * @var bool
-     */
-    protected static $_isDateInstance;
 
     /**
      * Gets the default locale.
@@ -330,12 +321,6 @@ trait DateFormatTrait
                     'If $format is an IntlDateFormatter constant, must be an array.'
                 );
             }
-        }
-
-        if (static::$_isDateInstance === null) {
-            static::$_isDateInstance =
-                is_subclass_of(static::class, ChronosDate::class) ||
-                is_subclass_of(static::class, MutableDate::class);
         }
 
         $formatter = datefmt_create(


### PR DESCRIPTION
DateFormatTrait::$_isDateInstance was made defunct in #13873.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
