### PR TITLE
Typecast numeric cell values to string in HtmlHelper::_renderCells()

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -790,6 +790,10 @@ class HtmlHelper extends Helper
                 }
             }
 
+            if(!is_string($cell) && is_numeric($cell)) {
+                $cell = (string) $cell;
+            }
+
             $cellsOut[] = $this->tableCell($cell, $cellOptions);
         }
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -729,7 +729,7 @@ class HtmlHelper extends Helper
         bool $continueOddEven = true
     ): string {
         if (is_string($data) || empty($data[0]) || !is_array($data[0])) {
-            $data = [$data];
+            $data = [[$data]];
         }
 
         if ($oddTrOptions === true) {


### PR DESCRIPTION

This patch typecast numeric cell values to string in HtmlHelper::_renderCells() before passing it to HtmlHelper::tableCell(), while strict typehint "String" for HtmlHelper::tableCell() stays untouched.
I personally would avoid to check if method "__toString()" exists if an class/object is passed, at the time of PHP-7.x, on a later PHP-8.x only release Uniontype typehint like "stringable|string|int|float" on HtmlHelper::tableCell() will do the trick for us in a much better way. 
On type bool, everyone has his personal opinion. (And i hate flamewar). My thoughts are, that common functions like substr() return (bool) false if they fail. If we typecast them silent, users may not take notice of misbehave of there code as no exception is thrown. 

Resolves https://github.com/cakephp/cakephp/issues/14921
