### PR TITLE
Use CURLOPT_NOBODY when sending HEAD requests. Fixes #14851

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -103,6 +103,10 @@ class Curl implements AdapterInterface
                 $out[CURLOPT_POST] = true;
                 break;
 
+            case Request::METHOD_HEAD:
+                $out[CURLOPT_NOBODY] = true;
+                break;
+
             default:
                 $out[CURLOPT_POST] = true;
                 $out[CURLOPT_CUSTOMREQUEST] = $request->getMethod();

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -336,6 +336,36 @@ class CurlTest extends TestCase
      *
      * @return void
      */
+    public function testBuildOptionsHead()
+    {
+        $options = [];
+        $request = new Request(
+            'http://localhost/things',
+            'HEAD',
+            ['Cookie' => 'testing=value']
+        );
+        $result = $this->curl->buildOptions($request, $options);
+        $expected = [
+            CURLOPT_URL => 'http://localhost/things',
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Cookie: testing=value',
+                'Connection: close',
+                'User-Agent: CakePHP',
+            ],
+            CURLOPT_NOBODY => true,
+            CURLOPT_CAINFO => $this->caFile,
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test converting client options into curl ones.
+     *
+     * @return void
+     */
     public function testBuildOptionsCurlOptions()
     {
         $options = [


### PR DESCRIPTION
This is the same fix as #14852 but then for CakePHP 4.x