### PR TITLE
3.x - Fix output buffers not being closed when the view triggers an exception.

### DIFF
--- a/tests/test_app/TestApp/Template/Element/exception_with_open_buffers.ctp
+++ b/tests/test_app/TestApp/Template/Element/exception_with_open_buffers.ctp
@@ -1,0 +1,3 @@
+<?php
+$this->start('non closing block');
+throw new \Exception('Exception with open buffers');


### PR DESCRIPTION
Backport of #14901