### PR TITLE
Add Shells interactive false back for Commands

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -172,6 +172,10 @@ abstract class BaseCommand implements CommandInterface
             return static::CODE_SUCCESS;
         }
 
+        if ($args->getOption('quiet')) {
+            $io->setInteractive(false);
+        }
+
         return $this->execute($args, $io);
     }
 

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -32,6 +32,27 @@ use SplFileObject;
 class ConsoleIo
 {
     /**
+     * Output constant making verbose shells.
+     *
+     * @var int
+     */
+    public const VERBOSE = 2;
+
+    /**
+     * Output constant for making normal shells.
+     *
+     * @var int
+     */
+    public const NORMAL = 1;
+
+    /**
+     * Output constants for making quiet shells.
+     *
+     * @var int
+     */
+    public const QUIET = 0;
+
+    /**
      * The output stream
      *
      * @var \Cake\Console\ConsoleOutput
@@ -60,27 +81,6 @@ class ConsoleIo
     protected $_helpers;
 
     /**
-     * Output constant making verbose shells.
-     *
-     * @var int
-     */
-    public const VERBOSE = 2;
-
-    /**
-     * Output constant for making normal shells.
-     *
-     * @var int
-     */
-    public const NORMAL = 1;
-
-    /**
-     * Output constants for making quiet shells.
-     *
-     * @var int
-     */
-    public const QUIET = 0;
-
-    /**
      * The current output level.
      *
      * @var int
@@ -103,6 +103,11 @@ class ConsoleIo
     protected $forceOverwrite = false;
 
     /**
+     * @var bool
+     */
+    protected $interactive = true;
+
+    /**
      * Constructor
      *
      * @param \Cake\Console\ConsoleOutput|null $out A ConsoleOutput object for stdout.
@@ -121,6 +126,15 @@ class ConsoleIo
         $this->_in = $in ?: new ConsoleInput('php://stdin');
         $this->_helpers = $helpers ?: new HelperRegistry();
         $this->_helpers->setIo($this);
+    }
+
+    /**
+     * @param bool $value Value
+     * @return void
+     */
+    public function setInteractive(bool $value): void
+    {
+        $this->interactive = $value;
     }
 
     /**
@@ -477,6 +491,10 @@ class ConsoleIo
      */
     protected function _getInput(string $prompt, ?string $options, ?string $default): string
     {
+        if (!$this->interactive) {
+            return (string)$default;
+        }
+
         $optionsText = '';
         if (isset($options)) {
             $optionsText = " $options ";

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -368,7 +368,6 @@ class CommandTest extends TestCase
         $command->executeCommand(new \stdClass(), [], $this->getMockIo(new ConsoleOutput()));
     }
 
-
     /**
      * Test that noninteractive commands use defaults where applicable.
      *

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -28,6 +28,7 @@ use InvalidArgumentException;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
+use TestApp\Command\NonInteractiveCommand;
 
 /**
  * Test case for Console\Command
@@ -130,6 +131,7 @@ class CommandTest extends TestCase
      */
     public function testRunCallsInitialize()
     {
+        /** @var \Cake\Console\Command|\PHPUnit\Framework\MockObject\MockObject $command */
         $command = $this->getMockBuilder(Command::class)
             ->setMethods(['initialize'])
             ->getMock();
@@ -222,6 +224,7 @@ class CommandTest extends TestCase
      */
     public function testRunOptionParserFailure()
     {
+        /** @var \Cake\Console\Command|\PHPUnit\Framework\MockObject\MockObject $command */
         $command = $this->getMockBuilder(Command::class)
             ->setMethods(['getOptionParser'])
             ->getMock();
@@ -365,6 +368,24 @@ class CommandTest extends TestCase
         $command->executeCommand(new \stdClass(), [], $this->getMockIo(new ConsoleOutput()));
     }
 
+
+    /**
+     * Test that noninteractive commands use defaults where applicable.
+     *
+     * @return void
+     */
+    public function testExecuteCommandNonInteractive()
+    {
+        $output = new ConsoleOutput();
+        $command = new Command();
+        $command->executeCommand(NonInteractiveCommand::class, ['--quiet'], $this->getMockIo($output));
+        $this->assertEquals(['Result: Default!'], $output->messages());
+    }
+
+    /**
+     * @param \Cake\Console\ConsoleOutput $output
+     * @return \Cake\Console\ConsoleIo|\PHPUnit\Framework\MockObject\MockObject
+     */
     protected function getMockIo($output)
     {
         $io = $this->getMockBuilder(ConsoleIo::class)

--- a/tests/test_app/TestApp/Command/NonInteractiveCommand.php
+++ b/tests/test_app/TestApp/Command/NonInteractiveCommand.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+
+class NonInteractiveCommand extends Command
+{
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $result = $io->ask('What?', 'Default!');
+        $io->quiet('Result: ' . $result);
+
+        return null;
+    }
+}


### PR DESCRIPTION
4.next pending of the fix+improvement of https://github.com/cakephp/cakephp/pull/14572
test case included now

I would like to also port this to 3.9 then afterward