### PR TITLE
Fix test failure on MySQL 8

### DIFF
--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -373,6 +373,7 @@ class QueryTest extends TestCase
             ->select(['title', 'name' => 'c.comment'])
             ->from('articles')
             ->leftJoin(['c' => 'comments'], ['created >' => $time], $types)
+            ->order(['created' => 'asc'])
             ->execute();
         $this->assertEquals(
             ['title' => 'First Article', 'name' => 'Second Comment for First Article'],


### PR DESCRIPTION
Do not assume database records are returned in order they were inserted.

Condition matches all except first comment.
MySQL 8 returned last one (`'Second Comment for Second Article'`), other databases returned `'Second Comment for First Article'` record. 
https://github.com/cakephp/cakephp/blob/06027e7fc10b68e31a0383b98f73470eb2a44d20/tests/Fixture/CommentsFixture.php#L45-L52