### PR TITLE
Fix getTable() collision. Make getName() usage consistent.

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -457,7 +457,7 @@ trait QueryTrait
             $table = $this->getRepository();
             throw new RecordNotFoundException(sprintf(
                 'Record not found in table "%s"',
-                $table->getTable()
+                $table->getTableName()
             ));
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -594,7 +594,7 @@ abstract class Association
                 $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
                     ' You should explicitly specify the "propertyName" option.';
                 trigger_error(
-                    sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
+                    sprintf($msg, $this->_propertyName, $this->_sourceTable->getTableName()),
                     E_USER_WARNING
                 );
             }
@@ -717,7 +717,7 @@ abstract class Association
     {
         $target = $this->getTarget();
         $joinType = empty($options['joinType']) ? $this->getJoinType() : $options['joinType'];
-        $table = $target->getTable();
+        $table = $target->getTableName();
 
         $options += [
             'includeFields' => true,
@@ -1092,9 +1092,9 @@ abstract class Association
 
         if (count($foreignKey) !== count($bindingKey)) {
             if (empty($bindingKey)) {
-                $table = $this->getTarget()->getTable();
+                $table = $this->getTarget()->getTableName();
                 if ($this->isOwningSide($this->getSource())) {
-                    $table = $this->getSource()->getTable();
+                    $table = $this->getSource()->getTableName();
                 }
                 $msg = 'The "%s" table does not define a primary key, and cannot have join conditions generated.';
                 throw new RuntimeException(sprintf($msg, $table));

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -160,7 +160,7 @@ class BelongsTo extends Association
         if (count($foreignKey) !== count($bindingKey)) {
             if (empty($bindingKey)) {
                 $msg = 'The "%s" table does not define a primary key. Please set one.';
-                throw new RuntimeException(sprintf($msg, $this->getTarget()->getTable()));
+                throw new RuntimeException(sprintf($msg, $this->getTarget()->getTableName()));
             }
 
             $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -205,7 +205,7 @@ class BelongsToMany extends Association
     public function getForeignKey()
     {
         if ($this->_foreignKey === null) {
-            $this->_foreignKey = $this->_modelKey($this->getSource()->getTable());
+            $this->_foreignKey = $this->_modelKey($this->getSource()->getTableName());
         }
 
         return $this->_foreignKey;
@@ -1104,7 +1104,7 @@ class BelongsToMany extends Association
         $joins = $query->clause('join');
         $matching = [
             $name => [
-                'table' => $this->junction()->getTable(),
+                'table' => $this->junction()->getTableName(),
                 'conditions' => $conditions,
                 'type' => Query::JOIN_TYPE_INNER,
             ],
@@ -1428,8 +1428,8 @@ class BelongsToMany extends Association
         if ($name === null) {
             if (empty($this->_junctionTableName)) {
                 $tablesNames = array_map('Cake\Utility\Inflector::underscore', [
-                    $this->getSource()->getTable(),
-                    $this->getTarget()->getTable(),
+                    $this->getSource()->getTableName(),
+                    $this->getTarget()->getTableName(),
                 ]);
                 sort($tablesNames);
                 $this->_junctionTableName = implode('_', $tablesNames);

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -592,7 +592,7 @@ class HasMany extends Association
     public function getForeignKey()
     {
         if ($this->_foreignKey === null) {
-            $this->_foreignKey = $this->_modelKey($this->getSource()->getTable());
+            $this->_foreignKey = $this->_modelKey($this->getSource()->getTableName());
         }
 
         return $this->_foreignKey;

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -113,7 +113,7 @@ class EavStrategy implements TranslateStrategyInterface
                 $fieldTable = $tableLocator->get($name, [
                     'className' => $table,
                     'alias' => $name,
-                    'table' => $this->translationTable->getTable(),
+                    'table' => $this->translationTable->getTableName(),
                 ]);
             } else {
                 $fieldTable = $tableLocator->get($name);

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -354,7 +354,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $name = namespaceSplit(get_class($table));
         $name = substr(end($name), 0, -5);
         if (empty($name)) {
-            $name = $table->getTable() ?: $table->getAlias();
+            $name = $table->getTableName() ?: $table->getAlias();
             $name = Inflector::camelize($name);
         }
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1149,7 +1149,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $repository = $this->getRepository();
 
         if (empty($this->_parts['from'])) {
-            $this->from([$repository->getAlias() => $repository->getTable()]);
+            $this->from([$repository->getAlias() => $repository->getTableName()]);
         }
         $this->_addDefaultFields();
         $this->getEagerLoader()->attachAssociations($this, $repository, !$this->_hasFields);
@@ -1252,7 +1252,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         if (!$table) {
             /** @var \Cake\ORM\Table $repository */
             $repository = $this->getRepository();
-            $table = $repository->getTable();
+            $table = $repository->getTableName();
         }
 
         return parent::update($table);
@@ -1271,7 +1271,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     {
         /** @var \Cake\ORM\Table $repository */
         $repository = $this->getRepository();
-        $this->from([$repository->getAlias() => $repository->getTable()]);
+        $this->from([$repository->getAlias() => $repository->getTableName()]);
 
         // We do not pass $table to parent class here
         return parent::delete();
@@ -1294,7 +1294,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     {
         /** @var \Cake\ORM\Table $repository */
         $repository = $this->getRepository();
-        $table = $repository->getTable();
+        $table = $repository->getTableName();
         $this->into($table);
 
         return parent::insert($columns, $types);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -364,7 +364,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $name Table name.
      * @return $this
-     * @deprecated 4.2.0 Use setName() instead.
+     * @deprecated 4.2.0 Use setTableName() instead.
      */
     public function setTable(string $name)
     {
@@ -393,10 +393,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the database table name.
      *
-     * This can include the database schema name if set using `setTable()`.
+     * This can include the database schema name if set using `setTableName()`.
      *
      * @return string
-     * @deprecated 4.2.0 Use getName() instead.
+     * @deprecated 4.2.0 Use getTableName() instead.
      */
     public function getTable(): string
     {
@@ -406,7 +406,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the database table name.
      *
-     * This can include the database schema name if set using `setTable()`.
+     * This can include the database schema name if set using `setTableName()`.
      *
      * @return string
      */

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -362,12 +362,30 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * This can include the database schema name in the form 'schema.table'.
      * If the name must be quoted, enable automatic identifier quoting.
      *
-     * @param string $table Table name.
+     * @param string $name Table name.
+     * @return $this
+     * @deprecated 4.2.0 Use setName() instead.
+     */
+    public function setTable(string $name)
+    {
+        $this->setTableName($name);
+
+        return $this;
+    }
+
+    /**
+     * Sets the database table name.
+     *
+     * This can include the database schema name in the form 'schema.table'.
+     * If the name must be quoted, enable automatic identifier quoting.
+     *
+     * @param string $name Table name.
+     *
      * @return $this
      */
-    public function setTable(string $table)
+    public function setTableName(string $name)
     {
-        $this->_table = $table;
+        $this->_table = $name;
 
         return $this;
     }
@@ -378,8 +396,21 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * This can include the database schema name if set using `setTable()`.
      *
      * @return string
+     * @deprecated 4.2.0 Use getName() instead.
      */
     public function getTable(): string
+    {
+        return $this->getTableName();
+    }
+
+    /**
+     * Returns the database table name.
+     *
+     * This can include the database schema name if set using `setTable()`.
+     *
+     * @return string
+     */
+    public function getTableName(): string
     {
         if ($this->_table === null) {
             $table = namespaceSplit(static::class);
@@ -506,7 +537,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $this->_schema = $this->_initializeSchema(
                 $this->getConnection()
                     ->getSchemaCollection()
-                    ->describe($this->getTable())
+                    ->describe($this->getTableName())
             );
             if (Configure::read('debug')) {
                 $this->checkAliasLengths();
@@ -535,7 +566,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 unset($schema['_constraints']);
             }
 
-            $schema = $this->getConnection()->getDriver()->newTableSchema($this->getTable(), $schema);
+            $schema = $this->getConnection()->getDriver()->newTableSchema($this->getTableName(), $schema);
 
             foreach ($constraints as $name => $value) {
                 $schema->addConstraint($name, $value);
@@ -1492,7 +1523,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
             throw new InvalidPrimaryKeyException(sprintf(
                 'Record not found in table "%s" with primary key [%s]',
-                $this->getTable(),
+                $this->getTableName(),
                 implode(', ', $primaryKey)
             ));
         }
@@ -1510,7 +1541,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $cacheKey = sprintf(
                     'get:%s.%s%s',
                     $this->getConnection()->configName(),
-                    $this->getTable(),
+                    $this->getTableName(),
                     json_encode($primaryKey)
                 );
             }
@@ -2012,7 +2043,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (empty($primary)) {
             $msg = sprintf(
                 'Cannot insert row in "%s" table, it has no primary key.',
-                $this->getTable()
+                $this->getTableName()
             );
             throw new RuntimeException($msg);
         }
@@ -2059,7 +2090,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $driver = $this->getConnection()->getDriver();
             foreach ($primary as $key => $v) {
                 if (!isset($data[$key])) {
-                    $id = $statement->lastInsertId($this->getTable(), $key);
+                    $id = $statement->lastInsertId($this->getTableName(), $key);
                     /** @var string $type */
                     $type = $schema->getColumnType($key);
                     $entity->set($key, TypeFactory::build($type)->toPHP($id, $driver));
@@ -2117,7 +2148,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         if (count($primaryColumns) === 0) {
             $entityClass = get_class($entity);
-            $table = $this->getTable();
+            $table = $this->getTableName();
             $message = "Cannot update `$entityClass`. The `$table` has no primary key.";
             throw new InvalidArgumentException($message);
         }
@@ -3064,7 +3095,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         return [
             'registryAlias' => $this->getRegistryAlias(),
-            'table' => $this->getTable(),
+            'table' => $this->getTableName(),
             'alias' => $this->getAlias(),
             'entityClass' => $this->getEntityClass(),
             'associations' => $this->_associations->keys(),

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -380,7 +380,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * If the name must be quoted, enable automatic identifier quoting.
      *
      * @param string $name Table name.
-     *
      * @return $this
      */
     public function setTableName(string $name)

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -225,7 +225,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             if (!empty($import['table'])) {
                 throw new CakeException('You cannot define both table and model.');
             }
-            $import['table'] = $this->getTableLocator()->get($import['model'])->getTable();
+            $import['table'] = $this->getTableLocator()->get($import['model'])->getTableName();
         }
 
         if (empty($import['table'])) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -938,7 +938,7 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
-        if (stripos($mock->getTable(), 'mock') === 0) {
+        if (stripos($mock->getTableName(), 'mock') === 0) {
             $mock->setTable(Inflector::tableize($baseClass));
         }
 

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -77,7 +77,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Table', $session);
         $this->assertSame('Sessions', $session->getAlias());
         $this->assertEquals(ConnectionManager::get('test'), $session->getConnection());
-        $this->assertSame('sessions', $session->getTable());
+        $this->assertSame('sessions', $session->getTableName());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -160,7 +160,7 @@ class BelongsToManyTest extends TestCase
         $junction = $assoc->junction();
         $this->assertInstanceOf(Table::class, $junction);
         $this->assertSame('ArticlesTags', $junction->getAlias());
-        $this->assertSame('articles_tags', $junction->getTable());
+        $this->assertSame('articles_tags', $junction->getTableName());
         $this->assertSame($this->article, $junction->getAssociation('Articles')->getTarget());
         $this->assertSame($this->tag, $junction->getAssociation('Tags')->getTarget());
 
@@ -254,7 +254,7 @@ class BelongsToManyTest extends TestCase
         ]);
         $junction = $assoc->junction();
         $this->assertSame('TagsArticles', $junction->getAlias());
-        $this->assertSame('tags_articles', $junction->getTable());
+        $this->assertSame('tags_articles', $junction->getTableName());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -40,6 +40,21 @@ class BelongsToTest extends TestCase
     protected $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**
+     * @var \Cake\ORM\Table
+     */
+    protected $company;
+
+    /**
+     * @var \Cake\ORM\Table
+     */
+    protected $client;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $companiesTypeMap;
+
+    /**
      * Set up
      *
      * @return void
@@ -99,8 +114,8 @@ class BelongsToTest extends TestCase
      */
     public function testForeignKeyIgnoreDatabaseName()
     {
-        $this->company->setTable('schema.companies');
-        $this->client->setTable('schema.clients');
+        $this->company->setTableName('schema.companies');
+        $this->client->setTableName('schema.clients');
         $assoc = new BelongsTo('Companies', [
             'sourceTable' => $this->client,
             'targetTable' => $this->company,

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -119,7 +119,7 @@ class HasManyTest extends TestCase
      */
     public function testForeignKeyIgnoreDatabaseName()
     {
-        $this->author->setTable('schema.authors');
+        $this->author->setTableName('schema.authors');
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author,
         ]);

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -428,7 +428,7 @@ class AssociationTest extends TestCase
         $plugin = $this->getTableLocator()->get('TestPlugin.ThisAssociationName');
         $this->assertSame($table, $plugin, 'Should be an instance of TestPlugin.Comments');
         $this->assertSame('TestPlugin.ThisAssociationName', $table->getRegistryAlias());
-        $this->assertSame('comments', $table->getTable());
+        $this->assertSame('comments', $table->getTableName());
         $this->assertSame('ThisAssociationName', $table->getAlias());
         $this->clearPlugins();
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -85,7 +85,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     public function testDefaultAliases()
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->getTable();
+        $table->getTableName();
         $table->addBehavior('Translate');
 
         $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
@@ -114,7 +114,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     {
         $table = $this->getTableLocator()->get('SomeRandomPlugin.Articles');
 
-        $table->getTable();
+        $table->getTableName();
         $table->addBehavior('Translate');
 
         $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
@@ -154,7 +154,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     public function testAutoReferenceName()
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->getTable();
+        $table->getTableName();
         $table->addBehavior('Translate');
 
         $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
@@ -185,7 +185,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     public function testChangingReferenceName()
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->getTable();
+        $table->getTableName();
         $table->addBehavior(
             'Translate',
             ['referenceName' => 'Posts']
@@ -245,7 +245,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $this->assertTrue($exists, 'The table registry should have an object in this key now');
 
         $translationTable = $this->getTableLocator()->get('ArticlesTranslations');
-        $this->assertSame('articles_translations', $translationTable->getTable());
+        $this->assertSame('articles_translations', $translationTable->getTableName());
         $this->assertSame('ArticlesTranslations', $translationTable->getAlias());
     }
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -94,7 +94,7 @@ class TranslateBehaviorTest extends TestCase
         $this->assertEquals(CustomI18nTable::class, $i18n->getName());
         $this->assertInstanceOf(CustomI18nTable::class, $i18n->getTarget());
         $this->assertSame('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
-        $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTable());
+        $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTableName());
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1395,7 +1395,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $other = $this->getTableLocator()->get('FriendlyTrees', [
-            'table' => $table->getTable(),
+            'table' => $table->getTableName(),
         ]);
         $table->hasOne('FriendlyTrees', [
             'foreignKey' => 'id',

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -183,11 +183,11 @@ class TableLocatorTest extends TestCase
             'table' => 'my_articles',
         ]);
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('my_articles', $result->getTable());
+        $this->assertSame('my_articles', $result->getTableName());
 
         $result2 = $this->_locator->get('Articles');
         $this->assertSame($result, $result2);
-        $this->assertSame('my_articles', $result->getTable());
+        $this->assertSame('my_articles', $result->getTableName());
 
         $this->assertSame($this->_locator, $result->associations()->getTableLocator());
     }
@@ -201,32 +201,32 @@ class TableLocatorTest extends TestCase
     {
         $result = $this->_locator->get('Droids');
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('droids', $result->getTable());
+        $this->assertSame('droids', $result->getTableName());
         $this->assertSame('Droids', $result->getAlias());
 
         $result = $this->_locator->get('R2D2', ['className' => 'Droids']);
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('droids', $result->getTable(), 'The table should be derived from the className');
+        $this->assertSame('droids', $result->getTableName(), 'The table should be derived from the className');
         $this->assertSame('R2D2', $result->getAlias());
 
         $result = $this->_locator->get('C3P0', ['className' => 'Droids', 'table' => 'rebels']);
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('rebels', $result->getTable(), 'The table should be taken from options');
+        $this->assertSame('rebels', $result->getTableName(), 'The table should be taken from options');
         $this->assertSame('C3P0', $result->getAlias());
 
         $result = $this->_locator->get('Funky.Chipmunks');
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('chipmunks', $result->getTable(), 'The table should be derived from the alias');
+        $this->assertSame('chipmunks', $result->getTableName(), 'The table should be derived from the alias');
         $this->assertSame('Chipmunks', $result->getAlias());
 
         $result = $this->_locator->get('Awesome', ['className' => 'Funky.Monkies']);
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('monkies', $result->getTable(), 'The table should be derived from the classname');
+        $this->assertSame('monkies', $result->getTableName(), 'The table should be derived from the classname');
         $this->assertSame('Awesome', $result->getAlias());
 
         $result = $this->_locator->get('Stuff', ['className' => Table::class]);
         $this->assertInstanceOf(Table::class, $result);
-        $this->assertSame('stuff', $result->getTable(), 'The table should be derived from the alias');
+        $this->assertSame('stuff', $result->getTableName(), 'The table should be derived from the alias');
         $this->assertSame('Stuff', $result->getAlias());
     }
 
@@ -241,7 +241,7 @@ class TableLocatorTest extends TestCase
             'table' => 'my_articles',
         ]);
         $result = $this->_locator->get('Articles');
-        $this->assertSame('my_articles', $result->getTable(), 'Should use getConfig() data.');
+        $this->assertSame('my_articles', $result->getTableName(), 'Should use getConfig() data.');
     }
 
     /**
@@ -255,7 +255,7 @@ class TableLocatorTest extends TestCase
         $result = $this->_locator->get('Articles', [
             'connectionName' => 'testing',
         ]);
-        $this->assertSame('articles', $result->getTable());
+        $this->assertSame('articles', $result->getTableName());
         $this->assertSame('test', $result->getConnection()->configName());
     }
 
@@ -436,7 +436,7 @@ class TableLocatorTest extends TestCase
 
         $table = $this->_locator->get('users', ['table' => 'users']);
         $this->assertInstanceOf(Table::class, $table);
-        $this->assertSame('users', $table->getTable());
+        $this->assertSame('users', $table->getTableName());
         $this->assertSame('users', $table->getAlias());
         $this->assertSame($connection, $table->getConnection());
         $this->assertEquals(array_keys($schema), $table->getSchema()->columns());
@@ -448,7 +448,7 @@ class TableLocatorTest extends TestCase
         $this->_locator->setConfig('users', $options);
         $table = $this->_locator->get('users', ['className' => MyUsersTable::class]);
         $this->assertInstanceOf(MyUsersTable::class, $table);
-        $this->assertSame('users', $table->getTable());
+        $this->assertSame('users', $table->getTableName());
         $this->assertSame('users', $table->getAlias());
         $this->assertSame($connection, $table->getConnection());
         $this->assertEquals(array_keys($schema), $table->getSchema()->columns());

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -201,10 +201,10 @@ class TableTest extends TestCase
         $table = new Table(['table' => 'users']);
 
         $query = $table->query();
-        $this->assertEquals('users', $query->getRepository()->getTable());
+        $this->assertEquals('users', $query->getRepository()->getTableName());
 
         $query = $table->subquery();
-        $this->assertEquals('users', $query->getRepository()->getTable());
+        $this->assertEquals('users', $query->getRepository()->getTableName());
 
         $sql = $query->select(['username'])->sql();
         $this->assertRegExpSql(
@@ -218,6 +218,38 @@ class TableTest extends TestCase
      * Tests the table method
      *
      * @return void
+     */
+    public function testNameMethod()
+    {
+        $table = new Table(['table' => 'users']);
+        $this->assertSame('users', $table->getTableName());
+
+        $table = new UsersTable();
+        $this->assertSame('users', $table->getTableName());
+
+        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
+        $table = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['find'])
+            ->setMockClassName('SpecialThingsTable')
+            ->getMock();
+        $this->assertSame('special_things', $table->getTableName());
+
+        $table = new Table(['alias' => 'LoveBoats']);
+        $this->assertSame('love_boats', $table->getTableName());
+
+        $table->setTableName('other');
+        $this->assertSame('other', $table->getTableName());
+
+        $table->addBehavior('Timestamp');
+        $table->setTableName('database.other');
+        $this->assertSame('database.other', $table->getTableName());
+    }
+
+    /**
+     * Tests the table method
+     *
+     * @return void
+     * @deprecated 4.2.0
      */
     public function testTableMethod()
     {
@@ -240,6 +272,7 @@ class TableTest extends TestCase
         $table->setTable('other');
         $this->assertSame('other', $table->getTable());
 
+        $table->addBehavior('Timestamp');
         $table->setTable('database.other');
         $this->assertSame('database.other', $table->getTable());
     }
@@ -788,8 +821,8 @@ class TableTest extends TestCase
         $Categories->hasMany('Children', ['foreignKey' => 'parent_id'] + $options);
         $Categories->belongsTo('Parent', $options);
 
-        $this->assertSame('categories', $Categories->Children->getTarget()->getTable());
-        $this->assertSame('categories', $Categories->Parent->getTarget()->getTable());
+        $this->assertSame('categories', $Categories->Children->getTarget()->getTableName());
+        $this->assertSame('categories', $Categories->Parent->getTarget()->getTableName());
 
         $this->assertSame('Children', $Categories->Children->getAlias());
         $this->assertSame('Children', $Categories->Children->getTarget()->getAlias());
@@ -970,7 +1003,7 @@ class TableTest extends TestCase
         $this->assertEquals(['b' => 'c'], $belongsToMany->getConditions());
         $this->assertEquals(['foo' => 'asc'], $belongsToMany->getSort());
         $this->assertSame($table, $belongsToMany->getSource());
-        $this->assertSame('things_tags', $belongsToMany->junction()->getTable());
+        $this->assertSame('things_tags', $belongsToMany->junction()->getTableName());
     }
 
     /**
@@ -1020,7 +1053,7 @@ class TableTest extends TestCase
         $belongsToMany = $associations->get('tags');
         $this->assertInstanceOf(BelongsToMany::class, $belongsToMany);
         $this->assertSame('tags', $belongsToMany->getName());
-        $this->assertSame('things_tags', $belongsToMany->junction()->getTable());
+        $this->assertSame('things_tags', $belongsToMany->junction()->getTableName());
         $this->assertSame(['Tags.starred' => true], $belongsToMany->getConditions());
     }
 
@@ -4354,7 +4387,7 @@ class TableTest extends TestCase
         } catch (\BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
-        $this->assertSame('articles', $articles->getTable());
+        $this->assertSame('articles', $articles->getTableName());
     }
 
     /**
@@ -4383,7 +4416,7 @@ class TableTest extends TestCase
         } catch (\BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
-        $this->assertSame('authors', $authors->getTable());
+        $this->assertSame('authors', $authors->getTableName());
     }
 
     /**
@@ -4414,7 +4447,7 @@ class TableTest extends TestCase
         } catch (\BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
-        $this->assertSame('authors', $authors->getTable());
+        $this->assertSame('authors', $authors->getTableName());
     }
 
     /**
@@ -4445,7 +4478,7 @@ class TableTest extends TestCase
         } catch (\BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
-        $this->assertSame('authors', $authors->getTable());
+        $this->assertSame('authors', $authors->getTableName());
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -346,7 +346,7 @@ class TestCaseTest extends TestCase
         $entity = new Entity([]);
 
         $this->assertInstanceOf('TestApp\Model\Table\PostsTable', $Posts);
-        $this->assertSame('posts', $Posts->getTable());
+        $this->assertSame('posts', $Posts->getTableName());
 
         $Posts = $this->getMockForModel('Posts', ['save']);
         $Posts->expects($this->at(0))
@@ -472,10 +472,10 @@ class TestCaseTest extends TestCase
         static::setAppNamespace();
 
         $I18n = $this->getMockForModel('CustomI18n', ['save']);
-        $this->assertSame('custom_i18n_table', $I18n->getTable());
+        $this->assertSame('custom_i18n_table', $I18n->getTableName());
 
         $Tags = $this->getMockForModel('Tags', ['save']);
-        $this->assertSame('tags', $Tags->getTable());
+        $this->assertSame('tags', $Tags->getTableName());
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/TestPluginCommentsTable.php
@@ -25,6 +25,6 @@ class TestPluginCommentsTable extends Table
 {
     public function initialize(array $config): void
     {
-        $this->setTable('test_plugin_comments');
+        $this->setTableName('test_plugin_comments');
     }
 }

--- a/tests/test_app/TestApp/Model/Table/CustomI18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/CustomI18nTable.php
@@ -22,7 +22,7 @@ class CustomI18nTable extends Table
 {
     public function initialize(array $config): void
     {
-        $this->setTable('custom_i18n_table');
+        $this->setTableName('custom_i18n_table');
     }
 
     public static function defaultConnectionName(): string

--- a/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
@@ -19,7 +19,7 @@ class GreedyCommentsTable extends Table
      */
     public function initialize(array $config): void
     {
-        $this->setTable('comments');
+        $this->setTableName('comments');
         $this->setAlias('Comments');
     }
 

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -30,7 +30,7 @@ class PaginatorPostsTable extends Table
      */
     public function initialize(array $config): void
     {
-        $this->setTable('posts');
+        $this->setTableName('posts');
         $this->belongsTo('PaginatorAuthor', [
             'foreignKey' => 'author_id',
         ]);

--- a/tests/test_app/TestApp/Model/Table/SluggedPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/SluggedPostsTable.php
@@ -23,7 +23,7 @@ class SluggedPostsTable extends Table
 {
     public function initialize(array $config): void
     {
-        $this->setTable('posts');
+        $this->setTableName('posts');
         $this->addBehavior('Sluggable');
     }
 }


### PR DESCRIPTION
This makes it consistent with Association::getName() and removes the IDE warning/error of string vs object since the naming collides here.
Table::getTable() vs Behavior::getTable()

This resolves this.
It also takes away the confusion, as in many cases getTable() would assume to actually get the table (just as the behavior does), when it is just the name.

The change must be documented in migration guide, of course.
The internal property is very internal, so I don't see an issue here with 4.2 as minor release.