### PR TITLE
Add session based CSRF token middleware

### DIFF
--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.5.0
+ * @since         4.2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Http\Middleware;

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -1,0 +1,217 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware;
+
+use ArrayAccess;
+use Cake\Http\Exception\InvalidCsrfTokenException;
+use Cake\Http\Session;
+use Cake\Utility\Hash;
+use Cake\Utility\Security;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+
+/**
+ * Provides CSRF protection via session based tokens.
+ *
+ * This middleware adds a CSRF token to the session. Each request must
+ * contain a token in request data, or the X-CSRF-Token header on each PATCH, POST,
+ * PUT, or DELETE request. This follows a 'synchronizer token' pattern.
+ *
+ * If the request data is missing or does not match the session data,
+ * an InvalidCsrfTokenException will be raised.
+ *
+ * This middleware integrates with the FormHelper automatically and when
+ * used together your forms will have CSRF tokens automatically added
+ * when `$this->Form->create(...)` is used in a view.
+ *
+ * If you use this middleware *do not* also use CsrfProtectionMiddleware.
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#sychronizer-token-pattern
+ */
+class SessionCsrfProtectionMiddleware implements MiddlewareInterface
+{
+    /**
+     * Config for the CSRF handling.
+     *
+     *  - `key` The session key to use. Defaults to `csrfToken`
+     *  - `field` The form field to check. Changing this will also require configuring
+     *    FormHelper.
+     *
+     * @var array
+     */
+    protected $_config = [
+        'key' => 'csrfToken',
+        'field' => '_csrfToken',
+    ];
+
+    /**
+     * Callback for deciding whether or not to skip the token check for particular request.
+     *
+     * CSRF protection token check will be skipped if the callback returns `true`.
+     *
+     * @var callable|null
+     */
+    protected $skipCheckCallback;
+
+    /**
+     * @var int
+     */
+    public const TOKEN_VALUE_LENGTH = 32;
+
+    /**
+     * Constructor
+     *
+     * @param array $config Config options. See $_config for valid keys.
+     */
+    public function __construct(array $config = [])
+    {
+        $this->_config = $config + $this->_config;
+    }
+
+    /**
+     * Checks and sets the CSRF token depending on the HTTP verb.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $method = $request->getMethod();
+        $hasData = in_array($method, ['PUT', 'POST', 'DELETE', 'PATCH'], true)
+            || $request->getParsedBody();
+
+        if (
+            $hasData
+            && $this->skipCheckCallback !== null
+            && call_user_func($this->skipCheckCallback, $request) === true
+        ) {
+            $request = $this->unsetTokenField($request);
+
+            return $handler->handle($request);
+        }
+
+        $session = $request->getAttribute('session');
+        if (!$session || !($session instanceof Session)) {
+            throw new RuntimeException('You must have a `session` attribute to use session based CSRF tokens');
+        }
+
+        $token = $session->read($this->_config['key']);
+        if ($token === null) {
+            $token = $this->createToken();
+            $session->write($this->_config['key'], $token);
+        }
+        $request = $request->withAttribute('csrfToken', $token);
+
+        if ($method === 'GET') {
+            return $handler->handle($request);
+        }
+
+        if ($hasData) {
+            $this->validateToken($request, $session);
+            $request = $this->unsetTokenField($request);
+        }
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * Set callback for allowing to skip token check for particular request.
+     *
+     * The callback will receive request instance as argument and must return
+     * `true` if you want to skip token check for the current request.
+     *
+     * @param callable $callback A callable.
+     * @return $this
+     */
+    public function skipCheckCallback(callable $callback)
+    {
+        $this->skipCheckCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Remove CSRF protection token from request data.
+     *
+     * This ensures that the token does not cause failures during
+     * form tampering protection.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
+     * @return \Psr\Http\Message\ServerRequestInterface
+     */
+    protected function unsetTokenField(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $body = $request->getParsedBody();
+        if (is_array($body)) {
+            unset($body[$this->_config['field']]);
+            $request = $request->withParsedBody($body);
+        }
+
+        return $request;
+    }
+
+    /**
+     * Create a new token to be used for CSRF protection
+     *
+     * This token is a simple unique random value as the compare
+     * value is stored in the session where it cannot be tampered with.
+     *
+     * @return string
+     */
+    public function createToken(): string
+    {
+        return Security::randomString(static::TOKEN_VALUE_LENGTH);
+    }
+
+    /**
+     * Validate the request data against the cookie token.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request to validate against.
+     * @param \Cake\Http\Session $session The session instance.
+     * @return void
+     * @throws \Cake\Http\Exception\InvalidCsrfTokenException When the CSRF token is invalid or missing.
+     */
+    protected function validateToken(ServerRequestInterface $request, Session $session): void
+    {
+        $token = $session->read($this->_config['key']);
+        if (!$token || !is_string($token)) {
+            throw new InvalidCsrfTokenException(__d('cake', 'Missing or incorrect CSRF session key'));
+        }
+
+        $body = $request->getParsedBody();
+        if (is_array($body) || $body instanceof ArrayAccess) {
+            $post = (string)Hash::get($body, $this->_config['field']);
+            if (hash_equals($post, $token)) {
+                return;
+            }
+        }
+
+        $header = $request->getHeaderLine('X-CSRF-Token');
+        if (hash_equals($header, $token)) {
+            return;
+        }
+
+        throw new InvalidCsrfTokenException(__d(
+            'cake',
+            'CSRF token from either the request body or request headers did not match or is missing.'
+        ));
+    }
+}

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.5.0
+ * @since         4.2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Http\Middleware;

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -16,15 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http\Middleware;
 
-use Cake\Http\Cookie\Cookie;
-use Cake\Http\Cookie\CookieInterface;
 use Cake\Http\Exception\InvalidCsrfTokenException;
 use Cake\Http\Middleware\SessionCsrfProtectionMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use Laminas\Diactoros\Response as DiactorosResponse;
-use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\TestRequestHandler;
 

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -1,0 +1,357 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieInterface;
+use Cake\Http\Exception\InvalidCsrfTokenException;
+use Cake\Http\Middleware\SessionCsrfProtectionMiddleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Response as DiactorosResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ServerRequestInterface;
+use TestApp\Http\TestRequestHandler;
+
+/**
+ * Test for SessionCsrfProtection
+ */
+class SessionCsrfProtectionMiddlewareTest extends TestCase
+{
+    /**
+     * Data provider for HTTP method tests.
+     *
+     * HEAD and GET do not populate $_POST or request->data.
+     *
+     * @return array
+     */
+    public static function safeHttpMethodProvider()
+    {
+        return [
+            ['GET'],
+            ['HEAD'],
+        ];
+    }
+
+    /**
+     * Data provider for HTTP methods that can contain request bodies.
+     *
+     * @return array
+     */
+    public static function httpMethodProvider()
+    {
+        return [
+            ['OPTIONS'], ['PATCH'], ['PUT'], ['POST'], ['DELETE'], ['PURGE'], ['INVALIDMETHOD'],
+        ];
+    }
+
+    /**
+     * Provides the request handler
+     *
+     * @return \Psr\Http\Server\RequestHandlerInterface
+     */
+    protected function _getRequestHandler()
+    {
+        return new TestRequestHandler(function () {
+            return new Response();
+        });
+    }
+
+    /**
+     * Test setting the cookie value
+     *
+     * @return void
+     */
+    public function testSettingTokenInSession()
+    {
+        $request = new ServerRequest([
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+            'webroot' => '/dir/',
+        ]);
+
+        $updatedRequest = null;
+        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
+            $updatedRequest = $request;
+
+            return new Response();
+        });
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $response = $middleware->process($request, $handler);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $token = $request->getSession()->read('csrfToken');
+        $this->assertNotEmpty($token, 'Should set a token.');
+        $this->assertRegExp('/^[a-f0-9]+$/', $token, 'Should look like a hash.');
+    }
+
+    /**
+     * Test that the CSRF tokens are not required for idempotent operations
+     *
+     * @dataProvider safeHttpMethodProvider
+     * @return void
+     */
+    public function testSafeMethodNoCsrfRequired($method)
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => 'nope',
+            ],
+        ]);
+        $request->getSession()->write('csrfToken', 'testing123');
+
+        // No exception means the test is valid
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    /**
+     * Test that the X-CSRF-Token works with the various http methods.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testValidTokenInHeader($method)
+    {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => $token,
+            ],
+            'post' => ['a' => 'b'],
+        ]);
+        $request->getSession()->write('csrfToken', $token);
+        $response = new Response();
+
+        // No exception means the test is valid
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    /**
+     * Test that the X-CSRF-Token works with the various http methods.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testInvalidTokenInHeader($method)
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => 'nope',
+            ],
+            'post' => ['a' => 'b'],
+        ]);
+        $request->getSession()->write('csrfToken', 'testing123');
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+
+        try {
+            $middleware->process($request, $this->_getRequestHandler());
+
+            $this->fail();
+        } catch (InvalidCsrfTokenException $exception) {
+            $token = $request->getSession()->read('csrfToken');
+            $this->assertSame('testing123', $token, 'session token should not change.');
+        }
+    }
+
+    /**
+     * Test that request data works with the various http methods.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testValidTokenInRequestData($method)
+    {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
+
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
+            'post' => ['_csrfToken' => $token],
+        ]);
+        $request->getSession()->write('csrfToken', $token);
+
+        $handler = new TestRequestHandler(function ($request) {
+            $this->assertNull($request->getData('_csrfToken'));
+
+            return new Response();
+        });
+
+        // No exception means everything is OK
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * Test that request data works with the various http methods.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testInvalidTokenRequestData($method)
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
+            'post' => ['_csrfToken' => 'nope'],
+        ]);
+        $request->getSession()->write('csrfToken', 'testing123');
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+
+        $this->expectException(InvalidCsrfTokenException::class);
+        $middleware->process($request, $this->_getRequestHandler());
+    }
+
+    /**
+     * Test that missing post field fails
+     *
+     * @return void
+     */
+    public function testInvalidTokenRequestDataMissing()
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [],
+        ]);
+        $request->getSession()->write('csrfToken', 'testing123');
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $this->expectException(InvalidCsrfTokenException::class);
+        $middleware->process($request, $this->_getRequestHandler());
+    }
+
+    /**
+     * Test that missing session key fails
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testInvalidTokenMissingSession($method)
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
+            'post' => ['_csrfToken' => 'could-be-valid'],
+            'cookies' => [],
+        ]);
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+
+        try {
+            $middleware->process($request, $this->_getRequestHandler());
+
+            $this->fail();
+        } catch (InvalidCsrfTokenException $exception) {
+            $token = $request->getSession()->read('csrfToken');
+            $this->assertNotEmpty($token, 'Should set a token in the session on failure.');
+        }
+    }
+
+    /**
+     * Test that the configuration options work.
+     *
+     * @return void
+     */
+    public function testConfigurationCookieCreate()
+    {
+        $request = new ServerRequest([
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+            'webroot' => '/dir/',
+        ]);
+
+        $middleware = new SessionCsrfProtectionMiddleware([
+            'key' => 'csrf',
+        ]);
+        $middleware->process($request, $this->_getRequestHandler());
+
+        $session = $request->getSession();
+        $this->assertEmpty($session->read('csrfToken'));
+        $token = $session->read('csrf');
+        $this->assertNotEmpty($token, 'Should set a token.');
+        $this->assertRegExp('/^[a-f0-9]+$/', $token, 'Should look like a hash.');
+    }
+
+    /**
+     * Test that the configuration options work.
+     *
+     * There should be no exception thrown.
+     *
+     * @return void
+     */
+    public function testConfigurationValidate()
+    {
+        $middleware = new SessionCsrfProtectionMiddleware([
+            'key' => 'csrf',
+            'field' => 'token',
+        ]);
+        $token = $middleware->createToken();
+        $request = new ServerRequest([
+            'environment' => ['REQUEST_METHOD' => 'POST'],
+            'post' => ['_csrfToken' => 'no match', 'token' => $token],
+        ]);
+        $request->getSession()->write('csrf', $token);
+
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSkippingTokenCheckUsingSkipCheckCallback()
+    {
+        $request = new ServerRequest([
+            'post' => [
+                '_csrfToken' => 'foo',
+            ],
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+        ]);
+        $request->getSession()->write('csrfToken', 'foo');
+
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $middleware->skipCheckCallback(function (ServerRequestInterface $request) {
+            $this->assertSame('POST', $request->getServerParams()['REQUEST_METHOD']);
+
+            return true;
+        });
+
+        $handler = new TestRequestHandler(function ($request) {
+            $this->assertEmpty($request->getParsedBody());
+
+            return new Response();
+        });
+
+        $response = $middleware->process($request, $handler);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}


### PR DESCRIPTION
The current double submit cookie CSRF middleware has a few potential weaknesses:

1. The tokens it uses are portable between users. If a user has their    browser compromised, CSRF tokens can be re-used between other    compromised users.
2. Tokens don't have an expiration time. If a CSRF token is leaked and   a user is compromised an old token can be used again.

These changes introduce an alternative CSRF middleware that stores the compare token in the session. This removes the need to do HMAC signing as the compare value is in the session where an attacker cannot change it. Furthermore, it also couples CSRF tokens to the user, and to the specific session. This mitigates both weaknesses with our existing CSRF middleware.

I didn't want to make the existing CSRF middleware more complicated and risk breaking backwards compatibility which is why this is a new middleware. A separate middleware makes opt-ing into session based tokens explicit.