### PR TITLE
Fix false being set in form inputs

### DIFF
--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -79,13 +79,13 @@ class BasicWidget implements WidgetInterface
 
         $data['value'] = $data['val'];
         unset($data['val']);
+        if ($data['value'] === false) {
+            $data['value'] = '0';
+        }
 
         $fieldName = $data['fieldName'] ?? null;
         if ($fieldName) {
-            if (
-                $data['type'] === 'number'
-                && !isset($data['step'])
-            ) {
+            if ($data['type'] === 'number' && !isset($data['step'])) {
                 $data = $this->setStep($data, $context, $fieldName);
             }
 

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -80,6 +80,7 @@ class BasicWidget implements WidgetInterface
         $data['value'] = $data['val'];
         unset($data['val']);
         if ($data['value'] === false) {
+            // explicitly convert to 0 to avoid empty string which is marshaled as null
             $data['value'] = '0';
         }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6545,7 +6545,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testHiddenField()
+    public function testHidden()
     {
         $this->article['errors'] = [
             'field' => true,
@@ -6560,6 +6560,33 @@ class FormHelperTest extends TestCase
         $result = $this->Form->hidden('field', ['value' => 'my value']);
         $expected = [
             'input' => ['type' => 'hidden', 'class' => 'form-error', 'name' => 'field', 'value' => 'my value'],
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test hidden() with various boolean values.
+     *
+     * @return void
+     */
+    public function testHiddenBooleanValues()
+    {
+        $this->Form->create($this->article);
+        $result = $this->Form->hidden('field', ['value' => null]);
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'field'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->hidden('field', ['value' => true]);
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'field', 'value' => '1'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->hidden('field', ['value' => false]);
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'field', 'value' => '0'],
         ];
         $this->assertHtml($expected, $result);
     }


### PR DESCRIPTION
Convert false values into 0 so that they can be marshalled back into false for boolean fields.

Fixes #14548
