### PR TITLE
Master: Microoptimization for ServerRequest::is() and ServerRequest::isAll()to stop and return on first matched/unmatched type

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -782,7 +782,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * defined with Cake\Http\ServerRequest::addDetector(). Any detector can be called
      * as `is($type)` or `is$Type()`.
      *
-     * @param string|array $type The type of request you want to check. If an array
+     * @param string|string[] $type The type of request you want to check. If an array
      *   this method will return true if the request matches any type.
      * @param array ...$args List of arguments
      * @return bool Whether or not the request is the type you are checking.
@@ -790,9 +790,13 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     public function is($type, ...$args)
     {
         if (is_array($type)) {
-            $result = array_map([$this, 'is'], $type);
+            foreach ($type as $_type) {
+                if ($this->is($_type)) {
+                    return true;
+                }
+            }
 
-            return count(array_filter($result)) > 0;
+            return false;
         }
 
         $type = strtolower($type);
@@ -949,9 +953,13 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      */
     public function isAll(array $types)
     {
-        $result = array_filter(array_map([$this, 'is'], $types));
+        foreach ($types as $type) {
+            if (!$this->is($type)) {
+                return false;
+            }
+        }
 
-        return count($result) === count($types);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Microoptimization for `ServerRequest::is()` and `ServerRequest::isAll()`to stop and return on first matched/unmatched type.

Instead of checking all passed types (calling `array_map()` + `array_filter()`), it breaks on first type via `return`.

Copied from https://github.com/cakephp/cakephp/pull/14652