### PR TITLE
Use integer for plural rule calc.

### DIFF
--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -133,7 +133,7 @@ class PluralRules
      * to the countable provided in $n.
      *
      * @param string $locale The locale to get the rule calculated for.
-     * @param int|float $n The number to apply the rules to.
+     * @param int $n The number to apply the rules to.
      * @return int The plural rule number that should be used.
      * @link http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
      * @link https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_and_Plurals#List_of_Plural_Rules

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -78,7 +78,7 @@ class Translator extends BaseTranslator
         // Resolve plural form.
         if (is_array($message)) {
             $count = $tokensValues['_count'] ?? 0;
-            $form = PluralRules::calculate($this->locale, $count);
+            $form = PluralRules::calculate($this->locale, (int)$count);
             $message = $message[$form] ?? (string)end($message);
         }
 


### PR DESCRIPTION
Does it make sense to restrict the argument to only integer, since also only those would currently match?
This way, also string or float "integers" would pass the rule here if casted before going into the method.
Passing floats seems pointless.

Would this be a change for 4.0 or 4.1?
We probably cannot add a typehint either way until 5.0.