### PR TITLE
A correct fix to getMockForModel issue #14747

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -837,12 +837,20 @@ abstract class TestCase extends BaseTestCase
         [, $baseClass] = pluginSplit($alias);
         $options += ['alias' => $baseClass, 'connection' => $connection];
         $options += $locator->getConfig($alias);
-        $existingMethods = array_intersect(get_class_methods($className), $methods);
+        $reflection = new ReflectionClass($className);
+        $classMethods = array_map(function ($method) {
+            return $method->name;
+        }, $reflection->getMethods());
+
+        $existingMethods = array_intersect($classMethods, $methods);
         $nonExistingMethods = array_diff($methods, $existingMethods);
 
         $builder = $this->getMockBuilder($className)
-            ->onlyMethods($existingMethods)
             ->setConstructorArgs([$options]);
+
+        if ($existingMethods || !$nonExistingMethods) {
+            $builder->onlyMethods($existingMethods);
+        }
 
         if ($nonExistingMethods) {
             $builder->addMethods($nonExistingMethods);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -360,12 +360,19 @@ class TestCaseTest extends TestCase
         $Tags = $this->getMockForModel('Tags', ['save']);
         $this->assertSame('TestApp\Model\Entity\Tag', $Tags->getEntityClass());
 
-        $SluggedPosts = $this->getMockForModel('SluggedPosts', ['save', 'slugify']);
+        $SluggedPosts = $this->getMockForModel('SluggedPosts', ['slugify']);
         $SluggedPosts->expects($this->at(0))
             ->method('slugify')
             ->with('some value')
             ->will($this->returnValue('mocked'));
         $this->assertSame('mocked', $SluggedPosts->slugify('some value'));
+
+        $SluggedPosts = $this->getMockForModel('SluggedPosts', ['save', 'slugify']);
+        $SluggedPosts->expects($this->at(0))
+            ->method('slugify')
+            ->with('some value two')
+            ->will($this->returnValue('mocked'));
+        $this->assertSame('mocked', $SluggedPosts->slugify('some value two'));
     }
 
     /**


### PR DESCRIPTION
This solves mock for non-public models methods and a bug when only mocking non-existing methods.
