### PR TITLE
Fix inconsistencies with datefmt_create constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
             "@phpstan",
             "@psalm"
         ],
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.32 psalm/phar:~3.12.2 && mv composer.backup composer.json"
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.32 psalm/phar:~3.13.1 && mv composer.backup composer.json"
     },
     "config": {
         "sort-packages": true,

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -40,10 +40,10 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::i18nFormat()
      */
-    protected static $_toStringFormat = [IntlDateFormatter::SHORT, -1];
+    protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
 
     /**
      * The format to use when converting this object to JSON.
@@ -56,7 +56,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int|\Closure
+     * @var string|int|int[]|\Closure
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = 'yyyy-MM-dd';
@@ -65,10 +65,10 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Date::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Date::$wordEnd`
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::parseDate()
      */
-    public static $wordFormat = [IntlDateFormatter::SHORT, -1];
+    public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Cake\I18n\Date::nice()`
@@ -81,10 +81,10 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::nice()
      */
-    public static $niceFormat = [IntlDateFormatter::MEDIUM, -1];
+    public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Date::timeAgoInWords()`

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -347,8 +347,9 @@ trait DateFormatTrait
             $pattern = $format;
         }
 
+        $locale = static::$defaultLocale ?? I18n::getLocale();
         $formatter = datefmt_create(
-            static::$defaultLocale,
+            $locale,
             $dateFormat,
             $timeFormat,
             $tz,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -21,7 +21,6 @@ use Closure;
 use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
-use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -36,7 +35,7 @@ trait DateFormatTrait
      *
      * Use static::setDefaultLocale() and static::getDefaultLocale() instead.
      *
-     * @var string
+     * @var string|null
      */
     protected static $defaultLocale;
 
@@ -171,7 +170,7 @@ trait DateFormatTrait
      * You can control the default locale used through `Time::setDefaultLocale()`.
      * If empty, the default will be taken from the `intl.default_locale` ini config.
      *
-     * @param string|int|array|null $format Format string.
+     * @param string|int|int[]|null $format Format string.
      * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed. The timezone stored for this object will not
      * be changed.
@@ -203,18 +202,18 @@ trait DateFormatTrait
      * Implements what IntlDateFormatter::formatObject() is in PHP 5.5+
      *
      * @param \DateTime|\DateTimeImmutable $date Date.
-     * @param string|int|array $format Format.
+     * @param string|int|int[] $format Format.
      * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
      */
     protected function _formatObject($date, $format, ?string $locale): string
     {
-        $pattern = $timeFormat = null;
+        $pattern = '';
 
         if (is_array($format)) {
             [$dateFormat, $timeFormat] = $format;
-        } elseif (is_numeric($format)) {
-            $dateFormat = $format;
+        } elseif (is_int($format)) {
+            $dateFormat = $timeFormat = $format;
         } else {
             $dateFormat = $timeFormat = IntlDateFormatter::FULL;
             $pattern = $format;
@@ -242,11 +241,11 @@ trait DateFormatTrait
             }
             $formatter = datefmt_create(
                 $locale,
-                (int)$dateFormat,
-                (int)$timeFormat,
+                $dateFormat,
+                $timeFormat,
                 $timezone,
                 $calendar,
-                (string)$pattern
+                $pattern
             );
             if ($formatter === false) {
                 throw new RuntimeException(
@@ -290,7 +289,7 @@ trait DateFormatTrait
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @param string|array|int $format Format.
+     * @param string|int|int[] $format Format.
      * @return void
      */
     public static function setToStringFormat($format): void
@@ -325,41 +324,36 @@ trait DateFormatTrait
      * ```
      *  $time = Time::parseDateTime('10/13/2013 12:54am');
      *  $time = Time::parseDateTime('13 Oct, 2013 13:54', 'dd MMM, y H:mm');
-     *  $time = Time::parseDateTime('10/10/2015', [IntlDateFormatter::SHORT, -1]);
+     *  $time = Time::parseDateTime('10/10/2015', [IntlDateFormatter::SHORT, IntlDateFormatter::NONE]);
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|int[]|null $format Any format accepted by IntlDateFormatter.
+     * @param string|int|int[]|null $format Any format accepted by IntlDateFormatter.
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      * @throws \InvalidArgumentException If $format is a single int instead of array of constants
      */
     public static function parseDateTime(string $time, $format = null, $tz = null)
     {
-        $dateFormat = $format ?: static::$_toStringFormat;
-        $timeFormat = $pattern = null;
+        $format = $format ?? static::$_toStringFormat;
+        $pattern = '';
 
-        if (is_array($dateFormat)) {
-            [$newDateFormat, $timeFormat] = $dateFormat;
-            $dateFormat = $newDateFormat;
+        if (is_array($format)) {
+            [$dateFormat, $timeFormat] = $format;
+        } elseif (is_int($format)) {
+            $dateFormat = $timeFormat = $format;
         } else {
-            $pattern = $dateFormat;
-            $dateFormat = null;
-
-            if (is_int($pattern)) {
-                throw new InvalidArgumentException(
-                    'If $format is an IntlDateFormatter constant, must be an array.'
-                );
-            }
+            $dateFormat = $timeFormat = IntlDateFormatter::FULL;
+            $pattern = $format;
         }
 
         $formatter = datefmt_create(
-            (string)static::$defaultLocale,
-            $dateFormat ?? 0,
-            $timeFormat ?? 0,
+            static::$defaultLocale,
+            $dateFormat,
+            $timeFormat,
             $tz,
             null,
-            $pattern ?? ''
+            $pattern
         );
         $formatter->setLenient(static::$lenientParsing);
 
@@ -403,7 +397,7 @@ trait DateFormatTrait
     public static function parseDate(string $date, $format = null)
     {
         if (is_int($format)) {
-            $format = [$format, -1];
+            $format = [$format, IntlDateFormatter::NONE];
         }
         $format = $format ?: static::$wordFormat;
 
@@ -433,9 +427,9 @@ trait DateFormatTrait
     public static function parseTime(string $time, $format = null)
     {
         if (is_int($format)) {
-            $format = [-1, $format];
+            $format = [IntlDateFormatter::NONE, $format];
         }
-        $format = $format ?: [-1, IntlDateFormatter::SHORT];
+        $format = $format ?: [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
 
         return static::parseDateTime($time, $format);
     }

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -42,7 +42,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, -1];
@@ -58,7 +58,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int|\Closure
+     * @var string|int|int[]|\Closure
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = 'yyyy-MM-dd';
@@ -67,10 +67,10 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Date::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Date::$wordEnd`
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::parseDate()
      */
-    public static $wordFormat = [IntlDateFormatter::SHORT, -1];
+    public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Cake\I18n\Date::nice()`
@@ -83,10 +83,10 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\DateFormatTrait::nice()
      */
-    public static $niceFormat = [IntlDateFormatter::MEDIUM, -1];
+    public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Date::timeAgoInWords()`

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -43,7 +43,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\FrozenTime::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT];
@@ -59,7 +59,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int|\Closure
+     * @var string|int|int[]|\Closure
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH':'mm':'ssxxx";
@@ -75,7 +75,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\FrozenTime::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT];
@@ -84,10 +84,10 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\FrozenTime::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\FrozenTime::$wordEnd`
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\FrozenTime::timeAgoInWords()
      */
-    public static $wordFormat = [IntlDateFormatter::SHORT, -1];
+    public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Time::timeAgoInWords()`

--- a/src/I18n/I18nDateTimeInterface.php
+++ b/src/I18n/I18nDateTimeInterface.php
@@ -122,7 +122,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
     /**
      * Sets the default format used when type converting instances of this type to string
      *
-     * @param string|array|int $format Format.
+     * @param string|int|int[] $format Format.
      * @return void
      */
     public static function setToStringFormat($format): void;

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -41,7 +41,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT];
@@ -57,7 +57,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int|\Closure
+     * @var string|int|int[]|\Closure
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH':'mm':'ssxxx";
@@ -73,7 +73,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\Time::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT];
@@ -82,10 +82,10 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Time::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Time::$wordEnd`
      *
-     * @var string|array|int
+     * @var string|int|int[]
      * @see \Cake\I18n\Time::timeAgoInWords()
      */
-    public static $wordFormat = [IntlDateFormatter::SHORT, -1];
+    public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
 
     /**
      * The format to use when formatting a time using `Time::timeAgoInWords()`

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -467,7 +467,7 @@ class TimeTest extends TestCase
         $expected = 'Thursday, Dey 24, 1388 at 1:59:28 PM GMT';
         $this->assertTimeFormat($expected, $result);
 
-        $result = $time->i18nFormat(\IntlDateFormatter::SHORT, null, 'fa-IR@calendar=persian');
+        $result = $time->i18nFormat([\IntlDateFormatter::SHORT, \IntlDateFormatter::FULL], null, 'fa-IR@calendar=persian');
         $expected = '۱۳۸۸/۱۰/۲۴،‏ ۱۳:۵۹:۲۸ GMT';
         $this->assertTimeFormat($expected, $result);
 
@@ -851,19 +851,6 @@ class TimeTest extends TestCase
 
         $time = $class::parseDateTime('13 foo 10 2013 12:54');
         $this->assertNull($time);
-    }
-
-    /**
-     * Test passing incorrect formatter options to parseDateTime
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseDateTimeInvalidFormat($class)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('If $format is an IntlDateFormatter constant, must be an array.');
-        $time = $class::parseDateTime('10/13/2013 12:54am', IntlDateFormatter::SHORT);
     }
 
     /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -563,7 +563,7 @@ class TimeHelperTest extends TestCase
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
-        $result = $this->Time->i18nFormat($time, \IntlDateFormatter::SHORT);
+        $result = $this->Time->i18nFormat($time, [\IntlDateFormatter::SHORT, \IntlDateFormatter::FULL]);
         $expected = '1/14/10, 12:59:28 AM';
         $this->assertStringStartsWith($expected, $result);
     }


### PR DESCRIPTION
This fixes some issue with `IntlDateFormatter` constants used by datefmt_create. Some of these were existing and some were caused by other fixes in 4.0 release.

Previously, both phpstan and psalm would throw invalid errors on the datefmt_create parameters. Both of these errors are now fixed which lets us clean things up.

- Use `int[]` instead of `array` for the formatter constants
- Replace -1 with `IntlDateFormatter::NONE`
- Don't default to 0 when one of the date/time formatters is null. 0 is `IntlDateFormatter::FULL`.
- When a single constant is passed as the argument for $format, this should be the format use for both date and time.
  This was the documented behavior and is now implemented by both formatter and parser interfaces.

This also removes the invalid exception when a single constant was passed. This was added in 4.0 due to a misunderstanding from the inconsistent implementation and static analyzer bugs.