### PR TITLE
Removed void return typehint from __call()

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -134,7 +134,7 @@ class FlashComponent extends Component
      * @return void
      * @throws \Cake\Http\Exception\InternalErrorException If missing the flash message.
      */
-    public function __call(string $name, array $args): void
+    public function __call(string $name, array $args)
     {
         $element = Inflector::underscore($name);
 


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/14642

Let's see what complains. Leaving the @return hint for now.