### PR TITLE
Interactive false for Commands.

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -172,6 +172,10 @@ abstract class BaseCommand implements CommandInterface
             return static::CODE_SUCCESS;
         }
 
+        if ($args->getOption('quiet')) {
+            $io->setInteractive(false);
+        }
+
         return $this->execute($args, $io);
     }
 

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -129,8 +129,7 @@ class ConsoleIo
     }
 
     /**
-     * @param bool $value
-     *
+     * @param bool $value Value
      * @return void
      */
     public function setInteractive(bool $value): void

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -32,6 +32,27 @@ use SplFileObject;
 class ConsoleIo
 {
     /**
+     * Output constant making verbose shells.
+     *
+     * @var int
+     */
+    public const VERBOSE = 2;
+
+    /**
+     * Output constant for making normal shells.
+     *
+     * @var int
+     */
+    public const NORMAL = 1;
+
+    /**
+     * Output constants for making quiet shells.
+     *
+     * @var int
+     */
+    public const QUIET = 0;
+
+    /**
      * The output stream
      *
      * @var \Cake\Console\ConsoleOutput
@@ -60,27 +81,6 @@ class ConsoleIo
     protected $_helpers;
 
     /**
-     * Output constant making verbose shells.
-     *
-     * @var int
-     */
-    public const VERBOSE = 2;
-
-    /**
-     * Output constant for making normal shells.
-     *
-     * @var int
-     */
-    public const NORMAL = 1;
-
-    /**
-     * Output constants for making quiet shells.
-     *
-     * @var int
-     */
-    public const QUIET = 0;
-
-    /**
      * The current output level.
      *
      * @var int
@@ -103,6 +103,11 @@ class ConsoleIo
     protected $forceOverwrite = false;
 
     /**
+     * @var bool
+     */
+    protected $interactive = true;
+
+    /**
      * Constructor
      *
      * @param \Cake\Console\ConsoleOutput|null $out A ConsoleOutput object for stdout.
@@ -121,6 +126,16 @@ class ConsoleIo
         $this->_in = $in ?: new ConsoleInput('php://stdin');
         $this->_helpers = $helpers ?: new HelperRegistry();
         $this->_helpers->setIo($this);
+    }
+
+    /**
+     * @param bool $value
+     *
+     * @return void
+     */
+    public function setInteractive(bool $value): void
+    {
+        $this->interactive = $value;
     }
 
     /**
@@ -477,6 +492,10 @@ class ConsoleIo
      */
     protected function _getInput(string $prompt, ?string $options, ?string $default): string
     {
+        if (!$this->interactive) {
+            return (string)$default;
+        }
+
         $optionsText = '';
         if (isset($options)) {
             $optionsText = " $options ";


### PR DESCRIPTION
Addresses https://github.com/cakephp/cakephp/issues/14571

Restores the ability to  use non-interactive mode

The command then has to set

    $io->setInteractive(false);

and e.g.

    bin/cake i18n extract -q --overwrite --extract-core=yes --relative-paths

would run without issues now using the defaults.
This can then further be used programmatically.

Right now, even quit and overwrite enabled, it still forces input confirmation:
```
Current paths: None
What is the path you would like to extract?
[Q]uit [D]one
[src/] > 
```
The default here is `src/`.

Additionally:
It also auto detects this based on -q (quiet) flag, as you would never use this in normal interactive mode, but for crons, for CI checks, for deploy scripts etc, and here you cannot interfere really anyway.
We could move this part to 4.1 if we wanted, to put this into a minor release.