### PR TITLE
Fix form-urlencoded PUT bodies not working in tests

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -49,6 +49,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
      * @param array $body $_POST superglobal
      * @param array $cookies $_COOKIE superglobal
      * @param array $files $_FILES superglobal
+     * @param string $input php://input Used to stub request streams in testing.
      * @return \Cake\Http\ServerRequest
      * @throws \InvalidArgumentException for invalid file values
      */
@@ -57,7 +58,8 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
         ?array $query = null,
         ?array $body = null,
         ?array $cookies = null,
-        ?array $files = null
+        ?array $files = null,
+        ?string $input = null
     ): ServerRequest {
         $server = normalizeServer($server ?: $_SERVER);
         $uri = static::createUri($server);
@@ -79,6 +81,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             'base' => $uri->base,
             'session' => $session,
             'mergeFilesAsObjects' => Configure::read('App.uploadedFilesAsObjects', true),
+            'input' => $input,
         ]);
 
         return $request;

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -592,19 +592,6 @@ trait IntegrationTestTrait
         }
 
         parse_str($query, $queryData);
-        $props = [
-            'url' => $url,
-            'session' => $session,
-            'query' => $queryData,
-            'files' => [],
-        ];
-        if (is_string($data)) {
-            $props['input'] = $data;
-        } else {
-            $data = $this->_addTokens($tokenUrl, $data);
-            $props['post'] = $this->_castToString($data);
-        }
-        $props['cookies'] = $this->_cookie;
 
         $env = [
             'REQUEST_METHOD' => $method,
@@ -627,7 +614,28 @@ trait IntegrationTestTrait
             }
             unset($this->_request['headers']);
         }
-        $props['environment'] = $env;
+        $props = [
+            'url' => $url,
+            'session' => $session,
+            'query' => $queryData,
+            'files' => [],
+            'environment' => $env,
+        ];
+
+        if (is_string($data)) {
+            $props['input'] = $data;
+        } elseif (
+            is_array($data) &&
+            isset($props['environment']['CONTENT_TYPE']) &&
+            $props['environment']['CONTENT_TYPE'] === 'application/x-www-form-urlencoded'
+        ) {
+            $props['input'] = http_build_query($data);
+        } else {
+            $data = $this->_addTokens($tokenUrl, $data);
+            $props['post'] = $this->_castToString($data);
+        }
+
+        $props['cookies'] = $this->_cookie;
         $props = Hash::merge($props, $this->_request);
 
         return $props;

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -23,7 +23,6 @@ use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
-use Laminas\Diactoros\Stream;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -162,16 +162,10 @@ class MiddlewareDispatcher
             $spec['query'],
             $spec['post'],
             $spec['cookies'],
-            $spec['files']
+            $spec['files'],
+            $spec['input'] ?? null
         );
         $request = $request->withAttribute('session', $spec['session']);
-
-        if (isset($spec['input'])) {
-            $stream = new Stream('php://memory', 'rw');
-            $stream->write($spec['input']);
-            $stream->rewind();
-            $request = $request->withBody($stream);
-        }
 
         return $request;
     }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -468,6 +468,24 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test that the PSR7 requests receive put data
+     *
+     * @return void
+     */
+    public function testPutDataFormUrlEncoded()
+    {
+        $this->configRequest([
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+        ]);
+        $this->put('/request_action/post_pass', ['title' => 'value']);
+        $this->assertResponseOk();
+        $data = json_decode('' . $this->_response->getBody());
+        $this->assertSame('value', $data->title);
+    }
+
+    /**
      * Test that the uploaded files are passed correctly to the request
      *
      * @return void


### PR DESCRIPTION
When using application/www-form-urlencoded content type request bodies are expected to be present in the input stream. Propagate the input data through the request factory so that the stream is in the correct state during ServerRequest's constructor.

Fixes #14565