### PR TITLE
Abort atomic save if deletion of junction record fails.

### DIFF
--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -1089,17 +1089,14 @@ class LinkConstraintTest extends TestCase
             ]),
         ]);
         $article->setDirty('tags', true);
-        $this->assertNotFalse(
-            $Articles->save($article, ['atomic' => false]),
-            'This should fail, but currently does not because junction delete errors are not being evaluated.'
-        );
+        $this->assertFalse($Articles->save($article));
         $this->assertEmpty(
             $article->getErrors(),
             'This should not be empty, but currently is because junction delete errors are not being returned.'
         );
 
         $this->markTestIncomplete(
-            'This test is incomplete because currently junction delete errors are neither evaluated, nor being returned.'
+            'This test is incomplete because currently junction delete errors are not returned.'
         );
     }
 }


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
