### PR TITLE
There's a notice half way through the tests

### DIFF
--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -42,6 +42,7 @@ class ConsoleErrorHandlerTest extends TestCase
             ->setMethods(['_stop'])
             ->setConstructorArgs([['stderr' => $this->stderr]])
             ->getMock();
+        Log::drop('stdout');
         Log::drop('stderr');
     }
 


### PR DESCRIPTION
See: https://travis-ci.com/github/cakephp/cakephp/jobs/335780299#L472

Not sure if there's a reason this isn't suppressed and the test right underneath is:
https://github.com/cakephp/cakephp/blob/master/tests/TestCase/Error/ConsoleErrorHandlerTest.php#L81

Interestingly, if you run just that single test case the output doesn't appear.