### PR TITLE
pj(): support of UTF-8 encoding

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -179,7 +179,7 @@ if (!function_exists('pj')) {
         }
 
         $template = (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') ? '<pre class="pj">%s</pre>' : "\n%s\n\n";
-        printf($template, trim(json_encode($var, JSON_PRETTY_PRINT)));
+        printf($template, trim(json_encode($var, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)));
 
         return $var;
     }


### PR DESCRIPTION
Hello my Friends
dd() function, can support utf-8 encryption, but pj() did not.
so pj() now can support of UTF-8 encoding :)