### PR TITLE
Added info message about enabling metadata cache when using SchemaCache.

### DIFF
--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -16,6 +16,7 @@ namespace Cake\Database;
 
 use Cake\Cache\Cache;
 use Cake\Database\Connection;
+use Cake\Log\Log;
 use RuntimeException;
 
 /**
@@ -104,6 +105,7 @@ class SchemaCache
 
         $config = $connection->config();
         if (empty($config['cacheMetadata'])) {
+            Log::info(sprintf('Metadata cache was disabled in config for `%s`. Enabling to clear cache.', $connection->configName()));
             $connection->cacheMetadata(true);
         }
 


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/14004

This restores the notice about always enabling metadata cache when using SchemaCache.
