### PR TITLE
3.next backports

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -12,9 +12,13 @@
  * @since         0.2.9
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 use Cake\Routing\Router;
 
-define('TIME_START', microtime(true));
+/**
+ * @var float
+ */
+define('TIME_START', (float)microtime(true));
 
 require CAKE . 'basics.php';
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,7 +26,6 @@ parameters:
         - '#PHPDoc tag @throws with type PHPUnit\\Exception is not subtype of Throwable#'
         - '#Call to an undefined method DOMNode::setAttribute\(\)#'
         - '#Binary operation "\+" between array|false and array results in an error#'
-        - '#Result of method Cake\\Auth\\BaseAuthenticate::unauthenticated\(\) \(void\) is used#'
         - '#Call to an undefined method DateTimeInterface::setTimezone\(\)#'
         - '#Access to undefined constant NumberFormatter::CURRENCY_ACCOUNTING#'
         - '#Class APCuIterator referenced with incorrect case: APCUIterator#'

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -253,7 +253,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
      *
      * @param \Cake\Http\ServerRequest $request A request object.
      * @param \Cake\Http\Response $response A response object.
-     * @return void
+     * @return \Cake\Http\Response|null|void
      */
     public function unauthenticated(ServerRequest $request, Response $response)
     {

--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -92,9 +92,10 @@ class BasicAuthenticate extends BaseAuthenticate
      */
     public function unauthenticated(ServerRequest $request, Response $response)
     {
-        $Exception = new UnauthorizedException();
-        $Exception->responseHeader($this->loginHeaders($request));
-        throw $Exception;
+        $unauthorizedException = new UnauthorizedException();
+        $unauthorizedException->responseHeader($this->loginHeaders($request));
+
+        throw $unauthorizedException;
     }
 
     /**

--- a/src/Auth/FallbackPasswordHasher.php
+++ b/src/Auth/FallbackPasswordHasher.php
@@ -61,7 +61,7 @@ class FallbackPasswordHasher extends AbstractPasswordHasher
      * Uses the first password hasher in the list to generate the hash
      *
      * @param string $password Plain text password to hash.
-     * @return string|false Password hash
+     * @return string|false Password hash or false
      */
     public function hash($password)
     {

--- a/src/Auth/Storage/StorageInterface.php
+++ b/src/Auth/Storage/StorageInterface.php
@@ -17,6 +17,8 @@ namespace Cake\Auth\Storage;
 /**
  * Describes the methods that any class representing an Auth data storage should
  * comply with.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 interface StorageInterface
 {

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -147,7 +147,7 @@ abstract class CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to add
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     abstract public function increment($key, $offset = 1);
 
@@ -156,7 +156,7 @@ abstract class CacheEngine
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     abstract public function decrement($key, $offset = 1);
 

--- a/src/Cache/CacheEngineInterface.php
+++ b/src/Cache/CacheEngineInterface.php
@@ -40,7 +40,7 @@ interface CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to add
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function increment($key, $offset = 1);
 
@@ -49,7 +49,7 @@ interface CacheEngineInterface
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
-     * @return bool|int New incremented value, false otherwise
+     * @return int|false New incremented value, false otherwise
      */
     public function decrement($key, $offset = 1);
 

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -23,6 +23,8 @@ use RuntimeException;
  * An object registry for cache engines.
  *
  * Used by Cake\Cache\Cache to load and manage cache engines.
+ *
+ * @extends \Cake\Core\ObjectRegistry<\Cake\Cache\CacheEngine>
  */
 class CacheRegistry extends ObjectRegistry
 {

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -41,7 +41,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      *
      * @param callable $c callable function that will receive each of the elements
      * in this collection
-     * @return \Cake\Collection\CollectionInterface
+     * @return $this
      */
     public function each(callable $c);
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -123,7 +123,7 @@ class CommandRunner implements EventDispatcherInterface
      * - Run the requested command.
      *
      * @param array $argv The arguments from the CLI environment.
-     * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance. Used primarily for testing.
+     * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo instance. Used primarily for testing.
      * @return int The exit code of the command.
      * @throws \RuntimeException
      */
@@ -327,9 +327,9 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @param \Cake\Console\CommandCollection $commands The command collection to check.
      * @param \Cake\Console\ConsoleIo $io ConsoleIo object for errors.
-     * @param string $name The name
-     * @return string The resolved class name
-     * @throws \RuntimeException
+     * @param string|null $name The name from the CLI args.
+     * @return string The resolved name.
+     * @throws \Cake\Console\Exception\MissingOptionException
      */
     protected function resolveName($commands, $io, $name)
     {
@@ -359,7 +359,7 @@ class CommandRunner implements EventDispatcherInterface
      * @param \Cake\Console\Command $command The command to run.
      * @param array $argv The CLI arguments to invoke.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int Exit code
+     * @return int|null Exit code
      */
     protected function runCommand(Command $command, array $argv, ConsoleIo $io)
     {
@@ -375,7 +375,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @param \Cake\Console\Shell $shell The shell to run.
      * @param array $argv The CLI arguments to invoke.
-     * @return int Exit code
+     * @return int|bool|null Exit code
      */
     protected function runShell(Shell $shell, array $argv)
     {
@@ -384,7 +384,9 @@ class CommandRunner implements EventDispatcherInterface
 
             return $shell->runCommand($argv, true);
         } catch (StopException $e) {
-            return $e->getCode();
+            $code = $e->getCode();
+
+            return $code === null ? $code : (int)$code;
         }
     }
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -329,7 +329,6 @@ class CommandRunner implements EventDispatcherInterface
      * @param \Cake\Console\ConsoleIo $io ConsoleIo object for errors.
      * @param string|null $name The name from the CLI args.
      * @return string The resolved name.
-     * @throws \Cake\Console\Exception\MissingOptionException
      */
     protected function resolveName($commands, $io, $name)
     {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -240,7 +240,7 @@ class PaginatorComponent extends Component
      * Set paginator instance.
      *
      * @param \Cake\Datasource\Paginator $paginator Paginator instance.
-     * @return self
+     * @return $this
      */
     public function setPaginator(Paginator $paginator)
     {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -57,7 +57,7 @@ class RequestHandlerComponent extends Component
     public $ext;
 
     /**
-     * The template to use when rendering the given content type.
+     * The template type to use when rendering the given content type.
      *
      * @var string|null
      */

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -64,12 +64,14 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * Set the controller associated with the collection.
      *
      * @param \Cake\Controller\Controller $controller Controller instance.
-     * @return void
+     * @return $this
      */
     public function setController(Controller $controller)
     {
         $this->_Controller = $controller;
         $this->setEventManager($controller->getEventManager());
+
+        return $this;
     }
 
     /**

--- a/src/Controller/Exception/SecurityException.php
+++ b/src/Controller/Exception/SecurityException.php
@@ -29,7 +29,7 @@ class SecurityException extends BadRequestException
     /**
      * Reason for request blackhole
      *
-     * @var string
+     * @var string|null
      */
     protected $_reason;
 
@@ -58,17 +58,19 @@ class SecurityException extends BadRequestException
      * Set Reason
      *
      * @param string|null $reason Reason details
-     * @return void
+     * @return $this
      */
     public function setReason($reason = null)
     {
         $this->_reason = $reason;
+
+        return $this;
     }
 
     /**
      * Get Reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {

--- a/src/Core/ClassLoader.php
+++ b/src/Core/ClassLoader.php
@@ -96,7 +96,7 @@ class ClassLoader
      *
      * @param string $prefix The namespace prefix.
      * @param string $relativeClass The relative class name.
-     * @return mixed Boolean false if no mapped file can be loaded, or the
+     * @return string|false Boolean false if no mapped file can be loaded, or the
      * name of the mapped file that was loaded.
      */
     protected function _loadMappedFile($prefix, $relativeClass)

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -40,7 +40,7 @@ use Cake\Core\Exception\Exception;
  * ];
  * ```
  *
- * @see Cake\Core\Configure::load() for how to load custom configuration files.
+ * @see \Cake\Core\Configure::load() for how to load custom configuration files.
  */
 class PhpConfig implements ConfigEngineInterface
 {

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -16,6 +16,8 @@ use RuntimeException;
 
 /**
  * Base class that all CakePHP Exceptions extend.
+ *
+ * @method int getCode()
  */
 class Exception extends RuntimeException
 {
@@ -91,7 +93,7 @@ class Exception extends RuntimeException
      *  - an associative array of "header name" => "header value"
      *  - an array of string headers is also accepted (deprecated)
      * @param string|null $value The header value.
-     * @return array
+     * @return array|null
      */
     public function responseHeader($header = null, $value = null)
     {

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -246,7 +246,7 @@ class Plugin
      * Returns the filesystem path for plugin's folder containing class folders.
      *
      * @param string $name name of the plugin in CamelCase format.
-     * @return string Path to the plugin folder container class folders.
+     * @return string Path to the plugin folder containing class files.
      * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
      */
     public static function classPath($name)
@@ -260,7 +260,7 @@ class Plugin
      * Returns the filesystem path for plugin's folder containing config files.
      *
      * @param string $name name of the plugin in CamelCase format.
-     * @return string Path to the plugin folder container config files.
+     * @return string Path to the plugin folder containing config files.
      * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
      */
     public static function configPath($name)

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -302,7 +302,7 @@ class Plugin
      * Loads the routes file for a plugin, or all plugins configured to load their respective routes file.
      *
      * If you need fine grained control over how routes are loaded for plugins, you
-     * can use {@see Cake\Routing\RouteBuilder::loadPlugin()}
+     * can use {@see \Cake\Routing\RouteBuilder::loadPlugin()}
      *
      * @param string|null $name name of the plugin, if null will operate on all
      *   plugins having enabled the loading of routes files.

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -44,7 +44,7 @@ class PluginCollection implements Iterator, Countable
     /**
      * Names of plugins
      *
-     * @var array
+     * @var string[]
      */
     protected $names = [];
 

--- a/src/Core/Retry/RetryStrategyInterface.php
+++ b/src/Core/Retry/RetryStrategyInterface.php
@@ -25,7 +25,7 @@ interface RetryStrategyInterface
     /**
      * Returns true if the action can be retried, false otherwise.
      *
-     * @param Exception $exception The exception that caused the action to fail
+     * @param \Exception $exception The exception that caused the action to fail
      * @param int $retryCount The number of times the action has been already called
      * @return bool Whether or not it is OK to retry the action
      */

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -70,7 +70,7 @@ class Comparison implements ExpressionInterface, FieldInterface
      *
      * @param string|\Cake\Database\ExpressionInterface $field the field name to compare to a value
      * @param mixed $value The value to be used in comparison
-     * @param string $type the type name used to cast the value
+     * @param string|null $type the type name used to cast the value
      * @param string $operator the operator used for comparing field and value
      */
     public function __construct($field, $value, $type, $operator)

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -192,7 +192,7 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type to fetch.
+     * @param int|string $type The type to fetch.
      * @return array|false
      */
     public function fetch($type = self::FETCH_TYPE_NUM)

--- a/src/Database/Statement/CallbackStatement.php
+++ b/src/Database/Statement/CallbackStatement.php
@@ -47,7 +47,7 @@ class CallbackStatement extends StatementDecorator
      *
      * The result will be processed by the callback when it is not `false`.
      *
-     * @param string $type Either 'num' or 'assoc' to indicate the result format you would like.
+     * @param string|int $type Either 'num' or 'assoc' to indicate the result format you would like.
      * @return array|false
      */
     public function fetch($type = parent::FETCH_TYPE_NUM)
@@ -63,7 +63,7 @@ class CallbackStatement extends StatementDecorator
      *
      * Each row in the result will be processed by the callback when it is not `false.
      *
-     * @param string $type Either 'num' or 'assoc' to indicate the result format you would like.
+     * @param string|int $type Either 'num' or 'assoc' to indicate the result format you would like.
      * @return array
      */
     public function fetchAll($type = parent::FETCH_TYPE_NUM)

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -35,6 +35,7 @@ class Basic
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
+            /** @var \Cake\Http\Client\Request $request */
             $request = $request->withHeader('Authorization', $value);
         }
 
@@ -53,6 +54,7 @@ class Basic
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
+            /** @var \Cake\Http\Client\Request $request */
             $request = $request->withHeader('Proxy-Authorization', $value);
         }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -42,8 +42,8 @@ use InvalidArgumentException;
  *
  * @link https://tools.ietf.org/html/rfc6265
  * @link https://en.wikipedia.org/wiki/HTTP_cookie
- * @see Cake\Http\Cookie\CookieCollection for working with collections of cookies.
- * @see Cake\Http\Response::getCookieCollection() for working with response cookies.
+ * @see \Cake\Http\Cookie\CookieCollection for working with collections of cookies.
+ * @see \Cake\Http\Response::getCookieCollection() for working with response cookies.
  */
 class Cookie implements CookieInterface
 {

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -75,7 +75,7 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Method used to read from a cache session.
      *
-     * @param string|int $id ID that uniquely identifies session in cache.
+     * @param string $id ID that uniquely identifies session in cache.
      * @return string Session data or empty string if it does not exist.
      */
     public function read($id)
@@ -92,8 +92,8 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Helper function called on write for cache sessions.
      *
-     * @param string|int $id ID that uniquely identifies session in cache.
-     * @param mixed $data The data to be saved.
+     * @param string $id ID that uniquely identifies session in cache.
+     * @param string $data The data to be saved.
      * @return bool True for successful write, false otherwise.
      */
     public function write($id, $data)
@@ -108,7 +108,7 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Method called on the destruction of a cache session.
      *
-     * @param string|int $id ID that uniquely identifies session in cache.
+     * @param string $id ID that uniquely identifies session in cache.
      * @return bool Always true.
      */
     public function destroy($id)

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -139,7 +139,7 @@ trait DateFormatTrait
      */
     public function nice($timezone = null, $locale = null)
     {
-        return $this->i18nFormat(static::$niceFormat, $timezone, $locale);
+        return (string)$this->i18nFormat(static::$niceFormat, $timezone, $locale);
     }
 
     /**
@@ -188,7 +188,7 @@ trait DateFormatTrait
      * You can control the default locale used through `Time::setDefaultLocale()`.
      * If empty, the default will be taken from the `intl.default_locale` ini config.
      *
-     * @param string|int|null $format Format string.
+     * @param string|int|array|null $format Format string.
      * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed. The timezone stored for this object will not
      * be changed.
@@ -219,7 +219,7 @@ trait DateFormatTrait
      * Returns a translated and localized date string.
      * Implements what IntlDateFormatter::formatObject() is in PHP 5.5+
      *
-     * @param \DateTime $date Date.
+     * @param \DateTime|\DateTimeImmutable $date Date.
      * @param string|int|array $format Format.
      * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
@@ -258,11 +258,11 @@ trait DateFormatTrait
             }
             $formatter = datefmt_create(
                 $locale,
-                $dateFormat,
-                $timeFormat,
+                (int)$dateFormat,
+                (int)$timeFormat,
                 $timezone,
                 $calendar,
-                $pattern
+                (string)$pattern
             );
             if (!$formatter) {
                 throw new RuntimeException(
@@ -281,7 +281,7 @@ trait DateFormatTrait
      */
     public function __toString()
     {
-        return $this->i18nFormat();
+        return (string)$this->i18nFormat();
     }
 
     /**
@@ -505,7 +505,7 @@ trait DateFormatTrait
         return [
             'time' => $this->format('Y-m-d H:i:s.uP'),
             'timezone' => $this->getTimezone()->getName(),
-            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->format('Y-m-d H:i:s.uP') : false,
+            'fixedNowTime' => static::hasTestNow() ? static::getTestNow()->format('Y-m-d\TH:i:s.uP') : false,
         ];
     }
 }

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -145,7 +145,7 @@ class MessagesFileLoader
      * Returns the folders where the file should be looked for according to the locale
      * and package name.
      *
-     * @return array The list of folders where the translation file should be looked for
+     * @return string[] The list of folders where the translation file should be looked for
      */
     public function translationsFolders()
     {

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -75,7 +75,7 @@ class Number
      *
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param float $value A floating point number.
+     * @param float|string $value A floating point number.
      * @param int $precision The precision of the returned number.
      * @param array $options Additional options
      * @return string Formatted float.
@@ -91,12 +91,14 @@ class Number
     /**
      * Returns a formatted-for-humans file size.
      *
-     * @param int $size Size in bytes
+     * @param int|string $size Size in bytes
      * @return string Human readable size
      * @link https://book.cakephp.org/3/en/core-libraries/number.html#interacting-with-human-readable-values
      */
     public static function toReadableSize($size)
     {
+        $size = (int)$size;
+
         switch (true) {
             case $size < 1024:
                 return __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size);
@@ -119,7 +121,7 @@ class Number
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param float $value A floating point number
+     * @param float|string $value A floating point number
      * @param int $precision The precision of the returned number
      * @param array $options Options
      * @return string Percentage string
@@ -147,7 +149,7 @@ class Number
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
      *
-     * @param float $value A floating point number.
+     * @param float|string $value A floating point number.
      * @param array $options An array with options.
      * @return string Formatted number
      */
@@ -156,7 +158,7 @@ class Number
         $formatter = static::formatter($options);
         $options += ['before' => '', 'after' => ''];
 
-        return $options['before'] . $formatter->format($value) . $options['after'];
+        return $options['before'] . $formatter->format((float)$value) . $options['after'];
     }
 
     /**
@@ -190,14 +192,14 @@ class Number
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
      *
-     * @param float $value A floating point number
+     * @param float|string $value A floating point number
      * @param array $options Options list.
      * @return string formatted delta
      */
     public static function formatDelta($value, array $options = [])
     {
         $options += ['places' => 0];
-        $value = number_format($value, $options['places'], '.', '');
+        $value = number_format((float)$value, $options['places'], '.', '');
         $sign = $value > 0 ? '+' : '';
         $options['before'] = isset($options['before']) ? $options['before'] . $sign : $sign;
 
@@ -222,7 +224,7 @@ class Number
      * - `useIntlCode` - Whether or not to replace the currency symbol with the international
      *   currency code.
      *
-     * @param float $value Value to format.
+     * @param float|string $value Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array $options Options list.
      * @return string Number formatted as a currency.

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -17,7 +17,7 @@ namespace Cake\I18n\Parser;
 use RuntimeException;
 
 /**
- * Parses file in PO format
+ * Parses file in MO format
  *
  * @copyright Copyright (c) 2010, Union of RAD http://union-of-rad.org (http://lithify.me/)
  * @copyright Copyright (c) 2014, Fabien Potencier https://github.com/symfony/Translation/blob/master/LICENSE
@@ -67,9 +67,9 @@ class MoFileParser
         $magic = unpack('V1', fread($stream, 4));
         $magic = hexdec(substr(dechex(current($magic)), -8));
 
-        if ($magic == self::MO_LITTLE_ENDIAN_MAGIC) {
+        if ($magic === self::MO_LITTLE_ENDIAN_MAGIC) {
             $isBigEndian = false;
-        } elseif ($magic == self::MO_BIG_ENDIAN_MAGIC) {
+        } elseif ($magic === self::MO_BIG_ENDIAN_MAGIC) {
             $isBigEndian = true;
         } else {
             throw new RuntimeException('Invalid format for MO translations file');
@@ -155,6 +155,6 @@ class MoFileParser
         $result = unpack($isBigEndian ? 'N1' : 'V1', fread($stream, 4));
         $result = current($result);
 
-        return (int)substr($result, -8);
+        return (int)substr((string)$result, -8);
     }
 }

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -163,7 +163,7 @@ class PoFileParser
 
             // Make sure every index is filled.
             end($plurals);
-            $count = key($plurals);
+            $count = (int)key($plurals);
 
             // Fill missing spots with an empty string.
             $empties = array_fill(0, $count + 1, '');

--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\I18n;
 
+use Cake\Core\Exception\Exception;
+
 /**
  * Utility class used to determine the plural number to be used for a variable
  * base on the locale
@@ -150,50 +152,52 @@ class PluralRules
             case 0:
                 return 0;
             case 1:
-                return $n == 1 ? 0 : 1;
+                return $n === 1 ? 0 : 1;
             case 2:
                 return $n > 1 ? 1 : 0;
             case 3:
-                return $n % 10 == 1 && $n % 100 != 11 ? 0 :
+                return $n % 10 === 1 && $n % 100 !== 11 ? 0 :
                     (($n % 10 >= 2 && $n % 10 <= 4) && ($n % 100 < 10 || $n % 100 >= 20) ? 1 : 2);
             case 4:
-                return $n == 1 ? 0 :
+                return $n === 1 ? 0 :
                     ($n >= 2 && $n <= 4 ? 1 : 2);
             case 5:
-                return $n == 1 ? 0 :
-                    ($n == 2 ? 1 : ($n < 7 ? 2 : ($n < 11 ? 3 : 4)));
+                return $n === 1 ? 0 :
+                    ($n === 2 ? 1 : ($n < 7 ? 2 : ($n < 11 ? 3 : 4)));
             case 6:
-                return $n % 10 == 1 && $n % 100 != 11 ? 0 :
+                return $n % 10 === 1 && $n % 100 !== 11 ? 0 :
                     ($n % 10 >= 2 && ($n % 100 < 10 || $n % 100 >= 20) ? 1 : 2);
             case 7:
-                return $n % 100 == 1 ? 1 :
-                    ($n % 100 == 2 ? 2 : ($n % 100 == 3 || $n % 100 == 4 ? 3 : 0));
+                return $n % 100 === 1 ? 1 :
+                    ($n % 100 === 2 ? 2 : ($n % 100 === 3 || $n % 100 === 4 ? 3 : 0));
             case 8:
-                return $n % 10 == 1 ? 0 : ($n % 10 == 2 ? 1 : 2);
+                return $n % 10 === 1 ? 0 : ($n % 10 === 2 ? 1 : 2);
             case 9:
-                return $n == 1 ? 0 :
-                    ($n == 0 || ($n % 100 > 0 && $n % 100 <= 10) ? 1 :
+                return $n === 1 ? 0 :
+                    ($n === 0 || ($n % 100 > 0 && $n % 100 <= 10) ? 1 :
                     ($n % 100 > 10 && $n % 100 < 20 ? 2 : 3));
             case 10:
-                return $n % 10 == 1 && $n % 100 != 11 ? 0 : ($n != 0 ? 1 : 2);
+                return $n % 10 === 1 && $n % 100 !== 11 ? 0 : ($n !== 0 ? 1 : 2);
             case 11:
-                return $n == 1 ? 0 :
+                return $n === 1 ? 0 :
                     ($n % 10 >= 2 && $n % 10 <= 4 && ($n % 100 < 10 || $n % 100 >= 20) ? 1 : 2);
             case 12:
-                return $n == 1 ? 0 :
-                    ($n == 0 || $n % 100 > 0 && $n % 100 < 20 ? 1 : 2);
+                return $n === 1 ? 0 :
+                    ($n === 0 || $n % 100 > 0 && $n % 100 < 20 ? 1 : 2);
             case 13:
-                return $n == 0 ? 0 :
-                    ($n == 1 ? 1 :
-                    ($n == 2 ? 2 :
+                return $n === 0 ? 0 :
+                    ($n === 1 ? 1 :
+                    ($n === 2 ? 2 :
                     ($n % 100 >= 3 && $n % 100 <= 10 ? 3 :
                     ($n % 100 >= 11 ? 4 : 5))));
             case 14:
-                return $n == 1 ? 0 :
-                    ($n == 2 ? 1 :
-                    ($n != 8 && $n != 11 ? 2 : 3));
+                return $n === 1 ? 0 :
+                    ($n === 2 ? 1 :
+                    ($n !== 8 && $n !== 11 ? 2 : 3));
             case 15:
-                return ($n % 10 != 1 || $n % 100 == 11) ? 1 : 0;
+                return $n % 10 !== 1 || $n % 100 === 11 ? 1 : 0;
         }
+
+        throw new Exception('Unable to find plural rule number.');
     }
 }

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -93,7 +93,7 @@ class Translator extends BaseTranslator
      * @param string $key The message key being handled.
      * @param string|array $message The message content.
      * @param array $vars The variables containing the `_context` key.
-     * @return string
+     * @return string|array
      */
     protected function resolveContext($key, $message, array $vars)
     {

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -75,7 +75,7 @@ class Translator extends BaseTranslator
 
         // Resolve plural form.
         if (is_array($message)) {
-            $count = isset($tokensValues['_count']) ? $tokensValues['_count'] : 0;
+            $count = isset($tokensValues['_count']) ? (int)$tokensValues['_count'] : 0;
             $form = PluralRules::calculate($this->locale, $count);
             $message = isset($message[$form]) ? $message[$form] : (string)end($message);
         }

--- a/src/I18n/TranslatorFactory.php
+++ b/src/I18n/TranslatorFactory.php
@@ -32,7 +32,7 @@ class TranslatorFactory extends BaseTranslatorFactory
      *
      * @var string
      */
-    protected $class = 'Cake\I18n\Translator';
+    protected $class = Translator::class;
 
     /**
      * Returns a new Translator.

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -118,7 +118,7 @@ class TranslatorRegistry extends TranslatorLocator
     /**
      * Gets a translator from the registry by package for a locale.
      *
-     * @param string $name The translator package to retrieve.
+     * @param string|null $name The translator package to retrieve.
      * @param string|null $locale The locale to use; if empty, uses the default
      * locale.
      * @return \Aura\Intl\TranslatorInterface|null A translator object.

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -12,6 +12,7 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 use Cake\I18n\I18n;
 
 if (!function_exists('__')) {

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -43,7 +43,7 @@ class BelongsTo extends Association
     /**
      * Gets the name of the field representing the foreign key to the target table.
      *
-     * @return string
+     * @return string|string[]
      */
     public function getForeignKey()
     {
@@ -142,7 +142,7 @@ class BelongsTo extends Association
      * clause for getting the results on the target table.
      *
      * @param array $options list of options passed to attachTo method
-     * @return array
+     * @return \Cake\Database\Expression\IdentifierExpression[]
      * @throws \RuntimeException if the number of columns in the foreignKey do not
      * match the number of columns in the target table primaryKey
      */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -220,7 +220,7 @@ class BelongsToMany extends Association
     /**
      * Gets the name of the field representing the foreign key to the source table.
      *
-     * @return string
+     * @return string|string[]
      */
     public function getForeignKey()
     {

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -306,8 +306,8 @@ class Behavior implements EventListenerInterface
      *  ]
      * ```
      *
-     * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
-     * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
+     * With the above example, a call to `$table->find('this')` will call `$behavior->findThis()`
+     * and a call to `$table->find('alias')` will call `$behavior->findMethodName()`
      *
      * It is recommended, though not required, to define implementedFinders in the config property
      * of child classes such that it is not necessary to use reflections to derive the available

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -27,6 +27,8 @@ use LogicException;
  * and constructing behavior objects.
  *
  * This class also provides method for checking and dispatching behavior methods.
+ *
+ * @extends \Cake\Core\ObjectRegistry<\Cake\ORM\Behavior>
  */
 class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterface
 {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -158,6 +158,14 @@ class Marshaller
      * ]);
      * ```
      *
+     * ```
+     * $result = $marshaller->one($data, [
+     *   'associated' => [
+     *     'Tags' => ['accessibleFields' => ['*' => true]]
+     *   ]
+     * ]);
+     * ```
+     *
      * @param array $data The data to hydrate.
      * @param array $options List of options
      * @return \Cake\Datasource\EntityInterface
@@ -309,10 +317,11 @@ class Marshaller
         $targetTable = $assoc->getTarget();
         $marshaller = $targetTable->marshaller();
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
-        if (in_array($assoc->type(), $types, true)) {
+        $type = $assoc->type();
+        if (in_array($type, $types, true)) {
             return $marshaller->one($value, (array)$options);
         }
-        if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
+        if ($type === Association::ONE_TO_MANY || $type === Association::MANY_TO_MANY) {
             $hasIds = array_key_exists('_ids', $value);
             $onlyIds = array_key_exists('onlyIds', $options) && $options['onlyIds'];
 
@@ -323,7 +332,7 @@ class Marshaller
                 return [];
             }
         }
-        if ($assoc->type() === Association::MANY_TO_MANY) {
+        if ($type === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
 
@@ -750,14 +759,17 @@ class Marshaller
         $targetTable = $assoc->getTarget();
         $marshaller = $targetTable->marshaller();
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
-        if (in_array($assoc->type(), $types, true)) {
+        $type = $assoc->type();
+        if (in_array($type, $types, true)) {
+            /** @psalm-suppress PossiblyInvalidArgument */
             return $marshaller->merge($original, $value, (array)$options);
         }
-        if ($assoc->type() === Association::MANY_TO_MANY) {
+        if ($type === Association::MANY_TO_MANY) {
+            /** @psalm-suppress PossiblyInvalidArgument */
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
         }
 
-        if ($assoc->type() === Association::ONE_TO_MANY) {
+        if ($type === Association::ONE_TO_MANY) {
             $hasIds = array_key_exists('_ids', $value);
             $onlyIds = array_key_exists('onlyIds', $options) && $options['onlyIds'];
             if ($hasIds && is_array($value['_ids'])) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -123,7 +123,7 @@ class ResultSet implements ResultSetInterface
     /**
      * Tracks value of $_autoFields property of $query passed to constructor.
      *
-     * @var bool
+     * @var bool|null
      */
     protected $_autoFields;
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -58,7 +58,7 @@ class Router
      * Contains the base string that will be applied to all generated URLs
      * For example `https://example.com`
      *
-     * @var string
+     * @var string|null
      */
     protected static $_fullBaseUrl;
 

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -133,12 +133,12 @@ class ProgressHelper extends Helper
         $barLen = ($this->_width - $numberLen) * ($this->_progress / $this->_total);
         $bar = '';
         if ($barLen > 1) {
-            $bar = str_repeat('=', $barLen - 1) . '>';
+            $bar = str_repeat('=', (int)$barLen - 1) . '>';
         }
 
         $pad = ceil($this->_width - $numberLen - $barLen);
         if ($pad > 0) {
-            $bar .= str_repeat(' ', $pad);
+            $bar .= str_repeat(' ', (int)$pad);
         }
         $percent = ($complete * 100) . '%';
         $bar .= str_pad($percent, $numberLen, ' ', STR_PAD_LEFT);

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -56,11 +56,15 @@ class TableHelper extends Helper
     /**
      * Get the width of a cell exclusive of style tags.
      *
-     * @param string $text The text to calculate a width for.
+     * @param string|null $text The text to calculate a width for.
      * @return int The width of the textual content in visible characters.
      */
     protected function _cellWidth($text)
     {
+        if ($text === null) {
+            return 0;
+        }
+
         if (strpos($text, '<') === false && strpos($text, '>') === false) {
             return mb_strwidth($text);
         }

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -81,9 +81,9 @@ class CommandTask extends Shell
      * Scan the provided paths for shells, and append them into $shellList
      *
      * @param string $type The type of object.
-     * @param array $shells The shell name.
+     * @param string[] $shells The shell names.
      * @param array $shellList List of shells.
-     * @param array $skip List of command names to skip.
+     * @param string[] $skip List of command names to skip.
      * @return array The updated $shellList
      */
     protected function _appendShells($type, $shells, $shellList, $skip)

--- a/src/TestSuite/TestEmailTransport.php
+++ b/src/TestSuite/TestEmailTransport.php
@@ -23,7 +23,7 @@ use Cake\Mailer\Transport\DebugTransport;
  *
  * Set this as the email transport to capture emails for later assertions
  *
- * @see Cake\TestSuite\EmailTrait
+ * @see \Cake\TestSuite\EmailTrait
  */
 class TestEmailTransport extends DebugTransport
 {

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -42,8 +42,8 @@ trait CookieCryptTrait
     /**
      * Encrypts $value using public $type method in Security class
      *
-     * @param string $value Value to encrypt
-     * @param string|bool $encrypt Encryption mode to use. False
+     * @param string|array $value Value to encrypt
+     * @param string|false $encrypt Encryption mode to use. False
      *   disabled encryption.
      * @param string|null $key Used as the security salt if specified.
      * @return string Encoded values
@@ -94,7 +94,7 @@ trait CookieCryptTrait
      * Decrypts $value using public $type method in Security class
      *
      * @param string[]|string $values Values to decrypt
-     * @param string|bool $mode Encryption mode
+     * @param string|false $mode Encryption mode
      * @param string|null $key Used as the security salt if specified.
      * @return string|array Decrypted values
      */

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -20,7 +20,7 @@ namespace Cake\Utility\Crypto;
  * This class is not intended to be used directly and should only
  * be used in the context of Cake\Utility\Security.
  *
- * @deprecated 3.3.0 It is recommended to use {@see Cake\Utility\Crypto\OpenSsl} instead.
+ * @deprecated 3.3.0 It is recommended to use {@see \Cake\Utility\Crypto\OpenSsl} instead.
  * @internal
  */
 class Mcrypt

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -37,7 +37,7 @@ class Hash
      *
      * @param array|\ArrayAccess $data Array of data or object implementing
      *   \ArrayAccess interface to operate on.
-     * @param string|array $path The path being searched for. Either a dot
+     * @param string|int|string[]|null $path The path being searched for. Either a dot
      *   separated string, or an array of path segments.
      * @param mixed $default The return value when the path does not exist
      * @throws \InvalidArgumentException
@@ -57,7 +57,7 @@ class Hash
         }
 
         if (is_string($path) || is_numeric($path)) {
-            $parts = explode('.', $path);
+            $parts = explode('.', (string)$path);
         } else {
             if (!is_array($path)) {
                 throw new InvalidArgumentException(sprintf(
@@ -105,7 +105,7 @@ class Hash
      *  - `>`, `<`, `>=`, `<=` Value comparison.
      *  - `=/.../` Regular expression pattern match.
      *
-     * Given a set of User array data, from a `$User->find('all')` call:
+     * Given a set of User array data, from a `$usersTable->find('all')` call:
      *
      * - `1.User.name` Get the name of the user at index 1.
      * - `{n}.User.name` Get the name of every user in the set of users.
@@ -348,7 +348,7 @@ class Hash
      *
      * @param string $op The operation to do.
      * @param array $data The data to operate on.
-     * @param array $path The path to work on.
+     * @param string[] $path The path to work on.
      * @param mixed $values The values to insert when doing inserts.
      * @return array data.
      */
@@ -386,6 +386,8 @@ class Hash
                 $_list =& $_list[$key];
             }
         }
+
+        return $data;
     }
 
     /**
@@ -536,10 +538,10 @@ class Hash
      * The `$format` string can use any format options that `vsprintf()` and `sprintf()` do.
      *
      * @param array $data Source array from which to extract the data
-     * @param array $paths An array containing one or more Hash::extract()-style key paths
+     * @param string[] $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
-     * @return array|null An array of strings extracted from `$path` and formatted with `$format`
-     * @link https://book.cakephp.org/3/en/core-libraries/hash.html#Cake\Utility\Hash::format
+     * @return string[]|null An array of strings extracted from `$path` and formatted with `$format`
+     * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::format
      * @see sprintf()
      * @see \Cake\Utility\Hash::extract()
      */
@@ -724,7 +726,7 @@ class Hash
     {
         $result = [];
         foreach ($data as $flat => $value) {
-            $keys = explode($separator, $flat);
+            $keys = explode($separator, (string)$flat);
             $keys = array_reverse($keys);
             $child = [
                 $keys[0] => $value,

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -541,7 +541,7 @@ class Hash
      * @param string[] $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
      * @return string[]|null An array of strings extracted from `$path` and formatted with `$format`
-     * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::format
+     * @link https://book.cakephp.org/3/en/core-libraries/hash.html#Cake\Utility\Hash::format
      * @see sprintf()
      * @see \Cake\Utility\Hash::extract()
      */

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -35,7 +35,7 @@ class Security
     /**
      * The HMAC salt to use for encryption and decryption routines
      *
-     * @var string
+     * @var string|null
      */
     protected static $_salt;
 
@@ -353,6 +353,12 @@ class Security
      */
     public static function getSalt()
     {
+        if (static::$_salt === null) {
+            throw new RuntimeException(
+                'Salt not set. Use Security::setSalt() to set one, ideally in `config/bootstrap.php`.'
+            );
+        }
+
         return static::$_salt;
     }
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Utility;
 
+use Cake\Core\Exception\Exception;
 use InvalidArgumentException;
 
 /**

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -123,7 +123,12 @@ class Xml
         }
 
         if (!is_string($input)) {
-            throw new XmlException('Invalid input.');
+            $type = gettype($input);
+            throw new XmlException("Invalid input. {$type} cannot be parsed as XML.");
+        }
+
+        if (strpos($input, '<') !== false) {
+            return static::_loadXml($input, $options);
         }
 
         throw new XmlException('XML cannot be read.');
@@ -294,7 +299,7 @@ class Xml
      * Recursive method to create childs from array
      *
      * @param \DOMDocument $dom Handler to DOMDocument
-     * @param \DOMElement $node Handler to DOMElement (child)
+     * @param \DOMDocument|\DOMElement $node Handler to DOMElement (child)
      * @param array $data Array of data to append to the $node.
      * @param string $format Either 'attributes' or 'tags'. This determines where nested keys go.
      * @return void
@@ -338,7 +343,7 @@ class Xml
                             $key = substr($key, 1);
                         }
                         $attribute = $dom->createAttribute($key);
-                        $attribute->appendChild($dom->createTextNode($value));
+                        $attribute->appendChild($dom->createTextNode((string)$value));
                         $node->appendChild($attribute);
                     }
                 } else {

--- a/src/Validation/RulesProvider.php
+++ b/src/Validation/RulesProvider.php
@@ -19,6 +19,8 @@ use ReflectionClass;
 /**
  * A Proxy class used to remove any extra arguments when the user intended to call
  * a method in another class that is not aware of validation providers signature
+ *
+ * @method bool extension(mixed $check, array $extensions, array $context = [])
  */
 class RulesProvider
 {
@@ -58,7 +60,7 @@ class RulesProvider
      *
      * @param string $method the validation method to call
      * @param array $arguments the list of arguments to pass to the method
-     * @return bool whether or not the validation rule passed
+     * @return bool Whether or not the validation rule passed
      */
     public function __call($method, $arguments)
     {

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -91,7 +91,7 @@ class BreadcrumbsHelper extends Helper
     /**
      * Prepend a crumb to the start of the queue.
      *
-     * @param string $title If provided as a string, it represents the title of the crumb.
+     * @param string|array $title If provided as a string, it represents the title of the crumb.
      * Alternatively, if you want to add multiple crumbs at once, you can provide an array, with each values being a
      * single crumb. Arrays are expected to be of this form:
      * - *title* The title of the crumb

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -35,11 +35,11 @@ use Traversable;
  *
  * Automatic generation of HTML FORMs from given data.
  *
- * @method string text($fieldName, array $options = [])
- * @method string number($fieldName, array $options = [])
- * @method string email($fieldName, array $options = [])
- * @method string password($fieldName, array $options = [])
- * @method string search($fieldName, array $options = [])
+ * @method string text(string $fieldName, array $options = [])
+ * @method string number(string $fieldName, array $options = [])
+ * @method string email(string $fieldName, array $options = [])
+ * @method string password(string $fieldName, array $options = [])
+ * @method string search(string $fieldName, array $options = [])
  * @property \Cake\View\Helper\HtmlHelper $Html
  * @property \Cake\View\Helper\UrlHelper $Url
  * @link https://book.cakephp.org/3/en/views/helpers/form.html
@@ -572,7 +572,7 @@ class FormHelper extends Helper
     /**
      * Correctly store the last created form action URL.
      *
-     * @param string|array $url The URL of the last form.
+     * @param string|array|null $url The URL of the last form.
      * @return void
      */
     protected function _lastAction($url)

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -498,6 +498,8 @@ class HtmlHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -579,6 +581,8 @@ class HtmlHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**
@@ -617,6 +621,8 @@ class HtmlHelper extends Helper
             $options['block'] = 'script';
         }
         $this->_View->append($options['block'], $out);
+
+        return null;
     }
 
     /**

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -118,7 +118,7 @@ class NumberHelper extends Helper
      *
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      *
-     * @param float $number A floating point number
+     * @param float|string $number A floating point number
      * @param int $precision The precision of the returned number
      * @param array $options Options
      * @return string Percentage string
@@ -142,7 +142,7 @@ class NumberHelper extends Helper
      * - `after` - The string to place after decimal numbers, e.g. ']'
      * - `escape` - Whether or not to escape html in resulting string
      *
-     * @param float $number A floating point number.
+     * @param float|string $number A floating point number.
      * @param array $options An array with options.
      * @return string Formatted number
      * @link https://book.cakephp.org/3/en/views/helpers/number.html#formatting-numbers
@@ -174,7 +174,7 @@ class NumberHelper extends Helper
      *   currency code.
      * - `escape` - Whether or not to escape html in resulting string
      *
-     * @param float $number Value to format.
+     * @param float|string $number Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array $options Options list.
      * @return string Number formatted as a currency.
@@ -199,7 +199,7 @@ class NumberHelper extends Helper
      * - `after` - The string to place after decimal numbers, e.g. ']'
      * - `escape` - Set to false to prevent escaping
      *
-     * @param float $value A floating point number
+     * @param float|string $value A floating point number
      * @param array $options Options list.
      * @return string formatted delta
      */
@@ -214,10 +214,10 @@ class NumberHelper extends Helper
     /**
      * Getter/setter for default currency
      *
-     * @param string|bool $currency Default currency string to be used by currency()
+     * @param string|false|null $currency Default currency string to be used by currency()
      * if $currency argument is not provided. If boolean false is passed, it will clear the
-     * currently stored value
-     * @return string Currency
+     * currently stored value. Null reads the current default.
+     * @return string|null Currency
      */
     public function defaultCurrency($currency)
     {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -185,7 +185,7 @@ class TimeHelper extends Helper
      *
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param bool $range if true returns a range in Y-m-d format
-     * @return int|array 1, 2, 3, or 4 quarter of year or array if $range true
+     * @return string[]|int 1, 2, 3, or 4 quarter of year or array if $range true
      * @see \Cake\I18n\Time::toQuarter()
      */
     public function toQuarter($dateString, $range = false)
@@ -343,11 +343,13 @@ class TimeHelper extends Helper
      *
      * This method is an alias for TimeHelper::i18nFormat().
      *
-     * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
-     * @param int|string|null $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
-     * @param bool|string $invalid Default value to display on invalid dates
+     * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string
+     *   or DateTime object (or a date format string).
+     * @param int|string|null $format date format string (or a UNIX timestamp,
+     *   strtotime() valid string or DateTime object).
+     * @param string|false $invalid Default value to display on invalid dates
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
-     * @return string Formatted and translated date string
+     * @return string|int|false Formatted and translated date string
      * @see \Cake\I18n\Time::i18nFormat()
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
@@ -359,11 +361,11 @@ class TimeHelper extends Helper
      * Returns a formatted date string, given either a Datetime instance,
      * UNIX timestamp or a valid strtotime() date string.
      *
-     * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
-     * @param string|null $format Intl compatible format string.
-     * @param bool|string $invalid Default value to display on invalid dates
+     * @param int|string|\DateTimeInterface|null $date UNIX timestamp, strtotime() valid string or DateTime object
+     * @param string|int|null $format Intl compatible format string.
+     * @param string|false $invalid Default value to display on invalid dates
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
-     * @return string|false Formatted and translated date string or value for `$invalid` on failure.
+     * @return string|int|false Formatted and translated date string or value for `$invalid` on failure.
      * @throws \Exception When the date cannot be parsed
      * @see \Cake\I18n\Time::i18nFormat()
      */

--- a/src/basics.php
+++ b/src/basics.php
@@ -102,7 +102,7 @@ if (!function_exists('breakpoint')) {
      * ```
      * eval(breakpoint());
      * ```
-     * @return string
+     * @return string|null
      */
     function breakpoint()
     {
@@ -113,6 +113,8 @@ if (!function_exists('breakpoint')) {
             'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
             E_USER_WARNING
         );
+
+        return null;
     }
 }
 

--- a/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
+++ b/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
@@ -6,14 +6,14 @@ namespace Cake\PHPStan;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 use PHPStan\Broker\Broker;
-use PHPStan\Reflection\BrokerAwareClassReflectionExtension;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 
-class AssociationTableMixinClassReflectionExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension, BrokerAwareClassReflectionExtension
+class AssociationTableMixinClassReflectionExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension, BrokerAwareExtension
 {
     /**
      * @var \PHPStan\Broker\Broker

--- a/tests/PHPStan/TableFindByPropertyMethodReflection.php
+++ b/tests/PHPStan/TableFindByPropertyMethodReflection.php
@@ -10,10 +10,14 @@ use PHPStan\Type\Type;
 
 class TableFindByPropertyMethodReflection implements MethodReflection
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     private $name;
 
-    /** @var \PHPStan\Reflection\ClassReflection */
+    /**
+     * @var \PHPStan\Reflection\ClassReflection
+     */
     private $declaringClass;
 
     public function __construct(string $name, ClassReflection $declaringClass)
@@ -67,6 +71,6 @@ class TableFindByPropertyMethodReflection implements MethodReflection
 
     public function getReturnType(): Type
     {
-        return new ObjectType('\Cake\ORM\Query');
+        return new ObjectType('Cake\ORM\Query');
     }
 }

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -35,6 +35,11 @@ class BasicAuthenticateTest extends TestCase
     public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
+     * @var \Cake\Auth\BasicAuthenticate
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -28,6 +28,11 @@ use Cake\TestSuite\TestCase;
 class ControllerAuthorizeTest extends TestCase
 {
     /**
+     * @var \Cake\Auth\ControllerAuthorize
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -61,14 +61,12 @@ class DigestAuthenticateTest extends TestCase
     {
         parent::setUp();
 
-        $salt = 'foo.bar';
-        Security::setSalt($salt);
         $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->auth = new DigestAuthenticate($this->Collection, [
             'realm' => 'localhost',
             'nonce' => 123,
             'opaque' => '123abc',
-            'secret' => $salt,
+            'secret' => Security::getSalt(),
             'passwordHasher' => 'ShouldNeverTryToUsePasswordHasher',
         ]);
 

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -61,12 +61,14 @@ class DigestAuthenticateTest extends TestCase
     {
         parent::setUp();
 
+        $salt = 'foo.bar';
+        Security::setSalt($salt);
         $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->auth = new DigestAuthenticate($this->Collection, [
             'realm' => 'localhost',
             'nonce' => 123,
             'opaque' => '123abc',
-            'secret' => Security::getSalt(),
+            'secret' => $salt,
             'passwordHasher' => 'ShouldNeverTryToUsePasswordHasher',
         ]);
 
@@ -511,7 +513,7 @@ DIGEST;
      */
     protected function generateNonce($secret = null, $expires = 300, $time = null)
     {
-        $secret = $secret ?: Configure::read('Security.salt');
+        $secret = $secret ?: Security::getSalt();
         $time = $time ?: microtime(true);
         $expiryTime = $time + $expires;
         $signatureValue = hash_hmac('sha256', $expiryTime . ':' . $secret, $secret);

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -48,6 +48,11 @@ class DigestAuthenticateTest extends TestCase
     public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
+     * @var \Cake\Auth\DigestAuthenticate
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -38,6 +38,11 @@ class FormAuthenticateTest extends TestCase
     public $fixtures = ['core.AuthUsers', 'core.Users'];
 
     /**
+     * @var \Cake\Auth\FormAuthenticate
+     */
+    protected $auth;
+
+    /**
      * setup
      *
      * @return void

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -282,7 +282,7 @@ class FormAuthenticateTest extends TestCase
         $PluginModel = $this->getTableLocator()->get('TestPlugin.AuthUsers');
         $user['id'] = 1;
         $user['username'] = 'gwoo';
-        $user['password'] = password_hash(Security::getSalt() . 'cake', PASSWORD_BCRYPT);
+        $user['password'] = password_hash('cake', PASSWORD_BCRYPT);
         $PluginModel->save(new Entity($user));
 
         $this->auth->setConfig('userModel', 'TestPlugin.AuthUsers');

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -12,7 +12,7 @@
  * @since         3.6.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestSuite\Console;
+namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\Arguments;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -269,6 +269,7 @@ class TimeTest extends TestCase
      */
     public function testTimeAgoInWordsAccuracy($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
             'accuracy' => ['year' => 'year'],
@@ -357,6 +358,7 @@ class TimeTest extends TestCase
      */
     public function testTimeAgoInWordsNegativeValues($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 month']);
         $this->assertEquals('2 months, 2 days ago', $result);
@@ -420,6 +422,7 @@ class TimeTest extends TestCase
      */
     public function testNice($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-04-20 20:00', 'UTC');
         $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
 
@@ -521,6 +524,7 @@ class TimeTest extends TestCase
      */
     public function testI18nFormatWithOffsetTimezone($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
@@ -670,6 +674,7 @@ class TimeTest extends TestCase
      */
     public function testDiffForHumans($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-04-20 10:10:10');
 
         $other = new $class('2014-04-27 10:10:10');
@@ -712,6 +717,7 @@ class TimeTest extends TestCase
     public function testDiffForHumansAbsolute($class)
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year', $time->diffForHumans(null, ['absolute' => true]));
 
@@ -731,6 +737,7 @@ class TimeTest extends TestCase
     public function testDiffForHumansNow($class)
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year ago', $time->diffForHumans());
 
@@ -789,7 +796,7 @@ class TimeTest extends TestCase
     {
         $time = new $class('2014-04-20 10:10:10');
 
-        $class::setJsonEncodeFormat(static function ($t) {
+        $class::setJsonEncodeFormat(static function (Time $t) {
             return $t->format(DATE_ATOM);
         });
         $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
@@ -806,11 +813,12 @@ class TimeTest extends TestCase
      */
     public function testDebugInfo($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('2014-04-20 10:10:10');
         $expected = [
             'time' => '2014-04-20 10:10:10.000000+00:00',
             'timezone' => 'UTC',
-            'fixedNowTime' => $class::getTestNow()->format('Y-m-d H:i:s.uP'),
+            'fixedNowTime' => $class::getTestNow()->format('Y-m-d\TH:i:s.uP'),
         ];
         $this->assertEquals($expected, $time->__debugInfo());
     }
@@ -823,6 +831,7 @@ class TimeTest extends TestCase
      */
     public function testParseDateTime($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = $class::parseDateTime('01/01/1970 00:00am');
         $this->assertNotNull($time);
         $this->assertEquals('1970-01-01 00:00', $time->format('Y-m-d H:i'));
@@ -848,6 +857,7 @@ class TimeTest extends TestCase
      */
     public function testParseDate($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = $class::parseDate('10/13/2013 12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
@@ -877,6 +887,7 @@ class TimeTest extends TestCase
      */
     public function testParseTime($class)
     {
+        /** @var \Cake\I18n\Time $time */
         $time = $class::parseTime('12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('00:54:00', $time->format('H:i:s'));
@@ -918,6 +929,7 @@ class TimeTest extends TestCase
     public function testRussianTimeAgoInWords($class)
     {
         I18n::setLocale('ru_RU');
+        /** @var \Cake\I18n\Time $time */
         $time = new $class('5 days ago');
         $result = $time->timeAgoInWords();
         $this->assertEquals('5 days ago', $result);
@@ -958,6 +970,7 @@ class TimeTest extends TestCase
      */
     public function testDefaultLocaleEffectsFormatting($class)
     {
+        /** @var \Cake\I18n\Time $result */
         $result = $class::parseDate('12/03/2015');
         $this->assertRegExp('/Dec 3, 2015[ ,]+12:00 AM/', $result->nice());
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -19,6 +19,7 @@ use Cake\I18n\FrozenTime;
 use Cake\I18n\I18n;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
+use DateTimeInterface;
 
 /**
  * TimeTest class
@@ -269,7 +270,7 @@ class TimeTest extends TestCase
      */
     public function testTimeAgoInWordsAccuracy($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
             'accuracy' => ['year' => 'year'],
@@ -358,7 +359,7 @@ class TimeTest extends TestCase
      */
     public function testTimeAgoInWordsNegativeValues($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 month']);
         $this->assertEquals('2 months, 2 days ago', $result);
@@ -422,7 +423,7 @@ class TimeTest extends TestCase
      */
     public function testNice($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-04-20 20:00', 'UTC');
         $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
 
@@ -524,7 +525,7 @@ class TimeTest extends TestCase
      */
     public function testI18nFormatWithOffsetTimezone($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
@@ -674,7 +675,7 @@ class TimeTest extends TestCase
      */
     public function testDiffForHumans($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-04-20 10:10:10');
 
         $other = new $class('2014-04-27 10:10:10');
@@ -717,7 +718,7 @@ class TimeTest extends TestCase
     public function testDiffForHumansAbsolute($class)
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year', $time->diffForHumans(null, ['absolute' => true]));
 
@@ -737,7 +738,7 @@ class TimeTest extends TestCase
     public function testDiffForHumansNow($class)
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-04-20 10:10:10');
         $this->assertEquals('1 year ago', $time->diffForHumans());
 
@@ -796,7 +797,7 @@ class TimeTest extends TestCase
     {
         $time = new $class('2014-04-20 10:10:10');
 
-        $class::setJsonEncodeFormat(static function (Time $t) {
+        $class::setJsonEncodeFormat(static function (DateTimeInterface $t) {
             return $t->format(DATE_ATOM);
         });
         $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
@@ -813,7 +814,7 @@ class TimeTest extends TestCase
      */
     public function testDebugInfo($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('2014-04-20 10:10:10');
         $expected = [
             'time' => '2014-04-20 10:10:10.000000+00:00',
@@ -831,7 +832,7 @@ class TimeTest extends TestCase
      */
     public function testParseDateTime($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = $class::parseDateTime('01/01/1970 00:00am');
         $this->assertNotNull($time);
         $this->assertEquals('1970-01-01 00:00', $time->format('Y-m-d H:i'));
@@ -857,7 +858,7 @@ class TimeTest extends TestCase
      */
     public function testParseDate($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = $class::parseDate('10/13/2013 12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
@@ -887,7 +888,7 @@ class TimeTest extends TestCase
      */
     public function testParseTime($class)
     {
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = $class::parseTime('12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('00:54:00', $time->format('H:i:s'));
@@ -929,7 +930,7 @@ class TimeTest extends TestCase
     public function testRussianTimeAgoInWords($class)
     {
         I18n::setLocale('ru_RU');
-        /** @var \Cake\I18n\Time $time */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $time */
         $time = new $class('5 days ago');
         $result = $time->timeAgoInWords();
         $this->assertEquals('5 days ago', $result);
@@ -970,7 +971,7 @@ class TimeTest extends TestCase
      */
     public function testDefaultLocaleEffectsFormatting($class)
     {
-        /** @var \Cake\I18n\Time $result */
+        /** @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $result */
         $result = $class::parseDate('12/03/2015');
         $this->assertRegExp('/Dec 3, 2015[ ,]+12:00 AM/', $result->nice());
 

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -20,8 +20,8 @@ use Psr\Log\LogLevel;
 
 /**
  * Class BaseLogImpl
- * Implementation of abstract class {@see Cake\Log\Engine\BaseLog},
- * required by test case {@see Cake\Test\TestCase\Log\Engine\BaseLogTest}.
+ * Implementation of abstract class {@see \Cake\Log\Engine\BaseLog},
+ * required by test case {@see \Cake\Test\TestCase\Log\Engine\BaseLogTest}.
  */
 class BaseLogImpl extends BaseLog
 {

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -12,10 +12,9 @@
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestSuite;
+namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Core\Exception\Exception as CakeException;
-use Cake\Core\Plugin;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -34,7 +34,7 @@ class ValidationTest extends TestCase
     /**
      * @var string
      */
-    public $locale;
+    protected $locale;
 
     /**
      * @var string
@@ -676,6 +676,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::creditCard('4916845885268360', ['visa']));
         $this->assertTrue(Validation::creditCard('4394514669078434', ['visa']));
         $this->assertTrue(Validation::creditCard('4485611378115042', ['visa']));
+        $this->assertTrue(Validation::creditCard('4485-6113-7811-5042', ['visa']));
         // Visa Electron
         $this->assertTrue(Validation::creditCard('4175003346287100', ['electron']));
         $this->assertTrue(Validation::creditCard('4913042516577228', ['electron']));
@@ -1752,13 +1753,13 @@ class ValidationTest extends TestCase
      */
     public function testLocalizedTime()
     {
-        $locale = I18N::getLocale();
+        $locale = I18n::getLocale();
 
         $this->assertFalse(Validation::localizedTime('', 'date'));
         $this->assertFalse(Validation::localizedTime('invalid', 'date'));
 
         // English (US)
-        I18N::setLocale('en_US');
+        I18n::setLocale('en_US');
         $this->assertTrue(Validation::localizedTime('12/31/2006', 'date'));
         $this->assertTrue(Validation::localizedTime('6.40pm', 'time'));
         $this->assertTrue(Validation::localizedTime('12/31/2006 6.40pm', 'datetime'));
@@ -1768,7 +1769,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::localizedTime('18:40', 'time')); // non-US format
 
         // German
-        I18N::setLocale('de_DE');
+        I18n::setLocale('de_DE');
         $this->assertTrue(Validation::localizedTime('31.12.2006', 'date'));
         $this->assertTrue(Validation::localizedTime('31. Dezember 2006', 'date'));
         $this->assertTrue(Validation::localizedTime('18:40', 'time'));
@@ -1776,12 +1777,12 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::localizedTime('December 31, 2006', 'date')); // non-German format
 
         // Russian
-        I18N::setLocale('ru_RU');
+        I18n::setLocale('ru_RU');
         $this->assertTrue(Validation::localizedTime('31 декабря 2006', 'date'));
 
         $this->assertFalse(Validation::localizedTime('December 31, 2006', 'date')); // non-Russian format
 
-        I18N::setLocale($locale);
+        I18n::setLocale($locale);
     }
 
     /**
@@ -2401,6 +2402,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::inList('2x', [1, 2, 3]));
         $this->assertFalse(Validation::inList(2, ['1', '2x', '3']));
         $this->assertFalse(Validation::inList('One', ['one', 'two']));
+        $this->assertFalse(Validation::inList(['one'], ['one', 'two']));
 
         // No hexadecimal for numbers.
         $this->assertFalse(Validation::inList('0x7B', ['ABC', '123']));
@@ -2410,6 +2412,8 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::inList('one', ['One', 'Two'], true));
         $this->assertTrue(Validation::inList('Two', ['one', 'two'], true));
         $this->assertFalse(Validation::inList('three', ['one', 'two'], true));
+        $this->assertFalse(Validation::inList(null, ['one', 'two'], true));
+        $this->assertFalse(Validation::inList(false, ['one', 'two'], true));
     }
 
     /**
@@ -2973,6 +2977,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::compareFields(false, 'other', Validation::COMPARE_SAME, $context));
         $this->assertTrue(Validation::compareFields(false, 'other', Validation::COMPARE_EQUAL, $context));
         $this->assertTrue(Validation::compareFields(null, 'other', Validation::COMPARE_SAME, $context));
+        $this->assertFalse(Validation::compareFields(false, 'other', Validation::COMPARE_SAME, $context));
     }
 
     /**
@@ -3072,6 +3077,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::geoCoordinate('-245.274398, -133.775136'));
         $this->assertTrue(Validation::geoCoordinate('51.165691', ['format' => 'lat']));
         $this->assertTrue(Validation::geoCoordinate('10.451526', ['format' => 'long']));
+        $this->assertFalse(Validation::geoCoordinate([]));
     }
 
     /**
@@ -3154,7 +3160,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::isInteger('2.5'));
         $this->assertFalse(Validation::isInteger(2.5));
         $this->assertFalse(Validation::isInteger([]));
-        $this->assertFalse(Validation::isInteger(new \StdClass()));
+        $this->assertFalse(Validation::isInteger(new \stdClass()));
         $this->assertFalse(Validation::isInteger('2 bears'));
         $this->assertFalse(Validation::isInteger(true));
         $this->assertFalse(Validation::isInteger(false));
@@ -3173,7 +3179,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::ascii([]));
         $this->assertFalse(Validation::ascii(1001));
         $this->assertFalse(Validation::ascii(3.14));
-        $this->assertFalse(Validation::ascii(new \StdClass()));
+        $this->assertFalse(Validation::ascii(new \stdClass()));
 
         // Latin-1 supplement
         $this->assertFalse(Validation::ascii('some' . "\xc2\x82" . 'value'));
@@ -3196,7 +3202,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::utf8([]));
         $this->assertFalse(Validation::utf8(1001));
         $this->assertFalse(Validation::utf8(3.14));
-        $this->assertFalse(Validation::utf8(new \StdClass()));
+        $this->assertFalse(Validation::utf8(new \stdClass()));
         $this->assertTrue(Validation::utf8('1 big blue bus.'));
         $this->assertTrue(Validation::utf8(',.<>[]{;/?\)()'));
 
@@ -3224,7 +3230,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::utf8([], ['extended' => true]));
         $this->assertFalse(Validation::utf8(1001, ['extended' => true]));
         $this->assertFalse(Validation::utf8(3.14, ['extended' => true]));
-        $this->assertFalse(Validation::utf8(new \StdClass(), ['extended' => true]));
+        $this->assertFalse(Validation::utf8(new \stdClass(), ['extended' => true]));
         $this->assertTrue(Validation::utf8('1 big blue bus.', ['extended' => true]));
         $this->assertTrue(Validation::utf8(',.<>[]{;/?\)()', ['extended' => true]));
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -246,7 +246,7 @@ class ValidationTest extends TestCase
 
         $this->assertFalse(Validation::lengthBetween('abcdefg', 1, 6));
         $this->assertFalse(Validation::lengthBetween('ÆΔΩЖÇ', 1, 3));
-        $this->assertFalse(Validation::lengthBetween(1, 1, 3));
+        $this->assertTrue(Validation::lengthBetween(1, 1, 3));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,7 @@ use Cake\Chronos\MutableDateTime;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
+use Cake\Utility\Security;
 
 if (is_file('vendor/autoload.php')) {
     require_once 'vendor/autoload.php';
@@ -131,6 +132,8 @@ Chronos::setTestNow(Chronos::now());
 
 ini_set('intl.default_locale', 'en_US');
 ini_set('session.gc_divisor', '1');
+
+Security::setSalt('a-long-but-not-random-value');
 
 loadPHPUnitAliases();
 


### PR DESCRIPTION
After diffing 4.next and 3.next, I found the following docblock and code changes that could be backported.

Some methods seem to be completely missing in API (validation), and here we would also need to backport tests then, of course.
https://github.com/cakephp/cakephp/pull/13538
=> I pulled those now into a separate PR https://github.com/cakephp/cakephp/pull/14682 for easier review.
Once that is done, I can rebase this one.

Note:
Validation has been fixed towards how 4.x behaves.
Now:

    $this->assertTrue(Validation::lengthBetween(1, 1, 3));

We should then also document this in the changelogs if we continue with it.