### PR TITLE
Fix incorrect locale set for records.

### DIFF
--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -439,7 +439,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     {
         $allowEmpty = $this->_config['allowEmptyTranslations'];
 
-        return $results->map(function ($row) use ($allowEmpty) {
+        return $results->map(function ($row) use ($allowEmpty, $locale) {
             /** @var \Cake\Datasource\EntityInterface|array|null $row */
             if ($row === null) {
                 return $row;
@@ -448,7 +448,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             $hydrated = !is_array($row);
 
             if (empty($row['translation'])) {
-                $row['_locale'] = $this->getLocale();
+                $row['_locale'] = $locale;
                 unset($row['translation']);
 
                 if ($hydrated) {

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -136,12 +136,19 @@ class TranslateBehaviorTest extends TestCase
         ];
         $this->assertSame($expected, $results);
 
+        $entity = $table->newEntity(['author_id' => 2, 'title' => 'Title 4', 'body' => 'Body 4']);
+        $table->save($entity);
+
         $results = $table->find('all', ['locale' => 'cze'])
-            ->combine('title', 'body', 'id')->toArray();
+            ->select(['id', 'title', 'body'])
+            ->disableHydration()
+            ->orderAsc('Articles.id')
+            ->toArray();
         $expected = [
-            1 => ['Titulek #1' => 'Obsah #1'],
-            2 => ['Titulek #2' => 'Obsah #2'],
-            3 => ['Titulek #3' => 'Obsah #3'],
+            ['id' => 1, 'title' => 'Titulek #1', 'body' => 'Obsah #1', '_locale' => 'cze'],
+            ['id' => 2, 'title' => 'Titulek #2', 'body' => 'Obsah #2', '_locale' => 'cze'],
+            ['id' => 3, 'title' => 'Titulek #3', 'body' => 'Obsah #3', '_locale' => 'cze'],
+            ['id' => 4, 'title' => null, 'body' => null, '_locale' => 'cze'],
         ];
         $this->assertSame($expected, $results);
     }


### PR DESCRIPTION
Use passed argument instead of getLocale() method since locale can be
changed per find() call.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
