### PR TITLE
4.1 - Added named window expression support

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -21,6 +21,7 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
+use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Statement\CallbackStatement;
 use Closure;
 use InvalidArgumentException;
@@ -85,6 +86,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         'where' => null,
         'group' => [],
         'having' => null,
+        'window' => [],
         'order' => null,
         'limit' => null,
         'offset' => null,
@@ -1324,6 +1326,35 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function andHaving($conditions, $types = [])
     {
         $this->_conjugate('having', $conditions, 'AND', $types);
+
+        return $this;
+    }
+
+    /**
+     * Adds a named window expression.
+     *
+     * You are responsible for adding windows in the order your database requires.
+     *
+     * @param string $name Window name
+     * @param \Cake\Database\Expression\WindowExpression|\Closure $window Window expression
+     * @param bool $overwrite Clear all previous query window expressions
+     * @return $this
+     */
+    public function window(string $name, $window, bool $overwrite = false)
+    {
+        if ($overwrite) {
+            $this->_parts['window'] = [];
+        }
+
+        if ($window instanceof Closure) {
+            $window = $window(new WindowExpression(), $this);
+            if (!($window instanceof WindowExpression)) {
+                throw new RuntimeException('You must return a `WindowExpression` from closure passed to `window()`.');
+            }
+        }
+
+        $this->_parts['window'][] = ['name' => $name, 'window' => $window];
+        $this->_dirty();
 
         return $this;
     }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -51,7 +51,7 @@ class QueryCompiler
      * @var array
      */
     protected $_selectParts = [
-        'select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit',
+        'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order', 'limit',
         'offset', 'union', 'epilog',
     ];
 
@@ -268,6 +268,29 @@ class QueryCompiler
         }
 
         return $joins;
+    }
+
+    /**
+     * Helper function to build the string representation of a window clause.
+     *
+     * @param array $parts List of windows to be transformed to string
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @return string
+     */
+    protected function _buildWindowPart(array $parts, Query $query, ValueBinder $generator): string
+    {
+        $windows = [];
+        foreach ($parts as $window) {
+            $expr = $window['window'];
+            if ($expr->isEmpty() && $expr->getName()) {
+                $windows[] = $window['name'] . ' AS (' . $expr->getName() . ')';
+            } else {
+                $windows[] = $window['name'] . ' AS (' . $expr->sql($generator) . ')';
+            }
+        }
+
+        return ' WINDOW ' . implode(', ', $windows);
     }
 
     /**

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -49,7 +49,7 @@ class SqlserverCompiler extends QueryCompiler
      * @inheritDoc
      */
     protected $_selectParts = [
-        'select', 'from', 'join', 'where', 'group', 'having', 'order', 'offset',
+        'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order', 'offset',
         'limit', 'union', 'epilog',
     ];
 

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -37,6 +37,12 @@ class AggregateExpressionTest extends FunctionExpressionTest
     {
         $f = (new AggregateExpression('MyFunction'))->over();
         $this->assertSame('MyFunction() OVER ()', $f->sql(new ValueBinder()));
+
+        $f = (new AggregateExpression('MyFunction'))->over('name');
+        $this->assertEqualsSql(
+            'MyFunction() OVER name',
+            $f->sql(new ValueBinder())
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -35,10 +35,13 @@ class WindowExpressionTest extends TestCase
     public function testEmptyWindow()
     {
         $w = new WindowExpression();
-        $this->assertSame('OVER ()', $w->sql(new ValueBinder()));
+        $this->assertTrue($w->isEmpty());
+        $this->assertSame(null, $w->getName());
+        $this->assertSame('', $w->sql(new ValueBinder()));
 
         $w->partition('')->order([]);
-        $this->assertSame('OVER ()', $w->sql(new ValueBinder()));
+        $this->assertTrue($w->isEmpty());
+        $this->assertSame('', $w->sql(new ValueBinder()));
     }
 
     /**
@@ -50,19 +53,19 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->partition('test');
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test)',
+            'PARTITION BY test',
             $w->sql(new ValueBinder())
         );
 
         $w->partition(new IdentifierExpression('identifier'));
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test, identifier)',
+            'PARTITION BY test, identifier',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->partition(new AggregateExpression('MyAggregate', ['param']));
         $this->assertEqualsSql(
-            'OVER (PARTITION BY MyAggregate(:param0))',
+            'PARTITION BY MyAggregate(:param0)',
             $w->sql(new ValueBinder())
         );
     }
@@ -76,19 +79,19 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->order('test');
         $this->assertEqualsSql(
-            'OVER (ORDER BY test)',
+            'ORDER BY test',
             $w->sql(new ValueBinder())
         );
 
         $w->order(['test2' => 'DESC']);
         $this->assertEqualsSql(
-            'OVER (ORDER BY test, test2 DESC)',
+            'ORDER BY test, test2 DESC',
             $w->sql(new ValueBinder())
         );
 
         $w->partition('test');
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test ORDER BY test, test2 DESC)',
+            'PARTITION BY test ORDER BY test, test2 DESC',
             $w->sql(new ValueBinder())
         );
     }
@@ -102,43 +105,43 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->range(null);
         $this->assertEqualsSql(
-            'OVER (RANGE UNBOUNDED PRECEDING)',
+            'RANGE UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(0);
         $this->assertEqualsSql(
-            'OVER (RANGE CURRENT ROW)',
+            'RANGE CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(2);
         $this->assertEqualsSql(
-            'OVER (RANGE 2 PRECEDING)',
+            'RANGE 2 PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null, null);
         $this->assertEqualsSql(
-            'OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            'RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(0, null);
         $this->assertEqualsSql(
-            'OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)',
+            'RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(0, 0);
         $this->assertEqualsSql(
-            'OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)',
+            'RANGE BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(1, 2);
         $this->assertEqualsSql(
-            'OVER (RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)',
+            'RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
@@ -150,7 +153,7 @@ class WindowExpressionTest extends TestCase
             WindowExpression::PRECEDING
         );
         $this->assertEqualsSql(
-            'OVER (RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING)',
+            'RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING',
             $w->sql(new ValueBinder())
         );
     }
@@ -164,43 +167,43 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->rows(null);
         $this->assertEqualsSql(
-            'OVER (ROWS UNBOUNDED PRECEDING)',
+            'ROWS UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(0);
         $this->assertEqualsSql(
-            'OVER (ROWS CURRENT ROW)',
+            'ROWS CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(2);
         $this->assertEqualsSql(
-            'OVER (ROWS 2 PRECEDING)',
+            'ROWS 2 PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(null, null);
         $this->assertEqualsSql(
-            'OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(0, null);
         $this->assertEqualsSql(
-            'OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)',
+            'ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(0, 0);
         $this->assertEqualsSql(
-            'OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)',
+            'ROWS BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(1, 2);
         $this->assertEqualsSql(
-            'OVER (ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)',
+            'ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
@@ -213,7 +216,7 @@ class WindowExpressionTest extends TestCase
         );
         $b = new ValueBinder();
         $this->assertEqualsSql(
-            'OVER (ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)',
+            'ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING',
             $w->sql($b)
         );
     }
@@ -227,43 +230,43 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->groups(null);
         $this->assertEqualsSql(
-            'OVER (GROUPS UNBOUNDED PRECEDING)',
+            'GROUPS UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(0);
         $this->assertEqualsSql(
-            'OVER (GROUPS CURRENT ROW)',
+            'GROUPS CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(2);
         $this->assertEqualsSql(
-            'OVER (GROUPS 2 PRECEDING)',
+            'GROUPS 2 PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(null, null);
         $this->assertEqualsSql(
-            'OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            'GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(0, null);
         $this->assertEqualsSql(
-            'OVER (GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)',
+            'GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(0, 0);
         $this->assertEqualsSql(
-            'OVER (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)',
+            'GROUPS BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(1, 2);
         $this->assertEqualsSql(
-            'OVER (GROUPS BETWEEN 1 PRECEDING AND 2 FOLLOWING)',
+            'GROUPS BETWEEN 1 PRECEDING AND 2 FOLLOWING',
             $w->sql(new ValueBinder())
         );
 
@@ -276,7 +279,7 @@ class WindowExpressionTest extends TestCase
         );
         $b = new ValueBinder();
         $this->assertEqualsSql(
-            'OVER (GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING)',
+            'GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING',
             $w->sql($b)
         );
     }
@@ -289,26 +292,27 @@ class WindowExpressionTest extends TestCase
     public function testExclusion()
     {
         $w = (new WindowExpression())->excludeCurrent();
+        $this->assertSame(true, $w->isEmpty());
         $this->assertEqualsSql(
-            'OVER ()',
+            '',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null)->excludeCurrent();
         $this->assertEqualsSql(
-            'OVER (RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW)',
+            'RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null)->excludeGroup();
         $this->assertEqualsSql(
-            'OVER (RANGE UNBOUNDED PRECEDING EXCLUDE GROUP)',
+            'RANGE UNBOUNDED PRECEDING EXCLUDE GROUP',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null)->excludeTies();
         $this->assertEqualsSql(
-            'OVER (RANGE UNBOUNDED PRECEDING EXCLUDE TIES)',
+            'RANGE UNBOUNDED PRECEDING EXCLUDE TIES',
             $w->sql(new ValueBinder())
         );
     }
@@ -322,25 +326,25 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->partition('test')->range(null);
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test RANGE UNBOUNDED PRECEDING)',
+            'PARTITION BY test RANGE UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->order('test')->range(null);
         $this->assertEqualsSql(
-            'OVER (ORDER BY test RANGE UNBOUNDED PRECEDING)',
+            'ORDER BY test RANGE UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->partition('test')->order('test')->range(null);
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING)',
+            'PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->partition('test')->order('test')->range(null)->excludeCurrent();
         $this->assertEqualsSql(
-            'OVER (PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW)',
+            'PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW',
             $w->sql(new ValueBinder())
         );
     }
@@ -365,6 +369,35 @@ class WindowExpressionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $w = (new WindowExpression())->range(0, -2);
+    }
+
+    /**
+     * Tests named windows
+     *
+     * @return void
+     */
+    public function testNamedWindow()
+    {
+        $w = new WindowExpression('name');
+        $this->assertTrue($w->isEmpty());
+        $this->assertSame('name', $w->getName());
+        $this->assertEqualsSql(
+            '',
+            $w->sql(new ValueBinder())
+        );
+
+        $w->setName('new_name');
+        $this->assertEqualsSql(
+            '',
+            $w->sql(new ValueBinder())
+        );
+
+        $w->order('test');
+        $this->assertFalse($w->isEmpty());
+        $this->assertEqualsSql(
+            'new_name ORDER BY test',
+            $w->sql(new ValueBinder())
+        );
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/14469.

The interface change is small, but the sql generation for window expressions had to change a lot.

- WindowExpression no longer generates the `OVER` clause
- AggregateExpression generates the `OVER` clause
- WindowExpression only generates sql when there is more than a name.

Because `OVER` and `WINDOW` clauses render window expressions differently, `WindowExpression` provides an `isEmpty()` helper.

# OVER clause

`SELECT COUNT(*) OVER name`  is different than `SELECT COUNT(*) OVER (name)`

We always generate an empty window expression that has a name without `()`. Users will not expect the edge case of `OVER (name)`.

# WINDOW clause

`WINDOW name AS (other_name)` is the only allowed syntax.

We always generate window clauses inside `()`.

# Examples

```
$query
    ->select('sum' => $query->func()->sum('field')->over('second_window')->order('field2')
    ->window('first_window', new WindowExpression())
    ->window('second_window', function ($expr) {
        return $expr->setName('first_window');
    });
```