### PR TITLE
Made Http\Client accept url without // and scheme

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -512,7 +512,10 @@ class Client implements ClientInterface
         if ($options['port'] && (int)$options['port'] !== $defaultPorts[$options['scheme']]) {
             $out .= ':' . $options['port'];
         }
-        $out .= '/' . ltrim($url, '/');
+        if ($options['host'] !== null) {
+            $out .= '/';
+        }
+        $out .= ltrim($url, '/');
 
         return $out;
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -175,6 +175,15 @@ class ClientTest extends TestCase
                 ],
                 'protocol relative url',
             ],
+            [
+                'http://example.com/test.html',
+                'example.com/test.html',
+                [],
+                [
+                    'scheme' => 'http',
+                ],
+                'url without any prefix',
+            ],
         ];
     }
 


### PR DESCRIPTION
Before 4.0 release, I can use url on `Http\Client` only with DNS ou IP address, but if I do the same now, I'll get a domain with 3 slashes (`///example.com`).

This make Client BC with 3.x releases.