### PR TITLE
Simplified window frame configuration

### DIFF
--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -79,11 +79,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     public function range($start, $end = 0)
     {
         $this->over();
-        if (func_num_args() === 1) {
-            $this->window->frame(self::RANGE, $start, self::PRECEDING);
-        } else {
-            $this->window->frame(self::RANGE, $start, self::PRECEDING, $end, self::FOLLOWING);
-        }
+        $this->window->range($start, $end);
 
         return $this;
     }
@@ -94,11 +90,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     public function rows(?int $start, ?int $end = 0)
     {
         $this->over();
-        if (func_num_args() === 1) {
-            $this->window->frame(self::ROWS, $start, self::PRECEDING);
-        } else {
-            $this->window->frame(self::ROWS, $start, self::PRECEDING, $end, self::FOLLOWING);
-        }
+        $this->window->rows($start, $end);
 
         return $this;
     }
@@ -109,11 +101,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     public function groups(?int $start, ?int $end = 0)
     {
         $this->over();
-        if (func_num_args() === 1) {
-            $this->window->frame(self::GROUPS, $start, self::PRECEDING);
-        } else {
-            $this->window->frame(self::GROUPS, $start, self::PRECEDING, $end, self::FOLLOWING);
-        }
+        $this->window->groups($start, $end);
 
         return $this;
     }
@@ -125,15 +113,11 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
         string $type,
         $startOffset,
         string $startDirection,
-        $endOffset = null,
-        string $endDirection = self::FOLLOWING
+        $endOffset,
+        string $endDirection
     ) {
         $this->over();
-        if (func_num_args() === 3) {
-            $this->window->frame($type, $startOffset, $startDirection);
-        } else {
-            $this->window->frame($type, $startOffset, $startDirection, $endOffset, $endDirection);
-        }
+        $this->window->frame($type, $startOffset, $startDirection, $endOffset, $endDirection);
 
         return $this;
     }

--- a/src/Database/Expression/WindowInterface.php
+++ b/src/Database/Expression/WindowInterface.php
@@ -136,8 +136,8 @@ interface WindowInterface
         string $type,
         $startOffset,
         string $startDirection,
-        $endOffset = null,
-        string $endDirection = self::FOLLOWING
+        $endOffset,
+        string $endDirection
     );
 
     /**

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -66,7 +66,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
         $f = (new AggregateExpression('MyFunction'))->range(null);
         $this->assertEqualsSql(
-            'MyFunction() OVER (RANGE UNBOUNDED PRECEDING)',
+            'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             $f->sql(new ValueBinder())
         );
 
@@ -78,7 +78,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
         $f = (new AggregateExpression('MyFunction'))->rows(null);
         $this->assertEqualsSql(
-            'MyFunction() OVER (ROWS UNBOUNDED PRECEDING)',
+            'MyFunction() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             $f->sql(new ValueBinder())
         );
 
@@ -90,23 +90,13 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
         $f = (new AggregateExpression('MyFunction'))->groups(null);
         $this->assertEqualsSql(
-            'MyFunction() OVER (GROUPS UNBOUNDED PRECEDING)',
+            'MyFunction() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             $f->sql(new ValueBinder())
         );
 
         $f = (new AggregateExpression('MyFunction'))->groups(null, null);
         $this->assertEqualsSql(
             'MyFunction() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
-            $f->sql(new ValueBinder())
-        );
-
-        $f = (new AggregateExpression('MyFunction'))->frame(
-            AggregateExpression::RANGE,
-            2,
-            AggregateExpression::PRECEDING
-        );
-        $this->assertEqualsSql(
-            'MyFunction() OVER (RANGE 2 PRECEDING)',
             $f->sql(new ValueBinder())
         );
 
@@ -130,19 +120,19 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeCurrent();
         $this->assertEqualsSql(
-            'MyFunction() OVER (RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW)',
+            'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)',
             $f->sql(new ValueBinder())
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeGroup();
         $this->assertEqualsSql(
-            'MyFunction() OVER (RANGE UNBOUNDED PRECEDING EXCLUDE GROUP)',
+            'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)',
             $f->sql(new ValueBinder())
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeTies();
         $this->assertEqualsSql(
-            'MyFunction() OVER (RANGE UNBOUNDED PRECEDING EXCLUDE TIES)',
+            'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)',
             $f->sql(new ValueBinder())
         );
     }

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -124,19 +124,19 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->range(null);
         $this->assertEqualsSql(
-            'RANGE UNBOUNDED PRECEDING',
+            'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(0);
         $this->assertEqualsSql(
-            'RANGE CURRENT ROW',
+            'RANGE BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(2);
         $this->assertEqualsSql(
-            'RANGE 2 PRECEDING',
+            'RANGE BETWEEN 2 PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
@@ -198,19 +198,19 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->rows(null);
         $this->assertEqualsSql(
-            'ROWS UNBOUNDED PRECEDING',
+            'ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(0);
         $this->assertEqualsSql(
-            'ROWS CURRENT ROW',
+            'ROWS BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->rows(2);
         $this->assertEqualsSql(
-            'ROWS 2 PRECEDING',
+            'ROWS BETWEEN 2 PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
@@ -261,19 +261,19 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->groups(null);
         $this->assertEqualsSql(
-            'GROUPS UNBOUNDED PRECEDING',
+            'GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(0);
         $this->assertEqualsSql(
-            'GROUPS CURRENT ROW',
+            'GROUPS BETWEEN CURRENT ROW AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->groups(2);
         $this->assertEqualsSql(
-            'GROUPS 2 PRECEDING',
+            'GROUPS BETWEEN 2 PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
@@ -330,19 +330,19 @@ class WindowExpressionTest extends TestCase
 
         $w = (new WindowExpression())->range(null)->excludeCurrent();
         $this->assertEqualsSql(
-            'RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW',
+            'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null)->excludeGroup();
         $this->assertEqualsSql(
-            'RANGE UNBOUNDED PRECEDING EXCLUDE GROUP',
+            'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->range(null)->excludeTies();
         $this->assertEqualsSql(
-            'RANGE UNBOUNDED PRECEDING EXCLUDE TIES',
+            'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES',
             $w->sql(new ValueBinder())
         );
     }
@@ -356,25 +356,25 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression())->partition('test')->range(null);
         $this->assertEqualsSql(
-            'PARTITION BY test RANGE UNBOUNDED PRECEDING',
+            'PARTITION BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->order('test')->range(null);
         $this->assertEqualsSql(
-            'ORDER BY test RANGE UNBOUNDED PRECEDING',
+            'ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->partition('test')->order('test')->range(null);
         $this->assertEqualsSql(
-            'PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING',
+            'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
         $w = (new WindowExpression())->partition('test')->order('test')->range(null)->excludeCurrent();
         $this->assertEqualsSql(
-            'PARTITION BY test ORDER BY test RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW',
+            'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW',
             $w->sql(new ValueBinder())
         );
     }


### PR DESCRIPTION
This removes a bunch of function argument count logic that was used to generate shortcut SQL syntax for window frames.

Now, the full window frame is generated when default values are used: `BETWEEN X AND CURRENT ROW`.

Basically, the default of 0 implies CURRENT ROW, but the sql was omitted trying to replicate the shortcut syntax. This makes the code a little confusing and hard to follow what the default means.

All db engines follow the standard of default end offset as `CURRENT ROW`. It's the default whether it's part of the query or not so we just generate the full statement each time. The shortcut syntax is nice when manually writing the query, but would prefer a 1-to-1 output when generating sql from arguments.
