### PR TITLE
4.next - Add required option support

### DIFF
--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -148,7 +148,7 @@ class ConsoleInputArgument
      */
     public function isRequired(): bool
     {
-        return (bool)$this->_required;
+        return $this->_required;
     }
 
     /**

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -217,7 +217,7 @@ class ConsoleInputOption
      */
     public function isRequired(): bool
     {
-        return (bool)$this->required;
+        return $this->required;
     }
 
     /**

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -77,6 +77,13 @@ class ConsoleInputOption
     protected $_choices;
 
     /**
+     * Is the option required.
+     *
+     * @var bool
+     */
+    protected $required;
+
+    /**
      * Make a new Input Option
      *
      * @param string $name The long name of the option, or an array with all the properties.
@@ -86,6 +93,7 @@ class ConsoleInputOption
      * @param string|bool|null $default The default value for this option.
      * @param string[] $choices Valid choices for this option.
      * @param bool $multiple Whether this option can accept multiple value definition.
+     * @param bool $required Whether this option is required or not.
      * @throws \Cake\Console\Exception\ConsoleException
      */
     public function __construct(
@@ -95,7 +103,8 @@ class ConsoleInputOption
         bool $isBoolean = false,
         $default = null,
         array $choices = [],
-        bool $multiple = false
+        bool $multiple = false,
+        bool $required = false
     ) {
         $this->_name = $name;
         $this->_short = $short;
@@ -103,6 +112,7 @@ class ConsoleInputOption
         $this->_boolean = $isBoolean;
         $this->_choices = $choices;
         $this->_multiple = $multiple;
+        $this->required = $required;
 
         if ($isBoolean) {
             $this->_default = (bool)$default;
@@ -159,8 +169,12 @@ class ConsoleInputOption
         if (strlen($name) < $width) {
             $name = str_pad($name, $width, ' ');
         }
+        $required = '';
+        if ($this->isRequired()) {
+            $required = ' <comment>(required)</comment>';
+        }
 
-        return sprintf('%s%s%s', $name, $this->_help, $default);
+        return sprintf('%s%s%s%s', $name, $this->_help, $default, $required);
     }
 
     /**
@@ -178,8 +192,12 @@ class ConsoleInputOption
         if ($this->_choices) {
             $default = ' ' . implode('|', $this->_choices);
         }
+        $template = '[%s%s]';
+        if ($this->isRequired()) {
+            $template = '%s%s';
+        }
 
-        return sprintf('[%s%s]', $name, $default);
+        return sprintf($template, $name, $default);
     }
 
     /**
@@ -190,6 +208,16 @@ class ConsoleInputOption
     public function defaultValue()
     {
         return $this->_default;
+    }
+
+    /**
+     * Check if this option is required
+     *
+     * @return bool
+     */
+    public function isRequired(): bool
+    {
+        return (bool)$this->required;
     }
 
     /**
@@ -261,6 +289,7 @@ class ConsoleInputOption
         $option->addAttribute('short', $short);
         $option->addAttribute('help', $this->_help);
         $option->addAttribute('boolean', (string)(int)$this->_boolean);
+        $option->addAttribute('required', (string)(int)$this->required);
         $option->addChild('default', (string)$default);
         $choices = $option->addChild('choices');
         foreach ($this->_choices as $valid) {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -425,6 +425,7 @@ class ConsoleOptionParser
                 'boolean' => false,
                 'multiple' => false,
                 'choices' => [],
+                'required' => false,
             ];
             $options += $defaults;
             $option = new ConsoleInputOption(
@@ -434,7 +435,8 @@ class ConsoleOptionParser
                 $options['boolean'],
                 $options['default'],
                 $options['choices'],
-                $options['multiple']
+                $options['multiple'],
+                $options['required'],
             );
         }
         $this->_options[$name] = $option;
@@ -705,7 +707,7 @@ class ConsoleOptionParser
         foreach ($this->_args as $i => $arg) {
             if ($arg->isRequired() && !isset($args[$i]) && empty($params['help'])) {
                 throw new ConsoleException(
-                    sprintf('Missing required arguments. The `%s` argument is required.', $arg->name())
+                    sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
                 );
             }
         }
@@ -719,6 +721,11 @@ class ConsoleOptionParser
             }
             if ($isBoolean && !isset($params[$name])) {
                 $params[$name] = false;
+            }
+            if ($option->isRequired() && !isset($params[$name])) {
+                throw new ConsoleException(
+                    sprintf('Missing required option. The `%s` option is required and has no default value.', $name)
+                );
             }
         }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -436,7 +436,7 @@ class ConsoleOptionParser
                 $options['default'],
                 $options['choices'],
                 $options['multiple'],
-                $options['required'],
+                $options['required']
             );
         }
         $this->_options[$name] = $option;

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -236,7 +236,7 @@ class CommandTest extends TestCase
 
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString(
-            'Error: Missing required arguments. The `name` argument is required',
+            'Error: Missing required argument. The `name` argument is required',
             $messages
         );
     }

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -351,13 +351,13 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->parse(['--test', '--no-default', 'value']);
         $this->assertSame(
             ['test' => 'default value', 'no-default' => 'value', 'help' => false],
-            $result[0],
+            $result[0]
         );
 
         $result = $parser->parse(['--no-default', 'value']);
         $this->assertSame(
             ['no-default' => 'value', 'help' => false, 'test' => 'default value'],
-            $result[0],
+            $result[0]
         );
 
         $this->expectException(ConsoleException::class);

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -341,11 +341,11 @@ xml;
 <description />
 <subcommands />
 <options>
-	<option name="--help" short="-h" help="Display this help." boolean="1">
+	<option name="--help" short="-h" help="Display this help." boolean="1" required="0">
 		<default>false</default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="0" required="0">
 		<default></default>
 		<choices>
 			<choice>one</choice>
@@ -392,11 +392,11 @@ xml;
 <description>Description text</description>
 <subcommands />
 <options>
-	<option name="--help" short="-h" help="Display this help." boolean="1">
+	<option name="--help" short="-h" help="Display this help." boolean="1" required="0">
 		<default>false</default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="0" required="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -434,11 +434,11 @@ xml;
 	<command name="method" help="This is another command" />
 </subcommands>
 <options>
-	<option name="--help" short="-h" help="Display this help." boolean="1">
+	<option name="--help" short="-h" help="Display this help." boolean="1" required="0">
 		<default>false</default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="0" required="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -472,15 +472,15 @@ xml;
 <description/>
 <subcommands/>
 <options>
-	<option name="--connection" short="-c" help="The connection to use." boolean="0">
+	<option name="--connection" short="-c" help="The connection to use." boolean="0" required="0">
 		<default>default</default>
 		<choices></choices>
 	</option>
-	<option name="--help" short="-h" help="Display this help." boolean="1">
+	<option name="--help" short="-h" help="Display this help." boolean="1" required="0">
 		<default>false</default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="0" required="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -513,11 +513,11 @@ xml;
 	<description/>
 	<subcommands/>
 	<options>
-		<option name="--help" short="-h" help="Display this help." boolean="1">
+		<option name="--help" short="-h" help="Display this help." boolean="1" required="0">
 			<default>false</default>
 			<choices></choices>
 		</option>
-		<option name="--test" short="" help="A test option." boolean="0">
+		<option name="--test" short="" help="A test option." boolean="0" required="0">
 			<default></default>
 			<choices></choices>
 		</option>

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1252,7 +1252,7 @@ TEXT;
 
         $io->expects($this->once())
             ->method('error')
-            ->with('Error: Missing required arguments. The `filename` argument is required.');
+            ->with('Error: Missing required argument. The `filename` argument is required.');
         $result = $shell->runCommand([]);
         $this->assertFalse($result, 'Shell should fail');
     }

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -129,7 +129,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->exec('integration args_and_options');
 
         $this->assertOutputEmpty();
-        $this->assertErrorContains('Missing required arguments');
+        $this->assertErrorContains('Missing required argument');
         $this->assertErrorContains('`arg` argument is required');
         $this->assertExitCode(Shell::CODE_ERROR);
     }


### PR DESCRIPTION
Allow CLI flags to be marked as required flags/options.

Fixes #12498
