### PR TITLE
reject HH time form according to the doc comment in Validation::time()

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -649,7 +649,7 @@ class Validation
         }
 
         $meridianClockRegex = '^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$';
-        $standardClockRegex = '^([01]\d|2[0-3])((:[0-5]\d){0,2}|(:[0-5]\d){2}\.\d{0,6})$';
+        $standardClockRegex = '^([01]\d|2[0-3])((:[0-5]\d){1,2}|(:[0-5]\d){2}\.\d{0,6})$';
 
         return static::_check($check, '%' . $meridianClockRegex . '|' . $standardClockRegex . '%');
     }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1650,6 +1650,11 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::time('1:00pm'));
         $this->assertFalse(Validation::time('13:00pm'));
         $this->assertFalse(Validation::time('9:00'));
+        $this->assertFalse(Validation::time('1'));
+        $this->assertFalse(Validation::time('12'));
+        $this->assertFalse(Validation::time('12:0'));
+        $this->assertFalse(Validation::time('12:000'));
+        $this->assertFalse(Validation::time('24'));
     }
 
     /**


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
# Related pull request
https://github.com/cakephp/cakephp/pull/14927

# Description
Validation::time() returns true when two digit (HH) numbers like 12, 19 are given.
According to the comment, only `HH` should be rejected.
https://github.com/cakephp/cakephp/blob/4.next/src/Validation/Validation.php#L628-L655

```
Validates time as 24hr (HH:MM[:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
```

 I committed the code change as the following.

- modify regular expression to reject when only `HH`, like 12, 23 are given and make regex to pass only `HH:MM` in standard clock expression.
- add test assertions to test above code change

# Discussion
- `HH` are basically the short version of standard clock expression, like 12(12:00), 18(18:00)
- So, I am also considering another option (modify doc comment like `HH[:MM][:SS][.FFFFFF]`)

