### PR TITLE
Fixed use of Closures for WindowExpression.

### DIFF
--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -20,7 +20,6 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * This represents a SQL window expression used by aggregate and window functions.
@@ -96,12 +95,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
         }
 
         if ($partitions instanceof Closure) {
-            $partitions = $partitions();
-            if (!($partitions instanceof ExpressionInterface)) {
-                throw new RuntimeException(
-                    'You must return an `ExpressionInterface` from a Closure passed to `partition()`.'
-                );
-            }
+            $partitions = $partitions(new QueryExpression([], [], ''));
         }
 
         if (!is_array($partitions)) {
@@ -129,20 +123,12 @@ class WindowExpression implements ExpressionInterface, WindowInterface
             return $this;
         }
 
-        if ($fields instanceof Closure) {
-            $fields = $fields();
-            if (!($fields instanceof OrderByExpression)) {
-                throw new RuntimeException(
-                    'You must return an `OrderByExpression` from a Closure passed to `order()`.'
-                );
-            }
-            $this->order = $fields;
-
-            return $this;
-        }
-
         if ($this->order === null) {
             $this->order = new OrderByExpression();
+        }
+
+        if ($fields instanceof Closure) {
+            $fields = $fields(new QueryExpression([], [], ''));
         }
 
         $this->order->add($fields);


### PR DESCRIPTION
@markstory  This aligns the use of Closure with `Query::order()` and other Query builders.

I pass a new `QueryExpression` instance to be consistent although it's not likely to be used for window builders.

The Closure is allowed to return non-expressions such as arrays and strings. `Query::order()` accepts a Closure that returns fields so `WindowExpression::order()` should do the same.

I misread what `Query::_conjugate()` was doing.