### PR TITLE
Fixed window name identifier quoting

### DIFF
--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -227,6 +227,7 @@ class CommonTableExpression implements ExpressionInterface
      */
     public function __clone()
     {
+        $this->name = clone $this->name;
         if ($this->query) {
             $this->query = clone $this->query;
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1428,7 +1428,7 @@ class Query implements ExpressionInterface, IteratorAggregate
             }
         }
 
-        $this->_parts['window'][] = ['name' => $name, 'window' => $window];
+        $this->_parts['window'][] = ['name' => new IdentifierExpression($name), 'window' => $window];
         $this->_dirty();
 
         return $this;

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -306,7 +306,7 @@ class QueryCompiler
     {
         $windows = [];
         foreach ($parts as $window) {
-            $windows[] = $window['name'] . ' AS (' . $window['window']->sql($generator) . ')';
+            $windows[] = $window['name']->sql($generator) . ' AS (' . $window['window']->sql($generator) . ')';
         }
 
         return ' WINDOW ' . implode(', ', $windows);

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -143,6 +143,9 @@ class CommonTableExpressionTest extends TestCase
         $cte = new CommonTableExpression('test', function () {
             return $this->connection->newQuery()->select('1');
         });
+        $cte2 = (clone $cte)->name('test2');
+        $this->assertNotSame($cte->sql(new ValueBinder()), $cte2->sql(new ValueBinder()));
+
         $cte2 = (clone $cte)->field('col1');
         $this->assertNotSame($cte->sql(new ValueBinder()), $cte2->sql(new ValueBinder()));
     }

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -427,6 +427,10 @@ class WindowExpressionTest extends TestCase
      */
     public function testCloning()
     {
+        $w1 = (new WindowExpression())->name('test');
+        $w2 = (clone $w1)->name('test2');
+        $this->assertNotSame($w1->sql(new ValueBinder()), $w2->sql(new ValueBinder()));
+
         $w1 = (new WindowExpression())->partition('test');
         $w2 = (clone $w1)->partition('new');
         $this->assertNotSame($w1->sql(new ValueBinder()), $w2->sql(new ValueBinder()));

--- a/tests/TestCase/Database/QueryTests/WindowQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTests.php
@@ -38,12 +38,21 @@ class WindowQueryTests extends TestCase
      */
     protected $connection = null;
 
+    /**
+     * @var bool
+     */
+    protected $autoQuote;
+
+    /**
+     * @var bool
+     */
     protected $skipTests = false;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
+        $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
 
         $driver = $this->connection->getDriver();
         if (
@@ -73,12 +82,12 @@ class WindowQueryTests extends TestCase
             ->select('*')
             ->window('name', new WindowExpression())
             ->sql();
-        $this->assertEqualsSql('SELECT * WINDOW name AS ()', $sql);
+        $this->assertRegExpSql('SELECT \* WINDOW <name> AS \(\)', $sql, !$this->autoQuote);
 
         $sql = $query
             ->window('name2', new WindowExpression('name'))
             ->sql();
-        $this->assertEqualsSql('SELECT * WINDOW name AS (), name2 AS (name)', $sql);
+        $this->assertRegExpSql('SELECT \* WINDOW <name> AS \(\), <name2> AS \(<name>\)', $sql, !$this->autoQuote);
 
         $sql = $query
             ->window('name', function ($window, $query) {


### PR DESCRIPTION
This also fixes CTE name cloning which was missed in a previous PR where string changed to IdentifierExpression.
