### PR TITLE
Use md5 as temporary placeholder in Text::insert()

### DIFF
--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -249,6 +249,11 @@ class TextTest extends TestCase
             'user.created' => Time::parse('2016-01-01'),
         ]);
         $this->assertSame($expected, $result);
+
+        $string = 'Sum is :sum (:ob).';
+        $expected = 'Sum is 26083 (foo).';
+        $result = Text::insert($string, ['sum' => 26083, 'ob' => 'foo']); // crc32('ob') = 26083
+        $this->assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
`Text::insert()` currently uses `crc32` as temporary placeholder.

It can accidentally return unexpected output with common keys or values, because `crc32` value can be very short (`crc32('ob') = 26083`, `crc32('jskng') = 400`).

`md5` is long enough to not accidentally collide with another value, also it is always same length string, so I undid 
https://github.com/cakephp/cakephp/pull/14822.