### PR TITLE
4.next - Add a getter for obtaining a query's results casting mode.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2188,7 +2188,11 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Disables the automatic casting of fields to their corresponding PHP data type
+     * Disables result casting.
+     *
+     * When disabled, the fields will be returned as received from the database
+     * driver (which in most environments means they are being returned as
+     * strings), which can improve performance with larger datasets.
      *
      * @return $this
      */
@@ -2200,7 +2204,10 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Enables the automatic casting of fields to their corresponding type
+     * Enables result casting.
+     *
+     * When enabled, the fields in the results returned by this Query will be
+     * casted to their corresponding PHP data type.
      *
      * @return $this
      */
@@ -2209,6 +2216,23 @@ class Query implements ExpressionInterface, IteratorAggregate
         $this->typeCastEnabled = true;
 
         return $this;
+    }
+
+    /**
+     * Returns whether result casting is enabled/disabled.
+     *
+     * When enabled, the fields in the results returned by this Query will be
+     * casted to their corresponding PHP data type.
+     *
+     * When disabled, the fields will be returned as received from the database
+     * driver (which in most environments means they are being returned as
+     * strings), which can improve performance with larger datasets.
+     *
+     * @return bool
+     */
+    public function isResultsCastingEnabled(): bool
+    {
+        return $this->typeCastEnabled;
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4708,6 +4708,21 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test obtaining the current results casting mode.
+     *
+     * @return void
+     */
+    public function testObtainingResultsCastingMode()
+    {
+        $query = new Query($this->connection);
+
+        $this->assertTrue($query->isResultsCastingEnabled());
+
+        $query->disableResultsCasting();
+        $this->assertFalse($query->isResultsCastingEnabled());
+    }
+
+    /**
      * Test that type conversion is only applied once.
      *
      * @return void


### PR DESCRIPTION
This aligns the results casting API with hydration and results buffering, which both have getters for the current mode (`isHydrationEnabled()`, `isBufferedResultsEnabled()`).
