### PR TITLE
Use CURSOR_FWDONLY instead of CURSOR_SCROLL

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -193,7 +193,7 @@ class Sqlserver extends Driver
     {
         $this->connect();
         $options = [
-            PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL,
+            PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY,
             PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
         ];
         $isObject = $query instanceof Query;

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -192,7 +192,10 @@ class Sqlserver extends Driver
     public function prepare($query): StatementInterface
     {
         $this->connect();
-        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY];
+        $options = [
+            PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL,
+            PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
+        ];
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -192,7 +192,7 @@ class Sqlserver extends Driver
     public function prepare($query): StatementInterface
     {
         $this->connect();
-        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY];
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1709,18 +1709,17 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->whereInList('id', [], ['allowEmpty' => true])
-            ->execute();
-        $sql = $query->sql();
-
-        $result = $query->execute();
-        $this->assertFalse($result->fetch('assoc'));
+            ->whereInList('id', [], ['allowEmpty' => true]);
 
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE 1=0',
-            $sql,
+            $query->sql(),
             !$this->autoQuote
         );
+
+        $statement = $query->execute();
+        $this->assertFalse($statement->fetch('assoc'));
+        $statement->closeCursor();
     }
 
     /**
@@ -2371,7 +2370,8 @@ class QueryTest extends TestCase
         $query->select('id')->from('comments')
             ->limit(1)
             ->offset(1)
-            ->execute();
+            ->execute()
+            ->closeCursor();
 
         $reflect = new ReflectionProperty($query, '_dirty');
         $reflect->setAccessible(true);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1815,12 +1815,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
-            $this->assertEquals(2, $result->rowCount());
-        } else {
-            $this->assertEquals(-1, $result->rowCount());
-        }
+        $this->assertEquals(2, $result->rowCount());
     }
 
     /**


### PR DESCRIPTION
Running tests on changing the cursor type to default `CURSOR_FWDONLY`. This should help performance while keeping the ability to buffer results.