### PR TITLE
Make milliseconds loggable

### DIFF
--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -18,6 +18,7 @@ namespace Cake\Log\Engine;
 
 use ArrayObject;
 use Cake\Core\InstanceConfigTrait;
+use DateTimeImmutable;
 use JsonSerializable;
 use Psr\Log\AbstractLogger;
 use Serializable;
@@ -171,6 +172,6 @@ abstract class BaseLog extends AbstractLogger
      */
     protected function _getFormattedDate(): string
     {
-        return date($this->_config['dateFormat']);
+        return (new DateTimeImmutable())->format($this->_config['dateFormat']);
     }
 }


### PR DESCRIPTION
Today, when you use 'Y-m-d H:i:s.v' as your log format, CakePHP will allways log `.000`.
This is because `date()` is constructed without milliseconds. DateTime is needed to actually use milliseconds. See https://www.php.net/manual/en/datetime.format.php

    Microseconds (added in PHP 5.2.2). Note that date() will always generate 000000 since it takes an integer parameter, whereas DateTime::format() does support microseconds if DateTime was created with microseconds. 

So this commit migrates to ImmutableDateTime::format

I started to write a test for this but did not continue: A test that checks if milliseconds is not '.000' would fail every 1000 runs on average. Sadly, i did not find a way to mock the Time in Cake. Maybe introducing a Cake `Clock` class with methods `Clock.dateTime()` (returns the current time or a mocked time), `Clock.mock(dateTime)` (sets a static class field to the mock time) and `Clock.unmock` would be an option. This could also be great for application developers that use TDD if it would be consistently used by Cake and part of the official Cake API.