### PR TITLE
4.next - Add support for receiving the query object in result formatter callables

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -400,7 +400,7 @@ trait QueryTrait
      *
      * ```
      * $query->formatResults(function ($results, $query) {
-     *     return $results->map(function ($row) {
+     *     return $results->map(function ($row) use ($query) {
      *         $data = [
      *             'bar' => 'baz',
      *         ];
@@ -416,13 +416,14 @@ trait QueryTrait
      * });
      * ```
      *
-     * Retaining access to the original query instance by inheriting the query variable:
+     * Retaining access to the association target query instance of joined associations,
+     * by inheriting the contain callback's query argument:
      *
      * ```
      * // Assuming a `Articles belongsTo Authors` association that uses the join strategy
      *
      * $articlesQuery->contain('Authors', function ($authorsQuery) {
-     *     return $query->formatResults(function ($results, $query) use ($authorsQuery) {
+     *     return $authorsQuery->formatResults(function ($results, $query) use ($authorsQuery) {
      *         // Here `$authorsQuery` will always be the instance
      *         // where the callback was attached to.
      *

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -539,7 +539,7 @@ trait QueryTrait
         }
 
         foreach ($this->_formatters as $formatter) {
-            $result = $formatter($result);
+            $result = $formatter($result, $this);
         }
 
         if (!empty($this->_formatters) && !($result instanceof $decorator)) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1000,7 +1000,7 @@ abstract class Association
 
         $property = $options['propertyPath'];
         $propertyPath = explode('.', $property);
-        $query->formatResults(function ($results) use ($formatters, $property, $propertyPath, $query) {
+        $query->formatResults(function ($results, $query) use ($formatters, $property, $propertyPath) {
             $extracted = [];
             foreach ($results as $result) {
                 foreach ($propertyPath as $propertyPathItem) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1014,7 +1014,7 @@ abstract class Association
             }
             $extracted = new Collection($extracted);
             foreach ($formatters as $callable) {
-                $extracted = new ResultSetDecorator($callable($extracted));
+                $extracted = new ResultSetDecorator($callable($extracted, $query));
             }
 
             /** @var \Cake\Collection\CollectionInterface $results */

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2230,7 +2230,7 @@ class QueryTest extends TestCase
     {
         $resultFormatterQuery = null;
 
-        $query = $this->getTableLocator()->get('authors')
+        $query = $this->getTableLocator()->get('Authors')
             ->find()
             ->formatResults(function ($results, $query) use (&$resultFormatterQuery) {
                 $resultFormatterQuery = $query;


### PR DESCRIPTION
Just like with other query builder methods, I'd find it handy to receive the query object as an argument in the results formatter callable. 

This would be especially helpful in situations where the result formatter stems from the query builder for a joined association, which can make it hard to impossible to get access to the actual/source query object, say for example in a `belongsTo` scenario where the result formatter is being defined in a finder or a `beforeFind` callback in the associated table class.

The specific situation where I stumbled over this, was when I needed to inject additional results in a formatter of a `belongsTo` association finder, and needed to know whether the source query has hydration and results casting enabled/disabled, so that I could match that and query and inject the additional results in the expected format.