### PR TITLE
Route will keep optional keys in default

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -439,11 +439,11 @@ class Route
         // Assign defaults, set passed args to pass
         foreach ($this->defaults as $key => $value) {
             if (isset($route[$key])) {
-				// preg_match returns an empty string if an optional key was not fournd
-				// We treat this as if the key was not found
-				if ($route[$key] !== '') {				
-	                continue;
-				}
+                // preg_match returns an empty string if an optional key was not fournd
+                // We treat this as if the key was not found
+                if ($route[$key] !== '') {
+                    continue;
+                }
             }
             if (is_int($key)) {
                 $route['pass'][] = $value;
@@ -652,12 +652,12 @@ class Route
             return null;
         }
         unset($url['_method'], $url['[method]'], $defaults['_method']);
-		
-		// The key names
-		$keyNames = array_flip($this->keys);
-		
-		// All defaults which are not a key
-		$defaultsNotKey = array_diff_key($defaults, $keyNames);
+
+        // The key names
+        $keyNames = array_flip($this->keys);
+
+        // All defaults which are not a key
+        $defaultsNotKey = array_diff_key($defaults, $keyNames);
 
         // Missing defaults, which are not a key, is a fail
         if (array_diff_key($defaultsNotKey, $url) !== []) {
@@ -712,11 +712,11 @@ class Route
         // check patterns for routed params, if they are not the default value
         if (!empty($this->options)) {
             foreach ($this->options as $key => $pattern) {
-				if (!array_key_exists($key, $defaults) || $defaults[$key] !== $url[$key]) {
-					if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])) {
-						return null;
-					}
-				}
+                if (!array_key_exists($key, $defaults) || $defaults[$key] !== $url[$key]) {
+                    if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])) {
+                        return null;
+                    }
+                }
             }
         }
         $url += $hostOptions;

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -438,12 +438,10 @@ class Route
 
         // Assign defaults, set passed args to pass
         foreach ($this->defaults as $key => $value) {
-            if (isset($route[$key])) {
-                // preg_match returns an empty string if an optional key was not fournd
-                // We treat this as if the key was not found
-                if ($route[$key] !== '') {
-                    continue;
-                }
+            // preg_match returns an empty string if an optional key was not found
+            // We treat this as if the key was not found
+            if (isset($route[$key]) && $route[$key] !== '') {
+                continue;
             }
             if (is_int($key)) {
                 $route['pass'][] = $value;
@@ -712,10 +710,11 @@ class Route
         // check patterns for routed params, if they are not the default value
         if (!empty($this->options)) {
             foreach ($this->options as $key => $pattern) {
-                if (!array_key_exists($key, $defaults) || $defaults[$key] !== $url[$key]) {
-                    if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])) {
+                if (
+                    (!array_key_exists($key, $defaults) || $defaults[$key] !== $url[$key]) &&
+                    isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])
+                ) {
                         return null;
-                    }
                 }
             }
         }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -534,7 +534,7 @@ class RouteTest extends TestCase
         $expected = [
             'controller' => 'pages',
             'action' => 'view',
-			'extra' => null,
+            'extra' => null,
         ];
         $this->assertEquals($expected, $route->defaults);
 
@@ -1247,98 +1247,99 @@ class RouteTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
     }
-	
-	
-	/**
-	 * Test parse with optional parameters at the beginning of the route
-	 * 
-	 * @return void
-	 */
-	public function testParseWithOptonalStartParameter() {
-		// {start} may be omitted
-		$route = new Route('/{start}/{controller}', 
-				['start' => null],
-				['start' => 'prefix|other']
-		);
-		
-		// Test route against path with {pref}
-		$result = $route->parse('/prefix/posts', 'GET');
-		$expected = [
-			'start' => 'prefix',
-			'controller'=> 'posts',
-            'pass' => [],
-            '_matchedRoute' => '/{start}/{controller}'
-		];
-		$this->assertSame($expected, $result);
-		
-		// Test route against path without {pref}
-		$result = $route->parse('/posts', 'GET');
-		$expected = [
-			'start' => null,
-			'controller'=> 'posts',
-            'pass' => [],
-            '_matchedRoute' => '/{start}/{controller}'
-		];
-		
-		$this->assertSame($expected, $result);
-		
-		// Test route against path with additional segment
-		// This should not match
-		$result = $route->parse('/posts/view', 'GET');
-		$this->assertNull($result);
-	}
-	
 
-	/**
-	 * Test parse with optional parameters at the end of the route
-	 * 
-	 * @return void
-	 */
-	public function testParseWithOptonalEndParameter() {
-		// {end} may be omitted
-		$route = new Route('/{controller}/{end}', 
-				['end' => null],
-				['end' => 'postfix|other']
-		);
-		
-		// Test route against path with {end}
-		$result = $route->parse('/posts/postfix', 'GET');
-		$expected = [
-			'controller'=> 'posts',
-			'end' => 'postfix',
+    /**
+     * Test parse with optional parameters at the beginning of the route
+     *
+     * @return void
+     */
+    public function testParseWithOptonalStartParameter()
+    {
+        // {start} may be omitted
+        $route = new Route(
+            '/{start}/{controller}',
+            ['start' => null],
+            ['start' => 'prefix|other'],
+        );
+
+        // Test route against path with {pref}
+        $result = $route->parse('/prefix/posts', 'GET');
+        $expected = [
+            'start' => 'prefix',
+            'controller' => 'posts',
             'pass' => [],
-            '_matchedRoute' => '/{controller}/{end}'
-		];
-		$this->assertSame($expected, $result);
-		
-		// Test route against path without {end}
-		$result = $route->parse('/posts', 'GET');
-		$expected = [
-			'controller'=> 'posts',
+            '_matchedRoute' => '/{start}/{controller}',
+        ];
+        $this->assertSame($expected, $result);
+
+        // Test route against path without {pref}
+        $result = $route->parse('/posts', 'GET');
+        $expected = [
+            'start' => null,
+            'controller' => 'posts',
             'pass' => [],
-			'end' => null,
-            '_matchedRoute' => '/{controller}/{end}'
-		];
-		
-		$this->assertSame($expected, $result);
-		
-		// Test route against path without {pref}
-		$result = $route->parse('/posts/', 'GET');
-		$expected = [
-			'controller'=> 'posts',
+            '_matchedRoute' => '/{start}/{controller}',
+        ];
+
+        $this->assertSame($expected, $result);
+
+        // Test route against path with additional segment
+        // This should not match
+        $result = $route->parse('/posts/view', 'GET');
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test parse with optional parameters at the end of the route
+     *
+     * @return void
+     */
+    public function testParseWithOptonalEndParameter()
+    {
+        // {end} may be omitted
+        $route = new Route(
+            '/{controller}/{end}',
+            ['end' => null],
+            ['end' => 'postfix|other'],
+        );
+
+        // Test route against path with {end}
+        $result = $route->parse('/posts/postfix', 'GET');
+        $expected = [
+            'controller' => 'posts',
+            'end' => 'postfix',
             'pass' => [],
-			'end' => null,
-            '_matchedRoute' => '/{controller}/{end}'
-		];
-		
-		$this->assertSame($expected, $result);
-		
-		// Test route against path with additional segment
-		// This should not match
-		$result = $route->parse('/posts/view', 'GET');
-		$this->assertNull($result);
-	}
-	
+            '_matchedRoute' => '/{controller}/{end}',
+        ];
+        $this->assertSame($expected, $result);
+
+        // Test route against path without {end}
+        $result = $route->parse('/posts', 'GET');
+        $expected = [
+            'controller' => 'posts',
+            'pass' => [],
+            'end' => null,
+            '_matchedRoute' => '/{controller}/{end}',
+        ];
+
+        $this->assertSame($expected, $result);
+
+        // Test route against path without {pref}
+        $result = $route->parse('/posts/', 'GET');
+        $expected = [
+            'controller' => 'posts',
+            'pass' => [],
+            'end' => null,
+            '_matchedRoute' => '/{controller}/{end}',
+        ];
+
+        $this->assertSame($expected, $result);
+
+        // Test route against path with additional segment
+        // This should not match
+        $result = $route->parse('/posts/view', 'GET');
+        $this->assertNull($result);
+    }
 
     /**
      * Test that middleware is returned from parse()
@@ -1549,9 +1550,9 @@ class RouteTest extends TestCase
 
         $route = new Route('/path/{optional}/fixed');
         $this->assertSame('/path/fixed', $route->match(['optional' => null]));
-	}
-	
-	/**
+    }
+
+    /**
      * Test matching fails on required keys (controller/action)
      *
      * @return void

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1259,7 +1259,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{start}/{controller}',
             ['start' => null],
-            ['start' => 'prefix|other'],
+            ['start' => 'prefix|other']
         );
 
         // Test route against path with {pref}
@@ -1300,7 +1300,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{controller}/{end}',
             ['end' => null],
-            ['end' => 'postfix|other'],
+            ['end' => 'postfix|other']
         );
 
         // Test route against path with {end}

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -534,6 +534,7 @@ class RouteTest extends TestCase
         $expected = [
             'controller' => 'pages',
             'action' => 'view',
+			'extra' => null,
         ];
         $this->assertEquals($expected, $route->defaults);
 
@@ -1246,6 +1247,98 @@ class RouteTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
     }
+	
+	
+	/**
+	 * Test parse with optional parameters at the beginning of the route
+	 * 
+	 * @return void
+	 */
+	public function testParseWithOptonalStartParameter() {
+		// {start} may be omitted
+		$route = new Route('/{start}/{controller}', 
+				['start' => null],
+				['start' => 'prefix|other']
+		);
+		
+		// Test route against path with {pref}
+		$result = $route->parse('/prefix/posts', 'GET');
+		$expected = [
+			'start' => 'prefix',
+			'controller'=> 'posts',
+            'pass' => [],
+            '_matchedRoute' => '/{start}/{controller}'
+		];
+		$this->assertSame($expected, $result);
+		
+		// Test route against path without {pref}
+		$result = $route->parse('/posts', 'GET');
+		$expected = [
+			'start' => null,
+			'controller'=> 'posts',
+            'pass' => [],
+            '_matchedRoute' => '/{start}/{controller}'
+		];
+		
+		$this->assertSame($expected, $result);
+		
+		// Test route against path with additional segment
+		// This should not match
+		$result = $route->parse('/posts/view', 'GET');
+		$this->assertNull($result);
+	}
+	
+
+	/**
+	 * Test parse with optional parameters at the end of the route
+	 * 
+	 * @return void
+	 */
+	public function testParseWithOptonalEndParameter() {
+		// {end} may be omitted
+		$route = new Route('/{controller}/{end}', 
+				['end' => null],
+				['end' => 'postfix|other']
+		);
+		
+		// Test route against path with {end}
+		$result = $route->parse('/posts/postfix', 'GET');
+		$expected = [
+			'controller'=> 'posts',
+			'end' => 'postfix',
+            'pass' => [],
+            '_matchedRoute' => '/{controller}/{end}'
+		];
+		$this->assertSame($expected, $result);
+		
+		// Test route against path without {end}
+		$result = $route->parse('/posts', 'GET');
+		$expected = [
+			'controller'=> 'posts',
+            'pass' => [],
+			'end' => null,
+            '_matchedRoute' => '/{controller}/{end}'
+		];
+		
+		$this->assertSame($expected, $result);
+		
+		// Test route against path without {pref}
+		$result = $route->parse('/posts/', 'GET');
+		$expected = [
+			'controller'=> 'posts',
+            'pass' => [],
+			'end' => null,
+            '_matchedRoute' => '/{controller}/{end}'
+		];
+		
+		$this->assertSame($expected, $result);
+		
+		// Test route against path with additional segment
+		// This should not match
+		$result = $route->parse('/posts/view', 'GET');
+		$this->assertNull($result);
+	}
+	
 
     /**
      * Test that middleware is returned from parse()
@@ -1456,9 +1549,9 @@ class RouteTest extends TestCase
 
         $route = new Route('/path/{optional}/fixed');
         $this->assertSame('/path/fixed', $route->match(['optional' => null]));
-    }
-
-    /**
+	}
+	
+	/**
      * Test matching fails on required keys (controller/action)
      *
      * @return void


### PR DESCRIPTION
#14628 Allow keys in a route to be optional
Beside removing the code which removes keys from defaults, I had to do a few more changes:
1) At the end of match(...) the code checks that defaults are present and unchanged. To stay compatible I had to create a subset of defaults without keys.

2) When compiling the route preg_match will return an empty string for each optional key in the route, and omit optional keys at the end. I check the result for empty strings and replace them with the default, as it would be done with optional keys at the end. 
Because there is a difference where the optional key is I added 2 tests.

3) Again in match url parameters are tested against options. A null value may pass the test, but to be clearer I explicitly allow the default value.

I hope it is OK if I target 4.next instead of master
