### PR TITLE
4.1 - Added connection name to QueryLogger log entries

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -905,7 +905,7 @@ class Connection implements ConnectionInterface
             );
         }
 
-        return $this->_logger = new QueryLogger();
+        return $this->_logger = new QueryLogger(['connection' => $this->configName()]);
     }
 
     /**

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -46,7 +46,7 @@ class QueryLogger extends BaseLog
     {
         Log::write(
             'debug',
-            (string)$context['query'],
+            'connection=' . $this->getConfig('connection', '') . ' ' . (string)$context['query'],
             ['scope' => $this->scopes() ?: ['queriesLog']]
         );
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -70,12 +70,18 @@ class ConnectionTest extends TestCase
     protected $connection;
 
     /**
+     * @var use Cake\Database\Log\QueryLogger
+     */
+    protected $defaultLogger;
+
+    /**
      * @return void
      */
     public function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
+        $this->defaultLogger = $this->connection->getLogger();
 
         $this->logState = $this->connection->isQueryLoggingEnabled();
         $this->connection->disableQueryLogging();
@@ -89,6 +95,7 @@ class ConnectionTest extends TestCase
     public function tearDown(): void
     {
         $this->connection->disableSavePoints();
+        $this->connection->setLogger($this->defaultLogger);
         $this->connection->enableQueryLogging($this->logState);
 
         Log::reset();
@@ -985,7 +992,7 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertSame('debug duration=0 rows=0 SELECT 1', $messages[0]);
+        $this->assertSame('debug connection=test duration=0 rows=0 SELECT 1', $messages[0]);
     }
 
     /**
@@ -1013,8 +1020,8 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertSame('debug duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('debug duration=0 rows=0 ROLLBACK', $messages[1]);
+        $this->assertSame('debug connection= duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug connection= duration=0 rows=0 ROLLBACK', $messages[1]);
     }
 
     /**
@@ -1037,8 +1044,8 @@ class ConnectionTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertSame('debug duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('debug duration=0 rows=0 COMMIT', $messages[1]);
+        $this->assertSame('debug connection= duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug connection= duration=0 rows=0 COMMIT', $messages[1]);
     }
 
     /**

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -63,7 +63,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^debug duration=\d rows=3 SELECT bar FROM foo$/', $messages[0]);
+        $this->assertRegExp('/^debug connection= duration=\d+ rows=3 SELECT bar FROM foo$/', $messages[0]);
     }
 
     /**
@@ -85,7 +85,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^debug duration=\d+ rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
+        $this->assertRegExp('/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
     }
 
     /**
@@ -116,8 +116,8 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertRegExp("/^debug duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
-        $this->assertRegExp("/^debug duration=\d rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
+        $this->assertRegExp("/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
+        $this->assertRegExp("/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
     }
 
     /**
@@ -146,7 +146,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp("/^debug duration=\d rows=0 SELECT bar FROM foo$/", $messages[0]);
+        $this->assertRegExp("/^debug connection= duration=\d+ rows=0 SELECT bar FROM foo$/", $messages[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -65,4 +65,24 @@ class QueryLoggerTest extends TestCase
         $this->assertCount(1, Log::engine('queryLoggerTest')->read());
         $this->assertCount(0, Log::engine('queryLoggerTest2')->read());
     }
+
+    /**
+     * Tests that the connection name is logged with the query.
+     *
+     * @return void
+     */
+    public function testLogConnection()
+    {
+        $logger = new QueryLogger(['connection' => 'test']);
+        $query = new LoggedQuery();
+        $query->query = 'SELECT a';
+
+        Log::setConfig('queryLoggerTest', [
+            'className' => 'Array',
+            'scopes' => ['queriesLog'],
+        ]);
+        $logger->log(LogLevel::DEBUG, '', compact('query'));
+
+        $this->assertStringContainsString('connection=test duration=', current(Log::engine('queryLoggerTest')->read()));
+    }
 }


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/13954

If users need to add more complex metadata to their query logs, they'll have to extend and set a custom logger.
