### PR TITLE
[2.x] Fix deprecated argument order in calls to implode()

### DIFF
--- a/lib/Cake/Console/Command/CompletionShell.php
+++ b/lib/Cake/Console/Command/CompletionShell.php
@@ -149,7 +149,7 @@ class CompletionShell extends AppShell {
  */
 	protected function _output($options = array()) {
 		if ($options) {
-			return $this->out(implode($options, ' '));
+			return $this->out(implode(' ', $options));
 		}
 	}
 }

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -609,8 +609,8 @@ class FormHelper extends AppHelper {
 		ksort($locked, SORT_STRING);
 		$fields += $locked;
 
-		$locked = implode(array_keys($locked), '|');
-		$unlocked = implode($unlockedFields, '|');
+		$locked = implode('|', array_keys($locked));
+		$unlocked = implode('|', $unlockedFields);
 		$hashParts = array(
 			$this->_lastAction,
 			serialize($fields),


### PR DESCRIPTION
Calling `implode($pieces, $glue)` instead of `implode($glue, $pieces)` produces a deprecation notice in PHP 7.4. The one in `FormHelper.php` is what caused problems for us, but I searched the codebase for all calls to `implode(` and found just one other instance of it in `CompletionShell.php`.