### PR TITLE
4.x - Fix output buffers not being closed when the view triggers an exception.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -34,6 +34,7 @@ use Cake\View\Exception\MissingTemplateException;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use Throwable;
 
 /**
  * View, the V in the MVC triad. View interacts with Helpers and view variables passed
@@ -687,8 +688,20 @@ class View implements EventDispatcherInterface
         if ($result) {
             return $result;
         }
+
+        $bufferLevel = ob_get_level();
         ob_start();
-        $block();
+
+        try {
+            $block();
+        } catch (Throwable $exception) {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+
+            throw $exception;
+        }
+
         $result = ob_get_clean();
 
         Cache::write($options['key'], $result, $options['config']);
@@ -1155,9 +1168,19 @@ class View implements EventDispatcherInterface
     protected function _evaluate(string $templateFile, array $dataForView): string
     {
         extract($dataForView);
+
+        $bufferLevel = ob_get_level();
         ob_start();
 
-        include func_get_arg(0);
+        try {
+            include func_get_arg(0);
+        } catch (Throwable $exception) {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+
+            throw $exception;
+        }
 
         return ob_get_clean();
     }

--- a/tests/test_app/templates/element/exception_with_open_buffers.php
+++ b/tests/test_app/templates/element/exception_with_open_buffers.php
@@ -1,0 +1,3 @@
+<?php
+$this->start('non closing block');
+throw new \Exception('Exception with open buffers');


### PR DESCRIPTION
When evaluating a template or caching a block, the view itself opens a buffer, and the templates/blocks that it evaluates might open buffers too. In case an exception happens, the opened buffers will not be closed, causing risky tests with PHPUnit, and possible further output to be swallowed unless the test itself closes/flushes the remaining buffers.

My thinking was that unclosed buffers aren't really a user error when caused by an exception, unlike when someone for example forgets to close an opened view block. However I'm still a little hesitant, because maybe there actually are situations where one would want such a problem to cause their tests to be marked as risky!?