### PR TITLE
Revert constructor signature change introduced in #14575.

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -49,7 +49,6 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
      * @param array $body $_POST superglobal
      * @param array $cookies $_COOKIE superglobal
      * @param array $files $_FILES superglobal
-     * @param string $input php://input Used to stub request streams in testing.
      * @return \Cake\Http\ServerRequest
      * @throws \InvalidArgumentException for invalid file values
      */
@@ -58,8 +57,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
         ?array $query = null,
         ?array $body = null,
         ?array $cookies = null,
-        ?array $files = null,
-        ?string $input = null
+        ?array $files = null
     ): ServerRequest {
         $server = normalizeServer($server ?: $_SERVER);
         $uri = static::createUri($server);
@@ -81,7 +79,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             'base' => $uri->base,
             'session' => $session,
             'mergeFilesAsObjects' => Configure::read('App.uploadedFilesAsObjects', true),
-            'input' => $input,
+            'input' => $server['CAKEPHP_INPUT'] ?? null,
         ]);
 
         return $request;

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -148,6 +148,7 @@ class MiddlewareDispatcher
     {
         if (isset($spec['input'])) {
             $spec['post'] = [];
+            $spec['environment']['CAKEPHP_INPUT'] = $spec['input'];
         }
         $environment = array_merge(
             array_merge($_SERVER, ['REQUEST_URI' => $spec['url']]),
@@ -161,8 +162,7 @@ class MiddlewareDispatcher
             $spec['query'],
             $spec['post'],
             $spec['cookies'],
-            $spec['files'],
-            $spec['input'] ?? null
+            $spec['files']
         );
         $request = $request->withAttribute('session', $spec['session']);
 


### PR DESCRIPTION
It's best not to change constructor signature in a bugfix release.
Also this change will avoid merge conflict with 4.next.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
