### PR TITLE
Inflection test cases around irregular.

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -327,7 +327,9 @@ class Inflector
             static::$_cache['irregular']['singular'] = '/(.*?(?:\\b|_))(' . implode('|', $wordList) . ')$/i';
 
             $upperWordList = array_map('ucfirst', $wordList);
-            static::$_cache['irregular']['singularUpper'] = '/(.*?(?:\\b|[a-z]))(' . implode('|', $upperWordList) . ')$/';
+            static::$_cache['irregular']['singularUpper'] = '/(.*?(?:\\b|[a-z]))(' .
+                implode('|', $upperWordList) .
+                ')$/';
         }
 
         if (

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -522,7 +522,7 @@ class Inflector
     }
 
     /**
-     * @param string $word
+     * @param string $word Word
      * @return string|null
      */
     protected static function _detectInflection(string $word): ?string

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -520,25 +520,4 @@ class Inflector
 
         return $result;
     }
-
-    /**
-     * @param string $word Word
-     * @return string|null
-     */
-    protected static function _detectInflection(string $word): ?string
-    {
-        $inflection = null;
-        if (strpos($word, ' ') !== false) {
-            return $inflection;
-        }
-
-        if (preg_match('#[A-Z]#', $word)) {
-            $inflection = 'camelize';
-        }
-        if ($inflection && preg_match('#^[a-z]#', $word)) {
-            $inflection = 'variable';
-        }
-
-        return $inflection;
-    }
 }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -271,29 +271,28 @@ class Inflector
         }
 
         if (!isset(static::$_cache['irregular']['pluralize'])) {
-            static::$_cache['irregular']['pluralize'] = '(?:' . implode('|', array_keys(static::$_irregular)) . ')';
+            $words = array_keys(static::$_irregular);
+            static::$_cache['irregular']['pluralize'] = '/(.*?(?:\\b|_))(' . implode('|', $words) . ')$/i';
+
+            $upperWords = array_map('ucfirst', $words);
+            static::$_cache['irregular']['upperPluralize'] = '/(.*?(?:\\b|[a-z]))(' . implode('|', $upperWords) . ')$/';
         }
 
-        $inflection = static::_detectInflection($word);
-        $normalizedWord = $word;
-        if ($inflection) {
-            $normalizedWord = Inflector::underscore($word);
-        }
-
-        if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['pluralize'] . ')$/i', $normalizedWord, $regs)) {
-            $result = $regs[1] . substr($regs[2], 0, 1) .
+        if (
+            preg_match(static::$_cache['irregular']['pluralize'], $word, $regs) ||
+            preg_match(static::$_cache['irregular']['upperPluralize'], $word, $regs)
+        ) {
+            static::$_cache['pluralize'][$word] = $regs[1] . substr($regs[2], 0, 1) .
                 substr(static::$_irregular[strtolower($regs[2])], 1);
-
-            static::$_cache['pluralize'][$word] = $inflection ? Inflector::$inflection($result) : $result;
 
             return static::$_cache['pluralize'][$word];
         }
 
         if (!isset(static::$_cache['uninflected'])) {
-            static::$_cache['uninflected'] = '(?:' . implode('|', static::$_uninflected) . ')';
+            static::$_cache['uninflected'] = '/^(' . implode('|', static::$_uninflected) . ')$/i';
         }
 
-        if (preg_match('/^(' . static::$_cache['uninflected'] . ')$/i', $word, $regs)) {
+        if (preg_match(static::$_cache['uninflected'], $word, $regs)) {
             static::$_cache['pluralize'][$word] = $word;
 
             return $word;
@@ -324,30 +323,29 @@ class Inflector
         }
 
         if (!isset(static::$_cache['irregular']['singular'])) {
-            static::$_cache['irregular']['singular'] = '(?:' . implode('|', static::$_irregular) . ')';
+            $wordList = array_values(static::$_irregular);
+            static::$_cache['irregular']['singular'] = '/(.*?(?:\\b|_))(' . implode('|', $wordList) . ')$/i';
+
+            $upperWordList = array_map('ucfirst', $wordList);
+            static::$_cache['irregular']['singularUpper'] = '/(.*?(?:\\b|[a-z]))(' . implode('|', $upperWordList) . ')$/';
         }
 
-        $inflection = static::_detectInflection($word);
-        $normalizedWord = $word;
-        if ($inflection) {
-            $normalizedWord = Inflector::underscore($word);
-        }
-
-        if (preg_match('/(.*?(?:\\b|_))(' . static::$_cache['irregular']['singular'] . ')$/i', $normalizedWord, $regs)) {
+        if (
+            preg_match(static::$_cache['irregular']['singular'], $word, $regs) ||
+            preg_match(static::$_cache['irregular']['singularUpper'], $word, $regs)
+        ) {
             $suffix = array_search(strtolower($regs[2]), static::$_irregular, true);
             $suffix = $suffix ? substr($suffix, 1) : '';
-            $result = $regs[1] . substr($regs[2], 0, 1) . $suffix;
-
-            static::$_cache['singularize'][$word] = $inflection ? Inflector::$inflection($result) : $result;
+            static::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . $suffix;
 
             return static::$_cache['singularize'][$word];
         }
 
         if (!isset(static::$_cache['uninflected'])) {
-            static::$_cache['uninflected'] = '(?:' . implode('|', static::$_uninflected) . ')';
+            static::$_cache['uninflected'] = '/^(' . implode('|', static::$_uninflected) . ')$/i';
         }
 
-        if (preg_match('/^(' . static::$_cache['uninflected'] . ')$/i', $word, $regs)) {
+        if (preg_match(static::$_cache['uninflected'], $word, $regs)) {
             static::$_cache['pluralize'][$word] = $word;
 
             return $word;

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -503,6 +503,7 @@ class InflectorTest extends TestCase
         $this->assertSame('test_criteria', Inflector::pluralize('test_criterion'));
         $this->assertSame('Criteria', Inflector::pluralize('Criterion'));
         $this->assertSame('TestCriteria', Inflector::pluralize('TestCriterion'));
+        $this->assertSame('Test Criteria', Inflector::pluralize('Test Criterion'));
     }
 
     /**
@@ -530,6 +531,7 @@ class InflectorTest extends TestCase
         $this->assertSame('test_criterion', Inflector::singularize('test_criteria'));
         $this->assertSame('Criterion', Inflector::singularize('Criteria'));
         $this->assertSame('TestCriterion', Inflector::singularize('TestCriteria'));
+        $this->assertSame('Test Criterion', Inflector::singularize('Test Criteria'));
     }
 
     /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -525,6 +525,11 @@ class InflectorTest extends TestCase
         $this->assertSame('inflecta', Inflector::singularize('inflectors'));
         $this->assertSame('contributa', Inflector::singularize('contributors'));
         $this->assertSame('singulars', Inflector::singularize('singulars'));
+
+        $this->assertSame('criterion', Inflector::singularize('criteria'));
+        $this->assertSame('test_criterion', Inflector::singularize('test_criteria'));
+        $this->assertSame('Criterion', Inflector::singularize('Criteria'));
+        $this->assertSame('TestCriterion', Inflector::singularize('TestCriteria'));
     }
 
     /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -498,6 +498,11 @@ class InflectorTest extends TestCase
         $this->assertSame('alertables', Inflector::pluralize('alert'));
         $this->assertSame('amazable', Inflector::pluralize('amaze'));
         $this->assertSame('phonezes', Inflector::pluralize('phone'));
+
+        $this->assertSame('criteria', Inflector::pluralize('criterion'));
+        $this->assertSame('test_criteria', Inflector::pluralize('test_criterion'));
+        $this->assertSame('Criteria', Inflector::pluralize('Criterion'));
+        $this->assertSame('TestCriteria', Inflector::pluralize('TestCriterion'));
     }
 
     /**


### PR DESCRIPTION
Tests for https://github.com/cakephp/cakephp/issues/14665

It shows that only the CamelCase versions have issues around multi words.
Probably due to the regex used.

Only this one fails for plural:

    $this->assertSame('TestCriteria', Inflector::pluralize('TestCriterion'));

And this one for singular:

    $this->assertSame('TestCriterion', Inflector::singularize('TestCriteria'));