### PR TITLE
Use specific test methods to assert PHP errors generation.

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -22,7 +22,6 @@ use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\NullEngine;
 use Cake\Cache\InvalidArgumentException;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Error\Error;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 
 /**
@@ -113,7 +112,7 @@ class CacheTest extends TestCase
             'fallback' => false,
         ]);
 
-        $this->expectException(Error::class);
+        $this->expectError();
 
         Cache::pool('tests');
     }
@@ -266,8 +265,8 @@ class CacheTest extends TestCase
             'className' => '\stdClass',
         ]);
 
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Cache engines must use Cake\Cache\CacheEngine');
+        $this->expectError();
+        $this->expectErrorMessage('Cache engines must use Cake\Cache\CacheEngine');
 
         Cache::pool('tests');
     }
@@ -285,8 +284,8 @@ class CacheTest extends TestCase
             'engine' => $mock,
         ]);
 
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('is not properly configured');
+        $this->expectError();
+        $this->expectErrorMessage('is not properly configured');
 
         Cache::pool('tests');
     }
@@ -746,7 +745,7 @@ class CacheTest extends TestCase
             'prefix' => '',
         ]);
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectError();
 
         Cache::write('fail', 'value', 'test_trigger');
     }

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -19,7 +19,6 @@ namespace Cake\Test\TestCase\Console;
 use Cake\Console\Shell;
 use Cake\Console\ShellDispatcher;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Error\Warning;
 
 /**
  * ShellDispatcherTest
@@ -430,7 +429,7 @@ class ShellDispatcherTest extends TestCase
      */
     public function testHelpOption()
     {
-        $this->expectException(Warning::class);
+        $this->expectWarning();
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->addMethods(['_stop'])
             ->getMock();
@@ -445,7 +444,7 @@ class ShellDispatcherTest extends TestCase
      */
     public function testVersionOption()
     {
-        $this->expectException(Warning::class);
+        $this->expectWarning();
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->addMethods(['_stop'])
             ->getMock();

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -25,8 +25,6 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Uri;
-use PHPUnit\Framework\Error\Notice;
-use PHPUnit\Framework\Error\Warning;
 use ReflectionFunction;
 use TestApp\Controller\Admin\PostsController;
 use TestApp\Controller\TestController;
@@ -110,8 +108,8 @@ class ControllerTest extends TestCase
         $controller->Bar = true;
         $this->assertTrue($controller->Bar);
 
-        $this->expectException(Notice::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectNotice();
+        $this->expectNoticeMessage(sprintf(
             'Undefined property: Controller::$Foo in %s on line %s',
             __FILE__,
             __LINE__ + 2
@@ -853,7 +851,7 @@ class ControllerTest extends TestCase
      */
     public function testComponentsPropertyError(): void
     {
-        $this->expectException(Warning::class);
+        $this->expectWarning();
         $request = new ServerRequest(['url' => '/']);
         $response = new Response();
 
@@ -868,7 +866,7 @@ class ControllerTest extends TestCase
      */
     public function testHelpersPropertyError(): void
     {
-        $this->expectException(Warning::class);
+        $this->expectWarning();
         $request = new ServerRequest(['url' => '/']);
         $response = new Response();
 

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -18,8 +18,6 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Error\Deprecated;
-use PHPUnit\Framework\Error\Warning;
 
 /**
  * Test cases for functions in Core\functions.php
@@ -82,8 +80,8 @@ class FunctionsTest extends TestCase
      */
     public function testDeprecationWarningEnabled()
     {
-        $this->expectException(Deprecated::class);
-        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
+        $this->expectDeprecation();
+        $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away', 2);
@@ -95,8 +93,8 @@ class FunctionsTest extends TestCase
      */
     public function testDeprecationWarningEnabledDefaultFrame()
     {
-        $this->expectException(Deprecated::class);
-        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectDeprecation();
+        $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away');
@@ -122,8 +120,8 @@ class FunctionsTest extends TestCase
      */
     public function testTriggerWarningEnabled()
     {
-        $this->expectException(Warning::class);
-        $this->expectExceptionMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectWarning();
+        $this->expectWarningMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function () {
             triggerWarning('This is going away');

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use DateTime;
 use InvalidArgumentException;
-use PHPUnit\Framework\Error\Warning;
 
 /**
  * Cookie collection test.
@@ -424,8 +423,8 @@ class CookieCollectionTest extends TestCase
      */
     public function testCookieSizeWarning()
     {
-        $this->expectException(Warning::class);
-        $this->expectExceptionMessage('The cookie `default` exceeds the recommended maximum cookie length of 4096 bytes.');
+        $this->expectWarning();
+        $this->expectWarningMessage('The cookie `default` exceeds the recommended maximum cookie length of 4096 bytes.');
 
         $string = Security::insecureRandomBytes(9000);
         $collection = new CookieCollection();

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -479,8 +479,8 @@ class AssociationTest extends TestCase
      */
     public function testPropertyNameClash()
     {
-        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
-        $this->expectExceptionMessageMatches('/^Association property name "foo" clashes with field of same name of table "test"/');
+        $this->expectWarning();
+        $this->expectWarningMessageMatches('/^Association property name "foo" clashes with field of same name of table "test"/');
         $this->source->setSchema(['foo' => ['type' => 'string']]);
         $this->assertSame('foo', $this->association->getProperty());
     }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -230,7 +230,7 @@ class TestFixtureTest extends TestCase
      */
     public function testCreateError()
     {
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectError();
         $fixture = new ArticlesFixture();
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()


### PR DESCRIPTION
This will avoid deprecation errors in PHPUnit 9.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
