### PR TITLE
Update Filesystem internal description

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -27,7 +27,11 @@ use RegexIterator;
 use SplFileInfo;
 
 /**
- * @since 4.0.0
+ * This provides convenience wrappers around common filesystem queries.
+ *
+ * This is an internal helper class that should not be used in application code
+ * as it provides no guarantee for compatibility.
+ *
  * @internal
  */
 class Filesystem


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/14532

This seems to be a commonly used helper in external code. 

Do we want to keep it internal or move it to a more general utility location so the filesystem namespace can be removed when File and Folder are removed?
