### PR TITLE
Improve error message for EmailTrait::MailContains

### DIFF
--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -62,6 +62,7 @@ class MailContains extends MailConstraintBase
 
     /**
      * Returns the type-dependent strings of all messages
+     * respects $this->at
      *
      * @return string
      */
@@ -72,6 +73,9 @@ class MailContains extends MailConstraintBase
         foreach ($messages as $message) {
             $method = $this->getTypeMethod();
             $messageMembers[] = $message->$method();
+        }
+        if ($this->at && isset($messageMembers[$this->at - 1])) {
+            $messageMembers = [$messageMembers[$this->at - 1]];
         }
         $result = join(PHP_EOL, $messageMembers);
 
@@ -86,9 +90,9 @@ class MailContains extends MailConstraintBase
     public function toString(): string
     {
         if ($this->at) {
-            return sprintf('is in email #%d', $this->at);
+            return sprintf('is in email #%d', $this->at) . $this->getAssertedMessages();
         }
 
-        return 'is in an email';
+        return 'is in an email' . $this->getAssertedMessages();
     }
 }

--- a/src/TestSuite/Constraint/Email/MailContainsHtml.php
+++ b/src/TestSuite/Constraint/Email/MailContainsHtml.php
@@ -38,9 +38,9 @@ class MailContainsHtml extends MailContains
     public function toString(): string
     {
         if ($this->at) {
-            return sprintf('is in the html message of email #%d', $this->at);
+            return sprintf('is in the html message of email #%d', $this->at) . $this->getAssertedMessages();
         }
 
-        return 'is in the html message of an email';
+        return 'is in the html message of an email' . $this->getAssertedMessages();
     }
 }

--- a/src/TestSuite/Constraint/Email/MailContainsText.php
+++ b/src/TestSuite/Constraint/Email/MailContainsText.php
@@ -38,7 +38,7 @@ class MailContainsText extends MailContains
     public function toString(): string
     {
         if ($this->at) {
-            return sprintf('is in the text message of email #%d', $this->at);
+            return sprintf('is in the text message of email #%d', $this->at) . $this->getAssertedMessages();
         }
 
         return 'is in the text message of an email' . $this->getAssertedMessages();

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -215,13 +215,13 @@ class EmailTraitTest extends TestCase
             'assertMailSentFromAt' => ['assertMailSentFromAt', 'Failed asserting that \'missing@example.com\' sent email #1.', [1, 'missing@example.com']],
             'assertMailSentWith' => ['assertMailSentWith', 'Failed asserting that \'Missing\' is in an email `subject`.', ['Missing', 'subject']],
             'assertMailSentWithAt' => ['assertMailSentWithAt', 'Failed asserting that \'Missing\' is in email #1 `subject`.', [1, 'Missing', 'subject']],
-            'assertMailContains' => ['assertMailContains', 'Failed asserting that \'Missing\' is in an email.', ['Missing']],
+            'assertMailContains' => ['assertMailContains', 'Failed asserting that \'Missing\' is in an email' . PHP_EOL . 'was: .', ['Missing']],
             'assertMailContainsAttachment' => ['assertMailContainsAttachment', 'Failed asserting that \'no_existing_file.php\' is an attachment of an email.', ['no_existing_file.php']],
-            'assertMailContainsHtml' => ['assertMailContainsHtml', 'Failed asserting that \'Missing\' is in the html message of an email.', ['Missing']],
+            'assertMailContainsHtml' => ['assertMailContainsHtml', 'Failed asserting that \'Missing\' is in the html message of an email' . PHP_EOL . 'was: .', ['Missing']],
             'assertMailContainsText' => ['assertMailContainsText', 'Failed asserting that \'Missing\' is in the text message of an email' . PHP_EOL . 'was: .', ['Missing']],
-            'assertMailContainsAt' => ['assertMailContainsAt', 'Failed asserting that \'Missing\' is in email #1.', [1, 'Missing']],
-            'assertMailContainsHtmlAt' => ['assertMailContainsHtmlAt', 'Failed asserting that \'Missing\' is in the html message of email #1.', [1, 'Missing']],
-            'assertMailContainsTextAt' => ['assertMailContainsTextAt', 'Failed asserting that \'Missing\' is in the text message of email #1.', [1, 'Missing']],
+            'assertMailContainsAt' => ['assertMailContainsAt', 'Failed asserting that \'Missing\' is in email #1' . PHP_EOL . 'was: .', [1, 'Missing']],
+            'assertMailContainsHtmlAt' => ['assertMailContainsHtmlAt', 'Failed asserting that \'Missing\' is in the html message of email #1' . PHP_EOL . 'was: .', [1, 'Missing']],
+            'assertMailContainsTextAt' => ['assertMailContainsTextAt', 'Failed asserting that \'Missing\' is in the text message of email #1' . PHP_EOL . 'was: .', [1, 'Missing']],
         ];
     }
 


### PR DESCRIPTION
additional changes for #14518 , first PR was #14523

I added the necessary code changings to cover these missing functionalities

* Add new error message for MailContains and MailContainsHtml
* changings also work with usage of $this->at
* adapted unit tests

**For my project's tests those changings work well, but a unit test for the changings is still missing because I have no idea how to test the assert error message of a unit test.**
