### PR TITLE
Rename SchemaCacheCommandsTest

### DIFF
--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -23,9 +23,9 @@ use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**
- * SchemacacheCommands test.
+ * SchemaCacheCommands test.
  */
-class SchemacacheCommandsTest extends TestCase
+class SchemaCacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 


### PR DESCRIPTION
Partly backport https://github.com/cakephp/cakephp/commit/803d60ae3244fac7f75aee63304b54f9d04f2710 from `4.next`.

There is problem when switching between `master` and `4.next` branches on Windows.