### PR TITLE
Rollback transaction on any Throwable

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -29,6 +29,7 @@ use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Log\Log;
 use Exception;
+use Throwable;
 
 /**
  * Represents a connection with a database server.
@@ -735,6 +736,9 @@ class Connection implements ConnectionInterface
 
         try {
             $result = $transaction($this);
+        } catch (Throwable $e) {
+            $this->rollback(false);
+            throw $e;
         } catch (Exception $e) {
             $this->rollback(false);
             throw $e;

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -26,6 +26,7 @@ use Cake\Database\Statement\BufferedStatement;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use Error;
 use Exception;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -1115,6 +1116,32 @@ class ConnectionTest extends TestCase
         $connection->transactional(function ($conn) use ($connection) {
             $this->assertSame($connection, $conn);
             throw new \InvalidArgumentException();
+        });
+    }
+
+    /**
+     * Tests that the transactional method will rollback the transaction
+     * and throw the same error if the callback raises one
+     *
+     * @return void
+     * @throws \Error
+     */
+    public function testTransactionalWithPHP7Error()
+    {
+        $this->skipIf(version_compare(PHP_VERSION, '7.0.0', '<'), 'Error class only exists since PHP 7.');
+
+        $this->expectException(\Error::class);
+        $driver = $this->getMockFormDriver();
+        $connection = $this->getMockBuilder(Connection::class)
+            ->setMethods(['connect', 'commit', 'begin', 'rollback'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
+        $connection->expects($this->at(0))->method('begin');
+        $connection->expects($this->at(1))->method('rollback');
+        $connection->expects($this->never())->method('commit');
+        $connection->transactional(function ($conn) use ($connection) {
+            $this->assertSame($connection, $conn);
+            throw new \Error();
         });
     }
 


### PR DESCRIPTION
Fixes #14717 

Whenever an Error is thrown in a transaction, the expectation is that this will be caught and the transaction is rolled back. For PHP 5.6 compatibility reasons, only Exception was caught in `Connection::transactional`. With PHP 7+ all Throwables should be handled also.

This change catches Throwable in addition to Exception, similar to (for instance) ErrorHandlerMiddleware handles the same. This is to ensure PHP backwards compatibility.