### PR TITLE
Xml entity loader

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -187,7 +187,7 @@ class Xml
 
         $internalErrors = libxml_use_internal_errors(true);
         if (!$options['loadEntities']) {
-            libxml_disable_entity_loader(true);
+            $previousDisabledEntityLoader = libxml_disable_entity_loader(true);
         }
         $flags = 0;
         if (!empty($options['parseHuge'])) {
@@ -205,8 +205,8 @@ class Xml
         } catch (Exception $e) {
             throw new XmlException('Xml cannot be read. ' . $e->getMessage(), null, $e);
         } finally {
-            if (!$options['loadEntities']) {
-                libxml_disable_entity_loader(false);
+            if (isset($previousDisabledEntityLoader)) {
+                libxml_disable_entity_loader($previousDisabledEntityLoader);
             }
             libxml_use_internal_errors($internalErrors);
         }

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -185,14 +185,18 @@ class Xml
         ];
         $options += $defaults;
 
-        $internalErrors = libxml_use_internal_errors(true);
-        if (!$options['loadEntities']) {
-            $previousDisabledEntityLoader = libxml_disable_entity_loader(true);
-        }
         $flags = 0;
         if (!empty($options['parseHuge'])) {
             $flags |= LIBXML_PARSEHUGE;
         }
+
+        $internalErrors = libxml_use_internal_errors(true);
+        if (LIBXML_VERSION < 20900 && !$options['loadEntities']) {
+            $previousDisabledEntityLoader = libxml_disable_entity_loader(true);
+        } elseif ($options['loadEntities']) {
+            $flags |= LIBXML_NOENT;
+        }
+
         try {
             $xml = new DOMDocument();
             $xml->loadHTML($input, $flags);


### PR DESCRIPTION
With libxml >= 2.9.0, loading of external entities is disabled,
even if libxml_disable_entity_loader(false) is called.
Instead the flag LIBXML_NOENT needs to be used to enable it.

See https://github.com/php/php-src/pull/5867