### PR TITLE
Ensure DateType marshalling works for both mutable and immutable types

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -449,9 +449,9 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\I18n\I18nDateTimeInterface|null
      */
-    protected function _parseLocaleValue(string $value)
+    protected function _parseLocaleValue(string $value): ?I18nDateTimeInterface
     {
-        /** @var \Cake\I18n\I18nDateTimeInterface $class */
+        /** @psalm-var class-string<\Cake\I18n\I18nDateTimeInterface> $class */
         $class = $this->_className;
 
         return $class::parseDateTime($value, $this->_localeMarshalFormat);
@@ -464,9 +464,9 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \DateTimeInterface|null
      */
-    protected function _parseValue(string $value)
+    protected function _parseValue(string $value): ?DateTimeInterface
     {
-        /** @var \DateTime|\DateTimeImmutable $class */
+        /** @psalm-var class-string<\DateTime>|class-string<\DateTimeImmutable> $class */
         $class = $this->_className;
 
         foreach ($this->_marshalFormats as $format) {

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Type;
 
 use Cake\I18n\Date;
 use Cake\I18n\FrozenDate;
+use Cake\I18n\I18nDateTimeInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -80,7 +81,9 @@ class DateType extends DateTimeType
     public function marshal($value): ?DateTimeInterface
     {
         $date = parent::marshal($value);
-        if ($date instanceof DateTime) {
+        if ($date && !$date instanceof I18nDateTimeInterface) {
+            // Clear time manually when I18n types aren't available and raw DateTime used
+            /** @psalm-var \DateTime|\DateTimeImmutable $date */
             $date->setTime(0, 0, 0);
         }
 
@@ -90,9 +93,9 @@ class DateType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected function _parseLocaleValue(string $value)
+    protected function _parseLocaleValue(string $value): ?I18nDateTimeInterface
     {
-        /** @var \Cake\I18n\I18nDateTimeInterface $class */
+        /** @psalm-var class-string<\Cake\I18n\I18nDateTimeInterface> $class */
         $class = $this->_className;
 
         return $class::parseDate($value, $this->_localeMarshalFormat);

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
+use Cake\I18n\I18nDateTimeInterface;
+
 /**
  * Time type converter.
  *
@@ -38,9 +40,9 @@ class TimeType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected function _parseLocaleValue(string $value)
+    protected function _parseLocaleValue(string $value): ?I18nDateTimeInterface
     {
-        /** @var \Cake\I18n\I18nDateTimeInterface $class */
+        /** @psalm-var class-string<\Cake\I18n\I18nDateTimeInterface> $class */
         $class = $this->_className;
 
         /** @psalm-suppress PossiblyInvalidArgument */

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -50,6 +50,18 @@ class DateTypeTest extends TestCase
     }
 
     /**
+     * Teardown
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->type->useImmutable();
+        $this->type->useLocaleParser(false)->setLocaleFormat(null);
+    }
+
+    /**
      * Test toPHP
      *
      * @return void
@@ -193,11 +205,11 @@ class DateTypeTest extends TestCase
     public function testMarshal($value, $expected)
     {
         $result = $this->type->marshal($value);
-        if (is_object($expected)) {
-            $this->assertEquals($expected, $result);
-        } else {
-            $this->assertSame($expected, $result);
-        }
+        $this->assertEquals($expected, $result);
+
+        $this->type->useMutable();
+        $result = $this->type->marshal($value);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -208,13 +220,15 @@ class DateTypeTest extends TestCase
     public function testMarshalWithLocaleParsing()
     {
         $this->type->useLocaleParser();
+        $this->assertNull($this->type->marshal('11/derp/2013'));
 
         $expected = new Date('13-10-2013');
         $result = $this->type->marshal('10/13/2013');
         $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
-        $this->assertNull($this->type->marshal('11/derp/2013'));
 
-        $this->type->useLocaleParser(false);
+        $this->type->useMutable();
+        $result = $this->type->marshal('10/13/2013');
+        $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
     }
 
     /**
@@ -225,12 +239,15 @@ class DateTypeTest extends TestCase
     public function testMarshalWithLocaleParsingWithFormat()
     {
         $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y');
+        $this->assertNull($this->type->marshal('11/derp/2013'));
 
         $expected = new Date('13-10-2013');
         $result = $this->type->marshal('13 Oct, 2013');
         $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
 
-        $this->type->useLocaleParser(false)->setLocaleFormat(null);
+        $this->type->useMutable();
+        $result = $this->type->marshal('13 Oct, 2013');
+        $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
     }
 
     /**


### PR DESCRIPTION
This cleans up a few unrelated areas:

- Make sure setTime(0, 0, 0) is called for both DateTime and DateTimeImmutable
- Add missing return type hints to parse functions
- Ensure DateType marshal() is tested for both mutable and immutable types