### PR TITLE
Refactor deprecations to clickable links in IDE.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -202,7 +202,7 @@ class Cache
      *
      * @param string $config The name of the configured cache backend.
      * @return \Psr\SimpleCache\CacheInterface&\Cake\Cache\CacheEngineInterface
-     * @deprecated 3.7.0 Use Cache::pool() instead. This method will be removed in 5.0.
+     * @deprecated 3.7.0 Use {@link pool()} instead. This method will be removed in 5.0.
      */
     public static function engine(string $config)
     {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * @deprecated 4.0.0 Use Cake\Command\Command instead.
+ * @deprecated 4.0.0 Use {@link \Cake\Command\Command} instead.
  */
 
 class_alias(

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -37,8 +37,8 @@ use Cake\Utility\Security;
  * - Requiring that SSL be used.
  *
  * @link https://book.cakephp.org/4/en/controllers/components/security.html
- * @deprecated 4.0.0 Use FormProtectionComponent instead, for form tampering protection
- *   or HttpsEnforcerMiddleware to enforce use of HTTPS (SSL) for requests.
+ * @deprecated 4.0.0 Use {@link FormProtectionComponent} instead, for form tampering protection
+ *   or {@link HttpsEnforcerMiddleware} to enforce use of HTTPS (SSL) for requests.
  */
 class SecurityComponent extends Component
 {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -452,7 +452,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
-     * @deprecated 4.0.0 Use and() instead.
+     * @deprecated 4.0.0 Use {@link and()} instead.
      */
     public function and_($conditions, $types = [])
     {
@@ -467,7 +467,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
-     * @deprecated 4.0.0 Use or() instead.
+     * @deprecated 4.0.0 Use {@link or()} instead.
      */
     public function or_($conditions, $types = [])
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -525,7 +525,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @return array Column name(s) for the primary key. An
      *   empty list will be returned when the table has no primary key.
-     * @deprecated 4.0.0 Renamed to getPrimaryKey()
+     * @deprecated 4.0.0 Renamed to {@link getPrimaryKey()}.
      */
     public function primaryKey(): array
     {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -450,7 +450,7 @@ trait EntityTrait
     /**
      * Removes a field or list of fields from this entity
      *
-     * @deprecated 4.0.0 Use unset() instead. Will be removed in 5.0.
+     * @deprecated 4.0.0 Use {@link unset()} instead. Will be removed in 5.0.
      * @param string|string[] $field The field to unset.
      * @return $this
      */

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -427,7 +427,7 @@ class Cookie implements CookieInterface
      * This will collapse any complex data in the cookie with json_encode()
      *
      * @return mixed
-     * @deprecated 4.0.0 Use getScalarValue() instead.
+     * @deprecated 4.0.0 Use {@link getScalarValue()} instead.
      */
     public function getStringValue()
     {

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -175,7 +175,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * Create a new token to be used for CSRF protection
      *
      * @return string
-     * @deprecated 4.0.6 Use CsrfProtectionMiddleware::createToken() instead.
+     * @deprecated 4.0.6 Use {@link createToken()} instead.
      */
     protected function _createToken(): string
     {

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -264,8 +264,8 @@ class Number
      * Getter/setter for default currency. This behavior is *deprecated* and will be
      * removed in future versions of CakePHP.
      *
-     * @deprecated 3.9 Use getDefaultCurrency() and setDefaultCurrency()
-     * @param string|false|null $currency Default currency string to be used by currency()
+     * @deprecated 3.9.0 Use {@link getDefaultCurrency()} and {@link setDefaultCurrency()} instead.
+     * @param string|false|null $currency Default currency string to be used by {@link currency()}
      * if $currency argument is not provided. If boolean false is passed, it will clear the
      * currently stored value
      * @return string|null Currency
@@ -310,7 +310,7 @@ class Number
     /**
      * Setter for default currency
      *
-     * @param string|null $currency Default currency string to be used by currency()
+     * @param string|null $currency Default currency string to be used by {@link currency()}
      * if $currency argument is not provided. If null is passed, it will clear the
      * currently stored value
      * @return void

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -38,7 +38,7 @@ use SimpleXMLElement;
  * Once made configuration profiles can be used to re-use across various email messages your
  * application sends.
  *
- * @deprecated 4.0.0 This class will be removed in CakePHP 5.0, use Cake\Mailer\Mailer instead.
+ * @deprecated 4.0.0 This class will be removed in CakePHP 5.0, use {@link \Cake\Mailer\Mailer} instead.
  */
 class Email implements JsonSerializable, Serializable
 {

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -293,7 +293,7 @@ class Mailer implements EventListenerInterface
      * @param string|array $key Variable name or hash of view variables.
      * @param mixed $value View variable value.
      * @return $this
-     * @deprecated 4.0.0 Use Mailer::setViewVars() instead.
+     * @deprecated 4.0.0 Use {@link Mailer::setViewVars()} instead.
      */
     public function set($key, $value = null)
     {

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -145,13 +145,13 @@ class TableLocator implements LocatorInterface
      *   `App\Model\Table\UsersTable` being used. If this class does not exist,
      *   then the default `Cake\ORM\Table` class will be used. By setting the `className`
      *   option you can define the specific class to use. The className option supports
-     *   plugin short class references {@link Cake\Core\App::shortName()}.
+     *   plugin short class references {@link \Cake\Core\App::shortName()}.
      * - `table` Define the table name to use. If undefined, this option will default to the underscored
      *   version of the alias name.
      * - `connection` Inject the specific connection object to use. If this option and `connectionName` are undefined,
      *   The table class' `defaultConnectionName()` method will be invoked to fetch the connection name.
      * - `connectionName` Define the connection name to use. The named connection will be fetched from
-     *   Cake\Datasource\ConnectionManager.
+     *   {@link \Cake\Datasource\ConnectionManager}.
      *
      * *Note* If your `$alias` uses plugin syntax only the name part will be used as
      * key in the registry. This means that if two plugins, or a plugin and app provide

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -105,7 +105,7 @@ class TableRegistry
      * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the table with.
      * @return \Cake\ORM\Table
-     * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::get() instead. Will be removed in 5.0
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::get()} instead. Will be removed in 5.0.
      */
     public static function get(string $alias, array $options = []): Table
     {
@@ -117,7 +117,7 @@ class TableRegistry
      *
      * @param string $alias The alias to check for.
      * @return bool
-     * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::exists() instead. Will be removed in 5.0
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::exists()} instead. Will be removed in 5.0
      */
     public static function exists(string $alias): bool
     {
@@ -130,7 +130,7 @@ class TableRegistry
      * @param string $alias The alias to set.
      * @param \Cake\ORM\Table $object The table to set.
      * @return \Cake\ORM\Table
-     * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::set() instead. Will be removed in 5.0
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::set()} instead. Will be removed in 5.0
      */
     public static function set(string $alias, Table $object): Table
     {
@@ -142,7 +142,7 @@ class TableRegistry
      *
      * @param string $alias The alias to remove.
      * @return void
-     * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::remove() instead. Will be removed in 5.0
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::remove()} instead. Will be removed in 5.0
      */
     public static function remove(string $alias): void
     {
@@ -153,7 +153,7 @@ class TableRegistry
      * Clears the registry of configuration and instances.
      *
      * @return void
-     * @deprecated 3.6.0 Use \Cake\ORM\Locator\TableLocator::clear() instead. Will be removed in 5.0
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::clear()} instead. Will be removed in 5.0
      */
     public static function clear(): void
     {

--- a/src/TestSuite/ConsoleIntegrationTestCase.php
+++ b/src/TestSuite/ConsoleIntegrationTestCase.php
@@ -19,7 +19,7 @@ namespace Cake\TestSuite;
  * A test case class intended to make integration tests of cake console commands
  * easier.
  *
- * @deprecated 3.7.0 Will be removed in 5.0.0. Use Cake\TestSuite\ConsoleIntegrationTestTrait instead
+ * @deprecated 3.7.0 Will be removed in 5.0.0. Use {@link \Cake\TestSuite\ConsoleIntegrationTestTrait} instead
  */
 abstract class ConsoleIntegrationTestCase extends TestCase
 {

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -25,7 +25,7 @@ namespace Cake\TestSuite;
  * more of your code easily and avoid some of the maintenance pitfalls
  * that mock objects create.
  *
- * @deprecated 3.7.0 Will be removed in 5.0.0. Use Cake\TestSuite\IntegrationTestTrait instead.
+ * @deprecated 3.7.0 Will be removed in 5.0.0. Use {@link \Cake\TestSuite\IntegrationTestTrait} instead.
  */
 abstract class IntegrationTestCase extends TestCase
 {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -400,7 +400,7 @@ class Validation
      * @param mixed $check Value to check
      * @param int $count Number of non-alphanumerics to check for
      * @return bool Success
-     * @deprecated 4.0 Use notAlphaNumeric() instead. Will be removed in 5.0
+     * @deprecated 4.0.0 Use {@link notAlphaNumeric()} instead. Will be removed in 5.0
      */
     public static function containsNonAlphaNumeric($check, int $count = 1): bool
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -722,8 +722,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Because this and `notEmpty()` modify the same internal state, the last
      * method called will take precedence.
      *
-     * @deprecated 3.7.0 Use allowEmptyString(), allowEmptyArray(), allowEmptyFile(),
-     *   allowEmptyDate(), allowEmptyTime() allowEmptyDateTime() or allowEmptyFor() instead.
+     * @deprecated 3.7.0 Use {@link allowEmptyString()}, {@link allowEmptyArray()}, {@link allowEmptyFile()},
+     *   {@link allowEmptyDate()}, {@link allowEmptyTime()}, {@link allowEmptyDateTime()} or {@link allowEmptyFor()} instead.
      * @param string|array $field the name of the field or a list of fields
      * @param bool|string|callable $when Indicates when the field is allowed to be empty
      * Valid values are true (always), 'create', 'update'. If a callable is passed then
@@ -1178,8 +1178,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Because this and `allowEmpty()` modify the same internal state, the last
      * method called will take precedence.
      *
-     * @deprecated 3.7.0 Use notEmptyString(), notEmptyArray(), notEmptyFile(),
-     *   notEmptyDate(), notEmptyTime() or notEmptyDateTime() instead.
+     * @deprecated 3.7.0 Use {@link notEmptyString()}, {@link notEmptyArray()}, {@link notEmptyFile()},
+     *   {@link notEmptyDate()}, {@link notEmptyTime()} or {@link notEmptyDateTime()} instead.
      * @param string|array $field the name of the field or list of fields
      * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when Indicates when the field is not allowed
@@ -1683,7 +1683,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::containsNonAlphaNumeric()
      * @return $this
-     * @deprecated 4.0 Use notAlphaNumeric() instead. Will be removed in 5.0
+     * @deprecated 4.0.0 Use {@link notAlphaNumeric()} instead. Will be removed in 5.0
      */
     public function containsNonAlphaNumeric(string $field, int $limit = 1, ?string $message = null, $when = null)
     {
@@ -2579,7 +2579,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param mixed $data Value to check against.
      * @return bool
-     * @deprecated 3.7.0 Use isEmpty() instead
+     * @deprecated 3.7.0 Use {@link isEmpty()} instead
      */
     protected function _fieldIsEmpty($data): bool
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -191,7 +191,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param array $data The data to be checked for errors
      * @param bool $newRecord whether the data to be validated is new or to be updated.
      * @return array[] Array of failed fields
-     * @deprecated 3.9.0 Renamed to validate()
+     * @deprecated 3.9.0 Renamed to {@link validate()}.
      */
     public function errors(array $data, bool $newRecord = true): array
     {

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -103,7 +103,7 @@ class ArrayContext implements ContextInterface
      * Get the fields used in the context as a primary key.
      *
      * @return string[]
-     * @deprecated 4.0.0 Renamed to getPrimaryKey()
+     * @deprecated 4.0.0 Renamed to {@link getPrimaryKey()}.
      */
     public function primaryKey(): array
     {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -176,7 +176,7 @@ class EntityContext implements ContextInterface
      * Gets the primary key columns from the root entity's schema.
      *
      * @return string[]
-     * @deprecated 4.0.0 Renamed to getPrimaryKey()
+     * @deprecated 4.0.0 Renamed to {@link getPrimaryKey()}.
      */
     public function primaryKey(): array
     {

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -60,7 +60,7 @@ class FormContext implements ContextInterface
      * Get the fields used in the context as a primary key.
      *
      * @return string[]
-     * @deprecated 4.0.0 Renamed to getPrimaryKey()
+     * @deprecated 4.0.0 Renamed to {@link getPrimaryKey()}.
      */
     public function primaryKey(): array
     {

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -48,7 +48,7 @@ class NullContext implements ContextInterface
      * Get the fields used in the context as a primary key.
      *
      * @return string[]
-     * @deprecated 4.0.0 Renamed to getPrimaryKey()
+     * @deprecated 4.0.0 Renamed to {@link getPrimaryKey()}.
      */
     public function primaryKey(): array
     {


### PR DESCRIPTION
We are already using it inside docblocks, only makes sense to allow deprecations to also follow those class names to the location.