### PR TITLE
4.1 - Cleaned up WindowExpression sql generation

### DIFF
--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -45,7 +45,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
         }
         if ($name) {
             // Set name manually in case this was chained from FunctionsBuilder wrapper
-            $this->window->setName($name);
+            $this->window->name($name);
         }
 
         return $this;
@@ -178,8 +178,8 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     {
         $sql = parent::sql($generator);
         if ($this->window !== null) {
-            if ($this->window->isEmpty() && $this->window->getName()) {
-                $sql .= ' OVER ' . $this->window->getName();
+            if ($this->window->isNamedOnly()) {
+                $sql .= ' OVER ' . $this->window->sql($generator);
             } else {
                 $sql .= ' OVER (' . $this->window->sql($generator) . ')';
             }

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -60,25 +60,16 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     }
 
     /**
-     * Return whether window expression is empty.
+     * Return whether is only a named window expression.
      *
-     * An expression is empty if it has no partition, order or frame clauses.
+     * These window expressions only specify a named window and do not
+     * specify their own partitions, frame or order.
      *
      * @return bool
      */
-    public function isEmpty(): bool
+    public function isNamedOnly(): bool
     {
-        return !$this->partitions && !$this->frame && !$this->order;
-    }
-
-    /**
-     * Return named window used in this expresion if set.
-     *
-     * @return string|null
-     */
-    public function getName(): ?string
-    {
-        return $this->name;
+        return $this->name && (!$this->partitions && !$this->frame && !$this->order);
     }
 
     /**
@@ -87,7 +78,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
      * @param string $name Window name
      * @return $this
      */
-    public function setName(string $name)
+    public function name(string $name)
     {
         $this->name = $name;
 
@@ -240,10 +231,6 @@ class WindowExpression implements ExpressionInterface, WindowInterface
      */
     public function sql(ValueBinder $generator): string
     {
-        if ($this->isEmpty()) {
-            return '';
-        }
-
         $clauses = [];
         if ($this->name) {
             $clauses[] = $this->name;

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -312,12 +312,7 @@ class QueryCompiler
     {
         $windows = [];
         foreach ($parts as $window) {
-            $expr = $window['window'];
-            if ($expr->isEmpty() && $expr->getName()) {
-                $windows[] = $window['name'] . ' AS (' . $expr->getName() . ')';
-            } else {
-                $windows[] = $window['name'] . ' AS (' . $expr->sql($generator) . ')';
-            }
+            $windows[] = $window['name'] . ' AS (' . $window['window']->sql($generator) . ')';
         }
 
         return ' WINDOW ' . implode(', ', $windows);

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -35,12 +35,9 @@ class WindowExpressionTest extends TestCase
     public function testEmptyWindow()
     {
         $w = new WindowExpression();
-        $this->assertTrue($w->isEmpty());
-        $this->assertSame(null, $w->getName());
         $this->assertSame('', $w->sql(new ValueBinder()));
 
         $w->partition('')->order([]);
-        $this->assertTrue($w->isEmpty());
         $this->assertSame('', $w->sql(new ValueBinder()));
     }
 
@@ -292,7 +289,6 @@ class WindowExpressionTest extends TestCase
     public function testExclusion()
     {
         $w = (new WindowExpression())->excludeCurrent();
-        $this->assertSame(true, $w->isEmpty());
         $this->assertEqualsSql(
             '',
             $w->sql(new ValueBinder())
@@ -378,22 +374,24 @@ class WindowExpressionTest extends TestCase
      */
     public function testNamedWindow()
     {
-        $w = new WindowExpression('name');
-        $this->assertTrue($w->isEmpty());
-        $this->assertSame('name', $w->getName());
+        $w = new WindowExpression();
+        $this->assertFalse($w->isNamedOnly());
+
+        $w->name('name');
+        $this->assertTrue($w->isNamedOnly());
         $this->assertEqualsSql(
-            '',
+            'name',
             $w->sql(new ValueBinder())
         );
 
-        $w->setName('new_name');
+        $w->name('new_name');
         $this->assertEqualsSql(
-            '',
+            'new_name',
             $w->sql(new ValueBinder())
         );
 
         $w->order('test');
-        $this->assertFalse($w->isEmpty());
+        $this->assertFalse($w->isNamedOnly());
         $this->assertEqualsSql(
             'new_name ORDER BY test',
             $w->sql(new ValueBinder())

--- a/tests/TestCase/Database/WindowQueryTests.php
+++ b/tests/TestCase/Database/WindowQueryTests.php
@@ -82,7 +82,7 @@ class WindowQueryTests extends TestCase
 
         $sql = $query
             ->window('name', function ($window, $query) {
-                return $window->setName('name3');
+                return $window->name('name3');
             }, true)
             ->sql();
         $this->assertEqualsSql('SELECT * WINDOW name AS (name3)', $sql);


### PR DESCRIPTION
This simplifies some sql generation to help clean up the window expression for 4.1.

- The expression is always generated by `sql()`.
- The parent expression/query builder does not need to extract the name to special case.
- The get/setName() is simplified to just an implicit setter.
- The meaning of "empty" is clarified in helper name.