### PR TITLE
Backports from 4.next.

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -20,7 +20,7 @@ if (!function_exists('__')) {
      * Returns a translated string if one is found; Otherwise, the submitted message.
      *
      * @param string $singular Text to translate.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string The translated text.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__
      */
@@ -46,7 +46,7 @@ if (!function_exists('__n')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__n
      */
@@ -73,7 +73,7 @@ if (!function_exists('__d')) {
      *
      * @param string $domain Domain.
      * @param string $msg String to translate.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__d
      */
@@ -101,7 +101,7 @@ if (!function_exists('__dn')) {
      * @param string $singular Singular string to translate.
      * @param string $plural Plural.
      * @param int $count Count.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__dn
      */
@@ -130,7 +130,7 @@ if (!function_exists('__x')) {
      *
      * @param string $context Context of the text.
      * @param string $singular Text to translate.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__x
      */
@@ -159,7 +159,7 @@ if (!function_exists('__xn')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__xn
      */
@@ -189,7 +189,7 @@ if (!function_exists('__dx')) {
      * @param string $domain Domain.
      * @param string $context Context of the text.
      * @param string $msg String to translate.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__dx
      */
@@ -222,7 +222,7 @@ if (!function_exists('__dxn')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param array ...$args Array with arguments or multiple arguments in function.
+     * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
      * @link https://book.cakephp.org/3/en/core-libraries/global-constants-and-functions.html#__dxn
      */


### PR DESCRIPTION
Backport phpdoc from 4.next to fix 'Expected parameter of type 'array|array[]', 'string' provided' hint