### PR TITLE
Make components protected on core level.

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -75,7 +75,7 @@ class Component implements EventListenerInterface
      *
      * @var array
      */
-    public $components = [];
+    protected $components = [];
 
     /**
      * Default config

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -176,7 +176,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      *
      * @var array
      */
-    public $components = ['RequestHandler', 'Flash'];
+    protected $components = ['RequestHandler', 'Flash'];
 
     /**
      * Objects that will be used for authentication checks.

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -62,9 +62,9 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * an object by setting the 'className' key, i.e.,
      *
      * ```
-     * public $components = [
+     * protected $components = [
      *   'Email' => [
-     *     'className' => '\App\Controller\Component\AliasedEmailComponent'
+     *     'className' => 'App\Controller\Component\AliasedEmailComponent'
      *   ];
      * ];
      * ```

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/Component/PluginsComponent.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/Component/PluginsComponent.php
@@ -24,5 +24,5 @@ use Cake\Controller\Component;
 
 class PluginsComponent extends Component
 {
-    public $components = ['TestPlugin.Other'];
+    protected $components = ['TestPlugin.Other'];
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/Component/TestPluginComponent.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/Component/TestPluginComponent.php
@@ -24,5 +24,5 @@ use Cake\Controller\Component;
 
 class TestPluginComponent extends Component
 {
-    public $components = ['TestPlugin.TestPluginOther'];
+    protected $components = ['TestPlugin.TestPluginOther'];
 }

--- a/tests/test_app/TestApp/Controller/Component/AppleComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/AppleComponent.php
@@ -30,7 +30,7 @@ class AppleComponent extends Component
      *
      * @var array
      */
-    public $components = ['Orange'];
+    protected $components = ['Orange'];
 
     /**
      * startup method

--- a/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
@@ -33,7 +33,7 @@ class ConfiguredComponent extends Component
      *
      * @var array
      */
-    public $components = [];
+    protected $components = [];
 
     /**
      * Constructor

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
@@ -29,5 +29,5 @@ class MutuallyReferencingOneComponent extends Component
      *
      * @var array
      */
-    public $components = ['MutuallyReferencingTwo'];
+    protected $components = ['MutuallyReferencingTwo'];
 }

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
@@ -29,5 +29,5 @@ class MutuallyReferencingTwoComponent extends Component
      *
      * @var array
      */
-    public $components = ['MutuallyReferencingOne'];
+    protected $components = ['MutuallyReferencingOne'];
 }

--- a/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
@@ -30,7 +30,7 @@ class OrangeComponent extends Component
      *
      * @var array
      */
-    public $components = ['Banana'];
+    protected $components = ['Banana'];
 
     /**
      * controller property

--- a/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
@@ -29,5 +29,5 @@ class ParamTestComponent extends Component
      *
      * @var array
      */
-    public $components = ['Banana' => ['config' => 'value']];
+    protected $components = ['Banana' => ['config' => 'value']];
 }

--- a/tests/test_app/TestApp/Controller/Component/SomethingWithFlashComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/SomethingWithFlashComponent.php
@@ -29,5 +29,5 @@ class SomethingWithFlashComponent extends Component
      *
      * @var array
      */
-    public $components = ['Flash'];
+    protected $components = ['Flash'];
 }

--- a/tests/test_app/TestApp/Controller/PaginatorTestController.php
+++ b/tests/test_app/TestApp/Controller/PaginatorTestController.php
@@ -12,5 +12,5 @@ class PaginatorTestController extends Controller
      *
      * @var array
      */
-    public $components = ['Paginator'];
+    protected $components = ['Paginator'];
 }


### PR DESCRIPTION
I was trying to set `protected $components`

> Access level to TinyAuth\Controller\Component\AuthUserComponent::$components must be public (as in class Cake\Controller\Component) in /home/travis/build/dereuromark/cakephp-tinyauth/src/Controller/Component/AuthUserComponent.php on line 18

It seems this was the only property forgotten to make protected on core level.
This fixes it.
If people have it declared public on plugin or project level it will not be a BC break but silently work (the other direction not).