### PR TITLE
4.1 datasource locatorinterface

### DIFF
--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
-use Cake\ORM\TableRegistry;
+use Cake\ORM\Locator\TableLocator;
 use InvalidArgumentException;
 
 /**
@@ -64,7 +64,7 @@ class FactoryLocator
     public static function get(string $type)
     {
         if (!isset(static::$_modelFactories['Table'])) {
-            static::$_modelFactories['Table'] = [TableRegistry::getTableLocator(), 'get'];
+            static::$_modelFactories['Table'] = new TableLocator();
         }
 
         if (!isset(static::$_modelFactories[$type])) {

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -27,7 +27,7 @@ class FactoryLocator
     /**
      * A list of model factory functions.
      *
-     * @var callable[]
+     * @var (callable|\Cake\Datasource\LocatorInterface)[]
      */
     protected static $_modelFactories = [];
 
@@ -35,10 +35,10 @@ class FactoryLocator
      * Register a callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable $factory The factory function used to create instances.
+     * @param callable|\Cake\Datasource\LocatorInterface $factory The factory function used to create instances.
      * @return void
      */
-    public static function add(string $type, callable $factory): void
+    public static function add(string $type, $factory): void
     {
         static::$_modelFactories[$type] = $factory;
     }
@@ -59,9 +59,9 @@ class FactoryLocator
      *
      * @param string $type The repository type to get the factory for.
      * @throws \InvalidArgumentException If the specified repository type has no factory.
-     * @return callable The factory for the repository type.
+     * @return callable|\Cake\Datasource\LocatorInterface The factory for the repository type.
      */
-    public static function get(string $type): callable
+    public static function get(string $type)
     {
         if (!isset(static::$_modelFactories['Table'])) {
             static::$_modelFactories['Table'] = [TableRegistry::getTableLocator(), 'get'];

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -40,6 +40,14 @@ class FactoryLocator
      */
     public static function add(string $type, $factory): void
     {
+        if (!$factory instanceof LocatorInterface && !is_callable($factory)) {
+            throw new InvalidArgumentException(sprintf(
+                '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+                . ' Got type `%s` instead.',
+                getTypeName($factory)
+            ));
+        }
+
         static::$_modelFactories[$type] = $factory;
     }
 

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use Cake\Datasource\Locator\LocatorInterface;
 use Cake\ORM\Locator\TableLocator;
 use InvalidArgumentException;
 
@@ -27,7 +28,7 @@ class FactoryLocator
     /**
      * A list of model factory functions.
      *
-     * @var (callable|\Cake\Datasource\LocatorInterface)[]
+     * @var (callable|\Cake\Datasource\Locator\LocatorInterface)[]
      */
     protected static $_modelFactories = [];
 
@@ -35,14 +36,14 @@ class FactoryLocator
      * Register a callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable|\Cake\Datasource\LocatorInterface $factory The factory function used to create instances.
+     * @param callable|\Cake\Datasource\Locator\LocatorInterface $factory The factory function used to create instances.
      * @return void
      */
     public static function add(string $type, $factory): void
     {
         if (!$factory instanceof LocatorInterface && !is_callable($factory)) {
             throw new InvalidArgumentException(sprintf(
-                '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+                '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
                 . ' Got type `%s` instead.',
                 getTypeName($factory)
             ));
@@ -67,7 +68,7 @@ class FactoryLocator
      *
      * @param string $type The repository type to get the factory for.
      * @throws \InvalidArgumentException If the specified repository type has no factory.
-     * @return callable|\Cake\Datasource\LocatorInterface The factory for the repository type.
+     * @return callable|\Cake\Datasource\Locator\LocatorInterface The factory for the repository type.
      */
     public static function get(string $type)
     {

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Locator;
+
+use Cake\Datasource\RepositoryInterface;
+use RuntimeException;
+
+/**
+ * Provides an abstract registry/factory for repository objects.
+ */
+abstract class AbstractLocator implements LocatorInterface
+{
+    /**
+     * Configuration for aliases to be used when creating instances.
+     *
+     * @var array
+     */
+    protected $_config = [];
+
+    /**
+     * Instances that belong to the registry.
+     *
+     * @var \Cake\Datasource\RepositoryInterface[]
+     */
+    protected $_instances = [];
+
+    /**
+     * Contains a list of options that were passed to get() method.
+     *
+     * @var array
+     */
+    protected $_options = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function setConfig($alias, $options = null)
+    {
+        if (!is_string($alias)) {
+            $this->_config = $alias;
+
+            return $this;
+        }
+
+        if (isset($this->_instances[$alias])) {
+            throw new RuntimeException(sprintf(
+                'You cannot configure "%s", it has already been constructed.',
+                $alias
+            ));
+        }
+
+        $this->_config[$alias] = $options;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConfig(?string $alias = null): array
+    {
+        if ($alias === null) {
+            return $this->_config;
+        }
+
+        return $this->_config[$alias] ?? [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exists(string $alias): bool
+    {
+        return isset($this->_instances[$alias]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(string $alias, RepositoryInterface $repository)
+    {
+        return $this->_instances[$alias] = $repository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function remove(string $alias): void
+    {
+        unset(
+            $this->_instances[$alias],
+            $this->_options[$alias]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        $this->_instances = [];
+        $this->_config = [];
+        $this->_options = [];
+    }
+}

--- a/src/Datasource/Locator/LocatorInterface.php
+++ b/src/Datasource/Locator/LocatorInterface.php
@@ -24,33 +24,13 @@ use Cake\Datasource\RepositoryInterface;
 interface LocatorInterface
 {
     /**
-     * Returns configuration for an alias or the full configuration array for
-     * all aliases.
-     *
-     * @param string|null $alias Alias to get config for, null for complete config.
-     * @return array The config data.
-     */
-    public function getConfig(?string $alias = null): array;
-
-    /**
-     * Stores a list of options to be used when instantiating an object
-     * with a matching alias.
-     *
-     * @param string|array $alias Name of the alias or array to completely
-     *   overwrite current config.
-     * @param array|null $options list of options for the alias
-     * @return $this
-     * @throws \RuntimeException When you attempt to configure an existing
-     *   table instance.
-     */
-    public function setConfig($alias, $options = null);
-
-    /**
      * Get a repository instance from the registry.
      *
      * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the table with.
      * @return \Cake\Datasource\RepositoryInterface
+     * @throws \RuntimeException When trying to get alias for which instance
+     *   has already been created with different options.
      */
     public function get(string $alias, array $options = []);
 

--- a/src/Datasource/Locator/LocatorInterface.php
+++ b/src/Datasource/Locator/LocatorInterface.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
  * @since         4.1.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Datasource;
+namespace Cake\Datasource\Locator;
+
+use Cake\Datasource\RepositoryInterface;
 
 /**
  * Registries for repository objects should implement this interface.

--- a/src/Datasource/LocatorInterface.php
+++ b/src/Datasource/LocatorInterface.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource;
+
+/**
+ * Registries for repository objects should implement this interface.
+ */
+interface LocatorInterface
+{
+    /**
+     * Returns configuration for an alias or the full configuration array for
+     * all aliases.
+     *
+     * @param string|null $alias Alias to get config for, null for complete config.
+     * @return array The config data.
+     */
+    public function getConfig(?string $alias = null): array;
+
+    /**
+     * Stores a list of options to be used when instantiating an object
+     * with a matching alias.
+     *
+     * @param string|array $alias Name of the alias or array to completely
+     *   overwrite current config.
+     * @param array|null $options list of options for the alias
+     * @return $this
+     * @throws \RuntimeException When you attempt to configure an existing
+     *   table instance.
+     */
+    public function setConfig($alias, $options = null);
+
+    /**
+     * Get a repository instance from the registry.
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the table with.
+     * @return \Cake\Datasource\RepositoryInterface
+     */
+    public function get(string $alias, array $options = []);
+
+    /**
+     * Set a repository instance.
+     *
+     * @param string $alias The alias to set.
+     * @param \Cake\Datasource\RepositoryInterface $object The repository to set.
+     * @return \Cake\Datasource\RepositoryInterface
+     */
+    public function set(string $alias, $object);
+
+    /**
+     * Check to see if an instance exists in the registry.
+     *
+     * @param string $alias The alias to check for.
+     * @return bool
+     */
+    public function exists(string $alias): bool;
+
+    /**
+     * Removes an repository instance from the registry.
+     *
+     * @param string $alias The alias to remove.
+     * @return void
+     */
+    public function remove(string $alias): void;
+
+    /**
+     * Clears the registry of configuration and instances.
+     *
+     * @return void
+     */
+    public function clear(): void;
+}

--- a/src/Datasource/LocatorInterface.php
+++ b/src/Datasource/LocatorInterface.php
@@ -56,10 +56,10 @@ interface LocatorInterface
      * Set a repository instance.
      *
      * @param string $alias The alias to set.
-     * @param \Cake\Datasource\RepositoryInterface $object The repository to set.
+     * @param \Cake\Datasource\RepositoryInterface $repository The repository to set.
      * @return \Cake\Datasource\RepositoryInterface
      */
-    public function set(string $alias, $object);
+    public function set(string $alias, RepositoryInterface $repository);
 
     /**
      * Check to see if an instance exists in the registry.

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -125,7 +125,13 @@ trait ModelAwareTrait
         if (!isset($factory)) {
             $factory = FactoryLocator::get($modelType);
         }
-        $this->{$alias} = $factory($modelClass, $options);
+
+        if ($factory instanceof LocatorInterface) {
+            $this->{$alias} = $factory->get($modelClass, $options);
+        } else {
+            $this->{$alias} = $factory($modelClass, $options);
+        }
+
         if (!$this->{$alias}) {
             throw new MissingModelException([$modelClass, $modelType]);
         }

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -46,7 +46,7 @@ trait ModelAwareTrait
     /**
      * A list of overridden model factory functions.
      *
-     * @var array
+     * @var (callable|\Cake\Datasource\LocatorInterface)[]
      */
     protected $_modelFactories = [];
 
@@ -143,10 +143,10 @@ trait ModelAwareTrait
      * Override a existing callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable $factory The factory function used to create instances.
+     * @param callable|\Cake\Datasource\LocatorInterface $factory The factory function used to create instances.
      * @return void
      */
-    public function modelFactory(string $type, callable $factory): void
+    public function modelFactory(string $type, $factory): void
     {
         $this->_modelFactories[$type] = $factory;
     }

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -91,15 +91,11 @@ trait ModelAwareTrait
      */
     public function loadModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
     {
-        if ($modelClass === null) {
-            $modelClass = $this->modelClass;
-        }
+        $modelClass = $modelClass ?? $this->modelClass;
         if (empty($modelClass)) {
             throw new UnexpectedValueException('Default modelClass is empty');
         }
-        if ($modelType === null) {
-            $modelType = $this->getModelType();
-        }
+        $modelType = $modelType ?? $this->getModelType();
 
         $options = [];
         if (strpos($modelClass, '\\') === false) {
@@ -119,13 +115,7 @@ trait ModelAwareTrait
             return $this->{$alias};
         }
 
-        if (isset($this->_modelFactories[$modelType])) {
-            $factory = $this->_modelFactories[$modelType];
-        }
-        if (!isset($factory)) {
-            $factory = FactoryLocator::get($modelType);
-        }
-
+        $factory = $this->_modelFactories[$modelType] ?? FactoryLocator::get($modelType);
         if ($factory instanceof LocatorInterface) {
             $this->{$alias} = $factory->get($modelClass, $options);
         } else {

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
+use Cake\Datasource\Locator\LocatorInterface;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -47,7 +48,7 @@ trait ModelAwareTrait
     /**
      * A list of overridden model factory functions.
      *
-     * @var (callable|\Cake\Datasource\LocatorInterface)[]
+     * @var (callable|\Cake\Datasource\Locator\LocatorInterface)[]
      */
     protected $_modelFactories = [];
 
@@ -134,14 +135,14 @@ trait ModelAwareTrait
      * Override a existing callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param callable|\Cake\Datasource\LocatorInterface $factory The factory function used to create instances.
+     * @param callable|\Cake\Datasource\Locator\LocatorInterface $factory The factory function used to create instances.
      * @return void
      */
     public function modelFactory(string $type, $factory): void
     {
         if (!$factory instanceof LocatorInterface && !is_callable($factory)) {
             throw new InvalidArgumentException(sprintf(
-                '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+                '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
                 . ' Got type `%s` instead.',
                 getTypeName($factory)
             ));

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -138,6 +139,14 @@ trait ModelAwareTrait
      */
     public function modelFactory(string $type, $factory): void
     {
+        if (!$factory instanceof LocatorInterface && !is_callable($factory)) {
+            throw new InvalidArgumentException(sprintf(
+                '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+                . ' Got type `%s` instead.',
+                getTypeName($factory)
+            ));
+        }
+
         $this->_modelFactories[$type] = $factory;
     }
 

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -51,9 +51,11 @@ trait LocatorAwareTrait
     public function getTableLocator(): LocatorInterface
     {
         if ($this->_tableLocator === null) {
+            /** @var \Cake\ORM\Locator\LocatorInterface $this->_tableLocator */
             $this->_tableLocator = FactoryLocator::get('Table');
         }
 
+        /** @var \Cake\ORM\Locator\LocatorInterface */
         return $this->_tableLocator;
     }
 }

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Locator;
 
-use Cake\ORM\TableRegistry;
+use Cake\Datasource\FactoryLocator;
 
 /**
  * Contains method for setting and accessing LocatorInterface instance
@@ -51,7 +51,7 @@ trait LocatorAwareTrait
     public function getTableLocator(): LocatorInterface
     {
         if ($this->_tableLocator === null) {
-            $this->_tableLocator = TableRegistry::getTableLocator();
+            $this->_tableLocator = FactoryLocator::get('Table');
         }
 
         return $this->_tableLocator;

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -22,7 +22,7 @@ use Cake\ORM\Table;
 /**
  * Registries for Table objects should implement this interface.
  */
-interface LocatorInterface extends \Cake\Datasource\LocatorInterface
+interface LocatorInterface extends \Cake\Datasource\Locator\LocatorInterface
 {
     /**
      * Get a table instance from the registry.

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Locator;
 
+use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Table;
 
 /**
@@ -33,11 +34,12 @@ interface LocatorInterface extends \Cake\Datasource\LocatorInterface
     public function get(string $alias, array $options = []): Table;
 
     /**
-     * Set an instance.
+     * Set a table instance.
      *
      * @param string $alias The alias to set.
-     * @param \Cake\ORM\Table $object The table to set.
+     * @param \Cake\ORM\Table $repository The table to set.
      * @return \Cake\ORM\Table
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function set(string $alias, $object): Table;
+    public function set(string $alias, RepositoryInterface $repository): Table;
 }

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -21,30 +21,8 @@ use Cake\ORM\Table;
 /**
  * Registries for Table objects should implement this interface.
  */
-interface LocatorInterface
+interface LocatorInterface extends \Cake\Datasource\LocatorInterface
 {
-    /**
-     * Returns configuration for an alias or the full configuration array for
-     * all aliases.
-     *
-     * @param string|null $alias Alias to get config for, null for complete config.
-     * @return array The config data.
-     */
-    public function getConfig(?string $alias = null): array;
-
-    /**
-     * Stores a list of options to be used when instantiating an object
-     * with a matching alias.
-     *
-     * @param string|array $alias Name of the alias or array to completely
-     *   overwrite current config.
-     * @param array|null $options list of options for the alias
-     * @return $this
-     * @throws \RuntimeException When you attempt to configure an existing
-     *   table instance.
-     */
-    public function setConfig($alias, $options = null);
-
     /**
      * Get a table instance from the registry.
      *
@@ -55,34 +33,11 @@ interface LocatorInterface
     public function get(string $alias, array $options = []): Table;
 
     /**
-     * Check to see if an instance exists in the registry.
-     *
-     * @param string $alias The alias to check for.
-     * @return bool
-     */
-    public function exists(string $alias): bool;
-
-    /**
      * Set an instance.
      *
      * @param string $alias The alias to set.
      * @param \Cake\ORM\Table $object The table to set.
      * @return \Cake\ORM\Table
      */
-    public function set(string $alias, Table $object): Table;
-
-    /**
-     * Clears the registry of configuration and instances.
-     *
-     * @return void
-     */
-    public function clear(): void;
-
-    /**
-     * Removes an instance from the registry.
-     *
-     * @param string $alias The alias to remove.
-     * @return void
-     */
-    public function remove(string $alias): void;
+    public function set(string $alias, $object): Table;
 }

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -25,6 +25,28 @@ use Cake\ORM\Table;
 interface LocatorInterface extends \Cake\Datasource\Locator\LocatorInterface
 {
     /**
+     * Returns configuration for an alias or the full configuration array for
+     * all aliases.
+     *
+     * @param string|null $alias Alias to get config for, null for complete config.
+     * @return array The config data.
+     */
+    public function getConfig(?string $alias = null): array;
+
+    /**
+     * Stores a list of options to be used when instantiating an object
+     * with a matching alias.
+     *
+     * @param string|array $alias Name of the alias or array to completely
+     *   overwrite current config.
+     * @param array|null $options list of options for the alias
+     * @return $this
+     * @throws \RuntimeException When you attempt to configure an existing
+     *   table instance.
+     */
+    public function setConfig($alias, $options = null);
+
+    /**
      * Get a table instance from the registry.
      *
      * @param string $alias The alias name you want to get.

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -18,6 +18,7 @@ namespace Cake\ORM\Locator;
 
 use Cake\Core\App;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\AssociationCollection;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
@@ -274,9 +275,9 @@ class TableLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
-    public function set(string $alias, $object): Table
+    public function set(string $alias, RepositoryInterface $repository): Table
     {
-        return $this->_instances[$alias] = $object;
+        return $this->_instances[$alias] = $repository;
     }
 
     /**

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -274,7 +274,7 @@ class TableLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
-    public function set(string $alias, Table $object): Table
+    public function set(string $alias, $object): Table
     {
         return $this->_instances[$alias] = $object;
     }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -65,6 +65,7 @@ class TableRegistry
      */
     public static function getTableLocator(): LocatorInterface
     {
+        /** @var \Cake\ORM\Locator\LocatorInterface */
         return FactoryLocator::get('Table');
     }
 

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
+use Cake\Datasource\FactoryLocator;
 use Cake\ORM\Locator\LocatorInterface;
 
 /**
@@ -58,32 +59,13 @@ use Cake\ORM\Locator\LocatorInterface;
 class TableRegistry
 {
     /**
-     * LocatorInterface implementation instance.
-     *
-     * @var \Cake\ORM\Locator\LocatorInterface
-     */
-    protected static $_locator;
-
-    /**
-     * Default LocatorInterface implementation class.
-     *
-     * @var string
-     * @psalm-var class-string<\Cake\ORM\Locator\TableLocator>
-     */
-    protected static $_defaultLocatorClass = Locator\TableLocator::class;
-
-    /**
      * Returns a singleton instance of LocatorInterface implementation.
      *
      * @return \Cake\ORM\Locator\LocatorInterface
      */
     public static function getTableLocator(): LocatorInterface
     {
-        if (static::$_locator === null) {
-            static::$_locator = new static::$_defaultLocatorClass();
-        }
-
-        return static::$_locator;
+        return FactoryLocator::get('Table');
     }
 
     /**
@@ -94,7 +76,7 @@ class TableRegistry
      */
     public static function setTableLocator(LocatorInterface $tableLocator): void
     {
-        static::$_locator = $tableLocator;
+        FactoryLocator::add('Table', $tableLocator);
     }
 
     /**

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
-use Cake\Datasource\LocatorInterface;
+use Cake\Datasource\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 
@@ -72,7 +72,7 @@ class FactoryLocatorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+            '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
             . ' Got type `string` instead.'
         );
 

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
+use Cake\Datasource\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
 use TestApp\Stub\Stub;
@@ -32,7 +33,8 @@ class FactoryLocatorTest extends TestCase
      */
     public function testGet()
     {
-        $this->assertIsCallable(FactoryLocator::get('Table'));
+        $factory = FactoryLocator::get('Table');
+        $this->assertTrue(is_callable($factory) || $factory instanceof LocatorInterface);
     }
 
     /**

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Datasource;
 use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\LocatorInterface;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * FactoryLocatorTest test case
@@ -65,6 +66,17 @@ class FactoryLocatorTest extends TestCase
         $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
         FactoryLocator::add('MyType', $locator);
         $this->assertInstanceOf(LocatorInterface::class, FactoryLocator::get('MyType'));
+    }
+
+    public function testFactoryAddException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+            . ' Got type `string` instead.'
+        );
+
+        FactoryLocator::add('Test', 'fail');
     }
 
     /**

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -17,9 +17,7 @@ namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\LocatorInterface;
-use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
-use TestApp\Stub\Stub;
 
 /**
  * FactoryLocatorTest test case
@@ -62,8 +60,11 @@ class FactoryLocatorTest extends TestCase
 
             return $mock;
         });
-
         $this->assertIsCallable(FactoryLocator::get('Test'));
+
+        $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
+        FactoryLocator::add('MyType', $locator);
+        $this->assertInstanceOf(LocatorInterface::class, FactoryLocator::get('MyType'));
     }
 
     /**
@@ -80,97 +81,10 @@ class FactoryLocatorTest extends TestCase
         FactoryLocator::get('Test');
     }
 
-    /**
-     * test loadModel() with plugin prefixed models
-     *
-     * Load model should not be called with Foo.Model Bar.Model Model
-     * But if it is, the first call wins.
-     *
-     * @return void
-     */
-    public function testLoadModelPlugin()
-    {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-        $stub->setModelType('Table');
-
-        $result = $stub->loadModel('TestPlugin.Comments');
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
-
-        $result = $stub->loadModel('Comments');
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
-    }
-
-    /**
-     * test alternate model factories.
-     *
-     * @return void
-     */
-    public function testModelFactory()
-    {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-
-        $stub->modelFactory('Table', function ($name) {
-            $mock = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-            $mock->name = $name;
-
-            return $mock;
-        });
-
-        $result = $stub->loadModel('Magic', 'Table');
-        $this->assertInstanceOf(RepositoryInterface::class, $result);
-        $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
-        $this->assertSame('Magic', $stub->Magic->name);
-    }
-
-    /**
-     * test alternate default model type.
-     *
-     * @return void
-     */
-    public function testModelType()
-    {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-
-        FactoryLocator::add('Test', function ($name) {
-            $mock = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-            $mock->name = $name;
-
-            return $mock;
-        });
-        $stub->setModelType('Test');
-
-        $result = $stub->loadModel('Magic');
-        $this->assertInstanceOf(RepositoryInterface::class, $result);
-        $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
-        $this->assertSame('Magic', $stub->Magic->name);
-    }
-
-    /**
-     * test MissingModelException being thrown
-     *
-     * @return void
-     */
-    public function testMissingModelException()
-    {
-        $this->expectException(\Cake\Datasource\Exception\MissingModelException::class);
-        $this->expectExceptionMessage('Model class "Magic" of type "Test" could not be found.');
-        $stub = new Stub();
-
-        FactoryLocator::add('Test', function ($name) {
-            return false;
-        });
-
-        $stub->loadModel('Magic', 'Test');
-    }
-
     public function tearDown(): void
     {
         FactoryLocator::drop('Test');
+        FactoryLocator::drop('MyType');
 
         parent::tearDown();
     }

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
+use Cake\Datasource\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Table\PaginatorPostsTable;
@@ -127,6 +128,18 @@ class ModelAwareTraitTest extends TestCase
         $this->assertInstanceOf(RepositoryInterface::class, $result);
         $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
         $this->assertSame('Magic', $stub->Magic->name);
+
+        $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
+        $mock2 = $this->getMockBuilder(RepositoryInterface::class)->getMock();
+        $mock2->alias = 'Foo';
+        $locator->expects($this->any())
+            ->method('get')
+            ->willReturn($mock2);
+
+        $stub->modelFactory('MyType', $locator);
+        $result = $stub->loadModel('Foo', 'MyType');
+        $this->assertInstanceOf(RepositoryInterface::class, $result);
+        $this->assertSame('Foo', $stub->Foo->alias);
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
-use Cake\Datasource\LocatorInterface;
+use Cake\Datasource\Locator\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -147,7 +147,7 @@ class ModelAwareTraitTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+            '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
             . ' Got type `string` instead.'
         );
 

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -19,6 +19,7 @@ use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use TestApp\Model\Table\PaginatorPostsTable;
 use TestApp\Stub\Stub;
 
@@ -140,6 +141,18 @@ class ModelAwareTraitTest extends TestCase
         $result = $stub->loadModel('Foo', 'MyType');
         $this->assertInstanceOf(RepositoryInterface::class, $result);
         $this->assertSame('Foo', $stub->Foo->alias);
+    }
+
+    public function testModelFactoryException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '`$factory` must be an instance of Cake\Datasource\LocatorInterface or a callable.'
+            . ' Got type `string` instead.'
+        );
+
+        $stub = new Stub();
+        $stub->modelFactory('MyType', 'fail');
     }
 
     /**


### PR DESCRIPTION
## The problem

Let's say someone want to use a custom locator for `Table` class instances throughout their app. The  global way to achieve that is customize the table locator using `FactoryLocator::set()` and set a callable for type `Table`.

Doing so would then make `ModelAwareTrait::loadModel()` (used in `Controller`) to use the callable one has set to get table instances. 

Another way to get table instances is using the `LocatorAwareTrait` (`Controller` uses it) and use `LocatorAwareTrait::getTableLocator()->get()`. Now the problem is `LocatorAwareTrait::getTableLocator()` by default will always return a `TableLocator` instance. So one would have to use `LocatorAwareTrait::setTableLocator()` to set a custom table locator which achieves the same as what the callable used for `FactoryLocator`.

This isn't practical. There should be a way to globally set a custom table locator which is used throughout the ORM as single source for table instances.

## Possible solutions

### Allow the default table locator class in `TableRegistry` to be customizable :-1: 
`LocatorAwareTrait::getTableLocator()` use `TableRegistry::getTableLocator()` to get the table locator. `TableRegistry` currently doesn't provide anyway to customize the default table locator class. So we could add public method to be able to do so.

But again this solution isn't practical. One would then have to configure `FactoryLocator` as well as `TableRegistry`, plus the former uses callable while the latter `ORM\LocatorInterface` instances. So this isn't much of a solution. Moreover `TableRegistry` is essentially a relic for BC compatibility which should be removed in future.

### Add a `Datasource\LocatorInterface` and allow `FactoryLocator` to use both callable and the interface instances. :+1: 

This is the solution I have implemented here.

- Added `Datasource\LocatorInterface` (there's also another issue for this)
- Updated `FactoryLocator` to use both callable and `Datasource\LocatorInterface` instances.
- `ORM\LocatorInterface` now extends `Datasource\LocatorInterface`.
- Updated the codebase to always use `FactoryLocator` as the single consistent source for table locator instances.

## Implications
- To allow `ORM\LocatorInterface` to `Datasource\LocatorInterface` the `Table` typehint for `$object` argument of `ORM\LocatorInterface::set()` had to be removed. This is technically a BC break and will throw an error for anyone who has extended `TableLocator` and customized the method. But IMO that's acceptable and anyone using a custom locator would actually appreciate this change, to be able to customize table locator from a single location.

If the changes seem reasonable I'll go ahead with making static analyzers happy and any other related potential clean ups that can be done.