### PR TITLE
Indent the HTML tags

### DIFF
--- a/tests/TestCase/Error/Debug/HtmlFormatterTest.php
+++ b/tests/TestCase/Error/Debug/HtmlFormatterTest.php
@@ -72,13 +72,18 @@ class HtmlFormatterTest extends TestCase
         $this->assertGreaterThan(0, count($dom->childNodes));
 
         $expected = <<<TEXT
-object(MyObject) id:1 {stringProp =&gt; &#039;value&#039;
-protected intProp =&gt; (int) 1
-protected floatProp =&gt; (float) 1.1
-protected boolProp =&gt; true
-private nullProp =&gt; null
-arrayProp =&gt; [&#039;&#039; =&gt; too much,(int) 1 =&gt; object(MyObject) id: 1 {},]}
+object(MyObject) id:1 {
+  stringProp =&gt; &#039;value&#039;
+  protected intProp =&gt; (int) 1
+  protected floatProp =&gt; (float) 1.1
+  protected boolProp =&gt; true
+  private nullProp =&gt; null
+  arrayProp =&gt; [
+    &#039;&#039; =&gt; too much,
+    (int) 1 =&gt; object(MyObject) id: 1 {},
+  ]
+}
 TEXT;
-        $this->assertStringContainsString(str_replace("\n", '', $expected), strip_tags($result));
+        $this->assertStringContainsString($expected, strip_tags($result));
     }
 }


### PR DESCRIPTION
Make the HTML output include whitespace. This makes copying and pasting into other formats easier as the text has whitespace.
