### PR TITLE
Fix incorrect path list in missing template and missing layout error pages

### DIFF
--- a/templates/Error/missing_cell_template.php
+++ b/templates/Error/missing_cell_template.php
@@ -29,7 +29,6 @@ $this->start('file');
 </p>
 <ul>
 <?php
-    $paths = $this->_paths($this->plugin);
     foreach ($paths as $path) :
         if (strpos($path, CORE_PATH) !== false) {
             continue;

--- a/templates/Error/missing_layout.php
+++ b/templates/Error/missing_layout.php
@@ -30,7 +30,6 @@ $this->start('subheading');
 </p>
 <ul>
 <?php
-    $paths = $this->_paths($this->plugin);
     foreach ($paths as $path):
         if (strpos($path, CORE_PATH) !== false) {
             continue;

--- a/templates/Error/missing_template.php
+++ b/templates/Error/missing_template.php
@@ -43,7 +43,6 @@ $this->start('subheading');
 </p>
 <ul>
 <?php
-    $paths = $this->_paths($this->plugin);
     foreach ($paths as $path):
         if (strpos($path, CORE_PATH) !== false) {
             continue;

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -580,7 +580,8 @@ class ViewTest extends TestCase
         $this->expectExceptionMessage('Template file `does_not_exist.php` could not be found');
         $this->expectExceptionMessage('The following paths were searched');
         $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'does_not_exist.php`');
-        $viewOptions = ['plugin' => null,
+        $viewOptions = [
+            'plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages',
         ];
@@ -602,7 +603,8 @@ class ViewTest extends TestCase
         $this->expectExceptionMessage('Layout file `whatever.php` could not be found');
         $this->expectExceptionMessage('The following paths were searched');
         $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'layout' . DS . 'whatever.php`');
-        $viewOptions = ['plugin' => null,
+        $viewOptions = [
+            'plugin' => null,
             'name' => 'Pages',
             'viewPath' => 'Pages',
             'layout' => 'whatever',


### PR DESCRIPTION
Use the path lists in the exception attributes instead of regenerating
the paths incorrectly.

Fixes #14704