### PR TITLE
Allow chainable fixture adding in TestCase

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -909,7 +909,7 @@ abstract class TestCase extends BaseTestCase
      * @param string $fixture Fixture
      * @return $this
      */
-    public function addFixture(string $fixture)
+    protected function addFixture(string $fixture)
     {
         $this->fixtures[] = $fixture;
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -81,25 +81,6 @@ abstract class TestCase extends BaseTestCase
     protected $_configure = [];
 
     /**
-     * @param string $name Name
-     * @param array $data Data
-     * @param string $dataName Data name
-     */
-    public function __construct($name = null, array $data = [], $dataName = '')
-    {
-        $this->initialize();
-
-        parent::__construct($name, $data, $dataName);
-    }
-
-    /**
-     * @return void
-     */
-    public function initialize(): void
-    {
-    }
-
-    /**
      * Overrides SimpleTestCase::skipIf to provide a boolean return value
      *
      * @param bool $shouldSkip Whether or not the test should be skipped.

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -906,6 +906,9 @@ abstract class TestCase extends BaseTestCase
      * - app.MyRecords
      * - plugin.MyPluginName.MyModelName
      *
+     * Use this method inside your test cases' {@link getFixtures()} method
+     * to build up the fixture list.
+     *
      * @param string $fixture Fixture
      * @return $this
      */

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -81,6 +81,25 @@ abstract class TestCase extends BaseTestCase
     protected $_configure = [];
 
     /**
+     * @param string $name Name
+     * @param array $data Data
+     * @param string $dataName Data name
+     */
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        $this->initialize();
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+    }
+
+    /**
      * Overrides SimpleTestCase::skipIf to provide a boolean return value
      *
      * @param bool $shouldSkip Whether or not the test should be skipped.
@@ -206,7 +225,7 @@ abstract class TestCase extends BaseTestCase
      * `Cake\TestSuite\IntegrationTestCaseTrait` to better simulate all routes
      * and plugins being loaded.
      *
-     * @param array|null $appArgs Constuctor parameters for the application class.
+     * @param array|null $appArgs Constructor parameters for the application class.
      * @return void
      * @since 4.0.1
      */
@@ -896,6 +915,24 @@ abstract class TestCase extends BaseTestCase
         Configure::write('App.namespace', $appNamespace);
 
         return $previous;
+    }
+
+    /**
+     * Adds a fixture to this test case.
+     *
+     * Examples:
+     * - core.Tags
+     * - app.MyRecords
+     * - plugin.MyPluginName.MyModelName
+     *
+     * @param string $fixture Fixture
+     * @return $this
+     */
+    public function addFixture(string $fixture)
+    {
+        $this->fixtures[] = $fixture;
+
+        return $this;
     }
 
     /**

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -428,6 +428,7 @@ class FixtureManagerTest extends TestCase
             ->method('getFixtures')
             ->willReturn(array_keys($fixtures));
 
+        /** @var \Cake\TestSuite\Fixture\FixtureManager|\PHPUnit\Framework\MockObject\MockObject $manager */
         $manager = $this->getMockBuilder(FixtureManager::class)
             ->setMethods(['_fixtureConnections'])
             ->getMock();


### PR DESCRIPTION
RFC
What do you think about allowing chainable adding of fixtures in TestCases using `->addFixture()` instead of the array property directly?
This would also allow autocompleting on it then in IDEs.

           /**
             * @return void
             */
            public function initialize(): void
            {
                $this->addFixture('core.Articles')
                    ->addFixture('app.SomeModel')
                    ->addFixture('plugin.Some/ComplicatedName.SomePluginModel');
            }

`initialize()` is called from the constructor as it has to be quite early for us allow setting them as such, otherwise we get a "table not found" error it seems.

We cannot use `setUp()` as it is too late.