### PR TITLE
Improve email validation

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -809,7 +809,7 @@ class Validation
 
         if ($regex === null) {
             // phpcs:ignore Generic.Files.LineLength
-            $regex = '/^[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+)*@' . self::$_pattern['hostname'] . '$/ui';
+            $regex = '/^[\p{L}0-9!#$%&\'*+\/=?^_`{|}\\[\\]~-]+(?:\.[\p{L}0-9!#$%&\'*+\/=?^_`{|}\\[\\]~-]+)*@' . self::$_pattern['hostname'] . '$/ui';
         }
         $return = static::_check($check, $regex);
         if ($deep === false || $deep === null) {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2109,6 +2109,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::email('$A12345@example.com'));
         $this->assertTrue(Validation::email('!def!xyz%abc@example.com'));
         $this->assertTrue(Validation::email('_somename@example.com'));
+        $this->assertTrue(Validation::email('123+samplebot[bot]@gitco.comb'));
 
         // Unicode
         $this->assertTrue(Validation::email('some@eräume.foo'));


### PR DESCRIPTION
Accept addresses containing [] these are in use by GitHub bots. This might be a bad idea as `[]` isn't entirely legal in an email address unless it is in a quoted string.