### PR TITLE
Set ajax response type in initialize()

### DIFF
--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -16,10 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\View;
 
-use Cake\Event\EventManager;
-use Cake\Http\Response;
-use Cake\Http\ServerRequest;
-
 /**
  * A view class that is used for AJAX responses.
  * Currently only switches the default layout and sets the response type - which just maps to
@@ -33,23 +29,11 @@ class AjaxView extends View
     protected $layout = 'ajax';
 
     /**
-     * Constructor
-     *
-     * @param \Cake\Http\ServerRequest|null $request The request object.
-     * @param \Cake\Http\Response|null $response The response object.
-     * @param \Cake\Event\EventManager|null $eventManager Event manager object.
-     * @param array $viewOptions View options.
+     * @inheritDoc
      */
-    public function __construct(
-        ?ServerRequest $request = null,
-        ?Response $response = null,
-        ?EventManager $eventManager = null,
-        array $viewOptions = []
-    ) {
-        if ($response) {
-            $response = $response->withType('ajax');
-        }
-
-        parent::__construct($request, $response, $eventManager, $viewOptions);
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->setResponse($this->getResponse()->withType('ajax'));
     }
 }

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -16,9 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\View;
 
-use Cake\Event\EventManager;
-use Cake\Http\Response;
-use Cake\Http\ServerRequest;
 use Cake\View\Exception\SerializationFailureException;
 use Exception;
 use TypeError;
@@ -52,24 +49,12 @@ abstract class SerializedView extends View
     ];
 
     /**
-     * Constructor
-     *
-     * @param \Cake\Http\ServerRequest|null $request Request instance.
-     * @param \Cake\Http\Response|null $response Response instance.
-     * @param \Cake\Event\EventManager|null $eventManager EventManager instance.
-     * @param array $viewOptions An array of view options
+     * @inheritDoc
      */
-    public function __construct(
-        ?ServerRequest $request = null,
-        ?Response $response = null,
-        ?EventManager $eventManager = null,
-        array $viewOptions = []
-    ) {
-        if ($response) {
-            $response = $response->withType($this->_responseType);
-        }
-
-        parent::__construct($request, $response, $eventManager, $viewOptions);
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->setResponse($this->getResponse()->withType($this->_responseType));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -391,6 +391,7 @@ class RequestHandlerComponentTest extends TestCase
         $view = $this->Controller->createView();
         $this->assertInstanceOf(AjaxView::class, $view);
         $this->assertSame('ajax', $view->getLayout());
+        $this->assertSame((new Response(['type' => 'ajax']))->getType(), $view->getResponse()->getType());
 
         $this->_init();
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'js'));


### PR DESCRIPTION
This allows the response type to be set on the default Response. Using initialize() also avoids overriding the constructor.