### PR TITLE
Deprecate whitelist in Paginator settings

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -46,7 +46,7 @@ class PaginatorComponent extends Component
      * - `maxLimit` - The maximum limit users can choose to view. Defaults to 100
      * - `limit` - The initial number of items per page. Defaults to 20.
      * - `page` - The starting page, defaults to 1.
-     * - `whitelist` - A list of parameters users are allowed to set using request
+     * - `allowedParameters` - A list of parameters users are allowed to set using request
      *   parameters. Modifying this list will allow users to have more influence
      *   over pagination, be careful with what you permit.
      *
@@ -56,7 +56,7 @@ class PaginatorComponent extends Component
         'page' => 1,
         'limit' => 20,
         'maxLimit' => 100,
-        'whitelist' => ['limit', 'sort', 'page', 'direction'],
+        'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
     ];
 
     /**
@@ -133,19 +133,19 @@ class PaginatorComponent extends Component
      *
      * By default CakePHP will automatically allow sorting on any column on the table object being
      * paginated. Often times you will want to allow sorting on either associated columns or calculated
-     * fields. In these cases you will need to define a whitelist of all the columns you wish to allow
-     * sorting on. You can define the whitelist in the `$settings` parameter:
+     * fields. In these cases you will need to define an allowed list of fields you wish to allow
+     * sorting on. You can define the allowed fields in the `$settings` parameter:
      *
      * ```
      * $settings = [
      *   'Articles' => [
      *     'finder' => 'custom',
-     *     'sortWhitelist' => ['title', 'author_id', 'comment_count'],
+     *     'allowedSort' => ['title', 'author_id', 'comment_count'],
      *   ]
      * ];
      * ```
      *
-     * Passing an empty array as whitelist disallows sorting altogether.
+     * Passing an empty array as allowed list disallows sorting altogether.
      *
      * ### Paginating with custom finders
      *
@@ -222,7 +222,7 @@ class PaginatorComponent extends Component
      * - Request parameters
      *
      * The result of this method is the aggregate of all the option sets combined together. You can change
-     * config value `whitelist` to modify which options/values can be set using request parameters.
+     * config value `allowedParameters` to modify which options/values can be set using request parameters.
      *
      * @param string $alias Model alias being paginated, if the general settings has a key with this value
      *   that key's settings will be used for pagination instead of the general ones.

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -140,7 +140,7 @@ class PaginatorComponent extends Component
      * $settings = [
      *   'Articles' => [
      *     'finder' => 'custom',
-     *     'allowedSort' => ['title', 'author_id', 'comment_count'],
+     *     'sortableFields' => ['title', 'author_id', 'comment_count'],
      *   ]
      * ];
      * ```

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -106,12 +106,12 @@ class Paginator implements PaginatorInterface
      * $settings = [
      *   'Articles' => [
      *     'finder' => 'custom',
-     *     'allowedSort' => ['title', 'author_id', 'comment_count'],
+     *     'sortableFields' => ['title', 'author_id', 'comment_count'],
      *   ]
      * ];
      * ```
      *
-     * Passing an empty array as allowedSort disallows sorting altogether.
+     * Passing an empty array as sortableFields disallows sorting altogether.
      *
      * ### Paginating with custom finders
      *
@@ -428,20 +428,20 @@ class Paginator implements PaginatorInterface
     }
 
     /**
-     * Shim method for reading the deprecated sortWhitelist or allowedSort options.
+     * Shim method for reading the deprecated sortWhitelist or sortableFields options.
      *
      * @param array $config The configuration data to coalesce and emit warnings on.
      * @return string[]|null
      */
     protected function getAllowedSort(array $config): ?array
     {
-        $allowed = $config['allowedSort'] ?? null;
+        $allowed = $config['sortableFields'] ?? null;
         if ($allowed !== null) {
             return $allowed;
         }
         $deprecated = $config['sortWhitelist'] ?? null;
         if ($deprecated !== null) {
-            deprecationWarning('The `sortWhitelist` option is deprecated. Use `allowedSort` instead.');
+            deprecationWarning('The `sortWhitelist` option is deprecated. Use `sortableFields` instead.');
         }
 
         return $deprecated;
@@ -519,7 +519,7 @@ class Paginator implements PaginatorInterface
      * result sets on un-indexed values.
      *
      * If you need to sort on associated columns or synthetic properties you
-     * will need to use the `allowedSort` option.
+     * will need to use the `sortableFields` option.
      *
      * Any columns listed in the allowed sort fields will be implicitly trusted.
      * You can use this to sort on synthetic columns, or columns added in custom
@@ -565,7 +565,7 @@ class Paginator implements PaginatorInterface
         $sortAllowed = false;
         $allowed = $this->getAllowedSort($options);
         if ($allowed !== null) {
-            $options['allowedSort'] = $options['sortWhitelist'] = $allowed;
+            $options['sortableFields'] = $options['sortWhitelist'] = $allowed;
 
             $field = key($options['order']);
             $sortAllowed = in_array($field, $allowed, true);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -181,6 +181,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -319,6 +320,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -352,6 +354,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -378,13 +381,21 @@ class PaginatorComponentTest extends TestCase
                 'limit' => 10,
                 'maxLimit' => 50,
             ],
-            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $result = $this->Paginator->mergeOptions('Silly', $settings);
+        $this->assertSame($settings['allowedParameters'], $result['whitelist']);
+        unset($result['whitelist']);
         $this->assertEquals($settings, $result);
 
         $result = $this->Paginator->mergeOptions('Posts', $settings);
-        $expected = ['page' => 1, 'limit' => 10, 'maxLimit' => 50, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 1,
+            'limit' => 10,
+            'maxLimit' => 50,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -417,6 +428,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -434,6 +446,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'non-existent',
         ];
         $this->assertEquals($expected, $result);
@@ -452,6 +465,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'scope',
         ];
         $this->assertEquals($expected, $result);
@@ -481,6 +495,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -502,16 +517,22 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
-        $expected = ['page' => 99, 'limit' => 75, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 99,
+            'limit' => 75,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        ];
         $this->assertEquals($expected, $result);
     }
 
     /**
-     * test that the default whitelist doesn't let people screw with things they should not be allowed to.
+     * test that the default allowed parameters doesn't let people screw with things they should not be allowed to.
      *
      * @return void
      */
-    public function testMergeOptionsDefaultWhiteList(): void
+    public function testMergeOptionsDefaultAllowedParameters(): void
     {
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'page' => 10,
@@ -527,7 +548,13 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
-        $expected = ['page' => 10, 'limit' => 10, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 10,
+            'limit' => 10,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -551,12 +578,19 @@ class PaginatorComponentTest extends TestCase
             'limit' => 20,
             'maxLimit' => 100,
         ];
-        $this->Paginator->setConfig('whitelist', ['fields']);
-        $result = $this->Paginator->mergeOptions('Post', $settings);
-        $expected = [
-            'page' => 10, 'limit' => 10, 'maxLimit' => 100, 'fields' => ['bad.stuff'], 'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
-        ];
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () use ($settings) {
+            $this->Paginator->setConfig('whitelist', ['fields']);
+            $result = $this->Paginator->mergeOptions('Post', $settings);
+            $expected = [
+                'page' => 10,
+                'limit' => 10,
+                'maxLimit' => 100,
+                'fields' => ['bad.stuff'],
+                'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction', 'fields'],
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -577,6 +611,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -591,6 +626,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 10,
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -619,6 +655,7 @@ class PaginatorComponentTest extends TestCase
                 'Users.username' => 'asc',
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -639,6 +676,7 @@ class PaginatorComponentTest extends TestCase
                 'Users.username' => 'asc',
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -663,6 +701,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'id',
             ]);
@@ -810,11 +849,11 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields not in whitelist won't be part of order conditions.
+     * test that fields not in allowedSort won't be part of order conditions.
      *
      * @return void
      */
-    public function testValidateSortWhitelistFailure(): void
+    public function testValidateAllowedSortFailure(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -825,7 +864,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => ['title', 'id'],
+            'allowedSort' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -833,11 +872,11 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields in the whitelist are not validated
+     * test that fields in the allowedSort are not validated
      *
      * @return void
      */
-    public function testValidateSortWhitelistTrusted(): void
+    public function testValidateAllowedSortTrusted(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -850,7 +889,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => ['body'],
+            'allowedSort' => ['body'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -863,11 +902,11 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that whitelist as empty array does not allow any sorting
+     * test that allowedSort as empty array does not allow any sorting
      *
      * @return void
      */
-    public function testValidateSortWhitelistEmpty(): void
+    public function testValidateAllowedSortEmpty(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -883,7 +922,7 @@ class PaginatorComponentTest extends TestCase
             ],
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => [],
+            'allowedSort' => [],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -891,11 +930,11 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields in the whitelist are not validated
+     * test that fields in the allowedSort are not validated
      *
      * @return void
      */
-    public function testValidateSortWhitelistNotInSchema(): void
+    public function testValidateSortNotInSchema(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -907,7 +946,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'score',
             'direction' => 'asc',
-            'sortWhitelist' => ['score'],
+            'allowedSort' => ['score'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -920,11 +959,11 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that multiple fields in the whitelist are not validated and properly aliased.
+     * test that multiple fields in the allowedSort are not validated and properly aliased.
      *
      * @return void
      */
-    public function testValidateSortWhitelistMultiple(): void
+    public function testValidateSortAllowMultiple(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -939,7 +978,7 @@ class PaginatorComponentTest extends TestCase
                 'body' => 'asc',
                 'foo.bar' => 'asc',
             ],
-            'sortWhitelist' => ['body', 'foo.bar'],
+            'allowedSort' => ['body', 'foo.bar'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -1017,7 +1056,7 @@ class PaginatorComponentTest extends TestCase
 
         $options = [
             'direction' => 'asc',
-            'sortWhitelist' => ['title', 'id'],
+            'allowedSort' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
         $this->assertEquals([], $result['order']);
@@ -1251,6 +1290,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => [],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => null,
             ]);
@@ -1288,6 +1328,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -1351,6 +1392,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -849,7 +849,7 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields not in allowedSort won't be part of order conditions.
+     * test that fields not in sortableFields won't be part of order conditions.
      *
      * @return void
      */
@@ -864,7 +864,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'allowedSort' => ['title', 'id'],
+            'sortableFields' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -872,7 +872,7 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields in the allowedSort are not validated
+     * test that fields in the sortableFields are not validated
      *
      * @return void
      */
@@ -889,7 +889,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'allowedSort' => ['body'],
+            'sortableFields' => ['body'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -902,7 +902,7 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that allowedSort as empty array does not allow any sorting
+     * test that sortableFields as empty array does not allow any sorting
      *
      * @return void
      */
@@ -922,7 +922,7 @@ class PaginatorComponentTest extends TestCase
             ],
             'sort' => 'body',
             'direction' => 'asc',
-            'allowedSort' => [],
+            'sortableFields' => [],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -930,7 +930,7 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that fields in the allowedSort are not validated
+     * test that fields in the sortableFields are not validated
      *
      * @return void
      */
@@ -946,7 +946,7 @@ class PaginatorComponentTest extends TestCase
         $options = [
             'sort' => 'score',
             'direction' => 'asc',
-            'allowedSort' => ['score'],
+            'sortableFields' => ['score'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -959,7 +959,7 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test that multiple fields in the allowedSort are not validated and properly aliased.
+     * test that multiple fields in the sortableFields are not validated and properly aliased.
      *
      * @return void
      */
@@ -978,7 +978,7 @@ class PaginatorComponentTest extends TestCase
                 'body' => 'asc',
                 'foo.bar' => 'asc',
             ],
-            'allowedSort' => ['body', 'foo.bar'],
+            'sortableFields' => ['body', 'foo.bar'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -1056,7 +1056,7 @@ class PaginatorComponentTest extends TestCase
 
         $options = [
             'direction' => 'asc',
-            'allowedSort' => ['title', 'id'],
+            'sortableFields' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
         $this->assertEquals([], $result['order']);

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -118,6 +118,7 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -203,6 +204,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -235,6 +237,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => $settings['order'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => null,
             ]);
@@ -273,6 +276,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -299,6 +303,7 @@ trait PaginatorTestTrait
                 'limit' => 10,
                 'maxLimit' => 50,
             ],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
         ];
         $defaults = $this->Paginator->getDefaults('Silly', $settings);
@@ -307,7 +312,13 @@ trait PaginatorTestTrait
 
         $defaults = $this->Paginator->getDefaults('Posts', $settings);
         $result = $this->Paginator->mergeOptions([], $defaults);
-        $expected = ['page' => 1, 'limit' => 10, 'maxLimit' => 50, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 1,
+            'limit' => 10,
+            'maxLimit' => 50,
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'whitelist' => ['limit', 'sort', 'page', 'direction']
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -341,6 +352,7 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -359,6 +371,7 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'non-existent',
         ];
         $this->assertEquals($expected, $result);
@@ -378,6 +391,7 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'scope',
         ];
         $this->assertEquals($expected, $result);
@@ -408,6 +422,7 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -430,16 +445,22 @@ trait PaginatorTestTrait
         ];
         $defaults = $this->Paginator->getDefaults('Post', $settings);
         $result = $this->Paginator->mergeOptions($params, $defaults);
-        $expected = ['page' => 99, 'limit' => 75, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 99,
+            'limit' => 75,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        ];
         $this->assertEquals($expected, $result);
     }
 
     /**
-     * test that the default whitelist doesn't let people screw with things they should not be allowed to.
+     * test that the default allowedParameters doesn't let people screw with things they should not be allowed to.
      *
      * @return void
      */
-    public function testMergeOptionsDefaultWhiteList()
+    public function testMergeOptionsDefaultAllowedParameters()
     {
         $params = [
             'page' => 10,
@@ -456,12 +477,18 @@ trait PaginatorTestTrait
         ];
         $defaults = $this->Paginator->getDefaults('Post', $settings);
         $result = $this->Paginator->mergeOptions($params, $defaults);
-        $expected = ['page' => 10, 'limit' => 10, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 10,
+            'limit' => 10,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        ];
         $this->assertEquals($expected, $result);
     }
 
     /**
-     * test that modifying the whitelist works.
+     * test that modifying the deprecated whitelist works.
      *
      * @return void
      */
@@ -480,13 +507,20 @@ trait PaginatorTestTrait
             'limit' => 20,
             'maxLimit' => 100,
         ];
-        $this->Paginator->setConfig('whitelist', ['fields']);
-        $defaults = $this->Paginator->getDefaults('Post', $settings);
-        $result = $this->Paginator->mergeOptions($params, $defaults);
-        $expected = [
-            'page' => 10, 'limit' => 10, 'maxLimit' => 100, 'fields' => ['bad.stuff'], 'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
-        ];
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () use ($settings, $params) {
+            $this->Paginator->setConfig('whitelist', ['fields']);
+            $defaults = $this->Paginator->getDefaults('Post', $settings);
+            $result = $this->Paginator->mergeOptions($params, $defaults);
+            $expected = [
+                'page' => 10,
+                'limit' => 10,
+                'maxLimit' => 100,
+                'fields' => ['bad.stuff'],
+                'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction', 'fields'],
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -508,6 +542,7 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -523,6 +558,7 @@ trait PaginatorTestTrait
             'maxLimit' => 10,
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -552,6 +588,7 @@ trait PaginatorTestTrait
                 'Users.username' => 'asc',
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
 
@@ -573,6 +610,7 @@ trait PaginatorTestTrait
                 'Users.username' => 'asc',
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -597,6 +635,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'id',
             ]);
@@ -654,16 +693,18 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'sort' => 'id',
                 'scope' => null,
                 'sortWhitelist' => ['id'],
+                'allowedSort' => ['id'],
             ]);
 
         $options = [
             'order' => [
                 'id' => 'asc',
             ],
-            'sortWhitelist' => ['id'],
+            'allowedSort' => ['id'],
         ];
         $this->Paginator->paginate($table, [], $options);
         $pagingParams = $this->Paginator->getPagingParams();
@@ -693,6 +734,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.title' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'sort' => 'title',
                 'scope' => null,
             ]);
@@ -739,8 +781,10 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sortWhitelist' => ['id'],
+                'allowedSort' => ['id'],
                 'sort' => 'id',
             ]);
 
@@ -750,7 +794,7 @@ trait PaginatorTestTrait
             'direction' => 'herp',
         ];
         $options = [
-            'sortWhitelist' => ['id'],
+            'allowedSort' => ['id'],
         ];
         $this->Paginator->paginate($table, $params, $options);
         $pagingParams = $this->Paginator->getPagingParams();
@@ -805,18 +849,18 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields not in whitelist won't be part of order conditions.
+     * test that fields not in allowedSort won't be part of order conditions.
      *
      * @return void
      */
-    public function testValidateSortWhitelistFailure()
+    public function testValidateAllowedSortFailure()
     {
         $model = $this->mockAliasHasFieldModel();
 
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => ['title', 'id'],
+            'allowedSort' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -824,18 +868,37 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields in the whitelist are not validated
+     * test that fields not in whitelist won't be part of order conditions.
      *
      * @return void
      */
-    public function testValidateSortWhitelistTrusted()
+    public function testValidateSortWhitelistFailure()
+    {
+        $this->deprecated(function () {
+            $model = $this->mockAliasHasFieldModel();
+            $options = [
+                'sort' => 'body',
+                'direction' => 'asc',
+                'sortWhitelist' => ['title', 'id'],
+            ];
+            $result = $this->Paginator->validateSort($model, $options);
+            $this->assertEquals([], $result['order']);
+        });
+    }
+
+    /**
+     * test that fields in the allowedSort are not validated
+     *
+     * @return void
+     */
+    public function testValidateAllowedSortTrusted()
     {
         $model = $this->mockAliasHasFieldModel();
 
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => ['body'],
+            'allowedsort' => ['body'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -848,11 +911,11 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that whitelist as empty array does not allow any sorting
+     * test that allowedSort as empty array does not allow any sorting
      *
      * @return void
      */
-    public function testValidateSortWhitelistEmpty()
+    public function testValidateAllowedSortEmpty()
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -863,7 +926,7 @@ trait PaginatorTestTrait
             ],
             'sort' => 'body',
             'direction' => 'asc',
-            'sortWhitelist' => [],
+            'allowedSort' => [],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -871,11 +934,11 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields in the whitelist are not validated
+     * test that fields in the allowedSort are not validated
      *
      * @return void
      */
-    public function testValidateSortWhitelistNotInSchema()
+    public function testValidateAllowedSortNotInSchema()
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -887,7 +950,7 @@ trait PaginatorTestTrait
         $options = [
             'sort' => 'score',
             'direction' => 'asc',
-            'sortWhitelist' => ['score'],
+            'allowedSort' => ['score'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -900,11 +963,11 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that multiple fields in the whitelist are not validated and properly aliased.
+     * test that multiple fields in the allowedSort are not validated and properly aliased.
      *
      * @return void
      */
-    public function testValidateSortWhitelistMultiple()
+    public function testValidateAllowedSortMultiple()
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -913,7 +976,7 @@ trait PaginatorTestTrait
                 'body' => 'asc',
                 'foo.bar' => 'asc',
             ],
-            'sortWhitelist' => ['body', 'foo.bar'],
+            'allowedSort' => ['body', 'foo.bar'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -1075,7 +1138,7 @@ trait PaginatorTestTrait
 
         $options = [
             'direction' => 'asc',
-            'sortWhitelist' => ['title', 'id'],
+            'allowedSort' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
         $this->assertEquals([], $result['order']);
@@ -1207,6 +1270,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => [],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => null,
             ]);
@@ -1242,6 +1306,7 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);
@@ -1303,6 +1368,7 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sort' => 'PaginatorPosts.id',
             ]);

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -697,14 +697,14 @@ trait PaginatorTestTrait
                 'sort' => 'id',
                 'scope' => null,
                 'sortWhitelist' => ['id'],
-                'allowedSort' => ['id'],
+                'sortableFields' => ['id'],
             ]);
 
         $options = [
             'order' => [
                 'id' => 'asc',
             ],
-            'allowedSort' => ['id'],
+            'sortableFields' => ['id'],
         ];
         $this->Paginator->paginate($table, [], $options);
         $pagingParams = $this->Paginator->getPagingParams();
@@ -784,7 +784,7 @@ trait PaginatorTestTrait
                 'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
                 'sortWhitelist' => ['id'],
-                'allowedSort' => ['id'],
+                'sortableFields' => ['id'],
                 'sort' => 'id',
             ]);
 
@@ -794,7 +794,7 @@ trait PaginatorTestTrait
             'direction' => 'herp',
         ];
         $options = [
-            'allowedSort' => ['id'],
+            'sortableFields' => ['id'],
         ];
         $this->Paginator->paginate($table, $params, $options);
         $pagingParams = $this->Paginator->getPagingParams();
@@ -849,7 +849,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields not in allowedSort won't be part of order conditions.
+     * test that fields not in sortableFields won't be part of order conditions.
      *
      * @return void
      */
@@ -860,7 +860,7 @@ trait PaginatorTestTrait
         $options = [
             'sort' => 'body',
             'direction' => 'asc',
-            'allowedSort' => ['title', 'id'],
+            'sortableFields' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -887,7 +887,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields in the allowedSort are not validated
+     * test that fields in the sortableFields are not validated
      *
      * @return void
      */
@@ -911,7 +911,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that allowedSort as empty array does not allow any sorting
+     * test that sortableFields as empty array does not allow any sorting
      *
      * @return void
      */
@@ -926,7 +926,7 @@ trait PaginatorTestTrait
             ],
             'sort' => 'body',
             'direction' => 'asc',
-            'allowedSort' => [],
+            'sortableFields' => [],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -934,7 +934,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that fields in the allowedSort are not validated
+     * test that fields in the sortableFields are not validated
      *
      * @return void
      */
@@ -950,7 +950,7 @@ trait PaginatorTestTrait
         $options = [
             'sort' => 'score',
             'direction' => 'asc',
-            'allowedSort' => ['score'],
+            'sortableFields' => ['score'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -963,7 +963,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that multiple fields in the allowedSort are not validated and properly aliased.
+     * test that multiple fields in the sortableFields are not validated and properly aliased.
      *
      * @return void
      */
@@ -976,7 +976,7 @@ trait PaginatorTestTrait
                 'body' => 'asc',
                 'foo.bar' => 'asc',
             ],
-            'allowedSort' => ['body', 'foo.bar'],
+            'sortableFields' => ['body', 'foo.bar'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
 
@@ -1138,7 +1138,7 @@ trait PaginatorTestTrait
 
         $options = [
             'direction' => 'asc',
-            'allowedSort' => ['title', 'id'],
+            'sortableFields' => ['title', 'id'],
         ];
         $result = $this->Paginator->validateSort($model, $options);
         $this->assertEquals([], $result['order']);

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -317,7 +317,7 @@ trait PaginatorTestTrait
             'limit' => 10,
             'maxLimit' => 50,
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
-            'whitelist' => ['limit', 'sort', 'page', 'direction']
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
         ];
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Replace the `whitelist` and `sortWhitelist` options with more appropriate and descriptive names. The added methods ensure that the new and old names behave as aliases for both configuration set via setConfig() and settings passed to paginate().
