### PR TITLE
Throw an error when the csrfToken attribute is already set

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -27,6 +27,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 
 /**
  * Provides CSRF protection & validation.
@@ -121,6 +122,14 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
             $request = $this->_unsetTokenField($request);
 
             return $handler->handle($request);
+        }
+        if ($request->getAttribute('csrfToken')) {
+            throw new RuntimeException(
+                'A CSRF token is already set in the request.' .
+                "\n" .
+                'Ensure you do not have the CSRF middleware applied more than once. ' .
+                'Check both your `Application::middleware()` method and `config/routes.php`.'
+            );
         }
 
         $cookies = $request->getCookieParams();


### PR DESCRIPTION
When the request already contains a csrfToken adding another one causes token mismatches. Raising an exception when we hit this scenario should help the developer figure out why they are seeing CSRF failures and give them suggestions on where to look for the extra CSRF middleware layer.

Related to issues like #14799