### PR TITLE
Backport PHP74 fixes

### DIFF
--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -80,7 +80,7 @@ class PoFileParser
 
         $messages = [];
         $item = $defaults;
-        $stage = null;
+        $stage = [];
 
         while ($line = fgets($stream)) {
             $line = trim($line);
@@ -89,7 +89,7 @@ class PoFileParser
                 // Whitespace indicated current item is done
                 $this->_addMessage($messages, $item);
                 $item = $defaults;
-                $stage = null;
+                $stage = [];
             } elseif (substr($line, 0, 7) === 'msgid "') {
                 // We start a new msg so save previous
                 $this->_addMessage($messages, $item);


### PR DESCRIPTION
Backport PHP 7.4 fixes from https://github.com/cakephp/cakephp/commit/4ef61c8bb30449a02ac70b7c5a575c6c763940fc#diff-3b755bd65668cf51b10b8aeedfef6e51R85 into 3.x

Solves this issue:

> Warning Error: count(): Parameter must be an array or an object that implements Countable in [vendor/cakephp/cakephp/src/I18n/Parser/PoFileParser.php, line 105]

