### PR TITLE
Removed MariaDB version check

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -253,15 +253,7 @@ class Mysql extends Driver
     public function supportsCTEs(): bool
     {
         if ($this->supportsCTEs === null) {
-            $version = $this->getVersion();
-            if (strpos($version, 'MariaDB') !== false) {
-                preg_match('/(\d+\.\d+.\d+)-MariaDB/i', $version, $matches);
-                $version = $matches[1];
-
-                $this->supportsCTEs = version_compare($version, '10.2.2', '>=');
-            } else {
-                $this->supportsCTEs = version_compare($version, '8.0.0', '>=');
-            }
+            $this->supportsCTEs = version_compare($this->getVersion(), '8.0.0', '>=');
         }
 
         return $this->supportsCTEs;


### PR DESCRIPTION
This was left from the CommonTableExpression work. We don't support MariaDB in the mysql driver directly anywhere else. I assume users will have a separate driver for this.

If we do need to support it, we should decide and fix it now so we can have proper version checks in other places.