### PR TITLE
Improve error message for EmailTrait::MailContains

### DIFF
--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -75,7 +75,7 @@ class MailContains extends MailConstraintBase
         }
         $result = join(PHP_EOL, $messageMembers);
 
-        return PHP_EOL . 'was: ' . substr($result, 0, 1000);
+        return PHP_EOL . 'was: ' . mb_substr($result, 0, 1000);
     }
 
     /**

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -55,7 +55,7 @@ class MailContains extends MailConstraintBase
     /**
      * @return string
      */
-    private function getTypeMethod(): string
+    protected function getTypeMethod(): string
     {
         return 'getBody' . ($this->type ? ucfirst($this->type) : 'String');
     }

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -73,9 +73,9 @@ class MailContains extends MailConstraintBase
             $method = $this->getTypeMethod();
             $messageMembers[] = $message->$method();
         }
-        $result = join(LF, $messageMembers);
+        $result = join(PHP_EOL, $messageMembers);
 
-        return LF . 'was: ' . substr($result, 0, 1000);
+        return PHP_EOL . 'was: ' . substr($result, 0, 1000);
     }
 
     /**

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -62,7 +62,7 @@ class MailContains extends MailConstraintBase
 
     /**
      * Returns the type-dependent strings of all messages
-     * 
+     *
      * @return string
      */
     protected function getAssertedMessages(): string

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -40,7 +40,7 @@ class MailContains extends MailConstraintBase
     {
         $messages = $this->getMessages();
         foreach ($messages as $message) {
-            $method = 'getBody' . ($this->type ? ucfirst($this->type) : 'String');
+            $method = $this->getTypeMethod();
             $message = $message->$method();
 
             $other = preg_quote($other, '/');
@@ -50,6 +50,30 @@ class MailContains extends MailConstraintBase
         }
 
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    private function getTypeMethod(): string
+    {
+        return 'getBody' . ($this->type ? ucfirst($this->type) : 'String');
+    }
+
+    /**
+     * returns the type-dependent strings of all messages
+     * @return string
+     */
+    protected function getAssertedMessages(): string
+    {
+        $messageMembers = [];
+        $messages = $this->getMessages();
+        foreach ($messages as $message) {
+            $method = $this->getTypeMethod();
+            $messageMembers[] = $message->$method();
+        }
+        $result = join(LF, $messageMembers);
+        return LF . 'was: ' . substr($result, 0, 1000);
     }
 
     /**

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -61,7 +61,8 @@ class MailContains extends MailConstraintBase
     }
 
     /**
-     * returns the type-dependent strings of all messages
+     * Returns the type-dependent strings of all messages
+     * 
      * @return string
      */
     protected function getAssertedMessages(): string
@@ -73,6 +74,7 @@ class MailContains extends MailConstraintBase
             $messageMembers[] = $message->$method();
         }
         $result = join(LF, $messageMembers);
+
         return LF . 'was: ' . substr($result, 0, 1000);
     }
 

--- a/src/TestSuite/Constraint/Email/MailContainsText.php
+++ b/src/TestSuite/Constraint/Email/MailContainsText.php
@@ -41,6 +41,6 @@ class MailContainsText extends MailContains
             return sprintf('is in the text message of email #%d', $this->at);
         }
 
-        return 'is in the text message of an email';
+        return 'is in the text message of an email' . $this->getAssertedMessages();
     }
 }

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -218,7 +218,7 @@ class EmailTraitTest extends TestCase
             'assertMailContains' => ['assertMailContains', 'Failed asserting that \'Missing\' is in an email.', ['Missing']],
             'assertMailContainsAttachment' => ['assertMailContainsAttachment', 'Failed asserting that \'no_existing_file.php\' is an attachment of an email.', ['no_existing_file.php']],
             'assertMailContainsHtml' => ['assertMailContainsHtml', 'Failed asserting that \'Missing\' is in the html message of an email.', ['Missing']],
-            'assertMailContainsText' => ['assertMailContainsText', 'Failed asserting that \'Missing\' is in the text message of an email' . PHP_EOL .'was: .', ['Missing']],
+            'assertMailContainsText' => ['assertMailContainsText', 'Failed asserting that \'Missing\' is in the text message of an email' . PHP_EOL . 'was: .', ['Missing']],
             'assertMailContainsAt' => ['assertMailContainsAt', 'Failed asserting that \'Missing\' is in email #1.', [1, 'Missing']],
             'assertMailContainsHtmlAt' => ['assertMailContainsHtmlAt', 'Failed asserting that \'Missing\' is in the html message of email #1.', [1, 'Missing']],
             'assertMailContainsTextAt' => ['assertMailContainsTextAt', 'Failed asserting that \'Missing\' is in the text message of email #1.', [1, 'Missing']],

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -218,7 +218,7 @@ class EmailTraitTest extends TestCase
             'assertMailContains' => ['assertMailContains', 'Failed asserting that \'Missing\' is in an email.', ['Missing']],
             'assertMailContainsAttachment' => ['assertMailContainsAttachment', 'Failed asserting that \'no_existing_file.php\' is an attachment of an email.', ['no_existing_file.php']],
             'assertMailContainsHtml' => ['assertMailContainsHtml', 'Failed asserting that \'Missing\' is in the html message of an email.', ['Missing']],
-            'assertMailContainsText' => ['assertMailContainsText', 'Failed asserting that \'Missing\' is in the text message of an email.', ['Missing']],
+            'assertMailContainsText' => ['assertMailContainsText', 'Failed asserting that \'Missing\' is in the text message of an email' . PHP_EOL .'was: .', ['Missing']],
             'assertMailContainsAt' => ['assertMailContainsAt', 'Failed asserting that \'Missing\' is in email #1.', [1, 'Missing']],
             'assertMailContainsHtmlAt' => ['assertMailContainsHtmlAt', 'Failed asserting that \'Missing\' is in the html message of email #1.', [1, 'Missing']],
             'assertMailContainsTextAt' => ['assertMailContainsTextAt', 'Failed asserting that \'Missing\' is in the text message of email #1.', [1, 'Missing']],


### PR DESCRIPTION
This PR fixes #14518 

This changing would have helped my with my use case.

Questions

* The changings need to be implemented for all classes that extend MailContains (for now only implemented for MailContainsText). Maybe there is a smarter way of adding the error message to the result of the __toString()-method than appending it in every class?
* $this->at is not yet considered - I don't know what it's for.
* Maybe each message should be truncated (show 100 characters?) and not the concatenated result of all messages (as implemented)? 
