### PR TITLE
Deprecate method that throws deprecation warning along the way.

### DIFF
--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -218,6 +218,7 @@ class NumberHelper extends Helper
      * if $currency argument is not provided. If boolean false is passed, it will clear the
      * currently stored value. Null reads the current default.
      * @return string|null Currency
+     * @deprecated 3.9.0 Use setDefaultCurrency()/getDefaultCurrency() instead.
      */
     public function defaultCurrency($currency)
     {


### PR DESCRIPTION
This should also be forward ported to 4.1 then

Refs https://github.com/cakephp/cakephp/issues/14776