### PR TITLE
4.1 - Added closure support to WindowExpression partition() and order()

### DIFF
--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -20,6 +20,7 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 use Closure;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * This represents a SQL window expression used by aggregate and window functions.
@@ -94,6 +95,15 @@ class WindowExpression implements ExpressionInterface, WindowInterface
             return $this;
         }
 
+        if ($partitions instanceof Closure) {
+            $partitions = $partitions();
+            if (!($partitions instanceof ExpressionInterface)) {
+                throw new RuntimeException(
+                    'You must return an `ExpressionInterface` from a Closure passed to `partition()`.'
+                );
+            }
+        }
+
         if (!is_array($partitions)) {
             $partitions = [$partitions];
         }
@@ -116,6 +126,18 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     public function order($fields)
     {
         if (!$fields) {
+            return $this;
+        }
+
+        if ($fields instanceof Closure) {
+            $fields = $fields();
+            if (!($fields instanceof OrderByExpression)) {
+                throw new RuntimeException(
+                    'You must return an `OrderByExpression` from a Closure passed to `order()`.'
+                );
+            }
+            $this->order = $fields;
+
             return $this;
         }
 

--- a/src/Database/Expression/WindowInterface.php
+++ b/src/Database/Expression/WindowInterface.php
@@ -49,7 +49,7 @@ interface WindowInterface
     /**
      * Adds one or more partition expressions to the window.
      *
-     * @param (\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $partitions Partition expressions
+     * @param \Closure|(\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $partitions Partition expressions
      * @return $this
      */
     public function partition($partitions);
@@ -57,7 +57,7 @@ interface WindowInterface
     /**
      * Adds one or more order clauses to the window.
      *
-     * @param (\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $fields Order expressions
+     * @param \Closure|(\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $fields Order expressions
      * @return $this
      */
     public function order($fields);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1460,7 +1460,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         if ($window instanceof Closure) {
             $window = $window(new WindowExpression(), $this);
             if (!($window instanceof WindowExpression)) {
-                throw new RuntimeException('You must return a `WindowExpression` from closure passed to `window()`.');
+                throw new RuntimeException('You must return a `WindowExpression` from a Closure passed to `window()`.');
             }
         }
 

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -17,10 +17,12 @@ namespace Cake\Test\TestCase\Database\Expression;
 
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Tests WindowExpression class
@@ -65,6 +67,27 @@ class WindowExpressionTest extends TestCase
             'PARTITION BY MyAggregate(:param0)',
             $w->sql(new ValueBinder())
         );
+
+        $w = (new WindowExpression())->partition(function () {
+            return new AggregateExpression('MyAggregate', ['param']);
+        });
+        $this->assertEqualsSql(
+            'PARTITION BY MyAggregate(:param0)',
+            $w->sql(new ValueBinder())
+        );
+    }
+
+    /**
+     * Tests exception is thrown from invalid partition.
+     *
+     * @return void
+     */
+    public function testInvalidPartition()
+    {
+        $this->expectException(RuntimeException::class);
+        (new WindowExpression())->partition(function () {
+            return 'string';
+        });
     }
 
     /**
@@ -91,6 +114,27 @@ class WindowExpressionTest extends TestCase
             'PARTITION BY test ORDER BY test, test2 DESC',
             $w->sql(new ValueBinder())
         );
+
+        $w = (new WindowExpression())->order(function () {
+            return new OrderByExpression(['test']);
+        });
+        $this->assertEqualsSql(
+            'ORDER BY test',
+            $w->sql(new ValueBinder())
+        );
+    }
+
+    /**
+     * Tests exception is thrown from invalid order.
+     *
+     * @return void
+     */
+    public function testInvalidOrder()
+    {
+        $this->expectException(RuntimeException::class);
+        (new WindowExpression())->order(function () {
+            return 'string';
+        });
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/14537

This allows passing closures to `partition()` and `order()` as they return expressions.

I made `order()` require an `OrderByExpression` because having a closure return individual fields felt strange.
