### PR TITLE
SaveMany should call `afterSaveCommit`

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2225,13 +2225,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
             throw new PersistenceFailedException($failed, ['saveMany']);
         }
-        
+
         if ($this->_transactionCommitted($options['atomic'], $options['_primary'])) {
             foreach ($entities as $entity) {
                 $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
             }
         }
-        
+
         return $entities;
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2180,6 +2180,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _saveMany(iterable $entities, $options = []): iterable
     {
+        $options = new ArrayObject(
+            (array)$options + [
+                'atomic' => true,
+                'checkRules' => true,
+                '_primary' => true,
+            ]
+        );
+
         /** @var bool[] $isNew */
         $isNew = [];
         $cleanup = function ($entities) use (&$isNew): void {
@@ -2217,7 +2225,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
             throw new PersistenceFailedException($failed, ['saveMany']);
         }
-
+        
+        if ($this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+            foreach ($entities as $entity) {
+                $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
+            }
+        }
+        
         return $entities;
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2811,7 +2811,16 @@ class TableTest extends TestCase
             new Entity(['name' => 'dakota']),
         ];
 
-        $table = $this->getTableLocator()->get('authors');
+        $timesCalled = 0;
+        $listener = function ($e, $entity, $options) use (&$timesCalled) {
+            $timesCalled++;
+        };
+        $table = $this->getTableLocator()
+            ->get('authors');
+
+        $table->getEventManager()
+            ->on('Model.afterSaveCommit', $listener);
+
         $result = $table->saveMany($entities);
 
         $this->assertSame($entities, $result);
@@ -2819,6 +2828,7 @@ class TableTest extends TestCase
         foreach ($entities as $entity) {
             $this->assertFalse($entity->isNew());
         }
+        $this->assertSame(2, $timesCalled);
     }
 
     /**


### PR DESCRIPTION
This fills a current gap where `saveMany()` does not call/trigger the `afterSaveCommit` callback (While other `many()` uses, like `deleteMany()` correctly trigger their `commit` callback)

Unsure if this should be in 4.next, or 4.0?

Will create tests shortly