### PR TITLE
Clean up tests using PHPStan level 1.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -39,6 +39,7 @@ use SimpleXMLElement;
  * application sends.
  *
  * @deprecated 4.0.0 This class will be removed in CakePHP 5.0, use Cake\Mailer\Mailer instead.
+ * @mixin \Cake\Mailer\Mailer
  */
 class Email implements JsonSerializable, Serializable
 {
@@ -607,7 +608,7 @@ class Email implements JsonSerializable, Serializable
     }
 
     /**
-     * Proxy all static method calls (for methods provided by StaticConfigTrat) to Mailer.
+     * Proxy all static method calls (for methods provided by StaticConfigTrait) to Mailer.
      *
      * @param string $name Method name.
      * @param array $arguments Method argument.

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -416,13 +416,15 @@ EXPECTED;
     public function testStackTrace()
     {
         ob_start();
-        [$r, $expected] = [stackTrace(), \Cake\Error\Debugger::trace()];
+        // phpcs:ignore
+        stackTrace(); $expected = Debugger::trace();
         $result = ob_get_clean();
         $this->assertSame($expected, $result);
 
         $opts = ['args' => true];
         ob_start();
-        [$r, $expected] = [stackTrace($opts), \Cake\Error\Debugger::trace($opts)];
+        // phpcs:ignore
+        stackTrace($opts); $expected = Debugger::trace($opts);
         $result = ob_get_clean();
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2708,8 +2708,8 @@ class CollectionTest extends TestCase
     /**
      * Yields all the elements as passed
      *
-     * @param array $itmes the elements to be yielded
-     * @return void
+     * @param array $items the elements to be yielded
+     * @return \Generator<array>
      */
     protected function yieldItems(array $items)
     {

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -32,10 +32,13 @@ class PluginAssetsCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 
+    /**
+     * @var string
+     */
     protected $wwwRoot;
 
     /**
-     * @var Cake\Filessytem\Filesystem;
+     * @var \Cake\Filesystem\Filesystem
      */
     protected $fs;
 
@@ -52,10 +55,6 @@ class PluginAssetsCommandsTest extends TestCase
             DS === '\\',
             'Skip AssetsTask tests on windows to prevent side effects for UrlHelper tests on AppVeyor.'
         );
-
-        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $this->wwwRoot = TMP . 'assets_task_webroot' . DS;
         Configure::write('App.wwwRoot', $this->wwwRoot);
@@ -122,7 +121,7 @@ class PluginAssetsCommandsTest extends TestCase
         $this->exec('plugin assets symlink');
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
         if (DS === '\\') {
-            $this->assertDirectoryExits($path);
+            $this->assertDirectoryExists($path);
         } else {
             $this->assertTrue(is_link($path));
         }

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -18,6 +18,8 @@ namespace Cake\Test\TestCase\Command;
 
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\NullEngine;
+use Cake\Console\ConsoleIo;
+use Cake\Database\SchemaCache;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -25,7 +27,7 @@ use Cake\TestSuite\TestCase;
 /**
  * SchemacacheCommands test.
  */
-class SchemacacheCommandsTest extends TestCase
+class SchemaCacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 
@@ -36,7 +38,15 @@ class SchemacacheCommandsTest extends TestCase
      */
     protected $fixtures = ['core.Articles', 'core.Tags'];
 
+    /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
     protected $connection;
+
+    /**
+     * @var \Cake\Cache\Engine\NullEngine|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $cache;
 
     /**
      * setup method

--- a/tests/TestCase/Command/ServerCommandTest.php
+++ b/tests/TestCase/Command/ServerCommandTest.php
@@ -25,6 +25,11 @@ use Cake\TestSuite\TestCase;
 class ServerCommandTest extends TestCase
 {
     /**
+     * @var \Cake\Command\ServerCommand
+     */
+    protected $command;
+
+    /**
      * setup method
      *
      * @return void
@@ -32,8 +37,7 @@ class ServerCommandTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $this->command = new ServerCommand($this->io);
+        $this->command = new ServerCommand();
     }
 
     /**

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -116,14 +116,11 @@ class CommandCollectionTest extends TestCase
     public function testAddInstance()
     {
         $collection = new CommandCollection();
-        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $shell = new RoutesCommand($io);
-        $collection->add('routes', $shell);
+        $command = new RoutesCommand();
+        $collection->add('routes', $command);
 
         $this->assertTrue($collection->has('routes'));
-        $this->assertSame($shell, $collection->get('routes'));
+        $this->assertSame($command, $collection->get('routes'));
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -39,6 +39,11 @@ use TestApp\Shell\SampleShell;
 class CommandRunnerTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $config;
+
+    /**
      * Tracking property for event triggering
      *
      * @var bool

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -26,6 +26,11 @@ use Cake\TestSuite\TestCase;
 class ConsoleInputTest extends TestCase
 {
     /**
+     * @var \Cake\Console\ConsoleInput
+     */
+    protected $in;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -27,6 +27,11 @@ use TestPlugin\Shell\Helper\ExampleHelper;
 class HelperRegistryTest extends TestCase
 {
     /**
+     * @var \Cake\Console\HelperRegistry
+     */
+    protected $helpers;
+
+    /**
      * setUp
      *
      * @return void

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -25,6 +25,11 @@ use Cake\TestSuite\TestCase;
 class TaskRegistryTest extends TestCase
 {
     /**
+     * @var \Cake\Console\TaskRegistry
+     */
+    protected $Tasks;
+
+    /**
      * setUp
      *
      * @return void
@@ -82,14 +87,11 @@ class TaskRegistryTest extends TestCase
      */
     public function testLoadPluginTask()
     {
-        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
-            ->disableOriginalConstructor()
-            ->getMock();
         $shell = $this->getMockBuilder('Cake\Console\Shell')
             ->disableOriginalConstructor()
             ->getMock();
         $this->loadPlugins(['TestPlugin']);
-        $this->Tasks = new TaskRegistry($shell, $dispatcher);
+        $this->Tasks = new TaskRegistry($shell);
 
         $result = $this->Tasks->load('TestPlugin.OtherTask');
         $this->assertInstanceOf('TestPlugin\Shell\Task\OtherTaskTask', $result, 'Task class is wrong.');

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -40,6 +40,11 @@ use TestApp\Controller\Component\TestAuthComponent;
 class AuthComponentTest extends TestCase
 {
     /**
+     * @var \TestApp\Controller\AuthTestController
+     */
+    protected $Controller;
+
+    /**
      * AuthComponent property
      *
      * @var \TestApp\Controller\Component\TestAuthComponent

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -111,7 +111,7 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningLevelDisabled()
     {
         $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function () {
-            $this->assertNull(deprecationWarning('This is going away'));
+            deprecationWarning('This is going away');
         });
     }
 
@@ -125,6 +125,7 @@ class FunctionsTest extends TestCase
 
         $this->withErrorReporting(E_ALL, function () {
             triggerWarning('This is going away');
+            $this->assertTrue(true);
         });
     }
 
@@ -136,7 +137,8 @@ class FunctionsTest extends TestCase
     public function testTriggerWarningLevelDisabled()
     {
         $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function () {
-            $this->assertNull(triggerWarning('This is going away'));
+            triggerWarning('This is going away');
+            $this->assertTrue(true);
         });
     }
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -28,6 +28,11 @@ use PDO;
 class SqlserverTest extends TestCase
 {
     /**
+     * @var bool
+     */
+    protected $missingExtension;
+
+    /**
      * Set up
      *
      * @return void

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -28,7 +28,7 @@ class QueryExpressionTest extends TestCase
     /**
      * Test setConjunction()/getConjunction() works.
      *
-     * @return
+     * @return void
      */
     public function testConjunction()
     {

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -35,6 +35,11 @@ use TestPlugin\Plugin as TestPlugin;
 class BaseApplicationTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $path;
+
+    /**
      * Setup
      *
      * @return void

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1183,7 +1183,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(['environment' => [
             'url' => '/',
             'HTTP_ACCEPT' => 'application/json;level=1, text/plain, */*',
-        ]], false);
+        ]]);
 
         $result = $request->parseAccept();
         $expected = [
@@ -1204,7 +1204,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(['environment' => [
             'url' => '/',
             'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8',
-        ]], false);
+        ]]);
         $result = $request->parseAccept();
         $expected = [
             '1.0' => ['text/html', 'application/xhtml+xml', 'application/xml', 'image/jpeg'],

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -300,18 +300,18 @@ class ServerTest extends TestCase
     {
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
-        $this->called = false;
+        $called = false;
 
-        $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) {
-            $middlewareQueue->add(function ($req, $res, $next) {
-                $this->called = true;
+        $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) use (&$called) {
+            $middlewareQueue->add(function ($req, $res, $next) use (&$called) {
+                $called = true;
 
                 return $next($req, $res);
             });
             $this->middlewareQueue = $middlewareQueue;
         });
         $server->run();
-        $this->assertTrue($this->called, 'Middleware added in the event was not triggered.');
+        $this->assertTrue($called, 'Middleware added in the event was not triggered.');
         $this->middlewareQueue->seek(3);
         $this->assertInstanceOf('Closure', $this->middlewareQueue->current()->getCallable(), '2nd last middleware is a closure');
     }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -234,16 +234,7 @@ class PoFileParserTest extends TestCase
      */
     public function testPlurals()
     {
-        $parser = new PoFileParser();
-        $file = $this->path . 'de' . DS . 'wa.po';
-        $messages = $parser->parse($file);
-
-        I18n::getTranslator('default', 'de_DE', function () use ($messages) {
-            $package = new Package('default');
-            $package->setMessages($messages);
-
-            return $package;
-        });
+        I18n::getTranslator('default', 'de_DE');
 
         // Check translated messages
         I18n::setLocale('de_DE');

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -28,6 +28,11 @@ use Cake\TestSuite\TestCase;
 class MailTransportTest extends TestCase
 {
     /**
+     * @var \Cake\Mailer\Transport\MailTransport|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $MailTransport;
+
+    /**
      * Setup
      *
      * @return void

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -163,7 +163,7 @@ class EntityTest extends TestCase
      */
     public function testSetOneParamWithSetter()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())->method('_setName')
@@ -184,7 +184,7 @@ class EntityTest extends TestCase
      */
     public function testMultipleWithSetter()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setName', '_setStuff'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -214,7 +214,7 @@ class EntityTest extends TestCase
      */
     public function testBypassSetters()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setName', '_setStuff'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -239,7 +239,7 @@ class EntityTest extends TestCase
      */
     public function testConstructor()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -263,7 +263,7 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithGuard()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -292,7 +292,7 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGetters()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())
@@ -313,7 +313,7 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGettersAfterSet()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())
@@ -338,7 +338,7 @@ class EntityTest extends TestCase
     public function testGetCacheClearedByUnset()
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())->method('_getName')
@@ -359,7 +359,7 @@ class EntityTest extends TestCase
      */
     public function testGetCamelCasedProperties()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getListIdName'])
             ->getMock();
         $entity->expects($this->any())->method('_getListIdName')
@@ -392,7 +392,7 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetter()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())->method('_setName')
@@ -413,7 +413,7 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetterTitleCase()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setName'])
             ->getMock();
         $entity->expects($this->once())
@@ -435,7 +435,7 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetter()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->once())->method('_getName')
@@ -456,7 +456,7 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetterTitleCase()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->expects($this->once())
@@ -502,7 +502,7 @@ class EntityTest extends TestCase
         $this->assertFalse($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getThings'])
             ->getMock();
         $entity->expects($this->once())->method('_getThings')
@@ -573,7 +573,7 @@ class EntityTest extends TestCase
      */
     public function testMagicUnset()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['unset'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -617,7 +617,7 @@ class EntityTest extends TestCase
      */
     public function testGetArrayAccess()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['get'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -641,7 +641,7 @@ class EntityTest extends TestCase
      */
     public function testSetArrayAccess()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['set'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -667,7 +667,8 @@ class EntityTest extends TestCase
      */
     public function testUnsetArrayAccess()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['unset'])
             ->getMock();
         $entity->expects($this->at(0))
@@ -685,10 +686,12 @@ class EntityTest extends TestCase
      */
     public function testMethodCache()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setFoo', '_getBar'])
             ->getMock();
-        $entity2 = $this->getMockBuilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity2 */
+        $entity2 = $this->getMockBuilder(Entity::class)
             ->setMethods(['_setBar'])
             ->getMock();
         $entity->expects($this->once())->method('_setFoo');
@@ -707,7 +710,8 @@ class EntityTest extends TestCase
      */
     public function testSetGetLongPropertyNames()
     {
-        $entity = $this->getMockBUilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getVeryLongProperty', '_setVeryLongProperty'])
             ->getMock();
         $entity->expects($this->once())->method('_getVeryLongProperty');
@@ -833,7 +837,7 @@ class EntityTest extends TestCase
 
         $entity->setErrors(['title' => ['badness']]);
         $entity->setDirty('title', true);
-        $this->assertEmpty($entity->getErrors('title'), 'Making a field dirty clears errors.');
+        $this->assertEmpty($entity->getErrors(), 'Making a field dirty clears errors.');
     }
 
     /**
@@ -952,14 +956,14 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithClean()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->never())->method('clean');
         $entity->__construct(['a' => 'b', 'c' => 'd']);
 
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -974,14 +978,14 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithMarkNew()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['setNew', 'clean'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->never())->method('clean');
         $entity->__construct(['a' => 'b', 'c' => 'd']);
 
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['setNew'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1063,7 +1067,8 @@ class EntityTest extends TestCase
      */
     public function testToArrayWithAccessor()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->setAccess('*', true);
@@ -1140,7 +1145,8 @@ class EntityTest extends TestCase
      */
     public function testToArrayVirtualProperties()
     {
-        $entity = $this->getMockBuilder('Cake\ORM\Entity')
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
             ->setMethods(['_getName'])
             ->getMock();
         $entity->setAccess('*', true);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -58,6 +58,16 @@ class QueryTest extends TestCase
     ];
 
     /**
+     * @var \Cake\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var \Cake\ORM\Table
+     */
+    protected $table;
+
+    /**
      * setUp method
      *
      * @return void
@@ -89,7 +99,7 @@ class QueryTest extends TestCase
             ],
         ];
 
-        $this->table = $table = $this->getTableLocator()->get('foo', ['schema' => $schema]);
+        $this->table = $this->getTableLocator()->get('foo', ['schema' => $schema]);
         $clients = $this->getTableLocator()->get('clients', ['schema' => $schema1]);
         $orders = $this->getTableLocator()->get('orders', ['schema' => $schema2]);
         $companies = $this->getTableLocator()->get('companies', ['schema' => $schema, 'table' => 'organizations']);
@@ -98,7 +108,7 @@ class QueryTest extends TestCase
         $stuffTypes = $this->getTableLocator()->get('stuffTypes', ['schema' => $schema]);
         $categories = $this->getTableLocator()->get('categories', ['schema' => $schema]);
 
-        $table->belongsTo('clients');
+        $this->table->belongsTo('clients');
         $clients->hasOne('orders');
         $clients->belongsTo('companies');
         $orders->belongsTo('orderTypes');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -54,6 +54,9 @@ use TestApp\Model\Table\UsersTable;
  */
 class TableTest extends TestCase
 {
+    /**
+     * @var string[]
+     */
     protected $fixtures = [
         'core.Articles',
         'core.Tags',
@@ -81,6 +84,16 @@ class TableTest extends TestCase
      * @var \Cake\Datasource\ConnectionInterface
      */
     protected $connection;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $usersTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $articlesTypeMap;
 
     /**
      * @return void
@@ -2246,7 +2259,7 @@ class TableTest extends TestCase
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -2343,13 +2356,13 @@ class TableTest extends TestCase
             ->will($this->returnValue(0));
 
         $called = false;
-        $listener = function ($e, $entity, $options) use ($data, &$called) {
+        $listener = function ($e, $entity, $options) use (&$called) {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -3183,7 +3196,7 @@ class TableTest extends TestCase
         $table->getEventManager()->on('Model.afterDelete', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listenerAfterCommit);

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -31,6 +31,11 @@ use PDOException;
 class FixtureManagerTest extends TestCase
 {
     /**
+     * @var \Cake\TestSuite\Fixture\FixtureManager
+     */
+    protected $manager;
+
+    /**
      * Setup method
      *
      * @return void

--- a/tests/TestCase/TestSuite/TestEmailTransportTest.php
+++ b/tests/TestCase/TestSuite/TestEmailTransportTest.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Mailer\Email;
+use Cake\Mailer\Transport\DebugTransport;
 use Cake\Mailer\TransportFactory;
-use Cake\Network\Email\DebugTransport;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestEmailTransport;
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -24,6 +24,16 @@ use Cake\Utility\Text;
  */
 class TextTest extends TestCase
 {
+    /**
+     * @var \Cake\Utility\Text
+     */
+    protected $Text;
+
+    /**
+     * @var string
+     */
+    protected $encoding;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -370,7 +370,7 @@ class FormHelperTest extends TestCase
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Return value of Cake\View\Form\ContextFactory::get() must implement interface Cake\View\Form\ContextInterface, instance of stdClass returned');
         $context = 'My data';
-        $this->Form->addContextProvider('test', function ($request, $data) use ($context) {
+        $this->Form->addContextProvider('test', function ($request, $data) {
             return new \stdClass();
         });
         $this->Form->create($context);

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 class ViewVarsTraitTest extends TestCase
 {
     /**
-     * @var \Cake\Controller\Controller;
+     * @var \Cake\Controller\Controller
      */
     protected $subject;
 


### PR DESCRIPTION
At some point we might want to think about using at least level 1 here for `tests/`.

All the issues found here was using this level
Now down from 1600 to 1000 errors for that directory