### PR TITLE
Rename getTable() to table() to remove naming collision.

### DIFF
--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -184,8 +184,19 @@ class Behavior implements EventListenerInterface
      * Get the table instance this behavior is bound to.
      *
      * @return \Cake\ORM\Table The bound table instance.
+     * @deprecated 4.2.0 Use table() instead.
      */
     public function getTable(): Table
+    {
+        return $this->table();
+    }
+
+    /**
+     * Get the table instance this behavior is bound to.
+     *
+     * @return \Cake\ORM\Table The bound table instance.
+     */
+    public function table(): Table
     {
         return $this->_table;
     }

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -211,7 +211,7 @@ class TimestampBehavior extends Behavior
 
         $ts = $this->timestamp(null, $refreshTimestamp);
 
-        $columnType = $this->getTable()->getSchema()->getColumnType($field);
+        $columnType = $this->table()->getSchema()->getColumnType($field);
         if (!$columnType) {
             return;
         }

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1394,7 +1394,7 @@ class TreeBehaviorTest extends TestCase
     public function testFindPathWithAssociation()
     {
         $table = $this->table;
-        $other = $this->getTableLocator()->get('FriendlyTrees', [
+        $this->getTableLocator()->get('FriendlyTrees', [
             'table' => $table->getTable(),
         ]);
         $table->hasOne('FriendlyTrees', [

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -51,7 +51,7 @@ class BehaviorTest extends TestCase
         $table = $this->getMockBuilder(Table::class)->getMock();
 
         $behavior = new TestBehavior($table);
-        $this->assertSame($table, $behavior->getTable());
+        $this->assertSame($table, $behavior->table()());
     }
 
     public function testReflectionCache()

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -51,7 +51,7 @@ class BehaviorTest extends TestCase
         $table = $this->getMockBuilder(Table::class)->getMock();
 
         $behavior = new TestBehavior($table);
-        $this->assertSame($table, $behavior->table()());
+        $this->assertSame($table, $behavior->table());
     }
 
     public function testReflectionCache()


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/14911

This has a smaller footprint, but will still have the issue of clarification of table vs name (object vs string).

This makes sense if we want to further improve our API in the future (towards 5.x) using
- set/get prefix only for such setter and getters
- don't use the prefix for pure collection() and object() handles exposed by the API (where there is no such setter)

What do people think?

For example it should probably also be
- request->session()->...
- but object::setConfig() and object::getConfig()