### PR TITLE
Throw exception when contain() in query builder for matching

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -751,6 +751,16 @@ abstract class Association
             }
         }
 
+        if (
+            !empty($options['matching']) &&
+            $this->_strategy === static::STRATEGY_JOIN &&
+            $dummy->getContain()
+        ) {
+            throw new RuntimeException(
+                "`{$this->getName()}` association cannot contain() associations when using JOIN strategy."
+            );
+        }
+
         $dummy->where($options['conditions']);
         $this->_dispatchBeforeFind($dummy);
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -32,6 +32,7 @@ use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use ReflectionProperty;
+use RuntimeException;
 
 /**
  * Tests Query class
@@ -46,6 +47,7 @@ class QueryTest extends TestCase
     protected $fixtures = [
         'core.Articles',
         'core.ArticlesTags',
+        'core.ArticlesTranslations',
         'core.Authors',
         'core.Comments',
         'core.Datatypes',
@@ -3574,6 +3576,28 @@ class QueryTest extends TestCase
             ->matching('articles')
             ->toArray();
         $this->assertEquals($expected, $results);
+    }
+
+    /**
+     * Tests contain() in query returned by innerJoinWith throws exception.
+     *
+     * @return void
+     */
+    public function testInnerJoinWithContain()
+    {
+        $comments = $this->getTableLocator()->get('Comments');
+        $articles = $comments->belongsTo('Articles');
+        $articles->hasOne('ArticlesTranslations');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('`Articles` association cannot contain() associations when using JOIN strategy');
+        $comments->find()
+            ->innerJoinWith('Articles', function (Query $q) {
+                return $q
+                    ->contain('ArticlesTranslations')
+                    ->where(['ArticlesTranslations.title' => 'Titel #1']);
+            })
+            ->sql();
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/12440

Original test case
https://github.com/cakephp/cakephp/pull/12693

The original issue doesn't describe the failure properly because `hasMany` will load through select.

This tests against the `matching` option set by `matching()` or `innerJoinWith()` that gets passed to the association from the eager loader although it's not one of the options consumed by `attachTo()`.