### PR TITLE
Add unit test for using subquery() in join clause

### DIFF
--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -4069,8 +4069,8 @@ class QueryTest extends TestCase
 
         $query = $this->getTableLocator()->get('Authors')->find();
         $query
-            ->select(['Authors.id', 'total_articles' => $query->func()->count('Articles.author_id')])
-            ->leftJoin(['Articles' => $subquery], ['Articles.author_id = Authors.id'])
+            ->select(['Authors.id', 'total_articles' => $query->func()->count('articles.author_id')])
+            ->leftJoin(['articles' => $subquery], ['articles.author_id = Authors.id'])
             ->group(['Authors.id'])
             ->order(['Authors.id' => 'ASC']);
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -4070,7 +4070,7 @@ class QueryTest extends TestCase
         $query = $this->getTableLocator()->get('Authors')->find();
         $query
             ->select(['Authors.id', 'total_articles' => $query->func()->count('articles.author_id')])
-            ->leftJoin(['articles' => $subquery], ['articles.author_id = Authors.id'])
+            ->leftJoin(['articles' => $subquery], ['articles.author_id' => new IdentifierExpression('Authors.id')])
             ->group(['Authors.id'])
             ->order(['Authors.id' => 'ASC']);
 


### PR DESCRIPTION
The example is a little silly since you would just use an association, but easiest test with the fixtures we have.