### PR TITLE
Fix double encoding in route errors

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -114,6 +114,18 @@ function initialize() {
   createCollapsibles(doc.querySelectorAll('.cake-dbg-array-items'));
   createCollapsibles(doc.querySelectorAll('.cake-dbg-object-props'));
   attachRefEvents(doc.querySelectorAll('.cake-dbg'));
+  openBlocks(doc.querySelectorAll('.cake-debug[data-open-all="true"]'));
+}
+
+/**
+ * Open all the collapsed sections in a block.
+ */
+function openBlocks(blocks) {
+  blocks.forEach(function (block) {
+    block.querySelectorAll('.cake-dbg-collapse[data-open="false"]').forEach(function (el) {
+      el.click();
+    });
+  });
 }
 
 /**

--- a/templates/Error/duplicate_named_route.php
+++ b/templates/Error/duplicate_named_route.php
@@ -38,17 +38,12 @@ Remove duplicate route names in your route configuration.</p>
     <h3>Duplicate Route</h3>
     <table cellspacing="0" cellpadding="0">
     <tr><th>Template</th><th>Defaults</th><th>Options</th></tr>
-    <?php
-    $other = $attributes['duplicate'];
-    echo '<tr>';
-    printf(
-        '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
-        h($other->template),
-        Debugger::exportVar($other->defaults),
-        Debugger::exportVar($other->options)
-    );
-    echo '</tr>';
-    ?>
+    <?php $other = $attributes['duplicate']; ?>
+    <tr>
+        <td width="25%"><?= h($other->template) ?></td>
+        <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($other->defaults) ?></div></td>
+        <td width="20%"><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($other->options) ?></div></td>
+    </tr>
     </table>
 <?php endif; ?>
 <?php $this->end() ?>

--- a/templates/Error/duplicate_named_route.php
+++ b/templates/Error/duplicate_named_route.php
@@ -34,13 +34,6 @@ The same <code>_name</code> option cannot be used twice,
 even if the names occur in different routing scopes.
 Remove duplicate route names in your route configuration.</p>
 
-<?php if (!empty($attributes['context'])) : ?>
-<p>The passed context was:</p>
-<pre>
-<?= Debugger::exportVar($attributes['context']); ?>
-</pre>
-<?php endif; ?>
-
 <?php if (isset($attributes['duplicate'])): ?>
     <h3>Duplicate Route</h3>
     <table cellspacing="0" cellpadding="0">
@@ -51,8 +44,8 @@ Remove duplicate route names in your route configuration.</p>
     printf(
         '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
         h($other->template),
-        h(Debugger::exportVar($other->defaults)),
-        h(Debugger::exportVar($other->options))
+        Debugger::exportVar($other->defaults),
+        Debugger::exportVar($other->options)
     );
     echo '</tr>';
     ?>

--- a/templates/Error/duplicate_named_route.php
+++ b/templates/Error/duplicate_named_route.php
@@ -36,13 +36,13 @@ Remove duplicate route names in your route configuration.</p>
 
 <?php if (isset($attributes['duplicate'])): ?>
     <h3>Duplicate Route</h3>
-    <table cellspacing="0" cellpadding="0">
+    <table cellspacing="0" cellpadding="0" width="100%">
     <tr><th>Template</th><th>Defaults</th><th>Options</th></tr>
     <?php $other = $attributes['duplicate']; ?>
     <tr>
-        <td width="25%"><?= h($other->template) ?></td>
+        <td><?= h($other->template) ?></td>
         <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($other->defaults) ?></div></td>
-        <td width="20%"><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($other->options) ?></div></td>
+        <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($other->options) ?></div></td>
     </tr>
     </table>
 <?php endif; ?>

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -35,9 +35,7 @@ Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 
 <?php if (!empty($attributes['context'])): ?>
 <p>The passed context was:</p>
-<pre>
-<?= h(Debugger::exportVar($attributes['context'])); ?>
-</pre>
+<?= Debugger::exportVar($attributes['context']); ?>
 <?php endif; ?>
 
 <h3>Connected Routes</h3>
@@ -49,8 +47,8 @@ foreach (Router::routes() as $route):
     printf(
         '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
         h($route->template),
-        h(Debugger::exportVar($route->defaults)),
-        h(Debugger::exportVar($route->options))
+        Debugger::exportVar($route->defaults),
+        Debugger::exportVar($route->options)
     );
     echo '</tr>';
 endforeach;

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -36,7 +36,7 @@ Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 <?php if (!empty($attributes['context'])): ?>
 <p>The passed context was:</p>
 <div class="cake-debug">
-<?= Debugger::exportVar($attributes['context']); ?>
+    <?= Debugger::exportVar($attributes['context']); ?>
 </div>
 <?php endif; ?>
 

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -41,13 +41,13 @@ Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 <?php endif; ?>
 
 <h3>Connected Routes</h3>
-<table cellspacing="0" cellpadding="0">
+<table cellspacing="0" cellpadding="0" width="100%">
 <tr><th>Template</th><th>Defaults</th><th>Options</th></tr>
 <?php foreach (Router::routes() as $route): ?>
     <tr>
-        <td width="25%"><?= h($route->template) ?></td>
+        <td><?= h($route->template) ?></td>
         <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($route->defaults) ?></div></td>
-        <td width="20%"><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($route->options) ?></div></td>
+        <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($route->options) ?></div></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -35,23 +35,20 @@ Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 
 <?php if (!empty($attributes['context'])): ?>
 <p>The passed context was:</p>
+<div class="cake-debug">
 <?= Debugger::exportVar($attributes['context']); ?>
+</div>
 <?php endif; ?>
 
 <h3>Connected Routes</h3>
 <table cellspacing="0" cellpadding="0">
 <tr><th>Template</th><th>Defaults</th><th>Options</th></tr>
-<?php
-foreach (Router::routes() as $route):
-    echo '<tr>';
-    printf(
-        '<td width="25%%">%s</td><td>%s</td><td width="20%%">%s</td>',
-        h($route->template),
-        Debugger::exportVar($route->defaults),
-        Debugger::exportVar($route->options)
-    );
-    echo '</tr>';
-endforeach;
-?>
+<?php foreach (Router::routes() as $route): ?>
+    <tr>
+        <td width="25%"><?= h($route->template) ?></td>
+        <td><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($route->defaults) ?></div></td>
+        <td width="20%"><div class="cake-debug" data-open-all="true"><?= Debugger::exportVar($route->options) ?></div></td>
+    </tr>
+<?php endforeach; ?>
 </table>
 <?php $this->end() ?>


### PR DESCRIPTION
Fix the double encoding errors reported in #14785. I've also improved the route error layouts a bit and improved the styling of the dumps so that they are formatted the same as normal debug() dumps, and made the table flow better and be full width.