### PR TITLE
Update Validation::time doc comment

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -617,7 +617,7 @@ class Validation
 
     /**
      * Time validation, determines if the string passed is a valid time.
-     * Validates time as 24hr (HH:MM[:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
+     * Validates time as 24hr (HH[:MM][:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
      *
      * Seconds and fractional seconds (microseconds) are allowed but optional
      * in 24hr format.

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1650,6 +1650,11 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::time('1:00pm'));
         $this->assertFalse(Validation::time('13:00pm'));
         $this->assertFalse(Validation::time('9:00'));
+        $this->assertTrue(Validation::time('00'));
+        $this->assertTrue(Validation::time('09'));
+        $this->assertTrue(Validation::time('10'));
+        $this->assertTrue(Validation::time('23'));
+        $this->assertFalse(Validation::time('24'));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1651,7 +1651,9 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::time('13:00pm'));
         $this->assertFalse(Validation::time('9:00'));
         $this->assertTrue(Validation::time('00'));
+        $this->assertFalse(Validation::time('0'));
         $this->assertTrue(Validation::time('09'));
+        $this->assertFalse(Validation::time('9'));
         $this->assertTrue(Validation::time('10'));
         $this->assertTrue(Validation::time('23'));
         $this->assertFalse(Validation::time('24'));


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->

# Related pull requests
https://github.com/cakephp/cakephp/pull/14927
https://github.com/cakephp/cakephp/pull/14929

# Description
https://github.com/cakephp/cakephp/blob/4.next/src/Validation/Validation.php#L628-L655
```
Validates time as 24hr (HH:MM[:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
```

- Validation::time should accept `HH` type string, but doc comment said check string must be `HH:MM`
- update doc comment `HH[:MM][:SS][.FFFFFF]` and add test assertions(00,01 - 23, 24)
