### PR TITLE
Fix query LoggingStatement prematurely fetching records.

### DIFF
--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -42,6 +42,20 @@ class LoggingStatement extends StatementDecorator
     protected $_compiledParams = [];
 
     /**
+     * Query execution start time.
+     *
+     * @var float
+     */
+    protected $startTime = 0.0;
+
+    /**
+     * Logged query
+     *
+     * @var \Cake\Database\Log\LoggedQuery|null
+     */
+    protected $loggedQuery;
+
+    /**
      * Wrapper for the execute function to calculate time spent
      * and log the query afterwards.
      *
@@ -51,40 +65,76 @@ class LoggingStatement extends StatementDecorator
      */
     public function execute(?array $params = null): bool
     {
-        $t = microtime(true);
-        $query = new LoggedQuery();
+        $this->startTime = microtime(true);
+
+        $this->loggedQuery = new LoggedQuery();
+        $this->loggedQuery->params = $params ?: $this->_compiledParams;
 
         try {
             $result = parent::execute($params);
         } catch (Exception $e) {
             /** @psalm-suppress UndefinedPropertyAssignment */
             $e->queryString = $this->queryString;
-            $query->error = $e;
-            $this->_log($query, $params, $t);
+            $this->loggedQuery->error = $e;
+            $this->_log();
             throw $e;
         }
 
-        $query->numRows = $this->rowCount();
-        $this->_log($query, $params, $t);
+        if (preg_match('/^(?!SELECT)/i', $this->queryString)) {
+            $this->loggedQuery->numRows = $this->rowCount();
+            $this->_log();
+        }
 
         return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fetch($type = self::FETCH_TYPE_NUM)
+    {
+        $record = parent::fetch($type);
+
+        if ($this->loggedQuery) {
+            $this->loggedQuery->numRows = $this->rowCount();
+            $this->_log();
+        }
+
+        return $record;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fetchAll($type = self::FETCH_TYPE_NUM)
+    {
+        $results = parent::fetchAll($type);
+
+        if ($this->loggedQuery) {
+            $this->loggedQuery->numRows = $this->rowCount();
+            $this->_log();
+        }
+
+        return $results;
     }
 
     /**
      * Copies the logging data to the passed LoggedQuery and sends it
      * to the logging system.
      *
-     * @param \Cake\Database\Log\LoggedQuery $query The query to log.
-     * @param array|null $params List of values to be bound to query.
-     * @param float $startTime The microtime when the query was executed.
      * @return void
      */
-    protected function _log(LoggedQuery $query, ?array $params, float $startTime): void
+    protected function _log(): void
     {
-        $query->took = (int)round((microtime(true) - $startTime) * 1000, 0);
-        $query->params = $params ?: $this->_compiledParams;
-        $query->query = $this->queryString;
-        $this->getLogger()->debug((string)$query, ['query' => $query]);
+        if ($this->loggedQuery === null) {
+            return;
+        }
+
+        $this->loggedQuery->took = (int)round((microtime(true) - $this->startTime) * 1000, 0);
+        $this->loggedQuery->query = $this->queryString;
+        $this->getLogger()->debug((string)$this->loggedQuery, ['query' => $this->loggedQuery]);
+
+        $this->loggedQuery = null;
     }
 
     /**

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -60,6 +60,7 @@ class LoggingStatementTest extends TestCase
         $st->queryString = 'SELECT bar FROM foo';
         $st->setLogger(new QueryLogger(['connection' => 'test']));
         $st->execute();
+        $st->fetchAll();
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
@@ -82,6 +83,7 @@ class LoggingStatementTest extends TestCase
         $st->queryString = 'SELECT bar FROM foo WHERE x=:a AND y=:b';
         $st->setLogger(new QueryLogger(['connection' => 'test']));
         $st->execute(['a' => 1, 'b' => 2]);
+        $st->fetchAll();
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);
@@ -110,9 +112,11 @@ class LoggingStatementTest extends TestCase
         $st->bindValue('a', 1);
         $st->bindValue('b', $date, 'date');
         $st->execute();
+        $st->fetchAll();
 
         $st->bindValue('b', new \DateTime('2014-01-01'), 'date');
         $st->execute();
+        $st->fetchAll();
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages);


### PR DESCRIPTION
LoggingStatement::execute() calling rowCount() for SELECT queries
caused records do be always fetched as associative arrays when using
buffered results. This meant that calling fetchAll() later with
type FETCH_TYPE_NUM for e.g. returned unexpected results.

Fixes #14676

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
