### PR TITLE
Improve doc block parameters

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -715,7 +715,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The arguments of this method are identical to the `leftJoin()` shorthand, please refer
      * to that methods description for further details.
      *
-     * @param string|string[] $table The table to join with
+     * @param string|(string|\Cake\ORM\Query)[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -730,7 +730,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Returns an array that can be passed to the join method describing a single join clause
      *
-     * @param string|string[] $table The table to join with
+     * @param string|(string|\Cake\ORM\Query)[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param string $type the join type to use

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -675,7 +675,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * See `join()` for further details on conditions and types.
      *
-     * @param string|string[] $table The table to join with
+     * @param string|string[]|\Cake\Database\ExpressionInterface[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -695,7 +695,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The arguments of this method are identical to the `leftJoin()` shorthand, please refer
      * to that methods description for further details.
      *
-     * @param string|array $table The table to join with
+     * @param string|string[]|\Cake\Database\ExpressionInterface[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -715,7 +715,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The arguments of this method are identical to the `leftJoin()` shorthand, please refer
      * to that methods description for further details.
      *
-     * @param string|(string|\Cake\ORM\Query)[] $table The table to join with
+     * @param string|string[]|\Cake\Database\ExpressionInterface[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -730,7 +730,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Returns an array that can be passed to the join method describing a single join clause
      *
-     * @param string|(string|\Cake\ORM\Query)[] $table The table to join with
+     * @param string|string[]|\Cake\Database\ExpressionInterface[] $table The table to join with
      * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
      * to use for joining.
      * @param string $type the join type to use


### PR DESCRIPTION
Fixes phpstan error:
```
 ------ -------------------------------------------------------------------- 
  1337   Parameter #1 $table of method Cake\Database\Query::innerJoin()      
         expects array<string>|string, array<string, Cake\ORM\Query> given.  
 ------ --------------------------------------------------------------------
```