### PR TITLE
Fix PaginatorHelper last & first with URL parameters

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1075,8 +1075,9 @@ class PaginatorHelper extends Helper
             }
         } elseif ($params['page'] > 1 && is_string($first)) {
             $first = $options['escape'] ? h($first) : $first;
+            $url = array_merge($options['url'], ['page' => 1]);
             $out .= $this->templater()->format('first', [
-                'url' => $this->generateUrl(['page' => 1], $options['model']),
+                'url' => $this->generateUrl($url, $options['model']),
                 'text' => $first,
             ]);
         }
@@ -1136,8 +1137,9 @@ class PaginatorHelper extends Helper
             }
         } elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
             $last = $options['escape'] ? h($last) : $last;
+            $url = array_merge($options['url'], ['page' => $params['pageCount']]);
             $out .= $this->templater()->format('last', [
-                'url' => $this->generateUrl(['page' => $params['pageCount']], $options['model']),
+                'url' => $this->generateUrl($url, $options['model']),
                 'text' => $last,
             ]);
         }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2582,6 +2582,46 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * test first() and last with url options
+     *
+     * @return void
+     */
+    public function testFirstAndLastUrlOptions()
+    {
+        $this->View->setRequest($this->View->getRequest()
+            ->withParam('paging.Article', [
+                'page' => 3,
+                'pageCount' => 5,
+                'direction' => 'DESC',
+                'sort' => 'Article.title',
+            ]));
+
+        $result = $this->Paginator->first('first', ['url' => ['?' => ['key' => 'value']]]);
+        $expected = [
+            'li' => ['class' => 'first'],
+            ['a' => [
+                'href' => '/index?key=value&amp;sort=Article.title&amp;direction=DESC',
+            ]],
+            'first',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->last('last', ['url' => ['?' => ['key' => 'value']]]);
+        $expected = [
+            'li' => ['class' => 'last'],
+            ['a' => [
+                'href' => '/index?key=value&amp;page=5&amp;sort=Article.title&amp;direction=DESC',
+            ]],
+            'last',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test first() on the fence-post
      *
      * @return void


### PR DESCRIPTION
Incorporate URL options when generating a single first/last link.

Fixes #14894