### PR TITLE
4.1 - Added exception for FunctionsBuilder::cast() when parameter is missing

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -127,10 +127,13 @@ class FunctionsBuilder
     }
 
     /**
-     * Returns a FunctionExpression representing a call to SQL CAST function.
+     * Returns a FunctionExpression representing a SQL CAST.
+     *
+     * The `$type` parameter is a SQL type. The return type for the returned expression
+     * is the default type name. Use `setReturnType()` to update it.
      *
      * @param string|\Cake\Database\ExpressionInterface $field Field or expression to cast.
-     * @param string $type The target data type
+     * @param string $type The SQL data type
      * @return \Cake\Database\Expression\FunctionExpression
      */
     public function cast($field, string $type = ''): FunctionExpression
@@ -142,6 +145,10 @@ class FunctionsBuilder
             );
 
             return new FunctionExpression('CAST', $field);
+        }
+
+        if (empty($type)) {
+            throw new InvalidArgumentException('The `$type` in a cast cannot be empty.');
         }
 
         $expression = new FunctionExpression('CAST', $this->toLiteralParam($field));

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\FunctionsBuilder;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * Tests FunctionsBuilder class
@@ -187,6 +188,17 @@ class FunctionsBuilderTest extends TestCase
         $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('CAST(NOW() AS varchar)', $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
+    }
+
+    /**
+     * Tests missing type in new CAST() wrapper throws exception.
+     *
+     * @return void
+     */
+    public function testInvalidCast()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->functions->cast('field');
     }
 
     /**


### PR DESCRIPTION
Added exception when the backwards compatible parameter is missing.

Added description explaining the return type is not automatically set like other `FunctionsBuilder` wrappers.

