### PR TITLE
Use env key matching interning array key.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ services:
 
 environment:
   global:
-    db_dsn: 'sqlserver://sa:Password12!@.\SQL2012SP1/cakephp?MultipleActiveResultSets=false'
+    DB_URL: 'sqlserver://sa:Password12!@.\SQL2012SP1/cakephp?MultipleActiveResultSets=false'
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;C:\php;%PATH%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,11 @@ jobs:
       env:
         REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       run: |
-        if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_DSN='sqlite:///:memory:'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.2' ]]; then export DB_DSN='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.4' ]]; then export DB_DSN='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
-        if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_DSN='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
-        if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_DSN='postgres://postgres:postgres@127.0.0.1/postgres'; fi
+        if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.2' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.4' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
+        if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
 
         if [[ ${{ matrix.php-version }} == '7.2' ]]; then
           vendor/bin/phpunit
@@ -174,7 +174,7 @@ jobs:
 
     - name: Run PHPUnit
       env:
-        DB_DSN: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
+        DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
           vendor/bin/phpunit --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,16 @@ php:
 
 env:
   matrix:
-    - DB=mysql DB_DSN='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
-    - DB=pgsql DB_DSN='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite DB_DSN='sqlite:///:memory:'
+    - DB=mysql DB_URL='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    - DB=pgsql DB_URL='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=sqlite DB_URL='sqlite:///:memory:'
 
 matrix:
   include:
     - php: 7.2
       env: PREFER_LOWEST=1
     - php: nightly
-      env: DB=sqlite DB_DSN='sqlite:///:memory:'
+      env: DB=sqlite DB_URL='sqlite:///:memory:'
 
   allow_failures:
     - php: nightly

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -48,16 +48,16 @@
         <ini name="error_reporting" value="32767"/>
 
         <!-- SQLite
-        <env name="DB_DSN" value="sqlite:///:memory:"/>
+        <env name="DB_URL" value="sqlite:///:memory:"/>
         -->
         <!-- Postgres
-        <env name="DB_DSN" value="postgres://localhost/cake_test?timezone=UTC"/>
+        <env name="DB_URL" value="postgres://localhost/cake_test?timezone=UTC"/>
         -->
         <!-- Mysql
-        <env name="DB_DSN" value="mysql://localhost/cake_test?timezone=UTC"/>
+        <env name="DB_URL" value="mysql://localhost/cake_test?timezone=UTC"/>
         -->
         <!-- SQL Server
-        <env name="DB_DSN" value="sqlserver://localhost/cake_test?timezone=UTC"/>
+        <env name="DB_URL" value="sqlserver://localhost/cake_test?timezone=UTC"/>
         -->
     </php>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -97,12 +97,12 @@ Cache::setConfig([
 ]);
 
 // Ensure default test connection is defined
-if (!getenv('DB_DSN')) {
-    putenv('DB_DSN=sqlite:///:memory:');
+if (!getenv('DB_URL')) {
+    putenv('DB_URL=sqlite:///:memory:');
 }
 
-ConnectionManager::setConfig('test', ['url' => getenv('DB_DSN')]);
-ConnectionManager::setConfig('test_custom_i18n_datasource', ['url' => getenv('DB_DSN')]);
+ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
+ConnectionManager::setConfig('test_custom_i18n_datasource', ['url' => getenv('DB_URL')]);
 
 Configure::write('Session', [
     'defaults' => 'php',


### PR DESCRIPTION
This always gets me
When setting up the url key I do DB_URL, only to find out it expects still DB_DSN here.

Should we just consolidate this here? Matching the array key it ends up in with?

    ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);

Especially since DSN is pretty broad and unclear term here, and we are using a URL pattern after all.