### PR TITLE
Add coverage for replacing the session via withAttribute()

### DIFF
--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -2046,6 +2046,22 @@ XML;
     }
 
     /**
+     * Test that replacing the session can be done via withAttribute()
+     *
+     * @return void
+     */
+    public function testWithAttributeSession()
+    {
+        $request = new ServerRequest([]);
+        $request->getSession()->write('attrKey', 'session-value');
+
+        $update = $request->withAttribute('session', Session::create());
+        $this->assertSame('session-value', $request->getAttribute('session')->read('attrKey'));
+        $this->assertNotSame($request->getAttribute('session'), $update->getAttribute('session'));
+        $this->assertNotSame($request->getSession()->read('attrKey'), $update->getSession()->read('attrKey'));
+    }
+
+    /**
      * Test getting all attributes.
      *
      * @return void


### PR DESCRIPTION
While this has been supported for a long time we haven't had explicit test coverage for it.

Refs #14707