### PR TITLE
Remove lower casing of association names in AssociationCollection.

### DIFF
--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -71,7 +71,7 @@ class AssociationCollection implements IteratorAggregate
     {
         [, $alias] = pluginSplit($alias);
 
-        return $this->_items[strtolower($alias)] = $association;
+        return $this->_items[$alias] = $association;
     }
 
     /**
@@ -110,7 +110,6 @@ class AssociationCollection implements IteratorAggregate
      */
     public function get(string $alias): ?Association
     {
-        $alias = strtolower($alias);
         if (isset($this->_items[$alias])) {
             return $this->_items[$alias];
         }
@@ -143,7 +142,7 @@ class AssociationCollection implements IteratorAggregate
      */
     public function has(string $alias): bool
     {
-        return isset($this->_items[strtolower($alias)]);
+        return isset($this->_items[$alias]);
     }
 
     /**
@@ -187,7 +186,7 @@ class AssociationCollection implements IteratorAggregate
      */
     public function remove(string $alias): void
     {
-        unset($this->_items[strtolower($alias)]);
+        unset($this->_items[$alias]);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -894,7 +894,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $association = $this->findAssociation($name);
         if (!$association) {
-            throw new InvalidArgumentException("The {$name} association is not defined on {$this->getAlias()}.");
+            $assocations = $this->associations()->keys();
+
+            $message = "The `{$name}` association is not defined on `{$this->getAlias()}`.";
+            if ($assocations) {
+                $message .= "\nValid associations are: " . implode(', ', $assocations);
+            }
+            throw new InvalidArgumentException($message);
         }
 
         return $association;

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -74,17 +74,14 @@ class AssociationCollectionTest extends TestCase
 
         $belongsTo = new BelongsTo('');
         $this->assertSame($belongsTo, $this->associations->add('Users', $belongsTo));
-        $this->assertTrue($this->associations->has('users'));
+        $this->assertFalse($this->associations->has('users'));
         $this->assertTrue($this->associations->has('Users'));
 
-        $this->assertSame($belongsTo, $this->associations->get('users'));
         $this->assertSame($belongsTo, $this->associations->get('Users'));
 
         $this->assertNull($this->associations->remove('Users'));
 
-        $this->assertFalse($this->associations->has('users'));
         $this->assertFalse($this->associations->has('Users'));
-        $this->assertNull($this->associations->get('users'));
         $this->assertNull($this->associations->get('Users'));
     }
 
@@ -195,10 +192,10 @@ class AssociationCollectionTest extends TestCase
         $belongsTo = new BelongsTo('');
         $this->associations->add('Users', $belongsTo);
         $this->associations->add('Categories', $belongsTo);
-        $this->assertEquals(['users', 'categories'], $this->associations->keys());
+        $this->assertEquals(['Users', 'Categories'], $this->associations->keys());
 
         $this->associations->remove('Categories');
-        $this->assertEquals(['users'], $this->associations->keys());
+        $this->assertEquals(['Users'], $this->associations->keys());
     }
 
     /**
@@ -481,7 +478,7 @@ class AssociationCollectionTest extends TestCase
         $belongsToMany = new BelongsToMany('');
         $this->associations->add('Cart', $belongsToMany);
 
-        $expected = ['users' => $belongsTo, 'cart' => $belongsToMany];
+        $expected = ['Users' => $belongsTo, 'Cart' => $belongsToMany];
         $result = iterator_to_array($this->associations, true);
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -527,11 +527,11 @@ class EagerLoaderTest extends TestCase
     public function testNormalizedMatchingPath()
     {
         $loader = new EagerLoader();
-        $loader->setMatching('Clients');
+        $loader->setMatching('clients');
         $assocs = $loader->attachableAssociations($this->table);
 
-        $this->assertEquals('Clients', $assocs['Clients']->aliasPath());
-        $this->assertEquals('_matchingData.Clients', $assocs['Clients']->propertyPath());
+        $this->assertEquals('clients', $assocs['clients']->aliasPath());
+        $this->assertEquals('_matchingData.clients', $assocs['clients']->propertyPath());
     }
 
     /**
@@ -542,15 +542,15 @@ class EagerLoaderTest extends TestCase
     public function testNormalizedDeepMatchingPath()
     {
         $loader = new EagerLoader();
-        $loader->setMatching('Clients.Orders');
+        $loader->setMatching('clients.orders');
         $assocs = $loader->attachableAssociations($this->table);
 
-        $this->assertEquals('Clients', $assocs['Clients']->aliasPath());
-        $this->assertEquals('_matchingData.Clients', $assocs['Clients']->propertyPath());
+        $this->assertEquals('clients', $assocs['clients']->aliasPath());
+        $this->assertEquals('_matchingData.clients', $assocs['clients']->propertyPath());
 
-        $assocs = $assocs['Clients']->associations();
-        $this->assertEquals('Clients.Orders', $assocs['Orders']->aliasPath());
-        $this->assertEquals('_matchingData.Orders', $assocs['Orders']->propertyPath());
+        $assocs = $assocs['clients']->associations();
+        $this->assertEquals('clients.orders', $assocs['orders']->aliasPath());
+        $this->assertEquals('_matchingData.orders', $assocs['orders']->propertyPath());
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3186,7 +3186,7 @@ class MarshallerTest extends TestCase
         $marshall = new Marshaller($this->articles);
 
         // Assert event options are correct
-        $this->articles->users->getEventManager()->on(
+        $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data, $options) {
                 $this->assertArrayHasKey('validate', $options);
@@ -3200,28 +3200,28 @@ class MarshallerTest extends TestCase
             }
         );
 
-        $this->articles->users->getEventManager()->on(
+        $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data, $options) {
                 $data['secret'] = 'h45h3d';
             }
         );
 
-        $this->articles->comments->getEventManager()->on(
+        $this->articles->Comments->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['comment'] .= ' (modified)';
             }
         );
 
-        $this->articles->tags->getEventManager()->on(
+        $this->articles->Tags->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['tag'] .= ' (modified)';
             }
         );
 
-        $this->articles->tags->junction()->getEventManager()->on(
+        $this->articles->Tags->junction()->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['modified_by'] = 1;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3496,7 +3496,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $results->toList());
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The Tags association is not defined on Articles');
+        $this->expectExceptionMessage('The `Tags` association is not defined on `Articles`.');
         $table
             ->find()
             ->disableHydration()

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -132,7 +132,7 @@ class LinkConstraintTest extends TestCase
     public function testNonExistentAssociation(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The NonExistent association is not defined on Articles.');
+        $this->expectExceptionMessage('The `NonExistent` association is not defined on `Articles`.');
 
         $Articles = $this->getTableLocator()->get('Articles');
 


### PR DESCRIPTION
It causes undeterministic behavior in the ORM. For e.g. using different casing
in contain() calls than the one used when declaring association caused related
records to be under different entity property in the resultset entities. Also related
record remained as an array instead of being hydrated as an entity.

Fixes #14554.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
