### PR TITLE
Use postgresql 9.6 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ services:
   - postgresql
   - mysql
 
+addons:
+  postgresql: '9.6'
+
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
With github actions running latest postgresql, we should try testing on the minimal version supported since 9.6 is still more popular.