### PR TITLE
Fix whitespace in debug output.

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -90,6 +90,7 @@ nesting works.
 }
 .cake-dbg-string {
   color: var(--color-green);
+  white-space: pre-wrap;
 }
 .cake-dbg-number {
   font-weight: bold;


### PR DESCRIPTION
Retain whitespace as much as possible with some line breaks for readability.

Fixes #14874
