### PR TITLE
Allow PDOStatement driver options to be set by SqlServer::prepare

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -193,7 +193,7 @@ class Sqlserver extends Driver
     public function prepare($query, array $options = []): StatementInterface
     {
         $this->connect();
-        if (!isset($options[PDO::ATTR_CURSOR]) {
+        if (!isset($options[PDO::ATTR_CURSOR])) {
             $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL] + $options;
         }
         $isObject = $query instanceof Query;

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -193,7 +193,9 @@ class Sqlserver extends Driver
     public function prepare($query, array $options = []): StatementInterface
     {
         $this->connect();
-        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL] + $options;
+        if (!isset($options[PDO::ATTR_CURSOR]) {
+            $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL] + $options;
+        }
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -187,12 +187,13 @@ class Sqlserver extends Driver
      * Prepares a sql statement to be executed
      *
      * @param string|\Cake\Database\Query $query The query to prepare.
+     * @param array $options The driver options to set on the statement.
      * @return \Cake\Database\StatementInterface
      */
-    public function prepare($query): StatementInterface
+    public function prepare($query, array $options = []): StatementInterface
     {
         $this->connect();
-        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+        $options += [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -193,7 +193,7 @@ class Sqlserver extends Driver
     public function prepare($query, array $options = []): StatementInterface
     {
         $this->connect();
-        $options += [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL] + $options;
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {


### PR DESCRIPTION
Fixes #14806

As stated at the issue, the `ATTR_CURSOR` attribute for `PDOStatement` is pre-defined at the driver not allowing us to set specific cursor types types, which can vary depending on our usage.

This PR adds the driver options argument `$options` to be able to include other options when instantiating an PDOStatement for the Sqlserver driver.

So we can simply enforce the cursor type by doing:

```php
$this->connection = ConnectionManager::get('default');
$query = 'EXEC PROCEDURE_NAME PARAM';
$driver = $this->connection->getDriver();
$stmt = $driver->prepare($query, [
    \PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => \PDO::SQLSRV_CURSOR_BUFFERED
]);
$stmt->execute();
$result = $stmt->fetchAll('assoc');
$stmt->closeCursor();
```