### PR TITLE
Micro optimization.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -303,13 +303,11 @@ class Connection implements ConnectionInterface
     public function execute(string $query, array $params = [], array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($query, $params, $types) {
+            $statement = $this->prepare($query);
             if (!empty($params)) {
-                $statement = $this->prepare($query);
                 $statement->bind($params, $types);
-                $statement->execute();
-            } else {
-                $statement = $this->query($query);
             }
+            $statement->execute();
 
             return $statement;
         });


### PR DESCRIPTION
Avoid extra method call.

`Connection::sql()` does the same thing as `Connection::execute()` except the `$statement->bind()` call.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
