### PR TITLE
Ensure plugin path config is loaded for each PluginCollection::findPath() call.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -122,6 +122,11 @@ class PluginCollection implements Iterator, Countable
      */
     public function findPath(string $name): string
     {
+        // Ensure plugin config is loaded each time. This is necessary primarily
+        // for testing because the Configure::clear() call in TestCase::tearDown()
+        // wipes out all configuration including plugin paths config.
+        $this->loadConfig();
+
         $path = Configure::read('plugins.' . $name);
         if ($path) {
             return $path;

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -222,8 +222,8 @@ return [
 PHP;
         file_put_contents($configPath, $file);
 
-        Configure::delete('plugins');
         $plugins = new PluginCollection();
+        Configure::delete('plugins');
         $path = $plugins->findPath('TestPlugin');
         unlink($configPath);
 


### PR DESCRIPTION
This is necessary primarily for testing because the Configure::clear() call
in TestCase::tearDown() wipes out all configuration including plugin paths config.

Reverts #14860. Closes #14889.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
