### PR TITLE
Generate truly random uuid() for Cake 2.x

### DIFF
--- a/lib/Cake/Utility/CakeText.php
+++ b/lib/Cake/Utility/CakeText.php
@@ -30,69 +30,23 @@ class CakeText {
  * @return string RFC 4122 UUID
  */
 	public static function uuid() {
-		$node = env('SERVER_ADDR');
-
-		if (strpos($node, ':') !== false) {
-			if (substr_count($node, '::')) {
-				$node = str_replace(
-					'::', str_repeat(':0000', 8 - substr_count($node, ':')) . ':', $node
-				);
-			}
-			$node = explode(':', $node);
-			$ipSix = '';
-
-			foreach ($node as $id) {
-				$ipSix .= str_pad(base_convert($id, 16, 2), 16, 0, STR_PAD_LEFT);
-			}
-			$node = base_convert($ipSix, 2, 10);
-
-			if (strlen($node) < 38) {
-				$node = null;
-			} else {
-				$node = crc32($node);
-			}
-		} elseif (empty($node)) {
-			$host = env('HOSTNAME');
-
-			if (empty($host)) {
-				$host = env('HOST');
-			}
-
-			if (!empty($host)) {
-				$ip = gethostbyname($host);
-
-				if ($ip === $host) {
-					$node = crc32($host);
-				} else {
-					$node = ip2long($ip);
-				}
-			}
-		} elseif ($node !== '127.0.0.1') {
-			$node = ip2long($node);
-		} else {
-			$node = null;
-		}
-
-		if (empty($node)) {
-			$node = crc32(Configure::read('Security.salt'));
-		}
-
-		if (function_exists('hphp_get_thread_id')) {
-			$pid = hphp_get_thread_id();
-		} elseif (function_exists('zend_thread_id')) {
-			$pid = zend_thread_id();
-		} else {
-			$pid = getmypid();
-		}
-
-		if (!$pid || $pid > 65535) {
-			$pid = mt_rand(0, 0xfff) | 0x4000;
-		}
-
-		list($timeMid, $timeLow) = explode(' ', microtime());
 		return sprintf(
-			"%08x-%04x-%04x-%02x%02x-%04x%08x", (int)$timeLow, (int)substr($timeMid, 2) & 0xffff,
-			mt_rand(0, 0xfff) | 0x4000, mt_rand(0, 0x3f) | 0x80, mt_rand(0, 0xff), $pid, $node
+			'%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+			// 32 bits for "time_low"
+			mt_rand(0, 65535),
+			mt_rand(0, 65535),
+			// 16 bits for "time_mid"
+			mt_rand(0, 65535),
+			// 12 bits before the 0100 of (version) 4 for "time_hi_and_version"
+			mt_rand(0, 4095) | 0x4000,
+			// 16 bits, 8 bits for "clk_seq_hi_res",
+			// 8 bits for "clk_seq_low",
+			// two most significant bits holds zero and one for variant DCE1.1
+			mt_rand(0, 0x3fff) | 0x8000,
+			// 48 bits for "node"
+			mt_rand(0, 65535),
+			mt_rand(0, 65535),
+			mt_rand(0, 65535)
 		);
 	}
 


### PR DESCRIPTION
Stop leaking local IP address, pid and potentially the crc32 of `Security.salt`.
As mentioned in https://github.com/MISP/MISP/pull/5932