### PR TITLE
Use client-side buffered cursor type

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -38,6 +38,7 @@
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <file name="src/Cache/Engine/ApcuEngine.php" />
+                <file name="src/Database/Driver/Sqlserver.php" />
             </errorLevel>
         </UndefinedConstant>
         <PropertyNotSetInConstructor errorLevel="suppress"/>

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -192,7 +192,10 @@ class Sqlserver extends Driver
     public function prepare($query): StatementInterface
     {
         $this->connect();
-        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+        $options = [
+            PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL,
+            PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
+        ];
         $isObject = $query instanceof Query;
         /** @psalm-suppress PossiblyInvalidMethodCall */
         if ($isObject && $query->isBufferedResultsEnabled() === false) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1815,12 +1815,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
-            $this->assertEquals(2, $result->rowCount());
-        } else {
-            $this->assertEquals(-1, $result->rowCount());
-        }
+        $this->assertEquals(2, $result->rowCount());
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/14806

Based on PDO_SQLSRV documentation, CURSOR_SCROLL types can be configured as SQLSRV_CURSOR_BUFFERED which moves the cursor client-side like you'd expect with buffered queries for other dbs.

https://docs.microsoft.com/en-us/sql/connect/php/cursor-types-pdo-sqlsrv-driver?view=sql-server-ver15
https://docs.microsoft.com/en-us/sql/connect/php/pdo-prepare?view=sql-server-ver15

The CURSOR_FWDONLY type (default) does not allow type attributes.

As noted in the docs, this is for small to medium size result sets. You can configure the maximum buffered size through attributes or php.ini settings.