### PR TITLE
Backport CS fixes for smaller diff.

### DIFF
--- a/src/Auth/FormAuthenticate.php
+++ b/src/Auth/FormAuthenticate.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -1112,7 +1112,6 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * Calling this method at the same time that you are iterating this collections, for example in
      * a foreach, will result in undefined behavior. Avoid doing this.
      *
-     *
      * @return int
      */
     public function count();

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -134,7 +134,6 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
 
     /**
      * @param string[] $names Names
-     *
      * @return string|null
      */
     protected function findPrefixedName(array $names)

--- a/src/Console/CommandCollectionAwareInterface.php
+++ b/src/Console/CommandCollectionAwareInterface.php
@@ -17,7 +17,6 @@ namespace Cake\Console;
 /**
  * An interface for shells that take a CommandCollection
  * during initialization.
- *
  */
 interface CommandCollectionAwareInterface
 {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -962,7 +962,6 @@ class AuthComponent extends Component
      * Getter for authenticate objects. Will return a particular authenticate object.
      *
      * @param string $alias Alias for the authenticate object
-     *
      * @return \Cake\Auth\BaseAuthenticate|null
      */
     public function getAuthenticate($alias)

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -114,7 +114,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var array
      * @link https://book.cakephp.org/3/en/controllers.html#configuring-helpers-to-load
-     *
      * @deprecated 3.0.0 You should configure helpers in your AppView::initialize() method.
      */
     public $helpers = [];
@@ -185,7 +184,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var array
      * @link https://book.cakephp.org/3/en/controllers/components.html
-     *
      * @deprecated 3.0.0 You should configure components in your Controller::initialize() method.
      */
     public $components = [];
@@ -294,7 +292,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * If called with the first parameter, it will be set as the controller $this->_components property
      *
      * @param \Cake\Controller\ComponentRegistry|null $components Component registry.
-     *
      * @return \Cake\Controller\ComponentRegistry
      */
     public function components($components = null)

--- a/src/Controller/Exception/AuthSecurityException.php
+++ b/src/Controller/Exception/AuthSecurityException.php
@@ -19,6 +19,7 @@ class AuthSecurityException extends SecurityException
 {
     /**
      * Security Exception type
+     *
      * @var string
      */
     protected $_type = 'auth';

--- a/src/Controller/Exception/SecurityException.php
+++ b/src/Controller/Exception/SecurityException.php
@@ -21,6 +21,7 @@ class SecurityException extends BadRequestException
 {
     /**
      * Security Exception type
+     *
      * @var string
      */
     protected $_type = 'secure';

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -99,7 +99,6 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
 
     /**
      * {@inheritDoc}
-     *
      */
     public function traverse(callable $visitor)
     {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -79,7 +79,6 @@ class CaseExpression implements ExpressionInterface
      * @param array|\Cake\Database\ExpressionInterface $conditions Must be a ExpressionInterface instance, or an array of ExpressionInterface instances.
      * @param array|\Cake\Database\ExpressionInterface $values associative array of values of each condition
      * @param array $types associative array of types to be associated with the values
-     *
      * @return $this
      */
     public function add($conditions = [], $values = [], $types = [])
@@ -106,7 +105,6 @@ class CaseExpression implements ExpressionInterface
      * @param array|\Cake\Database\ExpressionInterface $conditions Must be a ExpressionInterface instance, or an array of ExpressionInterface instances.
      * @param array|\Cake\Database\ExpressionInterface $values associative array of values of each condition
      * @param array $types associative array of types to be associated with the values
-     *
      * @return void
      */
     protected function _addExpressions($conditions, $values, $types)
@@ -160,7 +158,6 @@ class CaseExpression implements ExpressionInterface
      *
      * @param \Cake\Database\ExpressionInterface|string|array|null $value Value to set
      * @param string|null $type Type of value
-     *
      * @return void
      */
     public function elseValue($value = null, $type = null)
@@ -186,7 +183,6 @@ class CaseExpression implements ExpressionInterface
      *
      * @param array|string|\Cake\Database\ExpressionInterface $part The part to compile
      * @param \Cake\Database\ValueBinder $generator Sql generator
-     *
      * @return string
      */
     protected function _compile($part, ValueBinder $generator)
@@ -206,7 +202,6 @@ class CaseExpression implements ExpressionInterface
      * Converts the Node into a SQL string fragment.
      *
      * @param \Cake\Database\ValueBinder $generator Placeholder generator object
-     *
      * @return string
      */
     public function sql(ValueBinder $generator)
@@ -228,7 +223,6 @@ class CaseExpression implements ExpressionInterface
 
     /**
      * {@inheritDoc}
-     *
      */
     public function traverse(callable $visitor)
     {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -164,7 +164,6 @@ class Comparison implements ExpressionInterface, FieldInterface
 
     /**
      * {@inheritDoc}
-     *
      */
     public function traverse(callable $visitor)
     {

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -93,7 +93,6 @@ class UnaryExpression implements ExpressionInterface
 
     /**
      * {@inheritDoc}
-     *
      */
     public function traverse(callable $visitor)
     {

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -44,7 +44,6 @@ class CachedCollection extends Collection
 
     /**
      * {@inheritDoc}
-     *
      */
     public function describe($name, array $options = [])
     {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -218,7 +218,6 @@ class SqliteSchema extends BaseSchema
      * additional queries are done here. Sqlite constraint names are not
      * stable, and the names for constraints will not match those used to create
      * the table. This is a limitation in Sqlite's metadata features.
-     *
      */
     public function convertIndexDescription(TableSchema $schema, $row)
     {
@@ -396,7 +395,6 @@ class SqliteSchema extends BaseSchema
      *
      * Note integer primary keys will return ''. This is intentional as Sqlite requires
      * that integer primary keys be defined in the column definition.
-     *
      */
     public function constraintSql(TableSchema $schema, $name)
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -487,6 +487,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
     /**
      * {@inheritDoc}
+     *
      * @throws \Cake\Database\Exception
      */
     public function addIndex($name, $attrs)
@@ -572,6 +573,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
     /**
      * {@inheritDoc}
+     *
      * @throws \Cake\Database\Exception
      */
     public function addConstraint($name, $attrs)

--- a/src/Database/Statement/MysqlStatement.php
+++ b/src/Database/Statement/MysqlStatement.php
@@ -27,7 +27,6 @@ class MysqlStatement extends PDOStatement
 
     /**
      * {@inheritDoc}
-     *
      */
     public function execute($params = null)
     {

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -25,7 +25,6 @@ class SqliteStatement extends StatementDecorator
 
     /**
      * {@inheritDoc}
-     *
      */
     public function execute($params = null)
     {

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -114,7 +114,6 @@ class BinaryType extends Type implements TypeInterface
      * that make sense for the rest of the ORM/Database layers.
      *
      * @param mixed $value The value to convert.
-     *
      * @return mixed Converted value.
      */
     public function marshal($value)

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -122,7 +122,6 @@ class BinaryUuidType extends Type implements TypeInterface
      * that make sense for the rest of the ORM/Database layers.
      *
      * @param mixed $value The value to convert.
-     *
      * @return mixed Converted value.
      */
     public function marshal($value)
@@ -133,9 +132,7 @@ class BinaryUuidType extends Type implements TypeInterface
     /**
      * Converts a binary uuid to a string representation
      *
-     *
      * @param mixed $binary The value to convert.
-     *
      * @return string Converted value.
      */
     protected function convertBinaryUuidToString($binary)
@@ -154,9 +151,7 @@ class BinaryUuidType extends Type implements TypeInterface
     /**
      * Converts a string uuid to a binary representation
      *
-     *
      * @param string $string The value to convert.
-     *
      * @return string Converted value.
      */
     protected function convertStringToBinaryUuid($string)

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -419,7 +419,6 @@ class DateTimeType extends Type implements TypeInterface, BatchCastingInterface
      *
      * @param mixed $value value to be converted to PDO statement
      * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
-     *
      * @return mixed
      */
     public function toStatement($value, Driver $driver)

--- a/src/Database/Type/ExpressionTypeCasterTrait.php
+++ b/src/Database/Type/ExpressionTypeCasterTrait.php
@@ -19,7 +19,6 @@ use Cake\Database\Type;
 /**
  * Offers a method to convert values to ExpressionInterface objects
  * if the type they should be converted to implements ExpressionTypeInterface
- *
  */
 trait ExpressionTypeCasterTrait
 {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -43,7 +43,6 @@ use JsonSerializable;
  * @method array extractOriginalChanged(array $properties)
  * @method array getVisible()
  * @method $this setNew($new)
- *
  * @property mixed $id Alias for commonly used primary key.
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -61,7 +61,6 @@ trait EntityTrait
      * Holds the name of the class for the instance object
      *
      * @var string
-     *
      * @deprecated 3.2 This field is no longer being used
      */
     protected $_className;

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -158,7 +158,6 @@ trait ModelAwareTrait
      * Set the model type to be used by this class
      *
      * @param string $modelType The model type
-     *
      * @return $this
      */
     public function setModelType($modelType)
@@ -173,7 +172,6 @@ trait ModelAwareTrait
      *
      * @deprecated 3.5.0 Use getModelType()/setModelType() instead.
      * @param string|null $modelType The model type or null to retrieve the current
-     *
      * @return string|$this
      */
     public function modelType($modelType = null)

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -104,7 +104,6 @@ class Debugger
 
     /**
      * Constructor.
-     *
      */
     public function __construct()
     {

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -164,7 +164,6 @@ class ErrorHandler extends BaseErrorHandler
      * The PHP5 part will be removed with 4.0.
      *
      * @param \Throwable|\Exception $exception Exception.
-     *
      * @return void
      */
     protected function _logInternalError($exception)

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -130,7 +130,6 @@ class ErrorHandlerMiddleware
 
     /**
      * @param \Psr\Http\Message\ResponseInterface $response The response
-     *
      * @return \Psr\Http\Message\ResponseInterface A response
      */
     protected function handleInternalError($response)

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -38,7 +38,6 @@ interface EventDispatcherInterface
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
-     *
      * @return \Cake\Event\Event
      */
     public function dispatchEvent($name, $data = null, $subject = null);

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -100,7 +100,6 @@ trait EventDispatcherTrait
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
-     *
      * @return \Cake\Event\Event
      */
     public function dispatchEvent($name, $data = null, $subject = null)

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -105,7 +105,6 @@ class EventManager implements EventManagerInterface
      * @param array $options used to set the `priority` flag to the listener. In the future more options may be added.
      * Priorities are treated as queues. Lower values are called before higher ones, and multiple attachments
      * added to the same priority queue will be treated in the order of insertion.
-     *
      * @return void
      * @throws \InvalidArgumentException When event key is missing or callable is not an
      *   instance of Cake\Event\EventListenerInterface.

--- a/src/Event/EventManagerInterface.php
+++ b/src/Event/EventManagerInterface.php
@@ -51,7 +51,6 @@ interface EventManagerInterface
      * added to the same priority queue will be treated in the order of insertion.
      *
      * @param callable|null $callable The callable function you want invoked.
-     *
      * @return $this
      * @throws \InvalidArgumentException When event key is missing or callable is not an
      *   instance of Cake\Event\EventListenerInterface.

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -355,7 +355,6 @@ class Folder
      *
      * @param string $path Path to check
      * @return string Set of slashes ("\\" or "/")
-     *
      * @deprecated 3.7.0 This method will be removed in 4.0.0. Use correctSlashFor() instead.
      */
     public static function normalizePath($path)

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -282,7 +282,6 @@ class Stream implements AdapterInterface
      *
      * @param array $headers Unparsed headers.
      * @param string $body The response body.
-     *
      * @return \Cake\Http\Client\Response
      */
     protected function _buildResponse($headers, $body)

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -164,7 +164,6 @@ class Oauth
      * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string
-     *
      * @throws \RuntimeException
      */
     protected function _rsaSha1($request, $credentials)

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -57,6 +57,7 @@ class CspMiddleware
      * Apply the middleware.
      *
      * This will inject the CSP header into the response.
+     *
      * @param ServerRequestInterface $requestInterface The Request.
      * @param ResponseInterface $responseInterface The Response.
      * @param callable $next Callback to invoke the next middleware.

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -40,6 +40,7 @@ class EncryptedCookieMiddleware
 
     /**
      * The list of cookies to encrypt/decrypt
+     *
      * @var array
      */
     protected $cookieNames;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\StreamInterface;
  * returns a status code integer. Keep in mind that these consants might
  * include status codes that are now allowed which will throw an
  * `\InvalidArgumentException`.
- *
  */
 class Response implements ResponseInterface
 {
@@ -1065,7 +1064,6 @@ class Response implements ResponseInterface
      *        ]); // throws an exception due to invalid codes
      *
      *        For more on HTTP status codes see: http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
-     *
      * @return mixed Associative array of the HTTP codes as keys, and the message
      *    strings as values, or null of the given $code does not exist.
      * @throws \InvalidArgumentException If an attempt is made to add an invalid status code

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -13,7 +13,6 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  *
  * Parts of this file are derived from Zend-Diactoros
- *
  * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (https://www.zend.com/)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -707,7 +707,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Magic set method allows backward compatibility for former public properties
      *
-     *
      * @param string $name The property being accessed.
      * @param mixed $value The property value.
      * @return mixed Either the value of the parameter or null.

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -40,7 +40,6 @@ class CacheSession implements SessionHandlerInterface
      * @param array $config The configuration to use for this engine
      * It requires the key 'config' which is the name of the Cache config to use for
      * storing the session
-     *
      * @throws \InvalidArgumentException if the 'config' key is not provided
      */
     public function __construct(array $config = [])

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -52,7 +52,6 @@ class MoFileParser
      * was created on. Both 32bit and 64bit systems are supported.
      *
      * @param resource $resource The file to be parsed.
-     *
      * @return array List of messages extracted from the file
      * @throws \RuntimeException If stream content has an invalid format.
      */

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -66,7 +66,6 @@ class PoFileParser
      * Items with an empty id are ignored.
      *
      * @param string $resource The file name to parse
-     *
      * @return array
      */
     public function parse($resource)

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -29,7 +29,6 @@ class Translator extends BaseTranslator
     /**
      * Translates the message formatting any placeholders
      *
-     *
      * @param string $key The message key.
      * @param array $tokensValues Token values to interpolate into the
      *   message.

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -53,7 +53,6 @@ class SelectWithPivotLoader extends SelectLoader
 
     /**
      * {@inheritDoc}
-     *
      */
     public function __construct(array $options)
     {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -143,7 +143,6 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @param string $table the table name to use for storing each field translation
      * @param string $model the model field value
      * @param string $strategy the strategy used in the _i18n association
-     *
      * @return void
      */
     public function setupFieldAssociations($fields, $table, $model, $strategy)

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -350,7 +350,6 @@ class TableLocator implements LocatorInterface
      *
      * @param string $location Location to add.
      * @return $this
-     *
      * @since 3.8.0
      */
     public function addLocation($location)

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -228,8 +228,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * been added to the query by the first. If you need to change the list after the first call,
      * pass overwrite boolean true which will reset the select clause removing all previous additions.
      *
-     *
-     *
      * @param \Cake\ORM\Table|\Cake\ORM\Association $table The table to use to get an array of columns
      * @param string[] $excludedFields The un-aliased column names you do not want selected from $table
      * @param bool $overwrite Whether to reset/remove previous selected fields

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -425,6 +425,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
     /**
      * {@inheritDoc}
+     *
      * @deprecated 3.4.0 Use setAlias()/getAlias() instead.
      */
     public function alias($alias = null)
@@ -2336,7 +2337,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * The options argument will be converted into an \ArrayObject instance
      * for the duration of the callbacks, this allows listeners to modify
      * the options used in the delete operation.
-     *
      */
     public function delete(EntityInterface $entity, $options = [])
     {
@@ -2530,7 +2530,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Returns true if the finder exists for the table
      *
      * @param string $type name of finder to check
-     *
      * @return bool
      */
     public function hasFinder($type)

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -43,7 +43,6 @@ class AssetFilter extends DispatcherFilter
     protected $_cacheTime = '+1 day';
 
     /**
-     *
      * Constructor.
      *
      * @param array $config Array of config.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -771,7 +771,6 @@ class Router
      * ### Usage
      *
      * @see Router::url()
-     *
      * @param string|array|null $url An array specifying any of the following:
      *   'controller', 'action', 'plugin' additionally, you can provide routed
      *   elements or query string parameters. If string it can be name any valid url

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -86,6 +86,7 @@ class RoutesShell extends Shell
      * Generate a URL based on a set of parameters
      *
      * Takes variadic arguments of key/value pairs.
+     *
      * @return bool Success
      */
     public function generate()

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -113,12 +113,14 @@ class ExtractTask extends Shell
 
     /**
      * Displays marker error(s) if true
+     *
      * @var bool
      */
     protected $_markerError;
 
     /**
      * Count number of marker errors found
+     *
      * @var bool
      */
     protected $_countMarkerError = 0;

--- a/src/TestSuite/EmailAssertTrait.php
+++ b/src/TestSuite/EmailAssertTrait.php
@@ -23,7 +23,6 @@ use Cake\Mailer\Email;
  * @method void assertSame($expected, $result, $message)
  * @method void assertTextContains($needle, $haystack, $message)
  * @method \PHPUnit_Framework_MockObject_MockBuilder getMockBuilder($className)
- *
  * @deprecated 3.7.0 Use Cake\TestSuite\EmailTrait instead
  */
 trait EmailAssertTrait

--- a/src/TestSuite/EmailTrait.php
+++ b/src/TestSuite/EmailTrait.php
@@ -68,7 +68,6 @@ trait EmailTrait
     }
 
     /**
-     *
      * Asserts that no emails were sent
      *
      * @param string $message Message

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -189,7 +189,6 @@ trait IntegrationTestTrait
     protected $_flashMessages;
 
     /**
-     *
      * @var string|null
      */
     protected $_cookieEncryptionKey;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -636,9 +636,7 @@ class Validation
      * ISO8601 recognize datetime like 2019 as a valid date. To validate and check date integrity, use @see \Cake\Validation\Validation::datetime()
      *
      * @param string|\DateTimeInterface $check Value to check
-     *
      * @return bool True if the value is valid, false otherwise
-     *
      * @see Regex credits: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
      */
     public static function iso8601($check)
@@ -1677,7 +1675,6 @@ class Validation
      * body matches against checksum via Mod97-10 algorithm
      *
      * @param string $check The value to check
-     *
      * @return bool Success
      */
     public static function iban($check)

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -151,7 +151,6 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
     /**
      * Constructor
-     *
      */
     public function __construct()
     {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -162,7 +162,6 @@ class TimeHelper extends Helper
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return bool True if datetime string was yesterday
-     *
      */
     public function wasYesterday($dateString, $timezone = null)
     {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1097,7 +1097,6 @@ class View implements EventDispatcherInterface
      * Check if a block exists
      *
      * @param string $name Name of the block
-     *
      * @return bool
      */
     public function exists($name)

--- a/src/basics.php
+++ b/src/basics.php
@@ -97,6 +97,7 @@ if (!function_exists('breakpoint')) {
      * Command to return the eval-able code to startup PsySH in interactive debugger
      * Works the same way as eval(\Psy\sh());
      * psy/psysh must be loaded in your project
+     *
      * @link http://psysh.org/
      * ```
      * eval(breakpoint());

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ArticlesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/ArticlesTagsFixture.php
+++ b/tests/Fixture/ArticlesTagsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ArticlesTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/AssertIntegrationTestCase.php
+++ b/tests/Fixture/AssertIntegrationTestCase.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\IntegrationTestCase;
  */
 class AssertIntegrationTestCase extends IntegrationTestCase
 {
-
     /**
      * testBadAssertNoRedirect
      *

--- a/tests/Fixture/AttachmentsFixture.php
+++ b/tests/Fixture/AttachmentsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class AttachmentsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/AuthUsersFixture.php
+++ b/tests/Fixture/AuthUsersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class AuthUsersFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/AuthorsFixture.php
+++ b/tests/Fixture/AuthorsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class AuthorsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/AuthorsTagsFixture.php
+++ b/tests/Fixture/AuthorsTagsFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class AuthorsTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/BinaryUuiditemsFixture.php
+++ b/tests/Fixture/BinaryUuiditemsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class BinaryUuiditemsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CakeSessionsFixture.php
+++ b/tests/Fixture/CakeSessionsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CakeSessionsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CategoriesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CommentsFixture.php
+++ b/tests/Fixture/CommentsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CommentsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CompositeIncrementsFixture.php
+++ b/tests/Fixture/CompositeIncrementsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class CompositeIncrementsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/CounterCacheCategoriesFixture.php
+++ b/tests/Fixture/CounterCacheCategoriesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CounterCacheCategoriesFixture extends TestFixture
 {
-
     public $fields = [
         'id' => ['type' => 'integer'],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],

--- a/tests/Fixture/CounterCacheCommentsFixture.php
+++ b/tests/Fixture/CounterCacheCommentsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CounterCacheCommentsFixture extends TestFixture
 {
-
     public $fields = [
         'id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'length' => 255],

--- a/tests/Fixture/CounterCachePostsFixture.php
+++ b/tests/Fixture/CounterCachePostsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CounterCachePostsFixture extends TestFixture
 {
-
     public $fields = [
         'id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'length' => 255],

--- a/tests/Fixture/CounterCacheUserCategoryPostsFixture.php
+++ b/tests/Fixture/CounterCacheUserCategoryPostsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CounterCacheUserCategoryPostsFixture extends TestFixture
 {
-
     public $fields = [
         'id' => ['type' => 'integer'],
         'category_id' => ['type' => 'integer'],

--- a/tests/Fixture/CounterCacheUsersFixture.php
+++ b/tests/Fixture/CounterCacheUsersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CounterCacheUsersFixture extends TestFixture
 {
-
     public $fields = [
         'id' => ['type' => 'integer'],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class DatatypesFixture extends TestFixture
 {
-
     /**
      * @var array
      */

--- a/tests/Fixture/DateKeysFixture.php
+++ b/tests/Fixture/DateKeysFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class DateKeysFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/FeaturedTagsFixture.php
+++ b/tests/Fixture/FeaturedTagsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class FeaturedTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -9,9 +9,9 @@ use Exception;
  */
 class FixturizedTestCase extends TestCase
 {
-
     /**
      * Fixtures to use in this test
+     *
      * @var array
      */
     public $fixtures = ['core.Categories', 'core.Articles'];

--- a/tests/Fixture/GroupsFixture.php
+++ b/tests/Fixture/GroupsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class GroupsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/GroupsMembersFixture.php
+++ b/tests/Fixture/GroupsMembersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class GroupsMembersFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/MembersFixture.php
+++ b/tests/Fixture/MembersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class MembersFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/MenuLinkTreesFixture.php
+++ b/tests/Fixture/MenuLinkTreesFixture.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class MenuLinkTreesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/NumberTreesFixture.php
+++ b/tests/Fixture/NumberTreesFixture.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class NumberTreesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/OrderedUuidItemsFixture.php
+++ b/tests/Fixture/OrderedUuidItemsFixture.php
@@ -18,11 +18,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 /**
  * Class OrderedUuiditemFixture
- *
  */
 class OrderedUuidItemsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class OrdersFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/tests/Fixture/PolymorphicTaggedFixture.php
+++ b/tests/Fixture/PolymorphicTaggedFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class PolymorphicTaggedFixture extends TestFixture
 {
-
     /**
      * table property
      *

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class PostsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ProfilesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SessionsFixture.php
+++ b/tests/Fixture/SessionsFixture.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class SessionsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SiteArticlesFixture.php
+++ b/tests/Fixture/SiteArticlesFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class SiteArticlesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SiteArticlesTagsFixture.php
+++ b/tests/Fixture/SiteArticlesTagsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class SiteArticlesTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SiteAuthorsFixture.php
+++ b/tests/Fixture/SiteAuthorsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class SiteAuthorsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SiteTagsFixture.php
+++ b/tests/Fixture/SiteTagsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class SiteTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/SpecialTagsFixture.php
+++ b/tests/Fixture/SpecialTagsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class SpecialTagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class TagsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/TagsTranslationsFixture.php
+++ b/tests/Fixture/TagsTranslationsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class TagsTranslationsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/TestPluginCommentsFixture.php
+++ b/tests/Fixture/TestPluginCommentsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class TestPluginCommentsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/ThingsFixture.php
+++ b/tests/Fixture/ThingsFixture.php
@@ -18,7 +18,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class ThingsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/TranslatesFixture.php
+++ b/tests/Fixture/TranslatesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class TranslatesFixture extends TestFixture
 {
-
     /**
      * table property
      *

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class UsersFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/UuiditemsFixture.php
+++ b/tests/Fixture/UuiditemsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class UuiditemsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/Fixture/UuidportfoliosFixture.php
+++ b/tests/Fixture/UuidportfoliosFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class UuidportfoliosFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class BasicAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class ControllerAuthorizeTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Auth/DefaultPasswordHasherTest.php
+++ b/tests/TestCase/Auth/DefaultPasswordHasherTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class DefaultPasswordHasherTest extends TestCase
 {
-
     /**
      * Tests that a password not produced by DefaultPasswordHasher needs
      * to be rehashed

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -40,7 +40,6 @@ class ProtectedUser extends Entity
  */
 class DigestAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class FallbackPasswordHasherTest extends TestCase
 {
-
     /**
      * Tests that only the first hasher is user for hashing a password
      *

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -30,7 +30,6 @@ use TestApp\Auth\CallCounterPasswordHasher;
  */
 class FormAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class PasswordHasherFactoryTest extends TestCase
 {
-
     /**
      * test passwordhasher instance building
      *

--- a/tests/TestCase/Auth/Storage/SessionStorageTest.php
+++ b/tests/TestCase/Auth/Storage/SessionStorageTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class SessionStorageTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Security;
  */
 class WeakPasswordHasherTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -27,7 +27,6 @@ require_once CAKE . 'basics.php';
  */
 class BasicsTest extends TestCase
 {
-
     /**
      * test the array_diff_key compatibility function.
      *

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -30,7 +30,6 @@ use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
  */
 class CacheTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -45,7 +45,6 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Reset apc.user_request_time to original value
-     *
      */
     public static function teardownAfterClass()
     {

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class FileEngineTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -24,7 +24,6 @@ use Memcached;
  */
 class MemcachedEngineTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class RedisEngineTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class WincacheEngineTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class XcacheEngineTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -90,7 +90,6 @@ class CountableIterator extends \IteratorIterator implements \Countable
  */
 class CollectionTest extends TestCase
 {
-
     /**
      * Tests that it is possible to convert an array into a collection
      *

--- a/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
@@ -24,7 +24,6 @@ use NoRewindIterator;
  */
 class BufferedIteratorTest extends TestCase
 {
-
     /**
      * Tests that items are cached once iterated over them
      *

--- a/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class ExtractIteratorTest extends TestCase
 {
-
     /**
      * Tests it is possible to extract a column in the first level of an array
      *

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class FilterIteratorTest extends TestCase
 {
-
     /**
      * Tests that the iterator works correctly
      *

--- a/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class InsertIteratorTest extends TestCase
 {
-
     /**
      * Test insert simple path
      *

--- a/tests/TestCase/Collection/Iterator/MapReduceTest.php
+++ b/tests/TestCase/Collection/Iterator/MapReduceTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class MapReduceTest extends TestCase
 {
-
     /**
      * Tests the creation of an inversed index of words to documents using
      * MapReduce

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ReplaceIteratorTest extends TestCase
 {
-
     /**
      * Tests that the iterator works correctly
      *

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class SortIteratorTest extends TestCase
 {
-
     /**
      * Tests sorting numbers with an identity callbacks
      *

--- a/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class TreeIteratorTest extends TestCase
 {
-
     /**
      * Tests the printer function with defaults
      *

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -126,7 +126,6 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Instances that are not shells should fail.
-     *
      */
     public function testAddInvalidInstance()
     {
@@ -172,7 +171,6 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Class names that are not shells should fail
-     *
      */
     public function testInvalidShellClassName()
     {

--- a/tests/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConsoleErrorHandlerTest extends TestCase
 {
-
     /**
      * setup, create mocks
      *

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConsoleOptionParserTest extends TestCase
 {
-
     /**
      * test setting the console description
      *

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConsoleOutputTest extends TestCase
 {
-
     /**
      * setup
      *
@@ -283,7 +282,6 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test set wrong type.
-     *
      */
     public function testSetOutputWrongType()
     {

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class HelpFormatterTest extends TestCase
 {
-
     /**
      * test that the console max width is respected when generating help.
      *

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -25,7 +25,6 @@ use TestPlugin\Shell\Helper\ExampleHelper;
  */
 class HelperRegistryTest extends TestCase
 {
-
     /**
      * setUp
      *

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ShellDispatcherTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -46,7 +46,6 @@ class_alias(__NAMESPACE__ . '\TestBananaTask', 'Cake\Shell\Task\TestBananaTask')
  */
 class ShellTest extends TestCase
 {
-
     /**
      * Fixtures used in this test case
      *

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class TaskRegistryTest extends TestCase
 {
-
     /**
      * setUp
      *

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -35,7 +35,6 @@ use TestApp\Controller\Component\TestAuthComponent;
  */
 class AuthComponentTest extends TestCase
 {
-
     /**
      * AuthComponent property
      *

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -27,7 +27,6 @@ use Cake\Utility\Security;
  */
 class CookieComponentTest extends TestCase
 {
-
     /**
      * @var \Cake\Controller\Component\CookieComponent
      */

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class CsrfComponentTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -27,7 +27,6 @@ use Exception;
  */
 class FlashComponentTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -32,7 +32,6 @@ use stdClass;
  */
 class PaginatorTestController extends Controller
 {
-
     /**
      * components property
      *
@@ -50,7 +49,6 @@ class CustomPaginator extends Paginator
 
 class PaginatorComponentTest extends TestCase
 {
-
     /**
      * fixtures property
      *
@@ -1374,7 +1372,6 @@ class PaginatorComponentTest extends TestCase
      * Helper method for mocking queries.
      *
      * @param string|null $table
-     *
      * @return \Cake\ORM\Query|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function _getMockFindQuery($table = null)

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -35,7 +35,6 @@ use Zend\Diactoros\Stream;
  */
 class RequestHandlerComponentTest extends TestCase
 {
-
     /**
      * @var RequestHandlerTestController
      */

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -31,7 +31,6 @@ use Cake\Utility\Security;
  */
 class TestSecurityComponent extends SecurityComponent
 {
-
     /**
      * validatePost method
      *
@@ -60,7 +59,6 @@ class TestSecurityComponent extends SecurityComponent
  */
 class SecurityTestController extends Controller
 {
-
     /**
      * components property
      *
@@ -176,7 +174,6 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     *
      * Resets environment state.
      *
      * @return void

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -32,7 +32,6 @@ class CookieAliasComponent extends CookieComponent
 
 class ComponentRegistryTest extends TestCase
 {
-
     /**
      * setUp
      *

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -30,7 +30,6 @@ use TestApp\Controller\Component\SomethingWithCookieComponent;
  */
 class ComponentTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -33,7 +33,6 @@ use TestPlugin\Controller\TestPluginController;
  */
 class ControllerTestAppController extends Controller
 {
-
     /**
      * helpers property
      *
@@ -61,7 +60,6 @@ class ControllerTestAppController extends Controller
  */
 class TestController extends ControllerTestAppController
 {
-
     /**
      * Theme property
      *
@@ -159,7 +157,6 @@ class TestController extends ControllerTestAppController
  */
 class TestComponent extends Component
 {
-
     /**
      * beforeRedirect method
      *
@@ -226,7 +223,6 @@ class AnotherTestController extends ControllerTestAppController
  */
 class ControllerTest extends TestCase
 {
-
     /**
      * fixtures property
      *

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class AuthSecurityExceptionTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class SecurityExceptionTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -23,7 +23,6 @@ use TestApp\Core\TestApp;
  */
 class AppTest extends TestCase
 {
-
     /**
      * tearDown method
      *

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -30,7 +30,6 @@ use TestPlugin\Plugin as TestPlugin;
  */
 class BasePluginTest extends TestCase
 {
-
     /**
      * tearDown method
      *

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class IniConfigTest extends TestCase
 {
-
     /**
      * Test data to serialize and unserialize.
      *

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonConfigTest extends TestCase
 {
-
     /**
      * Test data to serialize and unserialize.
      *

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class PhpConfigTest extends TestCase
 {
-
     /**
      * Test data to serialize and unserialize.
      *

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConfigureTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -23,7 +23,6 @@ use Exception;
  */
 class CommandRetryTest extends TestCase
 {
-
     /**
      * Simple retry test
      *

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -84,7 +84,6 @@ class TestLogStaticConfig
  */
 class StaticConfigTraitTest extends TestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -36,7 +36,6 @@ use ReflectionProperty;
  */
 class ConnectionTest extends TestCase
 {
-
     public $fixtures = ['core.Things'];
 
     /**
@@ -492,6 +491,7 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests delete from table with conditions
+     *
      * @return void
      */
     public function testDeleteWithConditions()

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -23,7 +23,6 @@ use PDO;
  */
 class MysqlTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -23,7 +23,6 @@ use PDO;
  */
 class PostgresTest extends TestCase
 {
-
     /**
      * Test connecting to Postgres with default configuration
      *

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -23,7 +23,6 @@ use PDO;
  */
 class SqliteTest extends TestCase
 {
-
     /**
      * Test connecting to Sqlite with default configuration
      *

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -24,7 +24,6 @@ use PDO;
  */
 class SqlserverTest extends TestCase
 {
-
     /**
      * Set up
      *

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class CaseExpressionTest extends TestCase
 {
-
     /**
      * Test that the sql output works correctly
      *

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class FunctionExpressionTest extends TestCase
 {
-
     /**
      * Tests generating a function with no arguments
      *

--- a/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
+++ b/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
@@ -24,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class IdentifierExpressionTest extends TestCase
 {
-
     /**
      * Tests getting and setting the field
      *

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class TupleComparisonTest extends TestCase
 {
-
     /**
      * Tests generating a function with no arguments
      *

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -39,7 +39,6 @@ class UuidValue
  */
 class OrderedUuidType extends Type implements ExpressionTypeInterface
 {
-
     public function toPHP($value, Driver $d)
     {
         return new UuidValue($value);
@@ -68,11 +67,9 @@ class OrderedUuidType extends Type implements ExpressionTypeInterface
 /**
  * Tests for Expression objects casting values to other expressions
  * using the type classes
- *
  */
 class ExpressionTypeCastingIntegrationTest extends TestCase
 {
-
     public $fixtures = ['core.OrderedUuidItems'];
 
     public function setUp()

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
 
 class TestType extends StringType implements ExpressionTypeInterface
 {
-
     public function toExpression($value)
     {
         return new FunctionExpression('CONCAT', [$value, ' - foo']);
@@ -36,11 +35,9 @@ class TestType extends StringType implements ExpressionTypeInterface
 /**
  * Tests for Expression objects casting values to other expressions
  * using the type classes
- *
  */
 class ExpressionTypeCastingTest extends TestCase
 {
-
     /**
      * Setups a mock for FunctionsBuilder
      *

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class FunctionsBuilderTest extends TestCase
 {
-
     /**
      * Setups a mock for FunctionsBuilder
      *

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class LoggedQueryTest extends TestCase
 {
-
     /**
      * Tests that LoggedQuery can be converted to string
      *

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class LoggingStatementTest extends TestCase
 {
-
     /**
      * Tests that queries are logged when executed without params
      *

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class QueryLoggerTest extends TestCase
 {
-
     /**
      * Set up
      *

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -31,7 +31,6 @@ use TestApp\Database\Type\BarType;
  */
 class QueryTest extends TestCase
 {
-
     public $fixtures = [
         'core.Articles',
         'core.Authors',
@@ -868,6 +867,7 @@ class QueryTest extends TestCase
 
     /**
      * Tests exception message for impossible condition when using an expression
+     *
      * @return void
      */
     public function testSelectWhereArrayTypeEmptyWithExpression()
@@ -3069,7 +3069,6 @@ class QueryTest extends TestCase
      * warning about possible incompatibilities with aliases being removed
      * from the conditions.
      *
-     *
      * @return void
      */
     public function testDeleteRemovingAliasesCanBreakJoins()
@@ -3169,7 +3168,6 @@ class QueryTest extends TestCase
     /**
      * Test update with type checking
      * by passing an array as table arg
-     *
      *
      * @return void
      */
@@ -3653,7 +3651,6 @@ class QueryTest extends TestCase
 
     /**
      * Test that an exception is raised when mixing query + array types.
-     *
      */
     public function testInsertFailureMixingTypesArrayFirst()
     {
@@ -3668,7 +3665,6 @@ class QueryTest extends TestCase
 
     /**
      * Test that an exception is raised when mixing query + array types.
-     *
      */
     public function testInsertFailureMixingTypesQueryFirst()
     {
@@ -4950,6 +4946,7 @@ class QueryTest extends TestCase
 
     /**
      * Test that calling fetchAssoc return an associated array.
+     *
      * @return void
      * @throws \Exception
      */
@@ -4979,6 +4976,7 @@ class QueryTest extends TestCase
 
     /**
      * Test that calling fetchAssoc return an empty associated array.
+     *
      * @return void
      * @throws \Exception
      */
@@ -4998,6 +4996,7 @@ class QueryTest extends TestCase
 
     /**
      * Test that calling fetch with with FETCH_TYPE_OBJ return stdClass object.
+     *
      * @return void
      * @throws \Exception
      */
@@ -5020,6 +5019,7 @@ class QueryTest extends TestCase
 
     /**
      * Test that fetchColumn() will return the correct value at $position.
+     *
      * @throws \Exception
      * @return void
      */
@@ -5058,6 +5058,7 @@ class QueryTest extends TestCase
 
     /**
      * Test that fetchColumn() will return false if $position is not set.
+     *
      * @throws \Exception
      * @return void
      */

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -27,7 +27,6 @@ use PDO;
  */
 class MysqlSchemaTest extends TestCase
 {
-
     /**
      * Helper method for skipping tests that need a real connection.
      *

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -27,7 +27,6 @@ use PDO;
  */
 class PostgresSchemaTest extends TestCase
 {
-
     /**
      * Helper method for skipping tests that need a real connection.
      *

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -27,7 +27,6 @@ use PDO;
  */
 class SqliteSchemaTest extends TestCase
 {
-
     /**
      * Helper method for skipping tests that need a real connection.
      *

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class FooType extends Type
 {
-
     public function getBaseType()
     {
         return 'integer';
@@ -36,7 +35,6 @@ class FooType extends Type
  */
 class TableTest extends TestCase
 {
-
     public $fixtures = [
         'core.Articles',
         'core.Tags',
@@ -321,6 +319,7 @@ class TableTest extends TestCase
     /**
      * Test adding an constraint.
      * >
+     *
      * @return void
      */
     public function testAddConstraint()
@@ -340,6 +339,7 @@ class TableTest extends TestCase
     /**
      * Test adding an constraint with an overlapping unique index
      * >
+     *
      * @return void
      */
     public function testAddConstraintOverwriteUniqueIndex()

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class SchemaCacheTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/tests/TestCase/Database/Statement/StatementDecoratorTest.php
+++ b/tests/TestCase/Database/Statement/StatementDecoratorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class StatementDecoratorTest extends TestCase
 {
-
     /**
      * Tests that calling lastInsertId will proxy it to
      * the driver's lastInsertId method

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -85,7 +85,6 @@ class BinaryTypeTest extends TestCase
 
     /**
      * Test exceptions on invalid data.
-     *
      */
     public function testToPHPFailure()
     {

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -23,7 +23,6 @@ use PDO;
  */
 class StringTypeTest extends TestCase
 {
-
     /**
      * Setup
      *

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -26,7 +26,6 @@ use TestApp\Database\Type\FooType;
  */
 class TypeTest extends TestCase
 {
-
     /**
      * Original type map
      *

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -58,7 +58,6 @@ class FakeConnection
  */
 class ConnectionManagerTest extends TestCase
 {
-
     /**
      * tearDown method
      *
@@ -107,7 +106,6 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test invalid classes cause exceptions
-     *
      */
     public function testConfigInvalidOptions()
     {

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -36,7 +36,6 @@ class Stub
  */
 class ModelAwareTraitTest extends TestCase
 {
-
     /**
      * Test set modelClass
      *

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -23,7 +23,6 @@ use Cake\ORM\Entity;
 
 trait PaginatorTestTrait
 {
-
     /**
      * @var \Cake\Datasource\Paginator
      */

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class QueryCacherTest extends TestCase
 {
-
     /**
      * Setup method
      *

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ResultSetDecoratorTest extends TestCase
 {
-
     /**
      * Tests the decorator can wrap a simple iterator
      *

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -29,7 +29,6 @@ class DebuggerTestCaseDebugger extends Debugger
 
 class DebuggableThing
 {
-
     public function __debugInfo()
     {
         return ['foo' => 'bar', 'inner' => new self()];
@@ -49,7 +48,6 @@ class SecurityThing
  */
 class DebuggerTest extends TestCase
 {
-
     protected $_restoreError = false;
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -33,7 +33,6 @@ use ParseError;
  */
 class TestErrorHandler extends ErrorHandler
 {
-
     /**
      * Access the response used.
      *
@@ -67,12 +66,10 @@ class TestErrorHandler extends ErrorHandler
  */
 class ErrorHandlerTest extends TestCase
 {
-
     protected $_restoreError = false;
 
     /**
      * error level property
-     *
      */
     private static $errorLevel;
 

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -50,7 +50,6 @@ use TestApp\Controller\Admin\ErrorController;
  */
 class BlueberryComponent extends Component
 {
-
     /**
      * testName property
      *
@@ -75,7 +74,6 @@ class BlueberryComponent extends Component
  */
 class TestErrorController extends Controller
 {
-
     /**
      * uses property
      *
@@ -153,7 +151,6 @@ class MissingWidgetThing extends \Exception
  */
 class ExceptionRendererTest extends TestCase
 {
-
     /**
      * @var bool
      */

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -81,7 +81,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test an invalid rendering class.
-     *
      */
     public function testInvalidRenderer()
     {

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConditionDecoratorTest extends TestCase
 {
-
     /**
      * testCanTriggerIf
      *
@@ -93,7 +92,6 @@ class ConditionDecoratorTest extends TestCase
 
     /**
      * testCallableRuntimeException
-     *
      */
     public function testCallableRuntimeException()
     {

--- a/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class SubjectFilterDecoratorTest extends TestCase
 {
-
     /**
      * testCanTrigger
      *

--- a/tests/TestCase/Event/EventListTest.php
+++ b/tests/TestCase/Event/EventListTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class EvenListTest extends TestCase
 {
-
     /**
      * testAddEventAndFlush
      *

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -26,7 +26,6 @@ use TestApp\Event\TestEvent;
  */
 class EventTestListener
 {
-
     public $callList = [];
 
     /**
@@ -66,7 +65,6 @@ class EventTestListener
  */
 class CustomTestEventListenerInterface extends EventTestListener implements EventListenerInterface
 {
-
     public function implementedEvents()
     {
         return [
@@ -95,7 +93,6 @@ class CustomTestEventListenerInterface extends EventTestListener implements Even
  */
 class EventManagerTest extends TestCase
 {
-
     /**
      * @return void
      */
@@ -746,6 +743,7 @@ class EventManagerTest extends TestCase
     /**
      * Tests events dispatched by a local manager can be handled by
      * handler registered in the global event manager
+     *
      * @triggers my_event $manager
      */
     public function testDispatchLocalHandledByGlobal()

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class EventTest extends TestCase
 {
-
     /**
      * Tests the name() method
      *

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -26,7 +26,6 @@ use Exception;
 
 class ExceptionsTest extends TestCase
 {
-
     /**
      * Tests simple exceptions work.
      *

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -24,7 +24,6 @@ use SplFileInfo;
  */
 class FileTest extends TestCase
 {
-
     /**
      * File property
      *

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class FolderTest extends TestCase
 {
-
     /**
      * setUp clearstatcache() to flush file descriptors.
      *

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -26,7 +26,6 @@ use TestApp\Form\ValidateForm;
  */
 class FormTest extends TestCase
 {
-
     /**
      * Test schema()
      *

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class SchemaTest extends TestCase
 {
-
     /**
      * Test adding multiple fields.
      *

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class CurlTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class CakeStreamWrapper implements \ArrayAccess
 {
-
     private $_stream;
 
     private $_query = [];
@@ -101,7 +100,6 @@ class CakeStreamWrapper implements \ArrayAccess
  */
 class StreamTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class DigestTest extends TestCase
 {
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Cake\Http\Client
      */

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class OauthTest extends TestCase
 {
-
     private $privateKeyString = '-----BEGIN RSA PRIVATE KEY-----
 MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALRiMLAh9iimur8V
 A7qVvdqxevEuUkW4K+2KdMXmnQbG9Aa7k7eBjK1S+0LYmVjPKlJGNXHDGuy5Fw/d

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class CookieCollectionTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class FormDataTest extends TestCase
 {
-
     /**
      * Test getting the boundary.
      *

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -22,7 +22,6 @@ use Zend\Diactoros\Uri;
  */
 class RequestTest extends TestCase
 {
-
     /**
      * test string ata, header and constructor
      *
@@ -47,7 +46,6 @@ class RequestTest extends TestCase
      * @param array $headers The HTTP headers to set.
      * @param array|string|null $data The request body to use.
      * @param string $method The HTTP method to use.
-     *
      * @dataProvider additionProvider
      */
     public function testMethods(array $headers, $data, $method)

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -26,7 +26,6 @@ use InvalidArgumentException;
  */
 class ClientTest extends TestCase
 {
-
     /**
      * Test storing config options and modifying them.
      *

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -26,7 +26,6 @@ use DateTime;
  */
 class CookieCollectionTest extends TestCase
 {
-
     /**
      * Test constructor
      *

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class CookieTest extends TestCase
 {
-
     /**
      * Generate invalid cookie names.
      *

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class BodyParserMiddlewareTest extends TestCase
 {
-
     /**
      * Data provider for HTTP method tests.
      *

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -28,7 +28,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class CsrfProtectionMiddlewareTest extends TestCase
 {
-
     /**
      * Data provider for HTTP method tests.
      *

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -24,7 +24,6 @@ use Laminas\Diactoros\Response;
  */
 class SecurityHeadersMiddlewareTest extends TestCase
 {
-
     /**
      * Test adding the security headers
      *

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -124,7 +124,6 @@ class RunnerTest extends TestCase
 
     /**
      * Test that exceptions bubble up.
-     *
      */
     public function testRunExceptionInMiddleware()
     {

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class CacheSessionTest extends TestCase
 {
-
     protected static $_sessionBackup;
 
     /**

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class DatabaseSessionTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -26,7 +26,6 @@ use RuntimeException;
  */
 class TestCacheSession extends CacheSession
 {
-
     protected function _writeSession()
     {
         return true;
@@ -38,7 +37,6 @@ class TestCacheSession extends CacheSession
  */
 class TestDatabaseSession extends DatabaseSession
 {
-
     protected function _writeSession()
     {
         return true;
@@ -50,7 +48,6 @@ class TestDatabaseSession extends DatabaseSession
  */
 class TestWebSession extends Session
 {
-
     protected function _hasSession()
     {
         $isCLI = $this->_isCLI;
@@ -69,7 +66,6 @@ class TestWebSession extends Session
  */
 class SessionTest extends TestCase
 {
-
     protected static $_gcDivisor;
 
     /**

--- a/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class SprintfFormatterTest extends TestCase
 {
-
     /**
      * Tests that variables are interpolated correctly
      *

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -26,7 +26,6 @@ use Locale;
  */
 class I18nTest extends TestCase
 {
-
     /**
      * Used to restore the internal locale after tests
      *

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class MessagesFileLoaderTest extends TestCase
 {
-
     /**
      * Set Up
      *
@@ -67,6 +66,7 @@ class MessagesFileLoaderTest extends TestCase
 
     /**
      * Test reading MO files
+     *
      * @return void
      */
     public function testLoadingMoFiles()

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -26,7 +26,6 @@ use Locale;
  */
 class LocaleSelectorMiddlewareTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class MoFileParserTest extends TestCase
 {
-
     /**
      * Tests parsing a file with plurals and message context
      *

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class PluralRulesTest extends TestCase
 {
-
     /**
      * Returns the notable combinations for locales and numbers
      * with the respective plural form that should be selected

--- a/tests/TestCase/I18n/TranslatorFactoryTest.php
+++ b/tests/TestCase/I18n/TranslatorFactoryTest.php
@@ -26,7 +26,6 @@ class TranslatorFactoryTest extends TestCase
 {
     /**
      * Test that errors are emitted when stale cache files are found.
-     *
      */
     public function testNewInstanceErrorOnFallback()
     {

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -31,7 +31,6 @@ class BaseLogImpl extends BaseLog
      * @param mixed $level
      * @param mixed $message
      * @param array $context
-     *
      * @return mixed
      */
     public function log($level, $message, array $context = [])
@@ -42,7 +41,6 @@ class BaseLogImpl extends BaseLog
 
 class BaseLogTest extends TestCase
 {
-
     private $testData = ['ä', 'ö', 'ü'];
 
     private $logger;

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConsoleLogTest extends TestCase
 {
-
     /**
      * Test writing to ConsoleOutput
      */

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -25,7 +25,6 @@ use JsonSerializable;
  */
 class StringObject
 {
-
     /**
      * String representation of the object
      *
@@ -42,7 +41,6 @@ class StringObject
  */
 class JsonObject implements JsonSerializable
 {
-
     /**
      * String representation of the object
      *
@@ -59,7 +57,6 @@ class JsonObject implements JsonSerializable
  */
 class FileLogTest extends TestCase
 {
-
     /**
      * testLogFileWriting method
      *

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class SyslogLogTest extends TestCase
 {
-
     /**
      * Tests that the connection to the logger is open with the right arguments
      *

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class LogTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class LogTraitTest extends TestCase
 {
-
     public function tearDown()
     {
         parent::tearDown();

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -28,7 +28,6 @@ use SimpleXmlElement;
  */
 class TestEmail extends Email
 {
-
     /**
      * Wrap to protected method
      *
@@ -105,7 +104,6 @@ class TestEmail extends Email
  */
 class EmailTest extends TestCase
 {
-
     public $fixtures = ['core.Users'];
 
     /**
@@ -410,7 +408,6 @@ class EmailTest extends TestCase
      * Tests not found transport class name exception
      *
      * @return void
-     *
      */
     public function testClassNameException()
     {
@@ -424,7 +421,6 @@ class EmailTest extends TestCase
      * Tests that it is possible to unset the email pattern and make use of filter_var() instead.
      *
      * @return void
-     *
      */
     public function testUnsetEmailPattern()
     {
@@ -444,7 +440,6 @@ class EmailTest extends TestCase
      * Tests that passing an empty string throws an InvalidArgumentException.
      *
      * @return void
-     *
      */
     public function testEmptyTo()
     {
@@ -950,7 +945,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that using unknown transports fails.
-     *
      */
     public function testTransportInvalid()
     {
@@ -961,7 +955,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that using classes with no send method fails.
-     *
      */
     public function testTransportInstanceInvalid()
     {
@@ -971,7 +964,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that using unknown transports fails.
-     *
      */
     public function testTransportTypeInvalid()
     {
@@ -982,7 +974,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that using misconfigured transports fails.
-     *
      */
     public function testTransportMissingClassName()
     {
@@ -1044,7 +1035,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that exceptions are raised when duplicate transports are configured.
-     *
      */
     public function testConfigTransportErrorOnDuplicate()
     {
@@ -1177,7 +1167,6 @@ class EmailTest extends TestCase
 
     /**
      * Test that using an invalid profile fails.
-     *
      */
     public function testProfileInvalid()
     {

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -32,7 +32,6 @@ class Stub
  */
 class MailerAwareTraitTest extends TestCase
 {
-
     /**
      * Test getMailer
      *
@@ -49,7 +48,6 @@ class MailerAwareTraitTest extends TestCase
 
     /**
      * Test exception thrown by getMailer.
-     *
      */
     public function testGetMailerThrowsException()
     {

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class DebugTransportTest extends TestCase
 {
-
     /**
      * Setup
      *

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class MailTransportTest extends TestCase
 {
-
     /**
      * Setup
      *

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class SmtpTestTransport extends SmtpTransport
 {
-
     /**
      * Helper to change the socket
      *
@@ -66,7 +65,6 @@ class SmtpTestTransport extends SmtpTransport
  */
 class SmtpTransportTest extends TestCase
 {
-
     /**
      * Setup
      *

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class SocketTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class BelongsToTest extends TestCase
 {
-
     /**
      * Fixtures to use.
      *

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -423,7 +423,6 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test exceptional case.
-     *
      */
     public function testErrorOnUnknownAlias()
     {

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class AssociationProxyTest extends TestCase
 {
-
     /**
      * Fixtures to be loaded
      *

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class TestTable extends Table
 {
-
     public function initialize(array $config = [])
     {
         $this->setSchema(['id' => ['type' => 'integer']]);
@@ -41,7 +40,6 @@ class TestTable extends Table
  */
 class AssociationTest extends TestCase
 {
-
     /**
      * @var \Cake\ORM\Association|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class PostTable extends Table
 {
-
     public function findPublished(Query $query, array $options)
     {
         return $query->where(['published' => true]);
@@ -39,7 +38,6 @@ class PostTable extends Table
  */
 class CounterCacheBehaviorTest extends TestCase
 {
-
     /**
      * Fixture
      *

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\Error\Deprecated;
  */
 class TimestampBehaviorTest extends TestCase
 {
-
     /**
      * autoFixtures
      *

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -28,7 +28,6 @@ class TestEntity extends Entity
  */
 class TranslateTraitTest extends TestCase
 {
-
     /**
      * Tests that missing translation entries are created automatically
      *

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -36,7 +36,6 @@ class Article extends Entity
  */
 class TranslateBehaviorTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class TreeBehaviorTest extends TestCase
 {
-
     /**
      * fixtures
      *

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class BehaviorRegistryTest extends TestCase
 {
-
     /**
      * setup method.
      *
@@ -285,7 +284,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test errors on unknown methods.
-     *
      */
     public function testCallError()
     {
@@ -326,7 +324,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test errors on unknown methods.
-     *
      */
     public function testCallFinderError()
     {
@@ -338,7 +335,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test errors on unloaded behavior methods.
-     *
      */
     public function testUnloadBehaviorThenCall()
     {
@@ -352,7 +348,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test errors on unloaded behavior finders.
-     *
      */
     public function testUnloadBehaviorThenCallFinder()
     {

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class TestBehavior extends Behavior
 {
-
     /**
      * Test for event bindings.
      */
@@ -71,7 +70,6 @@ class TestBehavior extends Behavior
  */
 class Test2Behavior extends Behavior
 {
-
     protected $_defaultConfig = [
         'implementedFinders' => [
             'foo' => 'findFoo',
@@ -108,7 +106,6 @@ class Test2Behavior extends Behavior
  */
 class Test3Behavior extends Behavior
 {
-
     /**
      * Test for event bindings.
      */
@@ -182,7 +179,6 @@ class Test3Behavior extends Behavior
  */
 class BehaviorTest extends TestCase
 {
-
     /**
      * Test the side effects of the constructor.
      *
@@ -417,7 +413,6 @@ class BehaviorTest extends TestCase
     /**
      * testVerifyImplementedFindersInvalid
      *
-     *
      * @return void
      */
     public function testVerifyImplementedFindersInvalid()
@@ -455,7 +450,6 @@ class BehaviorTest extends TestCase
 
     /**
      * testVerifyImplementedMethodsInvalid
-     *
      *
      * @return void
      */

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class BindingKeyTest extends TestCase
 {
-
     /**
      * Fixture to be used
      *

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -29,7 +29,6 @@ use PDO;
  */
 class OpenArticleEntity extends Entity
 {
-
     protected $_accessible = [
         '*' => true,
     ];
@@ -40,7 +39,6 @@ class OpenArticleEntity extends Entity
  */
 class CompositeKeyTest extends TestCase
 {
-
     /**
      * Fixture to be used
      *

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -28,7 +28,6 @@ use InvalidArgumentException;
  */
 class EagerLoaderTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -24,7 +24,6 @@ use TestApp\Model\Entity\NonExtending;
  */
 class EntityTest extends TestCase
 {
-
     /**
      * Tests setting a single property in an entity without custom setters
      *

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class LocatorAwareTraitTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -29,7 +29,6 @@ use TestPlugin\Infrastructure\Table\AddressesTable as PluginAddressesTable;
  */
 class MyUsersTable extends Table
 {
-
     /**
      * Overrides default table name
      *
@@ -43,7 +42,6 @@ class MyUsersTable extends Table
  */
 class TableLocatorTest extends TestCase
 {
-
     /**
      * TableLocator instance.
      *

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -28,7 +28,6 @@ use Cake\Validation\Validator;
  */
 class OpenEntity extends Entity
 {
-
     protected $_accessible = [
         '*' => true,
     ];
@@ -39,7 +38,6 @@ class OpenEntity extends Entity
  */
 class Tag extends Entity
 {
-
     protected $_accessible = [
         'tag' => true,
     ];
@@ -50,7 +48,6 @@ class Tag extends Entity
  */
 class ProtectedArticle extends Entity
 {
-
     protected $_accessible = [
         'title' => true,
         'body' => true,
@@ -97,7 +94,6 @@ class GreedyCommentsTable extends Table
  */
 class MarshallerTest extends TestCase
 {
-
     public $fixtures = [
         'core.Articles',
         'core.ArticlesTags',

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -28,7 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class QueryRegressionTest extends TestCase
 {
-
     /**
      * Fixture to be used
      *
@@ -260,6 +259,7 @@ class QueryRegressionTest extends TestCase
      * Test for https://github.com/cakephp/cakephp/issues/3626
      *
      * Checks that join data is actually created and not tried to be updated every time
+     *
      * @return void
      */
     public function testCreateJointData()

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -31,7 +31,6 @@ use Cake\TestSuite\TestCase;
  */
 class QueryTest extends TestCase
 {
-
     /**
      * Fixture to be used
      *

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -28,7 +28,6 @@ use TestApp\Model\Entity\Article;
  */
 class ResultSetTest extends TestCase
 {
-
     public $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class RulesCheckerIntegrationTest extends TestCase
 {
-
     /**
      * Fixtures to be loaded
      *

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class SaveOptionsBuilderTest extends TestCase
 {
-
     public $fixtures = [
         'core.Articles',
         'core.Authors',

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class TableRegistryTest extends TestCase
 {
-
     /**
      * Original TableLocator.
      *

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -22,7 +22,6 @@ use InvalidArgumentException;
  */
 class TableRegressionTest extends TestCase
 {
-
     /**
      * Fixture to be used
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -46,7 +46,6 @@ use InvalidArgumentException;
  */
 class UsersTable extends Table
 {
-
 }
 
 class ProtectedEntity extends Entity
@@ -63,7 +62,6 @@ class ProtectedEntity extends Entity
  */
 class TableTest extends TestCase
 {
-
     public $fixtures = [
         'core.Articles',
         'core.Tags',
@@ -1028,7 +1026,6 @@ class TableTest extends TestCase
 
     /**
      * Test that exceptions from the Query bubble up.
-     *
      */
     public function testUpdateAllFailure()
     {
@@ -1093,7 +1090,6 @@ class TableTest extends TestCase
 
     /**
      * Test that exceptions from the Query bubble up.
-     *
      */
     public function testDeleteAllFailure()
     {
@@ -1861,7 +1857,6 @@ class TableTest extends TestCase
 
     /**
      * Ensure exceptions are raised on missing behaviors.
-     *
      */
     public function testAddBehaviorMissing()
     {

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Text;
  */
 class TableUuidTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class DispatcherFilterTest extends TestCase
 {
-
     /**
      * Test that the constructor takes config.
      *

--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AssetFilterTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class ControllerFactoryFilterTest extends TestCase
 {
-
     /**
      * testBeforeDispatch
      *

--- a/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
+++ b/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
@@ -26,7 +26,6 @@ use Locale;
  */
 class LocaleSelectorFilterTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -29,7 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class RoutingFilterTest extends TestCase
 {
-
     /**
      * test setting parameters in beforeDispatch method
      *

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -214,7 +214,6 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test missing routes not being caught.
-     *
      */
     public function testMissingRouteNotCaught()
     {

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class DashedRouteTest extends TestCase
 {
-
     /**
      * test that routes match their pattern.
      *

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class InflectedRouteTest extends TestCase
 {
-
     /**
      * test that routes match their pattern.
      *

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class PluginShortRouteTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class RedirectRouteTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -40,7 +40,6 @@ class RouteProtected extends Route
  */
 class RouteTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -29,7 +29,6 @@ use RuntimeException;
  */
 class RouteBuilderTest extends TestCase
 {
-
     /**
      * Setup method
      *

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
 
 class RouteCollectionTest extends TestCase
 {
-
     /**
      * Setup method
      *
@@ -37,7 +36,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parse() throws an error on unknown routes.
-     *
      */
     public function testParseMissingRoute()
     {
@@ -53,7 +51,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parse() throws an error on known routes called with unknown methods.
-     *
      */
     public function testParseMissingRouteMethod()
     {
@@ -244,7 +241,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parseRequest() throws an error on unknown routes.
-     *
      */
     public function testParseRequestMissingRoute()
     {
@@ -442,7 +438,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test match() throws an error on unknown routes.
-     *
      */
     public function testMatchError()
     {
@@ -510,7 +505,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test match() throws an error on named routes that fail to match
-     *
      */
     public function testMatchNamedError()
     {
@@ -639,7 +633,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test the add() with some _name.
-     *
      *
      * @return void
      */

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -30,7 +30,6 @@ use RuntimeException;
  */
 class RouterTest extends TestCase
 {
-
     /**
      * setUp method
      *
@@ -1845,7 +1844,6 @@ class RouterTest extends TestCase
 
     /**
      * Test exceptions when parsing fails.
-     *
      */
     public function testParseError()
     {

--- a/tests/TestCase/Shell/CacheShellTest.php
+++ b/tests/TestCase/Shell/CacheShellTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class CacheShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class CommandListShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class TestCompletionStringOutput extends ConsoleOutput
 {
-
     public $output = '';
 
     protected function _write($message)
@@ -38,7 +37,6 @@ class TestCompletionStringOutput extends ConsoleOutput
  */
 class CompletionShellTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -69,7 +69,6 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test that a callback is required.
-     *
      */
     public function testOutputFailure()
     {

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class I18nShellTest extends TestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/Shell/PluginShellTest.php
+++ b/tests/TestCase/Shell/PluginShellTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class PluginShellTest extends TestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class RoutesShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Shell/SchemaCacheShellTest.php
+++ b/tests/TestCase/Shell/SchemaCacheShellTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class SchemaCacheShellTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/tests/TestCase/Shell/ServerShellTest.php
+++ b/tests/TestCase/Shell/ServerShellTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ServerShellTest extends TestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/Shell/Task/AssetsTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssetsTaskTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class AssetsTaskTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class ExtractTaskTest extends TestCase
 {
-
     /**
      * setUp method
      *
@@ -388,6 +387,7 @@ class ExtractTaskTest extends TestCase
 
     /**
      * A useful function to mock/replace err or out function that allows to use expectOutput
+     *
      * @param string $val
      * @param int $nbLines
      */

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -22,7 +22,6 @@ use PHPUnit\Framework\AssertionFailedError;
 
 class ConsoleIntegrationTestTraitTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * setUp
      *

--- a/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
@@ -12,7 +12,6 @@ use Cake\TestSuite\TestCase;
  */
 class EventFiredTest extends TestCase
 {
-
     /**
      * tests EventFired constraint
      *

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -12,7 +12,6 @@ use Cake\TestSuite\TestCase;
  */
 class EventFiredWithTest extends TestCase
 {
-
     /**
      * tests EventFiredWith constraint
      *

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -29,7 +29,6 @@ use PDOException;
  */
 class FixtureManagerTest extends TestCase
 {
-
     /**
      * Setup method
      *
@@ -283,7 +282,6 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test that unknown types are handled gracefully.
-     *
      */
     public function testFixturizeInvalidType()
     {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -36,7 +36,6 @@ use PHPUnit\Framework\AssertionFailedError;
  */
 class IntegrationTestTraitTest extends IntegrationTestCase
 {
-
     /**
      * Setup method
      *

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -30,7 +30,6 @@ use Cake\Test\Fixture\FixturizedTestCase;
  */
 class SecondaryPostsTable extends Table
 {
-
     /**
      * @return string
      */
@@ -45,10 +44,8 @@ class SecondaryPostsTable extends Table
  */
 class TestCaseTest extends TestCase
 {
-
     /**
      * tests trying to assertEventFired without configuring an event list
-     *
      */
     public function testEventFiredMisconfiguredEventList()
     {
@@ -59,7 +56,6 @@ class TestCaseTest extends TestCase
 
     /**
      * tests trying to assertEventFired without configuring an event list
-     *
      */
     public function testEventFiredWithMisconfiguredEventList()
     {

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -26,7 +26,6 @@ use Exception;
  */
 class ArticlesFixture extends TestFixture
 {
-
     /**
      * Table property
      *
@@ -65,7 +64,6 @@ class ArticlesFixture extends TestFixture
  */
 class StringsTestsFixture extends TestFixture
 {
-
     /**
      * Table property
      *
@@ -102,7 +100,6 @@ class StringsTestsFixture extends TestFixture
  */
 class ImportsFixture extends TestFixture
 {
-
     /**
      * Import property
      *
@@ -126,7 +123,6 @@ class ImportsFixture extends TestFixture
  */
 class LettersFixture extends TestFixture
 {
-
     /**
      * records property
      *
@@ -144,7 +140,6 @@ class LettersFixture extends TestFixture
  */
 class TestFixtureTest extends TestCase
 {
-
     /**
      * Fixtures for this test.
      *

--- a/tests/TestCase/TestSuite/TestSuiteTest.php
+++ b/tests/TestCase/TestSuite/TestSuiteTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class TestSuiteTest extends TestCase
 {
-
     /**
      * testAddTestDirectory
      *

--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Crypto\Mcrypt;
  */
 class McryptTest extends TestCase
 {
-
     /**
      * Setup function.
      *

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Hash;
  */
 class HashTest extends TestCase
 {
-
     /**
      * Data provider
      *

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Inflector;
  */
 class InflectorTest extends TestCase
 {
-
     /**
      * A list of chars to test transliteration.
      *

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -35,7 +35,6 @@ class Base
 
 class Child extends Base
 {
-
     public $hasBoolean = ['test'];
 
     public $listProperty = ['Two', 'Three'];
@@ -57,7 +56,6 @@ class Child extends Base
 
 class Grandchild extends Child
 {
-
     public $listProperty = ['Four', 'Five'];
 
     public $assocProperty = [
@@ -80,7 +78,6 @@ class Grandchild extends Child
  */
 class MergeVariablesTraitTest extends TestCase
 {
-
     /**
      * Test merging vars as a list.
      *

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Security;
  */
 class SecurityTest extends TestCase
 {
-
     /**
      * testHash method
      *

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Text;
  */
 class TextTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();
@@ -617,6 +616,7 @@ TEXT;
 
     /**
      * Test truncate() method with both exact and html.
+     *
      * @return void
      */
     public function testTruncateExactHtml()

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Xml;
  */
 class XmlTest extends TestCase
 {
-
     /**
      * autoFixtures property
      *
@@ -36,6 +35,7 @@ class XmlTest extends TestCase
 
     /**
      * fixtures property
+     *
      * @var array
      */
     public $fixtures = [

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -22,7 +22,6 @@ use Cake\Validation\RulesProvider;
  */
 class RulesProviderTest extends TestCase
 {
-
     /**
      * Tests that RulesProvider proxies the method correctly and removes the
      * extra arguments that are passed according to the signature of validation

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -22,7 +22,6 @@ use Cake\Validation\ValidationRule;
  */
 class ValidationRuleTest extends TestCase
 {
-
     /**
      * Auxiliary method to test custom validators
      *

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\Error\Deprecated;
  */
 class ValidationSetTest extends TestCase
 {
-
     /**
      * testGetRule method
      *

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -31,7 +31,6 @@ require_once __DIR__ . '/stubs.php';
  */
 class ValidationTest extends TestCase
 {
-
     /**
      * @var string
      */
@@ -1626,7 +1625,6 @@ class ValidationTest extends TestCase
      * Tests that it is possible to pass an ISO8601 value
      *
      * @return void
-     *
      * @see Validation tests values credits: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
      */
     public function testDateTimeISO8601()

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -26,7 +26,6 @@ use Laminas\Diactoros\UploadedFile;
  */
 class ValidatorTest extends TestCase
 {
-
     /**
      * tests getRequiredMessage
      *
@@ -834,7 +833,6 @@ class ValidatorTest extends TestCase
 
     /**
      * Test allowEmptyString with callback
-     *
      */
     public function testAllowEmptyStringCallbackWhen()
     {

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -30,7 +30,6 @@ use TestApp\View\CustomJsonView;
  */
 class CellTest extends TestCase
 {
-
     /**
      * @var \Cake\View\View
      */

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -23,7 +23,6 @@ use Cake\View\Form\ArrayContext;
  */
 class ArrayContextTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -30,7 +30,6 @@ use TestApp\Model\Entity\Tag;
  */
 class Article extends Entity
 {
-
     /**
      * Testing stub method.
      *
@@ -47,7 +46,6 @@ class Article extends Entity
  */
 class EntityContextTest extends TestCase
 {
-
     /**
      * Fixtures to use.
      *
@@ -174,7 +172,6 @@ class EntityContextTest extends TestCase
 
     /**
      * Test an invalid table scope throws an error.
-     *
      */
     public function testInvalidTable()
     {
@@ -188,7 +185,6 @@ class EntityContextTest extends TestCase
 
     /**
      * Tests that passing a plain entity will give an error as it cannot be matched
-     *
      */
     public function testDefaultEntityError()
     {

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -20,7 +20,6 @@ use Cake\View\View;
 
 class BreadcrumbsHelperTest extends TestCase
 {
-
     /**
      * Instance of the BreadcrumbsHelper
      *
@@ -269,7 +268,6 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to a specific index
-     *
      */
     public function testInsertAtIndexOutOfBounds()
     {

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -28,7 +28,6 @@ use Cake\View\View;
  */
 class FlashHelperTest extends TestCase
 {
-
     /**
      * setUp method
      *
@@ -138,7 +137,6 @@ class FlashHelperTest extends TestCase
 
     /**
      * testFlashThrowsException
-     *
      */
     public function testFlashThrowsException()
     {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -41,7 +41,6 @@ class Article extends Entity
  */
 class ContactsTable extends Table
 {
-
     /**
      * Default schema
      *
@@ -77,7 +76,6 @@ class ContactsTable extends Table
  */
 class ValidateUsersTable extends Table
 {
-
     /**
      * schema method
      *
@@ -117,7 +115,6 @@ class ValidateUsersTable extends Table
  */
 class FormHelperTest extends TestCase
 {
-
     /**
      * Fixtures to be used
      *
@@ -466,10 +463,8 @@ class FormHelperTest extends TestCase
      * Test default context selection in create()
      *
      * @dataProvider contextSelectionProvider
-     *
      * @param mixed $data
      * @param string $class
-     *
      * @return void
      */
     public function testCreateContextSelectionBuiltIn($data, $class)
@@ -967,7 +962,6 @@ class FormHelperTest extends TestCase
 
     /**
      * Test base form URL when url param is passed with multiple parameters (&)
-     *
      */
     public function testCreateQueryStringRequest()
     {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -27,7 +27,6 @@ use Cake\View\Helper\HtmlHelper;
  */
 class HtmlHelperTest extends TestCase
 {
-
     /**
      * Regexp for CDATA start block
      *

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -29,7 +29,6 @@ use ReflectionMethod;
  */
 class NumberHelperTestObject extends NumberHelper
 {
-
     public function attach(NumberMock $cakeNumber)
     {
         $this->_engine = $cakeNumber;
@@ -53,7 +52,6 @@ class NumberMock
  */
 class NumberHelperTest extends TestCase
 {
-
     /**
      * setUp method
      *

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -27,7 +27,6 @@ use Cake\View\View;
  */
 class PaginatorHelperTest extends TestCase
 {
-
     /**
      * @var string
      */

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -29,7 +29,6 @@ use Cake\View\View;
  */
 class RssHelperTest extends TestCase
 {
-
     /**
      * @var \Cake\View\Helper\RssHelper
      */

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -25,7 +25,6 @@ use Cake\View\View;
  */
 class TextHelperTestObject extends TextHelper
 {
-
     public function attach(StringMock $string)
     {
         $this->_engine = $string;
@@ -49,7 +48,6 @@ class StringMock
  */
 class TextHelperTest extends TestCase
 {
-
     /**
      * @var \Cake\View\Helper\TextHelper
      */

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -25,7 +25,6 @@ use Cake\View\View;
  */
 class TimeHelperTest extends TestCase
 {
-
     /**
      * @var \Cake\View\Helper\TimeHelper
      */

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -27,7 +27,6 @@ use Cake\View\View;
  */
 class UrlHelperTest extends TestCase
 {
-
     /**
      * @var \Cake\View\Helper\UrlHelper
      */

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -25,7 +25,6 @@ use Cake\View\View;
  */
 class HtmlAliasHelper extends Helper
 {
-
     public function afterRender($viewFile)
     {
     }
@@ -36,7 +35,6 @@ class HtmlAliasHelper extends Helper
  */
 class HelperRegistryTest extends TestCase
 {
-
     /**
      * @var \Cake\View\HelperRegistry
      */

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -25,7 +25,6 @@ use Cake\View\View;
 
 class TestHelper extends Helper
 {
-
     /**
      * Settings for this helper.
      *
@@ -49,7 +48,6 @@ class TestHelper extends Helper
  */
 class HelperTest extends TestCase
 {
-
     /**
      * @var \Cake\View\View
      */

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonViewTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -20,7 +20,6 @@ use Cake\View\StringTemplate;
 
 class StringTemplateTest extends TestCase
 {
-
     /**
      * setUp
      *
@@ -200,7 +199,6 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test that loading non-existing templates causes errors.
-     *
      */
     public function testLoadErrorNoFile()
     {

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -39,7 +39,6 @@ class TestStringTemplate
  */
 class StringTemplateTraitTest extends TestCase
 {
-
     /**
      * @var TestStringTemplate
      */

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -33,7 +33,6 @@ use TestApp\View\AppView;
  */
 class ViewPostsController extends Controller
 {
-
     /**
      * name property
      *
@@ -72,7 +71,6 @@ class ViewPostsController extends Controller
  */
 class ThemePostsController extends Controller
 {
-
     /**
      * index method
      *
@@ -92,7 +90,6 @@ class ThemePostsController extends Controller
  */
 class TestView extends AppView
 {
-
     public function initialize()
     {
         $this->loadHelper('Html', ['mykey' => 'myval']);
@@ -149,7 +146,6 @@ class TestView extends AppView
  */
 class TestBeforeAfterHelper extends Helper
 {
-
     /**
      * property property
      *
@@ -187,7 +183,6 @@ class TestBeforeAfterHelper extends Helper
  */
 class TestObjectWithToString
 {
-
     /**
      * Return string value.
      *
@@ -215,7 +210,6 @@ class TestObjectWithoutToString
  */
 class TestViewEventListenerInterface implements EventListenerInterface
 {
-
     /**
      * type of view before rendering has occurred
      *
@@ -271,7 +265,6 @@ class TestViewEventListenerInterface implements EventListenerInterface
  */
 class ViewTest extends TestCase
 {
-
     /**
      * Fixtures used in this test.
      *

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class ViewVarsTraitTest extends TestCase
 {
-
     /**
      * @var \Cake\Controller\Controller;
      */

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\BasicWidget;
  */
 class BasicWidgetTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\ButtonWidget;
  */
 class ButtonWidgetTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\CheckboxWidget;
  */
 class CheckboxWidgetTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -24,10 +24,8 @@ use Cake\View\Widget\SelectBoxWidget;
  */
 class DateTimeWidgetTest extends TestCase
 {
-
     /**
      * @setUp
-     *
      * @return void
      */
     public function setUp()

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\FileWidget;
  */
 class FileWidgetTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\LabelWidget;
  */
 class LabelWidgetTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -25,7 +25,6 @@ use Cake\View\Widget\NestingLabelWidget;
  */
 class MultiCheckboxWidgetTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -25,7 +25,6 @@ use Cake\View\Widget\RadioWidget;
  */
 class RadioWidgetTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -24,7 +24,6 @@ use Cake\View\Widget\SelectBoxWidget;
  */
 class SelectBoxWidgetTest extends TestCase
 {
-
     /**
      * setup method.
      *

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -23,7 +23,6 @@ use Cake\View\Widget\TextareaWidget;
  */
 class TextareaWidgetTest extends TestCase
 {
-
     /**
      * setup
      *

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -25,7 +25,6 @@ use Cake\View\Widget\WidgetLocator;
  */
 class WidgetLocatorTestCase extends TestCase
 {
-
     /**
      * setup method
      *

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -28,7 +28,6 @@ use Cake\Utility\Xml;
  */
 class XmlViewTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/test_app/Plugin/Company/TestPluginFive/src/Plugin.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/src/Plugin.php
@@ -17,5 +17,4 @@ use Cake\Core\BasePlugin;
 
 class Plugin extends BasePlugin
 {
-
 }

--- a/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
@@ -15,7 +15,6 @@ namespace Company\TestPluginFive\Utility;
 
 class Hello
 {
-
     /**
      * foo method
      *

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
@@ -21,6 +21,5 @@ use Cake\ORM\Table;
  */
 class TestPluginThreeCommentsTable extends Table
 {
-
     protected $_table = 'test_plugin_three_comments';
 }

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Plugin.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Plugin.php
@@ -17,5 +17,4 @@ use Cake\Core\BasePlugin;
 
 class Plugin extends BasePlugin
 {
-
 }

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Utility/Hello.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Utility/Hello.php
@@ -15,7 +15,6 @@ namespace Company\TestPluginThree\Utility;
 
 class Hello
 {
-
     /**
      * foo method
      *

--- a/tests/test_app/Plugin/Company/TestPluginThree/tests/Fixture/ArticlesFixture.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/tests/Fixture/ArticlesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ArticlesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Cache/Engine/TestPluginCacheEngine.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Cache/Engine/TestPluginCacheEngine.php
@@ -24,7 +24,6 @@ use Cake\Cache\CacheEngine;
 
 class TestPluginCacheEngine extends CacheEngine
 {
-
     public function write($key, $value)
     {
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/Admin/CommentsController.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/Admin/CommentsController.php
@@ -22,7 +22,6 @@ use Cake\Controller\Controller;
  */
 class CommentsController extends Controller
 {
-
     /**
      * components
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/Component/PluginsComponent.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/Component/PluginsComponent.php
@@ -22,6 +22,5 @@ use Cake\Controller\Component;
 
 class PluginsComponent extends Component
 {
-
     public $components = ['TestPlugin.Other'];
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/Component/TestPluginComponent.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/Component/TestPluginComponent.php
@@ -22,6 +22,5 @@ use Cake\Controller\Component;
 
 class TestPluginComponent extends Component
 {
-
     public $components = ['TestPlugin.TestPluginOther'];
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/TestPluginController.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/TestPluginController.php
@@ -22,7 +22,6 @@ namespace TestPlugin\Controller;
 
 class TestPluginController extends TestPluginAppController
 {
-
     public function index()
     {
         $this->autoRender = false;

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/TestsController.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/TestsController.php
@@ -20,7 +20,6 @@ namespace TestPlugin\Controller;
 
 class TestsController extends TestPluginAppController
 {
-
     public $helpers = ['TestPlugin.OtherHelper', 'Html'];
 
     public $components = ['TestPlugin.Plugins'];

--- a/tests/test_app/Plugin/TestPlugin/src/Datasource/TestSource.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Datasource/TestSource.php
@@ -3,7 +3,6 @@ namespace TestPlugin\Datasource;
 
 class TestSource
 {
-
     /**
      * Config
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Error/TestPluginExceptionRenderer.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Error/TestPluginExceptionRenderer.php
@@ -26,7 +26,6 @@ use Cake\Error\ExceptionRenderer;
  */
 class TestPluginExceptionRenderer extends ExceptionRenderer
 {
-
     /**
      * Renders the response for the exception.
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
@@ -8,7 +8,6 @@ use SessionHandlerInterface;
  */
 class TestPluginSession implements SessionHandlerInterface
 {
-
     public function open($savePath, $name)
     {
         return true;

--- a/tests/test_app/Plugin/TestPlugin/src/Log/Engine/TestPluginLog.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Log/Engine/TestPluginLog.php
@@ -21,7 +21,6 @@ use Psr\Log\AbstractLogger;
  */
 class TestPluginLog extends AbstractLogger
 {
-
     public function log($level, $message, array $context = [])
     {
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Behavior/PersisterOneBehavior.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Behavior/PersisterOneBehavior.php
@@ -17,7 +17,6 @@ use Cake\ORM\Behavior;
 
 class PersisterOneBehavior extends Behavior
 {
-
     public function persist()
     {
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Author.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Author.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Author extends Entity
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Comment.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Comment.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Comment extends Entity
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
@@ -21,5 +21,4 @@ use Cake\ORM\Table;
  */
 class AuthorsTable extends Table
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/CommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/CommentsTable.php
@@ -21,5 +21,4 @@ use Cake\ORM\Table;
  */
 class CommentsTable extends Table
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
@@ -21,7 +21,6 @@ use Cake\ORM\Table;
  */
 class TestPluginCommentsTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->setTable('test_plugin_comments');

--- a/tests/test_app/Plugin/TestPlugin/src/Routing/Filter/Test2DispatcherFilter.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Routing/Filter/Test2DispatcherFilter.php
@@ -22,7 +22,6 @@ use Cake\Routing\DispatcherFilter;
  */
 class Test2DispatcherFilter extends DispatcherFilter
 {
-
     public function beforeDispatch(Event $event)
     {
         $event->data('response')->statusCode(500);

--- a/tests/test_app/Plugin/TestPlugin/src/Routing/Filter/TestDispatcherFilter.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Routing/Filter/TestDispatcherFilter.php
@@ -22,7 +22,6 @@ use Cake\Routing\DispatcherFilter;
  */
 class TestDispatcherFilter extends DispatcherFilter
 {
-
     public function beforeDispatch(Event $event)
     {
         $event->data('request')->params['altered'] = true;

--- a/tests/test_app/Plugin/TestPlugin/src/Routing/Route/TestRoute.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Routing/Route/TestRoute.php
@@ -5,5 +5,4 @@ use Cake\Routing\Route\Route;
 
 class TestRoute extends Route
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/ExampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/ExampleShell.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
 
 class ExampleShell extends Shell
 {
-
     /**
      * main method
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
 
 class SampleShell extends Shell
 {
-
     /**
      * main method
      *

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/Task/OtherTaskTask.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/Task/OtherTaskTask.php
@@ -24,5 +24,4 @@ use Cake\Console\Shell;
 
 class OtherTaskTask extends Shell
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Utility/TestPluginEngine.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Utility/TestPluginEngine.php
@@ -3,5 +3,4 @@ namespace TestPlugin\Utility;
 
 class TestPluginEngine
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Vendor/Example/ExampleExample.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Vendor/Example/ExampleExample.php
@@ -1,5 +1,4 @@
 <?php
 class ExampleExample
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
@@ -18,7 +18,6 @@ namespace TestPlugin\View\Cell;
  */
 class DummyCell extends \Cake\View\Cell
 {
-
     /**
      * Default cell action.
      *

--- a/tests/test_app/Plugin/TestPlugin/src/View/Helper/PluggedHelperHelper.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Helper/PluggedHelperHelper.php
@@ -22,6 +22,5 @@ use Cake\View\Helper;
 
 class PluggedHelperHelper extends Helper
 {
-
     public $helpers = ['TestPlugin.OtherHelper'];
 }

--- a/tests/test_app/Plugin/TestPlugin/src/View/Helper/TestPluginAppHelper.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Helper/TestPluginAppHelper.php
@@ -5,5 +5,4 @@ use Cake\View\Helper;
 
 class TestPluginAppHelper extends Helper
 {
-
 }

--- a/tests/test_app/Plugin/TestPlugin/tests/Fixture/ArticlesFixture.php
+++ b/tests/test_app/Plugin/TestPlugin/tests/Fixture/ArticlesFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class ArticlesFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/test_app/Plugin/TestPlugin/tests/Fixture/Blog/CommentsFixture.php
+++ b/tests/test_app/Plugin/TestPlugin/tests/Fixture/Blog/CommentsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class CommentsFixture extends TestFixture
 {
-
     /**
      * fields property
      *

--- a/tests/test_app/Plugin/TestPluginTwo/src/Model/Table/CommentsTable.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Model/Table/CommentsTable.php
@@ -21,5 +21,4 @@ use Cake\ORM\Table;
  */
 class CommentsTable extends Table
 {
-
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
 
 class ExampleShell extends Shell
 {
-
     /**
      * main method
      *

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
 
 class UniqueShell extends Shell
 {
-
     /**
      * main method
      *

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/WelcomeShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/WelcomeShell.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
 
 class WelcomeShell extends Shell
 {
-
     /**
      * say_hello method
      *

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -31,7 +31,6 @@ class Application extends BaseApplication
 
     /**
      * @param \Cake\Console\CommandCollection $commands
-     *
      * @return \Cake\Console\CommandCollection
      */
     public function console($commands)
@@ -43,7 +42,6 @@ class Application extends BaseApplication
 
     /**
      * @param \Cake\Http\MiddlewareQueue $middleware
-     *
      * @return \Cake\Http\MiddlewareQueue
      */
     public function middleware($middleware)

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -41,7 +41,6 @@ class ApplicationWithDefaultRoutes extends BaseApplication
 
     /**
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue
-     *
      * @return \Cake\Http\MiddlewareQueue
      */
     public function middleware($middlewareQueue)

--- a/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
@@ -31,7 +31,6 @@ class ApplicationWithPluginRoutes extends BaseApplication
 
     /**
      * @param \Cake\Http\MiddlewareQueue $middleware
-     *
      * @return \Cake\Http\MiddlewareQueue
      */
     public function middleware($middleware)

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -23,7 +23,6 @@ use Cake\Http\ServerRequest;
  */
 class TestAuthenticate extends BaseAuthenticate
 {
-
     public $callStack = [];
 
     public $authenticationProvider;

--- a/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
@@ -24,7 +24,6 @@ use Cake\Cache\CacheEngine;
 
 class TestAppCacheEngine extends CacheEngine
 {
-
     public function write($key, $value)
     {
         if ($key === 'fail') {

--- a/tests/test_app/TestApp/Controller/AbstractController.php
+++ b/tests/test_app/TestApp/Controller/AbstractController.php
@@ -17,6 +17,5 @@ use Cake\Controller\Controller;
 
 abstract class AbstractController extends Controller
 {
-
     abstract public function index();
 }

--- a/tests/test_app/TestApp/Controller/Admin/PostsController.php
+++ b/tests/test_app/TestApp/Controller/Admin/PostsController.php
@@ -22,7 +22,6 @@ use Cake\Controller\Controller;
  */
 class PostsController extends Controller
 {
-
     /**
      * components
      *

--- a/tests/test_app/TestApp/Controller/Admin/Sub/PostsController.php
+++ b/tests/test_app/TestApp/Controller/Admin/Sub/PostsController.php
@@ -22,7 +22,6 @@ use Cake\Controller\Controller;
  */
 class PostsController extends Controller
 {
-
     /**
      * index action
      *

--- a/tests/test_app/TestApp/Controller/AuthTestController.php
+++ b/tests/test_app/TestApp/Controller/AuthTestController.php
@@ -21,7 +21,6 @@ use Cake\Routing\Router;
  */
 class AuthTestController extends Controller
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/AppleComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/AppleComponent.php
@@ -23,7 +23,6 @@ use Cake\Event\Event;
  */
 class AppleComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/BananaComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/BananaComponent.php
@@ -20,7 +20,6 @@ use Cake\Controller\Component;
  */
 class BananaComponent extends Component
 {
-
     /**
      * testField property
      *

--- a/tests/test_app/TestApp/Controller/Component/MergeVarComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MergeVarComponent.php
@@ -20,5 +20,4 @@ use Cake\Controller\Component;
  */
 class MergeVarComponent extends Component
 {
-
 }

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
@@ -22,7 +22,6 @@ use Cake\Controller\Component;
  */
 class MutuallyReferencingOneComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
@@ -22,7 +22,6 @@ use Cake\Controller\Component;
  */
 class MutuallyReferencingTwoComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
@@ -24,7 +24,6 @@ use Cake\Event\Event;
  */
 class OrangeComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
@@ -22,7 +22,6 @@ use Cake\Controller\Component;
  */
 class ParamTestComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/Component/SomethingWithCookieComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/SomethingWithCookieComponent.php
@@ -22,7 +22,6 @@ use Cake\Controller\Component;
  */
 class SomethingWithCookieComponent extends Component
 {
-
     /**
      * components property
      *

--- a/tests/test_app/TestApp/Controller/ComponentTestController.php
+++ b/tests/test_app/TestApp/Controller/ComponentTestController.php
@@ -20,7 +20,6 @@ use Cake\Controller\Controller;
  */
 class ComponentTestController extends Controller
 {
-
     /**
      * uses property
      *

--- a/tests/test_app/TestApp/Controller/InterfaceController.php
+++ b/tests/test_app/TestApp/Controller/InterfaceController.php
@@ -3,6 +3,5 @@ namespace TestApp\Controller;
 
 interface InterfaceController
 {
-
     public function index();
 }

--- a/tests/test_app/TestApp/Controller/PagesController.php
+++ b/tests/test_app/TestApp/Controller/PagesController.php
@@ -25,11 +25,9 @@ use Cake\View\Exception\MissingTemplateException;
 
 /**
  * Static content controller
- *
  */
 class PagesController extends AppController
 {
-
     /**
      * Default helper
      *

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -22,7 +22,6 @@ use Psr\Http\Message\UploadedFileInterface;
  */
 class RequestActionController extends AppController
 {
-
     /**
      * The default model to use.
      *

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -23,7 +23,6 @@ use Cake\Controller\Controller;
  */
 class RequestHandlerTestController extends Controller
 {
-
     /**
      * test method for ajax redirection
      *

--- a/tests/test_app/TestApp/Controller/SomePagesController.php
+++ b/tests/test_app/TestApp/Controller/SomePagesController.php
@@ -21,7 +21,6 @@ use Cake\Http\Response;
  */
 class SomePagesController extends Controller
 {
-
     /**
      * display method
      *

--- a/tests/test_app/TestApp/Controller/TestAppsErrorController.php
+++ b/tests/test_app/TestApp/Controller/TestAppsErrorController.php
@@ -5,7 +5,6 @@ use Cake\Controller\ErrorController;
 
 class TestAppsErrorController extends ErrorController
 {
-
     public $helpers = [
         'Html',
         'Form',

--- a/tests/test_app/TestApp/Core/TestApp.php
+++ b/tests/test_app/TestApp/Core/TestApp.php
@@ -6,7 +6,6 @@ use Cake\Core\App;
 
 class TestApp extends App
 {
-
     public static $existsInBaseCallback;
 
     protected static function _classExistsInBase($name, $namespace)

--- a/tests/test_app/TestApp/Database/Driver/TestDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/TestDriver.php
@@ -17,7 +17,6 @@ use Cake\Database\Driver\Sqlite;
 
 class TestDriver extends Sqlite
 {
-
     public function enabled()
     {
         return true;

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -11,7 +11,6 @@ use TestApp\Controller\TestAppsErrorController;
 
 class TestAppsExceptionRenderer extends ExceptionRenderer
 {
-
     /**
      * {@inheritDoc}
      */

--- a/tests/test_app/TestApp/Form/ValidateForm.php
+++ b/tests/test_app/TestApp/Form/ValidateForm.php
@@ -18,7 +18,6 @@ use Cake\Form\Form;
 
 class ValidateForm extends Form
 {
-
     protected function _buildValidator(\Cake\Validation\Validator $validator)
     {
         return $validator

--- a/tests/test_app/TestApp/Http/CompatAuth.php
+++ b/tests/test_app/TestApp/Http/CompatAuth.php
@@ -23,7 +23,6 @@ use Cake\Http\Client\Request;
  */
 class CompatAuth
 {
-
     /**
      * Add Authorization header to the request via in-place mutation methods.
      *

--- a/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
+++ b/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
@@ -8,7 +8,6 @@ use SessionHandlerInterface;
  */
 class TestAppLibSession implements SessionHandlerInterface
 {
-
     public $options = [];
 
     public function __construct($options = [])

--- a/tests/test_app/TestApp/Log/Engine/TestAppLog.php
+++ b/tests/test_app/TestApp/Log/Engine/TestAppLog.php
@@ -23,7 +23,6 @@ use Cake\Log\Engine\BaseLog;
  */
 class TestAppLog extends BaseLog
 {
-
     public $passedScope = null;
 
     public function log($level, $message, array $context = [])

--- a/tests/test_app/TestApp/Mailer/TestMailer.php
+++ b/tests/test_app/TestApp/Mailer/TestMailer.php
@@ -21,7 +21,6 @@ use Cake\Mailer\Mailer;
  */
 class TestMailer extends Mailer
 {
-
     public function getEmailForAssertion()
     {
         return $this->_email;

--- a/tests/test_app/TestApp/Mailer/TestUserMailer.php
+++ b/tests/test_app/TestApp/Mailer/TestUserMailer.php
@@ -19,7 +19,6 @@ namespace TestApp\Mailer;
  */
 class TestUserMailer extends TestMailer
 {
-
     public function invite($email)
     {
         $this->_email

--- a/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
@@ -21,7 +21,6 @@ use Cake\ORM\Behavior;
  */
 class DuplicateBehavior extends Behavior
 {
-
     protected $_defaultConfig = [
         'implementedFinders' => [
             'children' => 'findChildren',

--- a/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
@@ -25,7 +25,6 @@ use Cake\Utility\Text;
 
 class SluggableBehavior extends Behavior
 {
-
     public function beforeFind(Event $event, Query $query, $options = [])
     {
         $query->where(['slug' => 'test']);

--- a/tests/test_app/TestApp/Model/Entity/Article.php
+++ b/tests/test_app/TestApp/Model/Entity/Article.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Article extends Entity
 {
-
 }

--- a/tests/test_app/TestApp/Model/Entity/ArticlesTag.php
+++ b/tests/test_app/TestApp/Model/Entity/ArticlesTag.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class ArticlesTag extends Entity
 {
-
 }

--- a/tests/test_app/TestApp/Model/Entity/Author.php
+++ b/tests/test_app/TestApp/Model/Entity/Author.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Author extends Entity
 {
-
 }

--- a/tests/test_app/TestApp/Model/Entity/Extending.php
+++ b/tests/test_app/TestApp/Model/Entity/Extending.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Extending extends Entity
 {
-
 }

--- a/tests/test_app/TestApp/Model/Entity/Tag.php
+++ b/tests/test_app/TestApp/Model/Entity/Tag.php
@@ -9,5 +9,4 @@ use Cake\ORM\Entity;
  */
 class Tag extends Entity
 {
-
 }

--- a/tests/test_app/TestApp/Model/Entity/VirtualUser.php
+++ b/tests/test_app/TestApp/Model/Entity/VirtualUser.php
@@ -6,7 +6,6 @@ use Cake\ORM\Entity;
 
 class VirtualUser extends Entity
 {
-
     protected $_virtual = [
         'bonus',
     ];

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -19,7 +19,6 @@ use Cake\ORM\Table;
  */
 class ArticlesTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->belongsTo('Authors');

--- a/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
@@ -19,7 +19,6 @@ use Cake\ORM\Table;
  */
 class ArticlesTagsTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->belongsTo('Articles');

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -21,7 +21,6 @@ use Cake\ORM\Table;
  */
 class AuthUsersTable extends Table
 {
-
     /**
      * Custom finder
      *

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -20,7 +20,6 @@ use Cake\ORM\Table;
  */
 class AuthorsTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->hasMany('articles');

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -18,7 +18,6 @@ use Cake\ORM\Table;
  */
 class I18nTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->setTable('custom_i18n_table');

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -21,7 +21,6 @@ use Cake\ORM\Table;
  */
 class PaginatorPostsTable extends Table
 {
-
     /**
      * initialize method
      *

--- a/tests/test_app/TestApp/Model/Table/PostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PostsTable.php
@@ -19,6 +19,5 @@ use Cake\ORM\Table;
 
 class PostsTable extends Table
 {
-
     protected $_table = 'posts';
 }

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -19,7 +19,6 @@ use Cake\ORM\Table;
  */
 class TagsTable extends Table
 {
-
     public function initialize(array $config)
     {
         $this->belongsTo('Authors');

--- a/tests/test_app/TestApp/Routing/Route/DashedRoute.php
+++ b/tests/test_app/TestApp/Routing/Route/DashedRoute.php
@@ -5,7 +5,6 @@ use Cake\Routing\Route\InflectedRoute;
 
 class DashedRoute extends InflectedRoute
 {
-
     protected function _underscore($url)
     {
         $url = parent::_underscore($url);

--- a/tests/test_app/TestApp/Shell/I18mShell.php
+++ b/tests/test_app/TestApp/Shell/I18mShell.php
@@ -24,7 +24,6 @@ use Cake\Console\Shell;
 
 class I18mShell extends Shell
 {
-
     /**
      * main method
      *

--- a/tests/test_app/TestApp/Shell/IntegrationShell.php
+++ b/tests/test_app/TestApp/Shell/IntegrationShell.php
@@ -25,7 +25,6 @@ use Cake\Console\Shell;
 
 class IntegrationShell extends Shell
 {
-
     /**
      * Option parser
      *

--- a/tests/test_app/TestApp/Shell/SampleShell.php
+++ b/tests/test_app/TestApp/Shell/SampleShell.php
@@ -24,7 +24,6 @@ use Cake\Console\Shell;
 
 class SampleShell extends Shell
 {
-
     public $tasks = ['Sample', 'Load'];
 
     /**

--- a/tests/test_app/TestApp/Shell/Task/SampleTask.php
+++ b/tests/test_app/TestApp/Shell/Task/SampleTask.php
@@ -19,7 +19,6 @@ use Cake\Console\Shell;
 
 class SampleTask extends Shell
 {
-
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class TestingDispatchShell extends Shell
 {
-
     protected function _welcome()
     {
         $this->out('<info>Welcome to CakePHP Console</info>');

--- a/tests/test_app/TestApp/Utility/TestAppEngine.php
+++ b/tests/test_app/TestApp/Utility/TestAppEngine.php
@@ -3,5 +3,4 @@ namespace TestApp\Utility;
 
 class TestAppEngine
 {
-
 }

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -18,7 +18,6 @@ namespace TestApp\View\Cell;
  */
 class ArticlesCell extends \Cake\View\Cell
 {
-
     /**
      * valid cell options.
      *

--- a/tests/test_app/TestApp/View/CustomJsonView.php
+++ b/tests/test_app/TestApp/View/CustomJsonView.php
@@ -20,5 +20,4 @@ use Cake\View\JsonView;
  */
 class CustomJsonView extends JsonView
 {
-
 }

--- a/tests/test_app/TestApp/View/Helper/BananaHelper.php
+++ b/tests/test_app/TestApp/View/Helper/BananaHelper.php
@@ -18,7 +18,6 @@ use Cake\View\Helper;
 
 class BananaHelper extends Helper
 {
-
     public function peel()
     {
         return '<b>peeled</b>';

--- a/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
+++ b/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
@@ -19,7 +19,6 @@ use Cake\View\Helper;
 
 class EventListenerTestHelper extends Helper
 {
-
     /**
      * Before render callback. Stub.
      *


### PR DESCRIPTION
I realized that the diff of 4.next against 3.next has too much CS noise that just makes it much harder to find the actual issues.

This resolves that. And it should still pass the 3.x ruleset.