### PR TITLE
Add function name to window so that debugkit can use it

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -117,6 +117,8 @@ function initialize() {
   attachRefEvents(doc.querySelectorAll('.cake-dbg'));
   openBlocks(doc.querySelectorAll('.cake-debug[data-open-all="true"]'));
 }
+// Add a name on window so DebugKit can add controls to dump blocks
+win.__cakeDebugBlockInit = initialize;
 
 /**
  * Open all the collapsed sections in a block.


### PR DESCRIPTION
Because jQuery's script tag insertion happens *after* DOMContentLoaded we need a window hook to allow debug kit to have interactive dump blocks.
