### PR TITLE
Fix auto loading of model when ModelAwareTrait::modelClass is set to FQCN.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingActionException;
+use Cake\Core\App;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -292,9 +293,14 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function __get(string $name)
     {
         if (!empty($this->modelClass)) {
-            [$plugin, $class] = pluginSplit($this->modelClass, true);
+            if (strpos($this->modelClass, '\\') === false) {
+                [, $class] = pluginSplit($this->modelClass, true);
+            } else {
+                $class = App::shortName($this->modelClass, 'Model/Table', 'Table');
+            }
+
             if ($class === $name) {
-                return $this->loadModel((string)$plugin . $class);
+                return $this->loadModel();
             }
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -27,7 +27,9 @@ use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Uri;
 use ReflectionFunction;
 use TestApp\Controller\Admin\PostsController;
+use TestApp\Controller\ArticlesController;
 use TestApp\Controller\TestController;
+use TestApp\Model\Table\ArticlesTable;
 use TestPlugin\Controller\TestPluginController;
 
 /**
@@ -138,6 +140,20 @@ class ControllerTest extends TestCase
             'TestApp\Model\Table\ArticlesTable',
             $Controller->Articles
         );
+    }
+
+    /**
+     * @link https://github.com/cakephp/cakephp/issues/14804
+     * @return void
+     */
+    public function testAutoLoadModelUsingFqcn(): void
+    {
+        Configure::write('App.namespace', 'TestApp');
+        $Controller = new ArticlesController(new ServerRequest(), new Response());
+
+        $this->assertInstanceOf(ArticlesTable::class, $Controller->Articles);
+
+        Configure::write('App.namespace', 'App');
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/ArticlesController.php
+++ b/tests/test_app/TestApp/Controller/ArticlesController.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.1.2
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+use TestApp\Model\Table\ArticlesTable;
+
+class ArticlesController extends Controller
+{
+    /**
+     * @var string
+     */
+    protected $modelClass = ArticlesTable::class;
+}


### PR DESCRIPTION
Fixes #14804.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
