### PR TITLE
Replaced assertStringStartsWithSql with assertRegExpSql

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -491,22 +491,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Assert that a string starts with SQL with db-specific characters like quotes removed.
-     *
-     * @param string $expected The expected sql
-     * @param string $actual The sql to compare
-     * @param string $message The message to display on failure
-     * @return void
-     */
-    public function assertStartsWithSql(
-        string $expected,
-        string $actual,
-        string $message = ''
-    ): void {
-        $this->assertStringStartsWith($expected, preg_replace('/[`"\[\]]/', '', $actual), $message);
-    }
-
-    /**
      * Assertion for comparing a regex pattern against a query having its identifiers
      * quoted. It accepts queries quoted with the characters `<` and `>`. If the third
      * parameter is set to true, it will alter the pattern to both accept quoted and

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
@@ -235,10 +235,11 @@ class CommonTableExpressionQueryTests extends TestCase
                     ->from('cte')
             );
 
-        $this->assertStartsWithSql(
-            "WITH cte(title, body) AS (SELECT 'Fourth Article', 'Fourth Article Body') " .
-                'INSERT INTO articles (title, body)',
-            $query->sql(new ValueBinder())
+        $this->assertRegExpSql(
+            "WITH <cte>\(<title>, <body>\) AS \(SELECT 'Fourth Article', 'Fourth Article Body'\) " .
+                'INSERT INTO <articles> \(<title>, <body>\)',
+            $query->sql(new ValueBinder()),
+            !$this->autoQuote
         );
 
         // run insert
@@ -291,10 +292,11 @@ class CommonTableExpressionQueryTests extends TestCase
                     ->from('cte')
             );
 
-        $this->assertStartsWithSql(
-            'INSERT INTO articles (title, body) ' .
-                "WITH cte(title, body) AS (SELECT 'Fourth Article', 'Fourth Article Body') SELECT * FROM cte",
-            $query->sql(new ValueBinder())
+        $this->assertRegExpSql(
+            'INSERT INTO <articles> \(<title>, <body>\) ' .
+                "WITH <cte>\(<title>, <body>\) AS \(SELECT 'Fourth Article', 'Fourth Article Body'\) SELECT \* FROM <cte>",
+            $query->sql(new ValueBinder()),
+            !$this->autoQuote
         );
 
         // run insert


### PR DESCRIPTION
This cleans up an earlier PR where I added assertStringStartsWithSql before I added assertRegExpSql to the official TestCase API. This should be the official way to check custom strings.

Will convert the other custom sql compares to this later.