### PR TITLE
Add defaulting and *orFail() to Session.

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -162,7 +162,7 @@ class Configure
      */
     public static function readOrFail(string $var)
     {
-        if (static::check($var) === false) {
+        if (!static::check($var)) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
         }
 
@@ -202,7 +202,7 @@ class Configure
      */
     public static function consumeOrFail(string $var)
     {
-        if (static::check($var) === false) {
+        if (!static::check($var)) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
         }
 

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -460,7 +460,7 @@ class Session
      */
     public function readOrFail(string $name)
     {
-        if ($this->check($name) === false) {
+        if (!$this->check($name)) {
             throw new RuntimeException(sprintf('Expected session key "%s" not found.', $name));
         }
 

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -430,10 +430,11 @@ class Session
      * Returns given session variable, or all of them, if no parameters given.
      *
      * @param string|null $name The name of the session variable (or a path as sent to Hash.extract)
+     * @param mixed $default The return value when the path does not exist
      * @return string|array|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
-    public function read(?string $name = null)
+    public function read(?string $name = null, $default = null)
     {
         if ($this->_hasSession() && !$this->started()) {
             $this->start();
@@ -447,7 +448,23 @@ class Session
             return $_SESSION ?: [];
         }
 
-        return Hash::get($_SESSION, $name);
+        return Hash::get($_SESSION, $name, $default);
+    }
+
+    /**
+     * Returns given session variable, or throws Exception if not found.
+     *
+     * @param string $name The name of the session variable (or a path as sent to Hash.extract)
+     * @throws \RuntimeException
+     * @return array|string|null
+     */
+    public function readOrFail(string $name)
+    {
+        if ($this->check($name) === false) {
+            throw new RuntimeException(sprintf('Expected session key "%s" not found.', $name));
+        }
+
+        return $this->read($name);
     }
 
     /**

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -431,7 +431,7 @@ class Session
      *
      * @param string|null $name The name of the session variable (or a path as sent to Hash.extract)
      * @param mixed $default The return value when the path does not exist
-     * @return string|array|null The value of the session variable, null if session not available,
+     * @return mixed|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
     public function read(?string $name = null, $default = null)
@@ -456,7 +456,7 @@ class Session
      *
      * @param string $name The name of the session variable (or a path as sent to Hash.extract)
      * @throws \RuntimeException
-     * @return array|string|null
+     * @return mixed|null
      */
     public function readOrFail(string $name)
     {
@@ -471,7 +471,7 @@ class Session
      * Reads and deletes a variable from session.
      *
      * @param string $name The key to read and remove (or a path as sent to Hash.extract).
-     * @return mixed The value of the session variable, null if session not available,
+     * @return mixed|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
     public function consume(string $name)

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Http;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Http\Session\TestAppLibSession;
 use TestApp\Http\Session\TestWebSession;
 
@@ -145,6 +146,48 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $this->assertNull($session->read(''));
+    }
+
+    /**
+     * Tests read() with defaulting.
+     *
+     * @return void
+     */
+    public function testReadDefault()
+    {
+        $session = new Session();
+        $this->assertSame('bar', $session->read('foo', 'bar'));
+    }
+
+    /**
+     * Tests readOrFail()
+     *
+     * @return void
+     */
+    public function testReadOrFail()
+    {
+        $session = new Session();
+        $session->write('testing', '1,2,3');
+        $result = $session->readOrFail('testing');
+        $this->assertSame('1,2,3', $result);
+
+        $session->write('testing', ['1' => 'one', '2' => 'two', '3' => 'three']);
+        $result = $session->readOrFail('testing.1');
+        $this->assertSame('one', $result);
+    }
+
+    /**
+     * Tests readOrFail() with nonexistent value
+     *
+     * @return void
+     */
+    public function testReadOrFailException()
+    {
+        $session = new Session();
+
+        $this->expectException(RuntimeException::class);
+
+        $session->readOrFail('testing');
     }
 
     /**


### PR DESCRIPTION
This resolves https://github.com/cakephp/cakephp/issues/14623

The advantage would be to have a string typehint for readOrFail(), same as for Configure.