### PR TITLE
Validation::time(string $check) returns true when two digit numbers like 12, 19 are given.

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1471,8 +1471,7 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::time('12'));
 		$this->assertFalse(Validation::time('12:0'));
 		$this->assertFalse(Validation::time('12:000'));
-		$this->assertFalse(Validation::time('25'));
-		$this->assertFalse(Validation::time('25:00'));
+		$this->assertFalse(Validation::time('24'));
 		$this->assertFalse(Validation::time('12:00:00'));
 	}
 

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1467,6 +1467,13 @@ class ValidationTest extends CakeTestCase {
 		$this->assertTrue(Validation::time('1:00pm'));
 		$this->assertFalse(Validation::time('13:00pm'));
 		$this->assertFalse(Validation::time('9:00'));
+		$this->assertFalse(Validation::time('1'));
+		$this->assertFalse(Validation::time('12'));
+		$this->assertFalse(Validation::time('12:0'));
+		$this->assertFalse(Validation::time('12:000'));
+		$this->assertFalse(Validation::time('25'));
+		$this->assertFalse(Validation::time('25:00'));
+		$this->assertFalse(Validation::time('12:00:00'));
 	}
 
 /**

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -392,7 +392,7 @@ class Validation {
  * @return bool Success
  */
 	public static function time($check) {
-		return static::_check($check, '%^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$|^([01]\d|2[0-3])(:[0-5]\d){0,2}$%');
+		return static::_check($check, '%^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$|^([01]\d|2[0-3]):[0-5]\d$%');
 	}
 
 /**


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

--->

`Validation::time()` returns true when two digit numbers like 12, 19 are given.
According the comment, only two digit numbers should be rejected.
https://github.com/cakephp/cakephp/blob/2.x/lib/Cake/Utility/Validation.php#L386-L396

```
* Validates time as 24hr (HH:MM) or am/pm ([H]H:MM[a|p]m)
```
Therefore, I committed the code change as the following.

- modify regular expression to reject when only two digit number, like 12, 23 are given and make regex to pass only [HH:MM] in standard clock expression.
- add test assertions to test above code change


