### PR TITLE
Tests for url and pagination first/last

### DIFF
--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2711,10 +2711,10 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->first('first', ['model' => 'Article']);
         $this->assertSame('', $result);
 
-        $result = $this->Paginator->first('first', ['model' => 'Client']);
+        $result = $this->Paginator->first('first', ['model' => 'Client', 'url' => ['?' => ['foo' => 'bar']]]);
         $expected = [
             'li' => ['class' => 'first'],
-            'a' => ['href' => '/'],
+            'a' => ['href' => '/?foo=bar'],
             'first',
             '/a',
             '/li',


### PR DESCRIPTION
Test case for https://github.com/cakephp/cakephp/issues/14894 on 4.x
It seems 4.x doesn't have the issue then.