### PR TITLE
Make phpunit methods protected as per docs

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -138,7 +138,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -157,7 +157,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         if ($this->_configure) {


### PR DESCRIPTION
Follow https://github.com/cakephp/phinx/pull/1862
Might also allow then plugins, apps to start using the documented visibility as the extending class can only be "wider", so no BC break if extending code is still public.
But it could not be protected if the core itself still has it public.