### PR TITLE
Add support for ignoring deprecations by path

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -303,9 +303,9 @@ if (!function_exists('deprecationWarning')) {
 
             $message = sprintf(
                 '%s - %s, line: %s' . "\n" .
-                ' You can disable deprecation warnings by setting `Error.errorLevel` to' .
+                ' You can disable all deprecation warnings by setting `Error.errorLevel` to' .
                 ' `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to ' .
-                ' `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations.',
+                ' `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations from only this file.',
                 $message,
                 $frame['file'],
                 $frame['line'],

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -292,6 +292,16 @@ if (!function_exists('deprecationWarning')) {
             $frame = $trace[$stackFrame];
             $frame += ['file' => '[internal]', 'line' => '??'];
 
+            $patterns = (array)Configure::read('Error.disableDeprecations');
+            $relative = substr($frame['file'], strlen(ROOT) + 1);
+            debug($relative);
+            foreach ($patterns as $pattern) {
+                $pattern = str_replace('/', DIRECTORY_SEPARATOR, $pattern);
+                if (fnmatch($pattern, $relative)) {
+                    return;
+                }
+            }
+
             $message = sprintf(
                 '%s - %s, line: %s' . "\n" .
                 ' You can disable deprecation warnings by setting `Error.errorLevel` to' .

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -293,7 +293,7 @@ if (!function_exists('deprecationWarning')) {
             $frame += ['file' => '[internal]', 'line' => '??'];
 
             $patterns = (array)Configure::read('Error.disableDeprecations');
-            $relative = substr($frame['file'], strlen(ROOT) + 1);
+            $relative = str_replace('/', DIRECTORY_SEPARATOR, substr($frame['file'], strlen(ROOT) + 1));
             foreach ($patterns as $pattern) {
                 $pattern = str_replace('/', DIRECTORY_SEPARATOR, $pattern);
                 if (fnmatch($pattern, $relative)) {
@@ -304,11 +304,12 @@ if (!function_exists('deprecationWarning')) {
             $message = sprintf(
                 '%s - %s, line: %s' . "\n" .
                 ' You can disable deprecation warnings by setting `Error.errorLevel` to' .
-                " `E_ALL & ~E_USER_DEPRECATED`, or add `{$relative}` to " .
+                " `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to " .
                 ' `Error.disableDeprecations` in your `config/app.php` to mute deprecations.',
                 $message,
                 $frame['file'],
-                $frame['line']
+                $frame['line'],
+                str_replace(DIRECTORY_SEPARATOR, '/', $relative)
             );
         }
 

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -292,10 +292,10 @@ if (!function_exists('deprecationWarning')) {
             $frame = $trace[$stackFrame];
             $frame += ['file' => '[internal]', 'line' => '??'];
 
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($frame['file'], strlen(ROOT) + 1));
             $patterns = (array)Configure::read('Error.disableDeprecations');
-            $relative = str_replace('/', DIRECTORY_SEPARATOR, substr($frame['file'], strlen(ROOT) + 1));
             foreach ($patterns as $pattern) {
-                $pattern = str_replace('/', DIRECTORY_SEPARATOR, $pattern);
+                $pattern = str_replace(DIRECTORY_SEPARATOR, '/', $pattern);
                 if (fnmatch($pattern, $relative)) {
                     return;
                 }
@@ -309,7 +309,7 @@ if (!function_exists('deprecationWarning')) {
                 $message,
                 $frame['file'],
                 $frame['line'],
-                str_replace(DIRECTORY_SEPARATOR, '/', $relative)
+                $relative
             );
         }
 

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -293,7 +293,7 @@ if (!function_exists('deprecationWarning')) {
             $frame += ['file' => '[internal]', 'line' => '??'];
 
             $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($frame['file'], strlen(ROOT) + 1));
-            $patterns = (array)Configure::read('Error.disableDeprecations');
+            $patterns = (array)Configure::read('Error.ignoredDeprecationPaths');
             foreach ($patterns as $pattern) {
                 $pattern = str_replace(DIRECTORY_SEPARATOR, '/', $pattern);
                 if (fnmatch($pattern, $relative)) {
@@ -305,7 +305,7 @@ if (!function_exists('deprecationWarning')) {
                 '%s - %s, line: %s' . "\n" .
                 ' You can disable deprecation warnings by setting `Error.errorLevel` to' .
                 ' `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to ' .
-                ' `Error.disableDeprecations` in your `config/app.php` to mute deprecations.',
+                ' `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations.',
                 $message,
                 $frame['file'],
                 $frame['line'],

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -304,7 +304,8 @@ if (!function_exists('deprecationWarning')) {
             $message = sprintf(
                 '%s - %s, line: %s' . "\n" .
                 ' You can disable deprecation warnings by setting `Error.errorLevel` to' .
-                ' `E_ALL & ~E_USER_DEPRECATED` in your config/app.php.',
+                " `E_ALL & ~E_USER_DEPRECATED`, or add `{$relative}` to " .
+                ' `Error.disableDeprecations` in your `config/app.php` to mute deprecations.',
                 $message,
                 $frame['file'],
                 $frame['line']

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -304,7 +304,7 @@ if (!function_exists('deprecationWarning')) {
             $message = sprintf(
                 '%s - %s, line: %s' . "\n" .
                 ' You can disable deprecation warnings by setting `Error.errorLevel` to' .
-                " `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to " .
+                ' `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to ' .
                 ' `Error.disableDeprecations` in your `config/app.php` to mute deprecations.',
                 $message,
                 $frame['file'],

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -294,7 +294,6 @@ if (!function_exists('deprecationWarning')) {
 
             $patterns = (array)Configure::read('Error.disableDeprecations');
             $relative = substr($frame['file'], strlen(ROOT) + 1);
-            debug($relative);
             foreach ($patterns as $pattern) {
                 $pattern = str_replace('/', DIRECTORY_SEPARATOR, $pattern);
                 if (fnmatch($pattern, $relative)) {

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Core;
 
+use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
 
@@ -96,6 +97,21 @@ class FunctionsTest extends TestCase
         $this->expectDeprecation();
         $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
+        $this->withErrorReporting(E_ALL, function () {
+            deprecationWarning('This is going away');
+        });
+    }
+
+    /**
+     * Test no error when deprecation matches ignore paths.
+     *
+     * @return void
+     */
+    public function testDeprecationWarningPathDisabled()
+    {
+        $this->expectNotToPerformAssertions();
+
+        Configure::write('Error.disableDeprecations', ['src/TestSuite/*']);
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away');
         });

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -111,7 +111,7 @@ class FunctionsTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        Configure::write('Error.disableDeprecations', ['src/TestSuite/*']);
+        Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
         $this->withErrorReporting(E_ALL, function () {
             deprecationWarning('This is going away');
         });


### PR DESCRIPTION
Being able to have deprecations on globally but silence problematic
parts of your application or a noisy plugin that can't be upgraded just
yet allows developers more control when upgrading.

Instead of having to hope they don't add new deprecations they can fix
a part of their application and then remove it from the deprecation
ignore patterns.

I've used glob here instead of regex as I don't think the power of regex
is needed for this.

Refs cakephp/cakephp#14915
Refs cakephp/app#803