### PR TITLE
Remove unneeded method call.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -122,8 +122,6 @@ class PluginCollection implements Iterator, Countable
      */
     public function findPath(string $name): string
     {
-        $this->loadConfig();
-
         $path = Configure::read('plugins.' . $name);
         if ($path) {
             return $path;


### PR DESCRIPTION
loadConfig() is already called from constructor.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
