### PR TITLE
Allow specifying "SameSite" attribute for CSRF protection cookie.

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -54,6 +54,9 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      *    Defaults to browser session.
      *  - `secure` Whether or not the cookie will be set with the Secure flag. Defaults to false.
      *  - `httpOnly` Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
+     *  - 'samesite' "SameSite" attribute for cookies. Defaults to `null`.
+     *    Valid values: `CookieInterface::SAMESITE_LAX`, `CookieInterface::SAMESITE_STRICT`,
+     *    `CookieInterface::SAMESITE_NONE` or `null`.
      *  - `field` The form field to check. Changing this will also require configuring
      *    FormHelper.
      *
@@ -64,6 +67,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         'expiry' => 0,
         'secure' => false,
         'httpOnly' => false,
+        'samesite' => null,
         'field' => '_csrfToken',
     ];
 
@@ -295,6 +299,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
                 'path' => $request->getAttribute('webroot'),
                 'secure' => $this->_config['secure'],
                 'httponly' => $this->_config['httpOnly'],
+                'samesite' => $this->_config['samesite'],
             ]
         );
 

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -53,7 +53,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      *  - `expiry` A strotime compatible value of how long the CSRF token should last.
      *    Defaults to browser session.
      *  - `secure` Whether or not the cookie will be set with the Secure flag. Defaults to false.
-     *  - `httpOnly` Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
+     *  - `httponly` Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
      *  - 'samesite' "SameSite" attribute for cookies. Defaults to `null`.
      *    Valid values: `CookieInterface::SAMESITE_LAX`, `CookieInterface::SAMESITE_STRICT`,
      *    `CookieInterface::SAMESITE_NONE` or `null`.
@@ -66,7 +66,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         'cookieName' => 'csrfToken',
         'expiry' => 0,
         'secure' => false,
-        'httpOnly' => false,
+        'httponly' => false,
         'samesite' => null,
         'field' => '_csrfToken',
     ];
@@ -92,6 +92,11 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function __construct(array $config = [])
     {
+        if (array_key_exists('httpOnly', $config)) {
+            $config['httponly'] = $config['httpOnly'];
+            deprecationWarning('Option `httpOnly` is deprecated. Use lowercased `httponly` instead.');
+        }
+
         $this->_config = $config + $this->_config;
     }
 
@@ -298,7 +303,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
                 'expires' => $this->_config['expiry'] ?: null,
                 'path' => $request->getAttribute('webroot'),
                 'secure' => $this->_config['secure'],
-                'httponly' => $this->_config['httpOnly'],
+                'httponly' => $this->_config['httponly'],
                 'samesite' => $this->_config['samesite'],
             ]
         );

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -367,7 +367,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'cookieName' => 'token',
             'expiry' => '+1 hour',
             'secure' => true,
-            'httpOnly' => true,
+            'httponly' => true,
             'samesite' => CookieInterface::SAMESITE_STRICT,
         ]);
         $response = $middleware->process($request, $this->_getRequestHandler());
@@ -379,8 +379,30 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertWithinRange(strtotime('+1 hour'), $cookie['expires'], 1, 'session duration.');
         $this->assertSame('/dir/', $cookie['path'], 'session path.');
         $this->assertTrue($cookie['secure'], 'cookie security flag missing');
-        $this->assertTrue($cookie['httponly'], 'cookie httpOnly flag missing');
+        $this->assertTrue($cookie['httponly'], 'cookie httponly flag missing');
         $this->assertSame(CookieInterface::SAMESITE_STRICT, $cookie['samesite'], 'samesite attribute missing');
+    }
+
+    public function testUsingDeprecatedConfigKey()
+    {
+        $this->deprecated(function () {
+            $request = new ServerRequest([
+                'environment' => ['REQUEST_METHOD' => 'GET'],
+                'webroot' => '/dir/',
+            ]);
+
+            $middleware = new CsrfProtectionMiddleware([
+                'cookieName' => 'token',
+                'expiry' => '+1 hour',
+                'secure' => true,
+                'httpOnly' => true,
+                'samesite' => CookieInterface::SAMESITE_STRICT,
+            ]);
+            $response = $middleware->process($request, $this->_getRequestHandler());
+
+            $cookie = $response->getCookie('token');
+            $this->assertTrue($cookie['httponly'], 'cookie httponly flag missing');
+        });
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Http\Middleware;
 
 use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieInterface;
 use Cake\Http\Exception\InvalidCsrfTokenException;
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\Response;
@@ -367,6 +368,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'expiry' => '+1 hour',
             'secure' => true,
             'httpOnly' => true,
+            'samesite' => CookieInterface::SAMESITE_STRICT,
         ]);
         $response = $middleware->process($request, $this->_getRequestHandler());
 
@@ -378,6 +380,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertSame('/dir/', $cookie['path'], 'session path.');
         $this->assertTrue($cookie['secure'], 'cookie security flag missing');
         $this->assertTrue($cookie['httponly'], 'cookie httpOnly flag missing');
+        $this->assertSame(CookieInterface::SAMESITE_STRICT, $cookie['samesite'], 'samesite attribute missing');
     }
 
     /**


### PR DESCRIPTION
Refs #14588

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
