### PR TITLE
4.1 datetime widget

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -94,9 +94,9 @@ class DateTimeWidget extends BasicWidget
      * - `step` The "step" attribute. Defaults to `1` for "time" and "datetime-local" type inputs.
      *   You can set it to `null` or `false` to prevent explicit step attribute being added in HTML.
      * - `format` A `date()` function compatible datetime format string.
-     *   By default the widget will use suitable format based on input type and
-     *   database type for the context. If explicit format is provided then no
-     *   default value will be set for `step` attribute and it too has to be
+     *   By default the widget will use a suitable format based on the input type and
+     *   database type for the context. If an explicit format is provided, then no
+     *   default value will be set for the `step` attribute, and it needs to be
      *   explicitly set if required.
      *
      * All other keys will be converted into HTML attributes.

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -91,6 +91,8 @@ class DateTimeWidget extends BasicWidget
      * - `escape` Set to false to disable escaping on all attributes.
      * - `type` A valid HTML date/time input type. Defaults to "datetime-local".
      * - `timezone` The timezone the input value should be converted to.
+     * - `step` The "step" attribute. Defaults to `1` for "time" and "datetime-local" type inputs.
+     *   You can set it to `null` or `false` to prevent explicit step attribute being added in HTML.
      *
      * All other keys will be converted into HTML attributes.
      *
@@ -109,7 +111,7 @@ class DateTimeWidget extends BasicWidget
             ));
         }
 
-        if (!isset($data['step'])) {
+        if (!array_key_exists('step', $data)) {
             $data['step'] = $this->defaultStep[$data['type']];
 
             if (isset($data['fieldName'])) {
@@ -193,7 +195,11 @@ class DateTimeWidget extends BasicWidget
         }
 
         $format = $this->formatMap[$options['type']];
-        if ($options['type'] === 'datetime-local' && $options['step'] < 1) {
+        if (
+            $options['type'] === 'datetime-local'
+            && is_numeric($options['step'])
+            && $options['step'] < 1
+        ) {
             $format = 'Y-m-d\TH:i:s.v';
         }
 

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -133,6 +133,35 @@ class DateTimeWidgetTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testUnsettingStep()
+    {
+        $result = $this->DateTime->render([
+            'val' => '2019-02-03 10:11:12',
+            'step' => null,
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => '',
+                'value' => '2019-02-03T10:11:12',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->DateTime->render([
+            'val' => '2019-02-03 10:11:12',
+            'step' => false,
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => '',
+                'value' => '2019-02-03T10:11:12',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     /**
      * Test rendering with templateVars
      *

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -162,6 +162,67 @@ class DateTimeWidgetTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    public function testDatetimeFormat()
+    {
+        $result = $this->DateTime->render([
+            'val' => '2019-02-03 10:11:12',
+            'format' => 'Y-m-d\TH:i',
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => '',
+                'value' => '2019-02-03T10:11',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->DateTime->render([
+            'val' => '2019-02-03 10:11:12',
+            'format' => 'Y-m-d\TH:i',
+            'step' => 120,
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'datetime-local',
+                'name' => '',
+                'step' => '120',
+                'value' => '2019-02-03T10:11',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->DateTime->render([
+            'type' => 'time',
+            'val' => '10:11:12',
+            'format' => 'H:i',
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'time',
+                'name' => '',
+                'value' => '10:11',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->DateTime->render([
+            'type' => 'time',
+            'val' => '10:11:12',
+            'format' => 'H:i',
+            'step' => 120,
+        ], $this->context);
+        $expected = [
+            'input' => [
+                'type' => 'time',
+                'name' => '',
+                'step' => '120',
+                'value' => '10:11',
+            ],
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
     /**
      * Test rendering with templateVars
      *


### PR DESCRIPTION
Alternative to #14612

- You can now set `step` attribute to `null` or `false` to prevent it form being added to HTML.
- You can use `format` option to explicitly specify the format to generate value strings for the input.
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
