### PR TITLE
Pass a new query into with() builders

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -394,7 +394,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * or returned from a closure, which will receive a new common table expression
-     * object as the first argument, and a reference to the current query object as
+     * object as the first argument, and a new blank query object as
      * the second argument:
      *
      * ```
@@ -402,8 +402,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *     \Cake\Database\Expression\CommonTableExpression $cte,
      *     \Cake\Database\Query $query
      *  ) {
-     *     $cteQuery = $query->getConnection()
-     *         ->newQuery()
+     *     $cteQuery = $query
      *         ->select('*')
      *         ->from('articles');
      *
@@ -424,7 +423,8 @@ class Query implements ExpressionInterface, IteratorAggregate
         }
 
         if ($cte instanceof Closure) {
-            $cte = $cte(new CommonTableExpression(), $this);
+            $query = $this->getConnection()->newQuery();
+            $cte = $cte(new CommonTableExpression(), $query);
             if (!($cte instanceof CommonTableExpression)) {
                 throw new RuntimeException(
                     'You must return a `CommonTableExpression` from a Closure passed to `with()`.'

--- a/tests/TestCase/Database/CommonTableExpressionQueryTests.php
+++ b/tests/TestCase/Database/CommonTableExpressionQueryTests.php
@@ -134,9 +134,7 @@ class CommonTableExpressionQueryTests extends TestCase
     {
         $query = $this->connection->newQuery()
             ->with(function (CommonTableExpression $cte, Query $query) {
-                $anchorQuery = $query->getConnection()
-                    ->newQuery()
-                    ->select(1);
+                $anchorQuery = $query->select(1);
 
                 $recursiveQuery = $query->getConnection()
                     ->newQuery()
@@ -338,8 +336,7 @@ class CommonTableExpressionQueryTests extends TestCase
 
         $query = $this->connection->newQuery()
             ->with(function (CommonTableExpression $cte, Query $query) {
-                $cteQuery = $query->getConnection()
-                    ->newQuery()
+                $cteQuery = $query
                     ->select('articles.id')
                     ->from('articles')
                     ->where(['articles.id !=' => 1]);
@@ -400,15 +397,13 @@ class CommonTableExpressionQueryTests extends TestCase
 
         $query = $this->connection->newQuery()
             ->with(function (CommonTableExpression $cte, Query $query) {
-                $cteQuery = $query->getConnection()
-                    ->newQuery()
-                    ->select('articles.id')
+                $query->select('articles.id')
                     ->from('articles')
                     ->where(['articles.id !=' => 1]);
 
                 return $cte
                     ->name('cte')
-                    ->query($cteQuery);
+                    ->query($query);
             })
             ->delete()
             ->from(['a' => 'articles'])


### PR DESCRIPTION
Passing in a new query saves a step for users who would have to otherwise create a new query as you pretty much never want to use a query for both the common table expression and the root query.
