### PR TITLE
Fix colours in dark terminals

### DIFF
--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -40,9 +40,9 @@ class ConsoleFormatter implements FormatterInterface
         // cyan
         'class' => '0;36',
         // grey
-        'punct' => '0;8',
-        // black
-        'property' => '0;30',
+        'punct' => '0;90',
+        // default foreground
+        'property' => '0;39',
         // magenta
         'visibility' => '0;35',
         // red


### PR DESCRIPTION
Don't use the black ansi code as it is hard to see in dark terminals. Instead use the foreground color which *should* be visible.

![Screen Shot 2020-05-02 at 22 17 03](https://user-images.githubusercontent.com/24086/80897056-034b4f80-8cc3-11ea-9129-e46881e91cf6.png)
