### PR TITLE
Fix null exception for special abstract table case

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -416,7 +416,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($this->_alias === null) {
             $alias = namespaceSplit(static::class);
             $alias = substr(end($alias), 0, -5) ?: $this->_table;
-            $this->_alias = $alias;
+            $this->_alias = (string)$alias;
         }
 
         return $this->_alias;


### PR DESCRIPTION
When having an abstract table (common for all app or plugin Table classes), you can run into issues with the code:

        if ($this->_alias === null) {
            $alias = namespaceSplit(static::class);
            $alias = substr(end($alias), 0, -5) ?: $this->_table;
            $this->_alias = (string)$alias;
        }

bin/cake migrations migrate -p Tools

can yield exception
```
using migration paths 
 - /.../vendor/dereuromark/cakephp-tools/config/Migrations
using seed paths 
 - /.../vendor/dereuromark/cakephp-tools/config/Seeds
Exception: Return value of Cake\ORM\Table::getAlias() must be of the type string, null returned
In [/.../vendor/cakephp/cakephp/src/ORM/Table.php, line 422]
```

due to

    static::class

being `'Tools\Model\Table\Table'` (like an abstract table class) and the substr() part running into null case for return on a typehinted string return.

My guess it lists all tables ( https://github.com/dereuromark/cakephp-tools/tree/master/src/Model/Table ) or tries to.

This resolved it.
