### PR TITLE
Add iterable type into generator doc.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -325,7 +325,7 @@ class PluginCollection implements Iterator, Countable
      * Filter the plugins to those with the named hook enabled.
      *
      * @param string $hook The hook to filter plugins by
-     * @return \Generator A generator containing matching plugins.
+     * @return \Generator|\Cake\Core\PluginInterface[] A generator containing matching plugins.
      * @throws \InvalidArgumentException on invalid hooks
      */
     public function with(string $hook): Generator

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -325,8 +325,9 @@ class PluginCollection implements Iterator, Countable
      * Filter the plugins to those with the named hook enabled.
      *
      * @param string $hook The hook to filter plugins by
-     * @return \Generator|\Cake\Core\PluginInterface[] A generator containing matching plugins.
+     * @return \Generator&\Cake\Core\PluginInterface[] A generator containing matching plugins.
      * @throws \InvalidArgumentException on invalid hooks
+     * @psalm-return \Generator<\Cake\Core\PluginInterface>
      */
     public function with(string $hook): Generator
     {


### PR DESCRIPTION
This makes it possible for IDE and stan to know the iterable type returned
I think it is actually wrong to set Generator as return type, should be iterable as base type here.
But that's probably for a minor or major to replace.

This just aims at better discoverability and to avoid having to inline annotate the with() usage everywhere.

I also saw other references as

    \Generator<\FQCN>

and

    iterable<\FQCN>

etc.
But those are not yet fully understood by IDEs usually.
See https://phpstan.org/r/51d234b0-e6fd-4408-a5b7-4151ea6a0646