### PR TITLE
Type cast config['timeout'] to int

### DIFF
--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -167,7 +167,7 @@ class Socket
             $remoteSocketTarget,
             $errNum,
             $errStr,
-            $this->_config['timeout'],
+            (int)$this->_config['timeout'],
             $connectAs,
             $context
         );
@@ -186,7 +186,7 @@ class Socket
         $this->connected = is_resource($this->connection);
         if ($this->connected) {
             /** @psalm-suppress PossiblyNullArgument */
-            stream_set_timeout($this->connection, $this->_config['timeout']);
+            stream_set_timeout($this->connection, (int)$this->_config['timeout']);
         }
 
         return $this->connected;


### PR DESCRIPTION
If you pass "timeout" as parameter in an url, the function `parseDsn` in `StaticConfigTrait.php` will interpret the value as string. This triggers a "type error" in `stream_socket_client`. Type casting the variable to int solves it.
Example url in StaticConfigTrait.php triggers the error:
`$dsn = 'smtp://user:secret@localhost:25?timeout=30&client=null&tls=null';`

Fixes https://github.com/cakephp/cakephp/issues/14794
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
