### PR TITLE
Keep all components annotated, even if deprecated.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -82,6 +82,8 @@ use UnexpectedValueException;
  * @property \Cake\Controller\Component\FormProtectionComponent $FormProtection
  * @property \Cake\Controller\Component\PaginatorComponent $Paginator
  * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
+ * @property \Cake\Controller\Component\SecurityComponent $Security
+ * @property \Cake\Controller\Component\AuthComponent $Auth
  * @link https://book.cakephp.org/4/en/controllers.html
  */
 class Controller implements EventListenerInterface, EventDispatcherInterface


### PR DESCRIPTION
They can still be in use, and should only be removed once the actual code is also removed.

Resolves https://github.com/dereuromark/cakephp-ide-helper/issues/208