### PR TITLE
Consolidate logging formatting for query logging

### DIFF
--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -108,6 +108,19 @@ class LoggedQuery implements JsonSerializable
     }
 
     /**
+     * Get the logging context data for a query.
+     *
+     * @return array
+     */
+    public function getContext(): array
+    {
+        return [
+            'numRows' => $this->numRows,
+            'took' => $this->took,
+        ];
+    }
+
+    /**
      * Returns data that will be serialized as JSON
      *
      * @return array
@@ -144,6 +157,6 @@ class LoggedQuery implements JsonSerializable
             $sql = $this->interpolate();
         }
 
-        return "duration={$this->took} rows={$this->numRows} {$sql}";
+        return $sql;
     }
 }

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -35,6 +35,7 @@ class QueryLogger extends BaseLog
     public function __construct(array $config = [])
     {
         $this->_defaultConfig['scopes'] = ['queriesLog'];
+        $this->_defaultConfig['connection'] = '';
 
         parent::__construct($config);
     }

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -44,10 +44,13 @@ class QueryLogger extends BaseLog
      */
     public function log($level, $message, array $context = [])
     {
-        Log::write(
-            'debug',
-            'connection=' . $this->getConfig('connection', '') . ' ' . (string)$context['query'],
-            ['scope' => $this->scopes() ?: ['queriesLog']]
-        );
+        $context['scope'] = $this->scopes() ?: ['queriesLog'];
+        $context['connection'] = $this->getConfig('connection');
+
+        if ($context['query'] instanceof LoggedQuery) {
+            $context = $context['query']->getContext() + $context;
+            $message = 'connection={connection} duration={took} rows={numRows} ' . $message;
+        }
+        Log::write('debug', $message, $context);
     }
 }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -34,7 +34,7 @@ class LoggedQueryTest extends TestCase
     {
         $logged = new LoggedQuery();
         $logged->query = 'SELECT foo FROM bar';
-        $this->assertSame('duration=0 rows=0 SELECT foo FROM bar', (string)$logged);
+        $this->assertSame('SELECT foo FROM bar', (string)$logged);
     }
 
     /**
@@ -48,7 +48,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4 AND e = :p5 AND f = :p6';
         $query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3, 'p4' => true, 'p5' => false, 'p6' => 0];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 3 AND c = NULL AND d = 1 AND e = 0 AND f = 0";
+        $expected = "SELECT a FROM b where a = 'string' AND b = 3 AND c = NULL AND d = 1 AND e = 0 AND f = 0";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -63,7 +63,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ? AND d = ? AND e = ? AND f = ?';
         $query->params = ['string', '3', null, true, false, 0];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = '3' AND c = NULL AND d = 1 AND e = 0 AND f = 0";
+        $expected = "SELECT a FROM b where a = 'string' AND b = '3' AND c = NULL AND d = 1 AND e = 0 AND f = 0";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -78,7 +78,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p1 AND c = :p2 AND d = :p2';
         $query->params = ['p1' => 'string', 'p2' => 3];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 'string' AND c = 3 AND d = 3";
+        $expected = "SELECT a FROM b where a = 'string' AND b = 'string' AND c = 3 AND d = 3";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -93,7 +93,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p11 AND c = :p20 AND d = :p2';
         $query->params = ['p11' => 'test', 'p1' => 'string', 'p2' => 3, 'p20' => 5];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'string' AND b = 'test' AND c = 5 AND d = 3";
+        $expected = "SELECT a FROM b where a = 'string' AND b = 'test' AND c = 5 AND d = 3";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -108,7 +108,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4';
         $query->params = ['p1' => '$2y$10$dUAIj', 'p2' => '$0.23', 'p3' => 'a\\0b\\1c\\d', 'p4' => "a'b"];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = '\$2y\$10\$dUAIj' AND b = '\$0.23' AND c = 'a\\\\0b\\\\1c\\\\d' AND d = 'a''b'";
+        $expected = "SELECT a FROM b where a = '\$2y\$10\$dUAIj' AND b = '\$0.23' AND c = 'a\\\\0b\\\\1c\\\\d' AND d = 'a''b'";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -124,7 +124,7 @@ class LoggedQueryTest extends TestCase
         $uuid = str_replace('-', '', Text::uuid());
         $query->params = ['p1' => hex2bin($uuid)];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = '{$uuid}'";
+        $expected = "SELECT a FROM b where a = '{$uuid}'";
         $this->assertEquals($expected, (string)$query);
     }
 
@@ -139,8 +139,22 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1';
         $query->params = ['p1' => "a\tz"];
 
-        $expected = "duration=0 rows=0 SELECT a FROM b where a = 'a\tz'";
+        $expected = "SELECT a FROM b where a = 'a\tz'";
         $this->assertEquals($expected, (string)$query);
+    }
+
+    public function testGetContext()
+    {
+        $query = new LoggedQuery();
+        $query->query = 'SELECT a FROM b where a = :p1';
+        $query->numRows = 10;
+        $query->took = 15;
+
+        $expected = [
+            'numRows' => 10,
+            'took' => 15,
+        ];
+        $this->assertSame($expected, $query->getContext());
     }
 
     /**

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -58,12 +58,12 @@ class LoggingStatementTest extends TestCase
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger(new QueryLogger());
+        $st->setLogger(new QueryLogger(['connection' => 'test']));
         $st->execute();
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^debug connection= duration=\d+ rows=3 SELECT bar FROM foo$/', $messages[0]);
+        $this->assertRegExp('/^debug connection=test duration=\d+ rows=3 SELECT bar FROM foo$/', $messages[0]);
     }
 
     /**
@@ -80,12 +80,12 @@ class LoggingStatementTest extends TestCase
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo WHERE x=:a AND y=:b';
-        $st->setLogger(new QueryLogger());
+        $st->setLogger(new QueryLogger(['connection' => 'test']));
         $st->execute(['a' => 1, 'b' => 2]);
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp('/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
+        $this->assertRegExp('/^debug connection=test duration=\d+ rows=4 SELECT bar FROM foo WHERE x=1 AND y=2$/', $messages[0]);
     }
 
     /**
@@ -106,7 +106,7 @@ class LoggingStatementTest extends TestCase
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo WHERE a=:a AND b=:b';
-        $st->setLogger(new QueryLogger());
+        $st->setLogger(new QueryLogger(['connection' => 'test']));
         $st->bindValue('a', 1);
         $st->bindValue('b', $date, 'date');
         $st->execute();
@@ -116,8 +116,8 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);
-        $this->assertRegExp("/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
-        $this->assertRegExp("/^debug connection= duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
+        $this->assertRegExp("/^debug connection=test duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2013-01-01'$/", $messages[0]);
+        $this->assertRegExp("/^debug connection=test duration=\d+ rows=4 SELECT bar FROM foo WHERE a='1' AND b='2014-01-01'$/", $messages[1]);
     }
 
     /**
@@ -136,7 +136,7 @@ class LoggingStatementTest extends TestCase
         $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->setLogger(new QueryLogger());
+        $st->setLogger(new QueryLogger(['connection' => 'test']));
         try {
             $st->execute();
         } catch (LogicException $e) {
@@ -146,7 +146,7 @@ class LoggingStatementTest extends TestCase
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
-        $this->assertRegExp("/^debug connection= duration=\d+ rows=0 SELECT bar FROM foo$/", $messages[0]);
+        $this->assertRegExp("/^debug connection=test duration=\d+ rows=0 SELECT bar FROM foo$/", $messages[0]);
     }
 
     /**
@@ -156,7 +156,7 @@ class LoggingStatementTest extends TestCase
      */
     public function testSetAndGetLogger()
     {
-        $logger = new QueryLogger();
+        $logger = new QueryLogger(['connection' => 'test']);
         $st = new LoggingStatement(
             $this->getMockBuilder(StatementInterface::class)->getMock(),
             $this->getMockBuilder(DriverInterface::class)->getMock()

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -47,7 +47,7 @@ class QueryLoggerTest extends TestCase
      */
     public function testLogFunction()
     {
-        $logger = new QueryLogger();
+        $logger = new QueryLogger(['connection' => '']);
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
         $query->params = ['string', '3', null];


### PR DESCRIPTION
Move context formatting out of LoggedQuery::__toString() and leverage the new log formatting that has been added to 4.1. This is a small behavior change but not an API breaking one in my opinion.
