### PR TITLE
Make Route normalize HTTP method conditions

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -187,9 +187,9 @@ class Route
     {
         $methods = is_array($methods)
             ? array_map('strtoupper', $methods)
-            : [strtoupper($methods)];
+            : strtoupper($methods);
 
-        $diff = array_diff($methods, static::VALID_METHODS);
+        $diff = array_diff((array)$methods, static::VALID_METHODS);
         if ($diff !== []) {
             throw new InvalidArgumentException(
                 sprintf('Invalid HTTP method received. `%s` is invalid.', implode(', ', $diff))

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -131,6 +131,12 @@ class Route
         $this->setExtensions((array)$this->options['_ext']);
         $this->setMiddleware((array)$this->options['_middleware']);
         unset($this->options['_middleware']);
+
+        if (isset($this->defaults['_method'])){
+            $this->defaults['_method'] = is_array($this->defaults['_method'])
+                ? array_map('strtoupper', $this->defaults['_method'])
+                : strtoupper($this->defaults['_method']);
+        }
     }
 
     /**
@@ -740,9 +746,10 @@ class Route
         if (empty($url['_method'])) {
             $url['_method'] = 'GET';
         }
+        $defaults = (array)$this->defaults['_method'];
         $methods = array_map('strtoupper', (array)$url['_method']);
         foreach ($methods as $value) {
-            if (in_array($value, (array)$this->defaults['_method'], true)) {
+            if (in_array($value, $defaults, true)) {
                 return true;
             }
         }

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -132,7 +132,7 @@ class Route
         $this->setMiddleware((array)$this->options['_middleware']);
         unset($this->options['_middleware']);
 
-        if (isset($this->defaults['_method'])){
+        if (isset($this->defaults['_method'])) {
             $this->defaults['_method'] = is_array($this->defaults['_method'])
                 ? array_map('strtoupper', $this->defaults['_method'])
                 : strtoupper($this->defaults['_method']);

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -133,9 +133,7 @@ class Route
         unset($this->options['_middleware']);
 
         if (isset($this->defaults['_method'])) {
-            $this->defaults['_method'] = is_array($this->defaults['_method'])
-                ? array_map('strtoupper', $this->defaults['_method'])
-                : strtoupper($this->defaults['_method']);
+            $this->defaults['_method'] = $this->normalizeAndValidateMethods($this->defaults['_method']);
         }
     }
 
@@ -174,16 +172,31 @@ class Route
      */
     public function setMethods(array $methods)
     {
-        $methods = array_map('strtoupper', $methods);
-        $diff = array_diff($methods, static::VALID_METHODS);
-        if ($diff !== []) {
-            throw new InvalidArgumentException(
-                sprintf('Invalid HTTP method received. %s is invalid.', implode(', ', $diff))
-            );
-        }
-        $this->defaults['_method'] = $methods;
+        $this->defaults['_method'] = $this->normalizeAndValidateMethods($methods);
 
         return $this;
+    }
+
+    /**
+     * Normalize method names to upper case and validate that they are valid HTTP methods.
+     *
+     * @param string|array $methods Methods.
+     * @return string|array
+     */
+    protected function normalizeAndValidateMethods($methods)
+    {
+        $methods = is_array($methods)
+            ? array_map('strtoupper', $methods)
+            : strtoupper($methods);
+
+        $diff = array_diff((array)$methods, static::VALID_METHODS);
+        if ($diff !== []) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid HTTP method received. `%s` is invalid.', implode(', ', $diff))
+            );
+        }
+
+        return $methods;
     }
 
     /**
@@ -426,6 +439,9 @@ class Route
      */
     public function parse(string $url, string $method): ?array
     {
+        if ($method !== '') {
+            $method = $this->normalizeAndValidateMethods($method);
+        }
         $compiledRoute = $this->compile();
         [$url, $ext] = $this->_parseExtension($url);
 
@@ -747,7 +763,7 @@ class Route
             $url['_method'] = 'GET';
         }
         $defaults = (array)$this->defaults['_method'];
-        $methods = array_map('strtoupper', (array)$url['_method']);
+        $methods = (array)$this->normalizeAndValidateMethods($url['_method']);
         foreach ($methods as $value) {
             if (in_array($value, $defaults, true)) {
                 return true;

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -118,10 +118,13 @@ class Route
      * - `_host` - Define the host name pattern if you want this route to only match
      *   specific host names. You can use `.*` and to create wildcard subdomains/hosts
      *   e.g. `*.example.com` matches all subdomains on `example.com`.
+     * - `_method` - Defines the HTTP method(s) the route applies to. It can be
+     *   a string or array of valid HTTP method name.
      *
      * @param string $template Template string with parameter placeholders
      * @param array $defaults Defaults for the route.
      * @param array $options Array of additional options for the Route
+     * @throws \InvalidArgumentException When `$options['_method']` are not in `VALID_METHODS` list.
      */
     public function __construct(string $template, array $defaults = [], array $options = [])
     {
@@ -168,7 +171,7 @@ class Route
      *
      * @param string[] $methods The HTTP methods to accept.
      * @return $this
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When methods are not in `VALID_METHODS` list.
      */
     public function setMethods(array $methods)
     {
@@ -180,8 +183,9 @@ class Route
     /**
      * Normalize method names to upper case and validate that they are valid HTTP methods.
      *
-     * @param string|array $methods Methods.
-     * @return string|array
+     * @param string|string[] $methods Methods.
+     * @return string|string[]
+     * @throws \InvalidArgumentException When methods are not in `VALID_METHODS` list.
      */
     protected function normalizeAndValidateMethods($methods)
     {
@@ -436,6 +440,7 @@ class Route
      * @param string $url The URL to attempt to parse.
      * @param string $method The HTTP method of the request being parsed.
      * @return array|null An array of request parameters, or null on failure.
+     * @throws \InvalidArgumentException When method is not an empty string or in `VALID_METHODS` list.
      */
     public function parse(string $url, string $method): ?array
     {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -187,9 +187,9 @@ class Route
     {
         $methods = is_array($methods)
             ? array_map('strtoupper', $methods)
-            : strtoupper($methods);
+            : [strtoupper($methods)];
 
-        $diff = array_diff((array)$methods, static::VALID_METHODS);
+        $diff = array_diff($methods, static::VALID_METHODS);
         if ($diff !== []) {
             throw new InvalidArgumentException(
                 sprintf('Invalid HTTP method received. `%s` is invalid.', implode(', ', $diff))

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -54,6 +54,13 @@ class RouteTest extends TestCase
         $this->assertFalse($route->compiled());
     }
 
+    public function testConstructionWithInvalidMethod()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
+        $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index', '_method' => 'nope']);
+    }
+
     /**
      * Test set middleware in the constructor
      *
@@ -1284,7 +1291,7 @@ class RouteTest extends TestCase
             '_method' => 'POST',
             '_matchedRoute' => '/sample',
         ];
-        $this->assertEquals($expected, $route->parse('/sample', 'POST'));
+        $this->assertEquals($expected, $route->parse('/sample', 'post'));
     }
 
     /**
@@ -1767,7 +1774,7 @@ class RouteTest extends TestCase
     public function testSetMethodsInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid HTTP method received. NOPE is invalid');
+        $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
         $route->setMethods(['nope']);
     }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1289,6 +1289,7 @@ class RouteTest extends TestCase
 
     /**
      * Test that http header conditions can cause route failures.
+     * And that http method names are normalized.
      *
      * @return void
      */
@@ -1297,7 +1298,7 @@ class RouteTest extends TestCase
         $route = new Route('/sample', [
             'controller' => 'posts',
             'action' => 'index',
-            '_method' => ['PUT', 'POST'],
+            '_method' => ['put', 'post'],
         ]);
         $this->assertNull($route->parse('/sample', 'GET'));
 

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -721,6 +721,31 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test connecting resources with restricted mappings.
+     *
+     * @return void
+     */
+    public function testResourcesWithMapOnly()
+    {
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes->resources('Articles', [
+            'map' => [
+                'conditions' => ['action' => 'conditions', 'method' => 'DeLeTe'],
+            ],
+            'only' => ['conditions']
+        ]);
+
+        $all = $this->collection->routes();
+        $this->assertCount(1, $all);
+        $this->assertSame('DELETE', $all[0]->defaults['_method'], 'method should be normalized.');
+        $this->assertSame('Articles', $all[0]->defaults['controller']);
+        $this->assertSame('conditions', $all[0]->defaults['action']);
+
+        $result = $this->collection->parse('/api/articles/conditions', 'DELETE');
+        $this->assertNotNull($result);
+    }
+
+    /**
      * Test connecting resources.
      *
      * @return void

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -732,7 +732,7 @@ class RouteBuilderTest extends TestCase
             'map' => [
                 'conditions' => ['action' => 'conditions', 'method' => 'DeLeTe'],
             ],
-            'only' => ['conditions']
+            'only' => ['conditions'],
         ]);
 
         $all = $this->collection->routes();


### PR DESCRIPTION
By normalizing the http method name to the correct case resource routes are a bit more ergonomic as case mistakes don't cause routes to fail matching.

Fixes #14902
