### PR TITLE
4.next - Allow fields to override valueSources

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2287,7 +2287,9 @@ class FormHelper extends Helper
             $valOptions = [
                 'default' => $options['default'] ?? null,
                 'schemaDefault' => $options['schemaDefault'] ?? true,
+                'valueSources' => $options['valueSources'] ?? null,
             ];
+            unset($options['valueSources']);
             $options['val'] = $this->getSourceValue($field, $valOptions);
         }
         if (!isset($options['val']) && isset($options['default'])) {
@@ -2527,7 +2529,15 @@ class FormHelper extends Helper
             'data' => 'getData',
             'query' => 'getQuery',
         ];
-        foreach ($this->getValueSources() as $valuesSource) {
+
+        $valueSources = $this->getValueSources();
+
+        if (isset($options['valueSources'])) {
+            $valueSources = $this->extractValidValueSources((array)$options['valueSources']);
+            unset($options['valueSources']);
+        }
+
+        foreach ($valueSources as $valuesSource) {
             if ($valuesSource === 'context') {
                 $val = $this->_getContext()->val($fieldname, $options);
                 if ($val !== null) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8368,7 +8368,6 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->getSourceValue('id', ['valueSources' => ['context']]);
         $this->assertNull($result);
-
     }
 
     /**


### PR DESCRIPTION
In my previous PR, I removed Request from Context classes to allow for ['context', 'data'], so FormHelper is now able to show changes that comes directly from the entity instead of restoring request data.

However, this is not enough if we _add_ or _remove_ fields from entity. In that case only ['context'] works, otherwise FormHelper restores values from request data in wrong places causing a lot of mess.

But with ['context'] we can't have fields in form that are not part of entity. For this reason my proposal is to allow for fields override of valueSources:

```
<?= $this->Form->create($entity, ['valueSources' => ['context']]) ?>

[...]

<?= $this->Form->control('non_entity_field', ['valueSources' => ['data']]) ?>
```

