### PR TITLE
Test improvements about assertion equals

### DIFF
--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -87,7 +87,7 @@ class DigestAuthenticateTest extends TestCase
         ]);
         $this->assertSame('AuthUser', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'pass'], $object->getConfig('fields'));
-        $this->assertEquals(123456, $object->getConfig('nonce'));
+        $this->assertSame(123456, $object->getConfig('nonce'));
         $this->assertEquals(env('SERVER_NAME'), $object->getConfig('realm'));
     }
 
@@ -464,7 +464,7 @@ DIGEST;
     {
         $result = DigestAuthenticate::password('mark', 'password', 'localhost');
         $expected = md5('mark:localhost:password');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -401,7 +401,7 @@ class FormAuthenticateTest extends TestCase
 
         $passwordHasher = $this->auth->passwordHasher();
         $result = $passwordHasher->getConfig();
-        $this->assertEquals(PASSWORD_BCRYPT, $result['hashType']);
+        $this->assertSame(PASSWORD_BCRYPT, $result['hashType']);
 
         $hash = password_hash('mypass', PASSWORD_BCRYPT);
         $User = $this->getTableLocator()->get('Users');

--- a/tests/TestCase/Auth/Storage/SessionStorageTest.php
+++ b/tests/TestCase/Auth/Storage/SessionStorageTest.php
@@ -130,7 +130,7 @@ class SessionStorageTest extends TestCase
             ->will($this->returnValue($url));
 
         $result = $this->storage->redirectUrl();
-        $this->assertEquals($url, $result);
+        $this->assertSame($url, $result);
 
         $this->session->expects($this->once())
             ->method('delete')

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -861,11 +861,11 @@ class CacheTest extends TestCase
 
         $expected = 'This is some data 0';
         $result = Cache::remember('test_key', $cacher, 'tests');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $counter = 1;
         $result = Cache::remember('test_key', $cacher, 'tests');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -883,7 +883,7 @@ class CacheTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'tests');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'tests');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -112,8 +112,7 @@ class ApcuEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'apcu');
-        $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'apcu');
@@ -121,7 +120,7 @@ class ApcuEngineTest extends TestCase
 
         $result = Cache::read('test', 'apcu');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         Cache::delete('test', 'apcu');
     }
@@ -229,16 +228,16 @@ class ApcuEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'apcu');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'apcu');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'apcu');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'apcu');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     /**
@@ -252,16 +251,16 @@ class ApcuEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::increment('test_increment', 1, 'apcu');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::read('test_increment', 'apcu');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::increment('test_increment', 2, 'apcu');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         $result = Cache::read('test_increment', 'apcu');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
     }
 
     /**
@@ -370,7 +369,7 @@ class ApcuEngineTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'apcu');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'apcu');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -78,8 +78,7 @@ class ArrayEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'array');
-        $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'array');
@@ -87,7 +86,7 @@ class ArrayEngineTest extends TestCase
 
         $result = Cache::read('test', 'array');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         Cache::delete('test', 'array');
     }
@@ -139,16 +138,16 @@ class ArrayEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'array');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'array');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'array');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'array');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     /**
@@ -277,7 +276,7 @@ class ArrayEngineTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'array');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'array');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -98,8 +98,7 @@ class FileEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'file_test');
-        $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertNull($result);
     }
 
     /**
@@ -110,8 +109,7 @@ class FileEngineTest extends TestCase
     public function testReadAndWrite()
     {
         $result = Cache::read('test', 'file_test');
-        $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'file_test');
@@ -119,7 +117,7 @@ class FileEngineTest extends TestCase
 
         $result = Cache::read('test', 'file_test');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         Cache::delete('test', 'file_test');
     }
@@ -297,11 +295,11 @@ class FileEngineTest extends TestCase
         $FileOne->set('prefix_one_key_one', $dataOne);
         $FileTwo->set('prefix_two_key_two', $dataTwo);
 
-        $this->assertEquals($expected, $FileOne->get('prefix_one_key_one'));
-        $this->assertEquals($expected, $FileTwo->get('prefix_two_key_two'));
+        $this->assertSame($expected, $FileOne->get('prefix_one_key_one'));
+        $this->assertSame($expected, $FileTwo->get('prefix_two_key_two'));
 
         $FileOne->clear();
-        $this->assertEquals($expected, $FileTwo->get('prefix_two_key_two'), 'secondary config was cleared by accident.');
+        $this->assertSame($expected, $FileTwo->get('prefix_two_key_two'), 'secondary config was cleared by accident.');
         $FileTwo->clear();
     }
 
@@ -521,7 +519,7 @@ class FileEngineTest extends TestCase
         $write = Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0664';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
@@ -529,7 +527,7 @@ class FileEngineTest extends TestCase
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0666';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
@@ -537,7 +535,7 @@ class FileEngineTest extends TestCase
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0644';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
 
@@ -545,7 +543,7 @@ class FileEngineTest extends TestCase
         Cache::write('masking_test', $data, 'mask_test');
         $result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
         $expected = '0640';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Cache::delete('masking_test', 'mask_test');
         Cache::drop('mask_test');
     }
@@ -695,7 +693,7 @@ class FileEngineTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'file_test');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'file_test');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -155,7 +155,7 @@ class MemcachedEngineTest extends TestCase
                 Memcached::OPT_BINARY_PROTOCOL => true,
             ],
         ]);
-        $this->assertEquals(1, $memcached->getOption(Memcached::OPT_BINARY_PROTOCOL));
+        $this->assertSame(1, $memcached->getOption(Memcached::OPT_BINARY_PROTOCOL));
     }
 
     /**
@@ -193,7 +193,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_PHP, $Memcached->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertSame(Memcached::SERIALIZER_PHP, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -217,7 +217,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_JSON, $Memcached->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertSame(Memcached::SERIALIZER_JSON, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -241,7 +241,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_IGBINARY, $Memcached->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertSame(Memcached::SERIALIZER_IGBINARY, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -265,7 +265,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_MSGPACK, $Memcached->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertSame(Memcached::SERIALIZER_MSGPACK, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -472,8 +472,7 @@ class MemcachedEngineTest extends TestCase
         $this->_configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'memcached');
-        $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertNull($result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'memcached');
@@ -481,7 +480,7 @@ class MemcachedEngineTest extends TestCase
 
         $result = Cache::read('test', 'memcached');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         Cache::delete('test', 'memcached');
     }
@@ -597,7 +596,7 @@ class MemcachedEngineTest extends TestCase
         sleep(2);
         $result = Cache::read('long_expiry_test', 'memcached');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
     }
 
     /**
@@ -679,16 +678,16 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'memcached');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'memcached');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'memcached');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'memcached');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         Cache::delete('test_decrement', 'memcached');
     }
@@ -711,16 +710,16 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'compressed_memcached');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'compressed_memcached');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'compressed_memcached');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'compressed_memcached');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         Cache::delete('test_decrement', 'compressed_memcached');
     }
@@ -736,16 +735,16 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::increment('test_increment', 1, 'memcached');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::read('test_increment', 'memcached');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::increment('test_increment', 2, 'memcached');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         $result = Cache::read('test_increment', 'memcached');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         Cache::delete('test_increment', 'memcached');
     }
@@ -788,16 +787,16 @@ class MemcachedEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::increment('test_increment', 1, 'compressed_memcached');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::read('test_increment', 'compressed_memcached');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::increment('test_increment', 2, 'compressed_memcached');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         $result = Cache::read('test_increment', 'compressed_memcached');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         Cache::delete('test_increment', 'compressed_memcached');
     }
@@ -970,7 +969,7 @@ class MemcachedEngineTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'memcached');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'memcached');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -232,7 +232,7 @@ class RedisEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::read('test', 'redis');
-        $this->assertEquals($data, $result);
+        $this->assertSame($data, $result);
 
         $data = [1, 2, 3];
         $this->assertTrue(Cache::write('array_data', $data, 'redis'));
@@ -313,7 +313,7 @@ class RedisEngineTest extends TestCase
         sleep(2);
         $result = Cache::read('long_expiry_test', 'redis');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
     }
 
     /**
@@ -365,16 +365,16 @@ class RedisEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'redis');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'redis');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'redis');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'redis');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     /**
@@ -386,16 +386,16 @@ class RedisEngineTest extends TestCase
     {
         Cache::delete('test_increment', 'redis');
         $result = Cache::increment('test_increment', 1, 'redis');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $result = Cache::read('test_increment', 'redis');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $result = Cache::increment('test_increment', 2, 'redis');
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
 
         $result = Cache::read('test_increment', 'redis');
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
     }
 
     /**
@@ -431,13 +431,13 @@ class RedisEngineTest extends TestCase
         Cache::delete('test_decrement', 'redis');
 
         $result = Cache::increment('test_increment', 1, 'redis');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
         $result = Cache::decrement('test_decrement', 1, 'redis');
-        $this->assertEquals(-1, $result);
+        $this->assertSame(-1, $result);
 
-        $this->assertEquals(1, Cache::read('test_increment', 'redis'));
-        $this->assertEquals(-1, Cache::read('test_decrement', 'redis'));
+        $this->assertSame(1, Cache::read('test_increment', 'redis'));
+        $this->assertSame(-1, Cache::read('test_decrement', 'redis'));
     }
 
     /**
@@ -596,7 +596,7 @@ class RedisEngineTest extends TestCase
 
         $expected = 'test data';
         $result = Cache::read('test_add_key', 'redis');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::add('test_add_key', 'test data 2', 'redis');
         $this->assertFalse($result);

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -78,7 +78,7 @@ class WincacheEngineTest extends TestCase
 
         $result = Cache::read('test', 'wincache');
         $expecting = '';
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'wincache');
@@ -86,7 +86,7 @@ class WincacheEngineTest extends TestCase
 
         $result = Cache::read('test', 'wincache');
         $expecting = $data;
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         Cache::delete('test', 'wincache');
     }
@@ -190,16 +190,16 @@ class WincacheEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::decrement('test_decrement', 1, 'wincache');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::read('test_decrement', 'wincache');
-        $this->assertEquals(4, $result);
+        $this->assertSame(4, $result);
 
         $result = Cache::decrement('test_decrement', 2, 'wincache');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
 
         $result = Cache::read('test_decrement', 'wincache');
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     /**
@@ -218,16 +218,16 @@ class WincacheEngineTest extends TestCase
         $this->assertTrue($result);
 
         $result = Cache::increment('test_increment', 1, 'wincache');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::read('test_increment', 'wincache');
-        $this->assertEquals(6, $result);
+        $this->assertSame(6, $result);
 
         $result = Cache::increment('test_increment', 2, 'wincache');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
 
         $result = Cache::read('test_increment', 'wincache');
-        $this->assertEquals(8, $result);
+        $this->assertSame(8, $result);
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -70,11 +70,11 @@ class CollectionTest extends TestCase
     public function testAvg($items)
     {
         $collection = new Collection($items);
-        $this->assertEquals(2, $collection->avg());
+        $this->assertSame(2, $collection->avg());
 
         $items = [['foo' => 1], ['foo' => 2], ['foo' => 3]];
         $collection = new Collection($items);
-        $this->assertEquals(2, $collection->avg('foo'));
+        $this->assertSame(2, $collection->avg('foo'));
     }
 
     /**
@@ -112,7 +112,7 @@ class CollectionTest extends TestCase
     public function testAvgWithMatcher($items)
     {
         $collection = new Collection($items);
-        $this->assertEquals(2, $collection->avg('foo'));
+        $this->assertSame(2, $collection->avg('foo'));
     }
 
     /**
@@ -139,7 +139,7 @@ class CollectionTest extends TestCase
     public function testMedian($items)
     {
         $collection = new Collection($items);
-        $this->assertEquals(4, $collection->median());
+        $this->assertSame(4, $collection->median());
     }
 
     /**
@@ -162,7 +162,7 @@ class CollectionTest extends TestCase
     public function testMedianEven($items)
     {
         $collection = new Collection($items);
-        $this->assertEquals(2.5, $collection->median());
+        $this->assertSame(2.5, $collection->median());
     }
 
     /**
@@ -194,7 +194,7 @@ class CollectionTest extends TestCase
      */
     public function testMedianWithMatcher($items)
     {
-        $this->assertEquals(333, (new Collection($items))->median('invoice.total'));
+        $this->assertSame(333, (new Collection($items))->median('invoice.total'));
     }
 
     /**
@@ -507,7 +507,7 @@ class CollectionTest extends TestCase
             ->method('__invoke')
             ->with(16, 4, 'd')
             ->will($this->returnValue(20));
-        $this->assertEquals(20, $collection->reduce($callable, 10));
+        $this->assertSame(20, $collection->reduce($callable, 10));
     }
 
     /**
@@ -535,7 +535,7 @@ class CollectionTest extends TestCase
             ->method('__invoke')
             ->with(6, 4, 'd')
             ->will($this->returnValue(10));
-        $this->assertEquals(10, $collection->reduce($callable));
+        $this->assertSame(10, $collection->reduce($callable));
     }
 
     /**
@@ -1023,7 +1023,7 @@ class CollectionTest extends TestCase
     {
         $list = (new Collection($list))->buffered();
         $collection = new Collection($list);
-        $this->assertEquals(8, $collection->append($list)->count());
+        $this->assertSame(8, $collection->append($list)->count());
     }
 
     /**
@@ -1036,7 +1036,7 @@ class CollectionTest extends TestCase
     {
         $list = (new Collection($list))->buffered();
         $collection = new Collection($list);
-        $this->assertEquals(4, $collection->append($list)->countKeys());
+        $this->assertSame(4, $collection->append($list)->countKeys());
     }
 
     /**
@@ -2139,12 +2139,12 @@ class CollectionTest extends TestCase
     public function testLast()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals(3, $collection->last());
+        $this->assertSame(3, $collection->last());
 
         $collection = $collection->map(function ($e) {
             return $e * 2;
         });
-        $this->assertEquals(6, $collection->last());
+        $this->assertSame(6, $collection->last());
     }
 
     /**
@@ -2166,7 +2166,7 @@ class CollectionTest extends TestCase
     public function testLastWithCountable()
     {
         $collection = new Collection(new ArrayObject([1, 2, 3]));
-        $this->assertEquals(3, $collection->last());
+        $this->assertSame(3, $collection->last());
     }
 
     /**
@@ -2189,7 +2189,7 @@ class CollectionTest extends TestCase
     {
         $iterator = new NoRewindIterator(new ArrayIterator([1, 2, 3]));
         $collection = new Collection($iterator);
-        $this->assertEquals(3, $collection->last());
+        $this->assertSame(3, $collection->last());
     }
 
     /**
@@ -2296,10 +2296,10 @@ class CollectionTest extends TestCase
     public function testSumOfWithIdentity()
     {
         $collection = new Collection([1, 2, 3]);
-        $this->assertEquals(6, $collection->sumOf());
+        $this->assertSame(6, $collection->sumOf());
 
         $collection = new Collection(['a' => 1, 'b' => 4, 'c' => 6]);
-        $this->assertEquals(11, $collection->sumOf());
+        $this->assertSame(11, $collection->sumOf());
     }
 
     /**

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -285,9 +285,9 @@ class PluginAssetsCommandsTest extends TestCase
 
         $this->exec('plugin assets copy');
 
-        $this->assertTrue(is_dir($this->wwwRoot . 'test_plugin'));
+        $this->assertDirectoryExists($this->wwwRoot . 'test_plugin');
 
-        $this->assertTrue(is_dir($this->wwwRoot . 'company' . DS . 'test_plugin_three'));
+        $this->assertDirectoryExists($this->wwwRoot . 'company' . DS . 'test_plugin_three');
 
         $this->exec('plugin assets remove');
 

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -313,7 +313,7 @@ class CommandCollectionTest extends TestCase
             'Duplicate shell was given a full alias'
         );
         $this->assertSame('TestPlugin\Shell\ExampleShell', $result['example']);
-        $this->assertEquals($result['example'], $result['test_plugin.example']);
+        $this->assertSame($result['example'], $result['test_plugin.example']);
         $this->assertSame('TestPlugin\Shell\SampleShell', $result['test_plugin.sample']);
 
         $result = $collection->discoverPlugin('Company/TestPluginThree');

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -349,9 +349,9 @@ class ConsoleIoTest extends TestCase
         if (DS === '\\') {
             $newLine = "\r\n";
         }
-        $this->assertEquals($this->io->nl(), $newLine);
-        $this->assertEquals($this->io->nl(2), $newLine . $newLine);
-        $this->assertEquals($this->io->nl(1), $newLine);
+        $this->assertSame($this->io->nl(), $newLine);
+        $this->assertSame($this->io->nl(2), $newLine . $newLine);
+        $this->assertSame($this->io->nl(1), $newLine);
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -44,7 +44,7 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertSame('A test', $parser->getDescription(), 'getting value is wrong.');
 
         $result = $parser->setDescription(['A test', 'something']);
-        $this->assertEquals("A test\nsomething", $parser->getDescription(), 'getting value is wrong.');
+        $this->assertSame("A test\nsomething", $parser->getDescription(), 'getting value is wrong.');
     }
 
     /**
@@ -61,7 +61,7 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertSame('A test', $parser->getEpilog(), 'getting value is wrong.');
 
         $result = $parser->setEpilog(['A test', 'something']);
-        $this->assertEquals("A test\nsomething", $parser->getEpilog(), 'getting value is wrong.');
+        $this->assertSame("A test\nsomething", $parser->getEpilog(), 'getting value is wrong.');
     }
 
     /**
@@ -1040,8 +1040,8 @@ TEXT;
         ];
         $parser = ConsoleOptionParser::buildFromArray($spec);
 
-        $this->assertEquals($spec['description'], $parser->getDescription());
-        $this->assertEquals($spec['epilog'], $parser->getEpilog());
+        $this->assertSame($spec['description'], $parser->getDescription());
+        $this->assertSame($spec['epilog'], $parser->getEpilog());
 
         $options = $parser->options();
         $this->assertArrayHasKey('name', $options);
@@ -1137,8 +1137,8 @@ TEXT;
         $parser = ConsoleOptionParser::buildFromArray($spec);
         $result = $parser->toArray();
 
-        $this->assertEquals($spec['description'], $result['description']);
-        $this->assertEquals($spec['epilog'], $result['epilog']);
+        $this->assertSame($spec['description'], $result['description']);
+        $this->assertSame($spec['epilog'], $result['epilog']);
 
         $options = $result['options'];
         $this->assertArrayHasKey('name', $options);

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -855,22 +855,22 @@ I am a test task, I dispatch another Shell
 I am a dispatched Shell
 
 TEXT;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $Shell->runCommand(['test_task_dispatch_array'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $Shell->runCommand(['test_task_dispatch_command_string'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $Shell->runCommand(['test_task_dispatch_command_array'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = <<<TEXT
 <info>Welcome to CakePHP Console</info>
@@ -882,7 +882,7 @@ TEXT;
         ob_start();
         $Shell->runCommand(['test_task_dispatch_with_param'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = <<<TEXT
 <info>Welcome to CakePHP Console</info>
@@ -894,7 +894,7 @@ TEXT;
         ob_start();
         $Shell->runCommand(['test_task_dispatch_with_multiple_params'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = <<<TEXT
 <info>Welcome to CakePHP Console</info>
@@ -906,7 +906,7 @@ TEXT;
         ob_start();
         $Shell->runCommand(['test_task_dispatch_with_requested_off'], true);
         $result = ob_get_clean();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1301,7 +1301,7 @@ TEXT;
         $this->Shell->tasks = ['TestApple'];
         $this->Shell->loadTasks();
         $expected = 'TestApple';
-        $this->assertEquals($expected, $this->Shell->TestApple->name);
+        $this->assertSame($expected, $this->Shell->TestApple->name);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -609,7 +609,7 @@ class AuthComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Auth->startup($event);
         $expected = Router::normalize($this->Auth->getConfig('loginRedirect'));
-        $this->assertEquals($expected, $this->Auth->redirectUrl());
+        $this->assertSame($expected, $this->Auth->redirectUrl());
 
         $this->Auth->getController()->getRequest()->getSession()->delete('Auth');
 
@@ -637,7 +637,7 @@ class AuthComponentTest extends TestCase
             '?' => ['redirect' => '/posts/view/1'],
         ], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
 
         // Auth.redirect gets set when accessing a protected action without being authenticated
         $this->Auth->getController()->getRequest()->getSession()->delete('Auth');
@@ -655,7 +655,7 @@ class AuthComponentTest extends TestCase
         $this->assertInstanceOf('Cake\Http\Response', $response);
         $expected = Router::url(['controller' => 'AuthTest', 'action' => 'login', '?' => ['redirect' => '/posts/view/1']], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     /**
@@ -682,7 +682,7 @@ class AuthComponentTest extends TestCase
         $this->assertInstanceOf('Cake\Http\Response', $response);
         $expected = Router::url(['controller' => 'AuthTest', 'action' => 'login', '?' => ['redirect' => '/foo/bar']], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     /**
@@ -706,7 +706,7 @@ class AuthComponentTest extends TestCase
         $this->assertInstanceOf('Cake\Http\Response', $response);
         $expected = Router::url(['controller' => 'AuthTest', 'action' => 'login'], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     public function testLoginRedirectQueryString(): void
@@ -730,7 +730,7 @@ class AuthComponentTest extends TestCase
             '?' => ['redirect' => '/posts/view/29?print=true&refer=menu'],
         ], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     public function testLoginRedirectQueryStringWithComplexLoginActionUrl(): void
@@ -755,7 +755,7 @@ class AuthComponentTest extends TestCase
             'passed-param',
             '?' => ['a' => 'b', 'redirect' => '/posts/view/29?print=true&refer=menu'],
         ], true);
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     public function testLoginRedirectDifferentBaseUrl(): void
@@ -795,7 +795,7 @@ class AuthComponentTest extends TestCase
 
         $expected = Router::url(['controller' => 'Users', 'action' => 'login', '?' => ['redirect' => '/posts/add']], true);
         $redirectHeader = $response->getHeaderLine('Location');
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
 
         $this->Auth->getController()->getRequest()->getSession()->delete('Auth');
         Configure::write('App', $appConfig);
@@ -1161,7 +1161,7 @@ class AuthComponentTest extends TestCase
             'action' => 'login',
             '?' => ['redirect' => '/admin/auth_test/add'],
         ], true);
-        $this->assertEquals($expected, $redirectHeader);
+        $this->assertSame($expected, $redirectHeader);
     }
 
     /**
@@ -1182,7 +1182,7 @@ class AuthComponentTest extends TestCase
         $response = $this->Auth->startup($event);
 
         $this->assertTrue($event->isStopped());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertSame(403, $response->getStatusCode());
         $this->assertFalse($response->hasHeader('Location'));
     }
 
@@ -1411,7 +1411,7 @@ class AuthComponentTest extends TestCase
         ];
         $this->Auth->setUser($user);
         $this->assertTrue((bool)$this->Auth->user());
-        $this->assertEquals($user['username'], $this->Auth->user('username'));
+        $this->assertSame($user['username'], $this->Auth->user('username'));
     }
 
     /**
@@ -1597,10 +1597,10 @@ class AuthComponentTest extends TestCase
             $this->assertEquals($data['User'], $result);
 
             $result = $this->Auth->user('username');
-            $this->assertEquals($data['User']['username'], $result);
+            $this->assertSame($data['User']['username'], $result);
 
             $result = $this->Auth->user('Group.name');
-            $this->assertEquals($data['User']['Group']['name'], $result);
+            $this->assertSame($data['User']['Group']['name'], $result);
 
             $result = $this->Auth->user('invalid');
             $this->assertNull($result);
@@ -1646,7 +1646,7 @@ class AuthComponentTest extends TestCase
         $response = $this->Auth->startup($event);
         $this->assertInstanceOf(Response::class, $response);
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://localhost/users/login?redirect=%2Fauth_test',
             $response->getHeaderLine('Location')
         );

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -212,7 +212,7 @@ class PaginatorComponentTest extends TestCase
             ->count();
         $result = $this->Paginator->paginate($table, $settings)->count();
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -789,7 +789,7 @@ class PaginatorComponentTest extends TestCase
         }
 
         $params = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(
+        $this->assertSame(
             1,
             $params['PaginatorPosts']['page'],
             'Page number should not be 0'
@@ -821,7 +821,7 @@ class PaginatorComponentTest extends TestCase
         }
 
         $params = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(
+        $this->assertSame(
             3,
             $params['PaginatorPosts']['pageCount'],
             'Page count number should not be 0'
@@ -1037,7 +1037,7 @@ class PaginatorComponentTest extends TestCase
         $result = $this->Paginator->validateSort($model, $options);
         $expected = 'model.author_id DESC';
 
-        $this->assertEquals($expected, $result['order']);
+        $this->assertSame($expected, $result['order']);
     }
 
     /**
@@ -1155,16 +1155,16 @@ class PaginatorComponentTest extends TestCase
         ]));
         $this->Paginator->paginate($table, $settings);
         $params = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(100, $params['PaginatorPosts']['limit']);
-        $this->assertEquals(100, $params['PaginatorPosts']['perPage']);
+        $this->assertSame(100, $params['PaginatorPosts']['limit']);
+        $this->assertSame(100, $params['PaginatorPosts']['perPage']);
 
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'limit' => '10',
         ]));
         $this->Paginator->paginate($table, $settings);
         $params = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(10, $params['PaginatorPosts']['limit']);
-        $this->assertEquals(10, $params['PaginatorPosts']['perPage']);
+        $this->assertSame(10, $params['PaginatorPosts']['limit']);
+        $this->assertSame(10, $params['PaginatorPosts']['perPage']);
     }
 
     /**
@@ -1194,8 +1194,8 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post', 'Third Post', 'Fourth Post'], $titleExtractor($result));
 
         $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(4, $result['PaginatorPosts']['current']);
-        $this->assertEquals(4, $result['PaginatorPosts']['count']);
+        $this->assertSame(4, $result['PaginatorPosts']['current']);
+        $this->assertSame(4, $result['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published'];
         $result = $this->Paginator->paginate($table, $settings);
@@ -1203,8 +1203,8 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post', 'Third Post'], $titleExtractor($result));
 
         $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(3, $result['PaginatorPosts']['current']);
-        $this->assertEquals(3, $result['PaginatorPosts']['count']);
+        $this->assertSame(3, $result['PaginatorPosts']['current']);
+        $this->assertSame(3, $result['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published', 'limit' => 2, 'page' => 2];
         $result = $this->Paginator->paginate($table, $settings);
@@ -1212,9 +1212,9 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['Third Post'], $titleExtractor($result));
 
         $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(1, $result['PaginatorPosts']['current']);
-        $this->assertEquals(3, $result['PaginatorPosts']['count']);
-        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
+        $this->assertSame(1, $result['PaginatorPosts']['current']);
+        $this->assertSame(3, $result['PaginatorPosts']['count']);
+        $this->assertSame(2, $result['PaginatorPosts']['pageCount']);
 
         $settings = ['finder' => 'published', 'limit' => 2];
         $result = $this->Paginator->paginate($table, $settings);
@@ -1222,12 +1222,12 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post'], $titleExtractor($result));
 
         $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(2, $result['PaginatorPosts']['current']);
-        $this->assertEquals(3, $result['PaginatorPosts']['count']);
-        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
+        $this->assertSame(2, $result['PaginatorPosts']['current']);
+        $this->assertSame(3, $result['PaginatorPosts']['count']);
+        $this->assertSame(2, $result['PaginatorPosts']['pageCount']);
         $this->assertTrue($result['PaginatorPosts']['nextPage']);
         $this->assertFalse($result['PaginatorPosts']['prevPage']);
-        $this->assertEquals(2, $result['PaginatorPosts']['perPage']);
+        $this->assertSame(2, $result['PaginatorPosts']['perPage']);
         $this->assertNull($result['PaginatorPosts']['limit']);
     }
 
@@ -1258,9 +1258,9 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertEquals(2, $result['PaginatorPosts']['current']);
-        $this->assertEquals(3, $result['PaginatorPosts']['count']);
-        $this->assertEquals(2, $result['PaginatorPosts']['pageCount']);
+        $this->assertSame(2, $result['PaginatorPosts']['current']);
+        $this->assertSame(3, $result['PaginatorPosts']['count']);
+        $this->assertSame(2, $result['PaginatorPosts']['pageCount']);
         $this->assertTrue($result['PaginatorPosts']['nextPage']);
         $this->assertFalse($result['PaginatorPosts']['prevPage']);
     }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -422,7 +422,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->RequestHandler->beforeRender(new Event('Controller.beforeRender', $this->Controller));
 
-        $this->assertEquals($extension, $this->RequestHandler->ext);
+        $this->assertSame($extension, $this->RequestHandler->ext);
         $this->assertSame('text/html', $this->Controller->getResponse()->getType());
 
         $view = $this->Controller->createView();
@@ -583,7 +583,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->setRequest($this->request->withHeader('Accept', 'application/xml;q=1.0'));
 
         $this->RequestHandler->renderAs($this->Controller, 'xml', ['attachment' => 'myfile.xml']);
-        $this->assertEquals(XmlView::class, $this->Controller->viewBuilder()->getClassName());
+        $this->assertSame(XmlView::class, $this->Controller->viewBuilder()->getClassName());
         $this->assertSame('application/xml', $this->Controller->getResponse()->getType());
         $this->assertSame('UTF-8', $this->Controller->getResponse()->getCharset());
         $this->assertStringContainsString('myfile.xml', $this->Controller->getResponse()->getHeaderLine('Content-Disposition'));
@@ -799,7 +799,7 @@ class RequestHandlerComponentTest extends TestCase
         $requestHandler = new RequestHandlerComponent($this->Controller->components());
         $requestHandler->beforeRender($event);
         $this->assertTrue($event->isStopped());
-        $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
+        $this->assertSame(304, $this->Controller->getResponse()->getStatusCode());
         $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-Type'), 'header should not be removed.');
     }
@@ -824,7 +824,7 @@ class RequestHandlerComponentTest extends TestCase
         $requestHandler = new RequestHandlerComponent($this->Controller->components());
         $requestHandler->beforeRender($event);
         $this->assertTrue($event->isStopped());
-        $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
+        $this->assertSame(304, $this->Controller->getResponse()->getStatusCode());
         $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-Type'));
     }
@@ -853,7 +853,7 @@ class RequestHandlerComponentTest extends TestCase
         $requestHandler->beforeRender($event);
         $this->assertTrue($event->isStopped());
 
-        $this->assertEquals(304, $this->Controller->getResponse()->getStatusCode());
+        $this->assertSame(304, $this->Controller->getResponse()->getStatusCode());
         $this->assertSame('', (string)$this->Controller->getResponse()->getBody());
         $this->assertFalse($this->Controller->getResponse()->hasHeader('Content-type'));
     }

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -285,7 +285,7 @@ class ComponentRegistryTest extends TestCase
         $this->Components->load('Auth');
         $this->assertInstanceOf(Countable::class, $this->Components);
         $count = count($this->Components);
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -321,12 +321,12 @@ class ControllerTest extends TestCase
         $Controller = new Controller();
         $uri = new Uri('/foo/bar');
         $response = $Controller->redirect($uri);
-        $this->assertEquals('http://localhost/foo/bar', $response->getHeaderLine('Location'));
+        $this->assertSame('http://localhost/foo/bar', $response->getHeaderLine('Location'));
 
         $Controller = new Controller();
         $uri = new Uri('http://cakephp.org/foo/bar');
         $response = $Controller->redirect($uri);
-        $this->assertEquals('http://cakephp.org/foo/bar', $response->getHeaderLine('Location'));
+        $this->assertSame('http://cakephp.org/foo/bar', $response->getHeaderLine('Location'));
     }
 
     /**
@@ -381,7 +381,7 @@ class ControllerTest extends TestCase
 
         $response = $Controller->redirect('http://cakephp.org', 301);
         $this->assertSame('https://book.cakephp.org', $response->getHeaderLine('Location'));
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
     }
 
     /**
@@ -402,7 +402,7 @@ class ControllerTest extends TestCase
         $response = $Controller->redirect('http://cakephp.org', 301);
 
         $this->assertSame('http://cakephp.org', $response->getHeaderLine('Location'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     public function testRedirectBeforeRedirectListenerReturnResponse(): void
@@ -997,11 +997,11 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new ServerRequest(), new Response());
         $Controller->getEventManager()->on('Controller.beforeRender', function ($event) {
-            $this->assertEquals(
+            $this->assertSame(
                 '/Element/test_element',
                 $event->getSubject()->viewBuilder()->getTemplate()
             );
-            $this->assertEquals(
+            $this->assertSame(
                 'default',
                 $event->getSubject()->viewBuilder()->getLayout()
             );

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -42,7 +42,7 @@ class AuthSecurityExceptionTest extends TestCase
      */
     public function testGetType(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'auth',
             $this->authSecurityException->getType(),
             '::getType should always return the type of `auth`.'

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -47,7 +47,7 @@ class SecurityExceptionTest extends TestCase
      */
     public function testGetType(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'secure',
             $this->securityException->getType(),
             '::getType should always return the type of `secure`.'
@@ -63,7 +63,7 @@ class SecurityExceptionTest extends TestCase
     {
         $sampleMessage = 'foo';
         $this->securityException->setMessage($sampleMessage);
-        $this->assertEquals(
+        $this->assertSame(
             $sampleMessage,
             $this->securityException->getMessage(),
             '::getMessage should always return the message set.'
@@ -79,7 +79,7 @@ class SecurityExceptionTest extends TestCase
     {
         $sampleReason = 'canary';
         $this->securityException->setReason($sampleReason);
-        $this->assertEquals(
+        $this->assertSame(
             $sampleReason,
             $this->securityException->getReason(),
             '::getReason should always return the reason set.'

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -133,7 +133,7 @@ class IniConfigTest extends TestCase
 
         $this->assertTrue(isset($config['database']['db']['username']));
         $this->assertSame('mark', $config['database']['db']['username']);
-        $this->assertEquals(3, $config['nesting']['one']['two']['three']);
+        $this->assertSame('3', $config['nesting']['one']['two']['three']);
         $this->assertFalse(isset($config['database.db.username']));
         $this->assertFalse(isset($config['database']['db.username']));
     }

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -77,7 +77,7 @@ class ConfigureTest extends TestCase
         $expected = 'ok';
         Configure::write('This.Key.Exists', $expected);
         $result = Configure::readOrFail('This.Key.Exists');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -103,7 +103,7 @@ class ConfigureTest extends TestCase
         Configure::write('level1.level2.level3_1', $expected);
         Configure::write('level1.level2.level3_2', 'something_else');
         $result = Configure::read('level1.level2.level3_1');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Configure::read('level1.level2.level3_2');
         $this->assertSame('something_else', $result);
@@ -121,7 +121,7 @@ class ConfigureTest extends TestCase
 
         $default = 'default';
         $result = Configure::read('something_I_just_made_up_now', $default);
-        $this->assertEquals($default, $result);
+        $this->assertSame($default, $result);
 
         $default = ['default'];
         $result = Configure::read('something_I_just_made_up_now', $default);
@@ -180,7 +180,7 @@ class ConfigureTest extends TestCase
 
         Configure::write('debug', true);
         $result = ini_get('display_errors');
-        $this->assertEquals('1', $result);
+        $this->assertSame('1', $result);
     }
 
     /**
@@ -395,13 +395,13 @@ class ConfigureTest extends TestCase
         $this->assertTrue($result);
         $expected = '/test_app/Plugin/TestPlugin/Config/load.php';
         $config = Configure::read('plugin_load');
-        $this->assertEquals($expected, $config);
+        $this->assertSame($expected, $config);
 
         $result = Configure::load('TestPlugin.more.load', 'test');
         $this->assertTrue($result);
         $expected = '/test_app/Plugin/TestPlugin/Config/more.load.php';
         $config = Configure::read('plugin_more_load');
-        $this->assertEquals($expected, $config);
+        $this->assertSame($expected, $config);
         $this->clearPlugins();
     }
 
@@ -621,7 +621,7 @@ class ConfigureTest extends TestCase
         $expected = 'ok';
         Configure::write('This.Key.Exists', $expected);
         $result = Configure::consumeOrFail('This.Key.Exists');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -204,7 +204,7 @@ class PluginCollectionTest extends TestCase
         $plugins = new PluginCollection();
         $path = $plugins->findPath('TestPlugin');
 
-        $this->assertEquals(TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS, $path);
+        $this->assertSame(TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS, $path);
     }
 
     public function testFindPathLoadsConfigureData()

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -57,7 +57,7 @@ class PluginTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         $instance = Plugin::getCollection()->get('TestPlugin');
-        $this->assertSame(TestPlugin::class, get_class($instance));
+        $this->assertInstanceOf(TestPlugin::class, $instance);
     }
 
     /**
@@ -69,7 +69,7 @@ class PluginTest extends TestCase
     {
         $this->loadPlugins(['TestPluginTwo']);
         $instance = Plugin::getCollection()->get('TestPluginTwo');
-        $this->assertSame(BasePlugin::class, get_class($instance));
+        $this->assertInstanceOf(BasePlugin::class, $instance);
     }
 
     /**

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -43,7 +43,7 @@ class CommandRetryTest extends TestCase
 
         $strategy = new \TestApp\Database\Retry\TestRetryStrategy(true);
         $retry = new CommandRetry($strategy, 2);
-        $this->assertEquals(2, $retry->run($action));
+        $this->assertSame(2, $retry->run($action));
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -39,7 +39,7 @@ class ModelAwareTraitTest extends TestCase
         $this->assertNull($stub->getModelClass());
 
         $stub->setProps('StubArticles');
-        $this->assertEquals('StubArticles', $stub->getModelClass());
+        $this->assertSame('StubArticles', $stub->getModelClass());
     }
 
     /**

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -67,8 +67,8 @@ class PaginatorTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post', 'Third Post', 'Fourth Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(4, $pagingParams['PaginatorPosts']['current']);
-        $this->assertEquals(4, $pagingParams['PaginatorPosts']['count']);
+        $this->assertSame(4, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(4, $pagingParams['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published'];
         $result = $this->Paginator->paginate($table, [], $settings);
@@ -76,8 +76,8 @@ class PaginatorTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post', 'Third Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(3, $pagingParams['PaginatorPosts']['current']);
-        $this->assertEquals(3, $pagingParams['PaginatorPosts']['count']);
+        $this->assertSame(3, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(3, $pagingParams['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published', 'limit' => 2, 'page' => 2];
         $result = $this->Paginator->paginate($table, [], $settings);
@@ -85,9 +85,9 @@ class PaginatorTest extends TestCase
         $this->assertEquals(['Third Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(1, $pagingParams['PaginatorPosts']['current']);
-        $this->assertEquals(3, $pagingParams['PaginatorPosts']['count']);
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['pageCount']);
+        $this->assertSame(1, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(3, $pagingParams['PaginatorPosts']['count']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['pageCount']);
 
         $settings = ['finder' => 'published', 'limit' => 2];
         $result = $this->Paginator->paginate($table, [], $settings);
@@ -95,12 +95,12 @@ class PaginatorTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['current']);
-        $this->assertEquals(3, $pagingParams['PaginatorPosts']['count']);
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['pageCount']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(3, $pagingParams['PaginatorPosts']['count']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['pageCount']);
         $this->assertTrue($pagingParams['PaginatorPosts']['nextPage']);
         $this->assertFalse($pagingParams['PaginatorPosts']['prevPage']);
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['perPage']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['perPage']);
         $this->assertNull($pagingParams['PaginatorPosts']['limit']);
     }
 
@@ -131,9 +131,9 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
-        $this->assertEquals(2, $result['current']);
-        $this->assertEquals(3, $result['count']);
-        $this->assertEquals(2, $result['pageCount']);
+        $this->assertSame(2, $result['current']);
+        $this->assertSame(3, $result['count']);
+        $this->assertSame(2, $result['pageCount']);
         $this->assertTrue($result['nextPage']);
         $this->assertFalse($result['prevPage']);
     }

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -83,8 +83,8 @@ class ResultSetDecoratorTest extends TestCase
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
 
-        $this->assertEquals(1, $decorator->first());
-        $this->assertEquals(1, $decorator->first());
+        $this->assertSame(1, $decorator->first());
+        $this->assertSame(1, $decorator->first());
     }
 
     /**
@@ -97,7 +97,7 @@ class ResultSetDecoratorTest extends TestCase
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
 
-        $this->assertEquals(3, $decorator->count());
+        $this->assertSame(3, $decorator->count());
         $this->assertCount(3, $decorator);
     }
 }

--- a/tests/TestCase/Datasource/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/SimplePaginatorTest.php
@@ -61,7 +61,7 @@ class SimplePaginatorTest extends PaginatorTest
         $this->assertEquals(['First Post', 'Second Post', 'Third Post', 'Fourth Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(4, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(4, $pagingParams['PaginatorPosts']['current']);
         $this->assertNull($pagingParams['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published'];
@@ -70,7 +70,7 @@ class SimplePaginatorTest extends PaginatorTest
         $this->assertEquals(['First Post', 'Second Post', 'Third Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(3, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(3, $pagingParams['PaginatorPosts']['current']);
         $this->assertNull($pagingParams['PaginatorPosts']['count']);
 
         $settings = ['finder' => 'published', 'limit' => 2, 'page' => 2];
@@ -79,7 +79,7 @@ class SimplePaginatorTest extends PaginatorTest
         $this->assertEquals(['Third Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(1, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(1, $pagingParams['PaginatorPosts']['current']);
         $this->assertNull($pagingParams['PaginatorPosts']['count']);
         $this->assertSame(0, $pagingParams['PaginatorPosts']['pageCount']);
 
@@ -89,12 +89,12 @@ class SimplePaginatorTest extends PaginatorTest
         $this->assertEquals(['First Post', 'Second Post'], $titleExtractor($result));
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['current']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['current']);
         $this->assertNull($pagingParams['PaginatorPosts']['count']);
-        $this->assertEquals(0, $pagingParams['PaginatorPosts']['pageCount']);
+        $this->assertSame(0, $pagingParams['PaginatorPosts']['pageCount']);
         $this->assertTrue($pagingParams['PaginatorPosts']['nextPage']);
         $this->assertFalse($pagingParams['PaginatorPosts']['prevPage']);
-        $this->assertEquals(2, $pagingParams['PaginatorPosts']['perPage']);
+        $this->assertSame(2, $pagingParams['PaginatorPosts']['perPage']);
         $this->assertNull($pagingParams['PaginatorPosts']['limit']);
     }
 
@@ -125,9 +125,9 @@ class SimplePaginatorTest extends PaginatorTest
         $this->assertEquals($expected, $result);
 
         $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
-        $this->assertEquals(2, $result['current']);
+        $this->assertSame(2, $result['current']);
         $this->assertNull($result['count']);
-        $this->assertEquals(0, $result['pageCount']);
+        $this->assertSame(0, $result['pageCount']);
         $this->assertTrue($result['nextPage']);
         $this->assertFalse($result['prevPage']);
     }

--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -79,7 +79,7 @@ class ConsoleErrorHandlerTest extends TestCase
             ->method('_stop');
 
         $this->Error->handleError(E_NOTICE, 'This is a notice error', '/some/file', 275);
-        $this->assertEquals($content, $this->stderr->messages()[0]);
+        $this->assertSame($content, $this->stderr->messages()[0]);
     }
 
     /**
@@ -94,7 +94,7 @@ class ConsoleErrorHandlerTest extends TestCase
 
         $this->Error->handleError(E_USER_ERROR, 'This is a fatal error', '/some/file', 275);
         $this->assertCount(1, $this->stderr->messages());
-        $this->assertEquals($content, $this->stderr->messages()[0]);
+        $this->assertSame($content, $this->stderr->messages()[0]);
         ob_end_clean();
     }
 
@@ -114,7 +114,7 @@ class ConsoleErrorHandlerTest extends TestCase
         $this->Error->handleException($exception);
 
         $this->assertCount(1, $this->stderr->messages());
-        $this->assertEquals($message, $this->stderr->messages()[0]);
+        $this->assertSame($message, $this->stderr->messages()[0]);
     }
 
     /**

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -71,6 +71,6 @@ object(MyObject) id:1 {
 }
 TEXT;
         $noescape = preg_replace('/\\033\[\d\;\d+\;m([^\\\\]+)\\033\[0m/', '$1', $expected);
-        $this->assertEquals($expected, $noescape);
+        $this->assertSame($expected, $noescape);
     }
 }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -670,7 +670,7 @@ object(TestApp\Error\Thing\DebuggableThing) id:0 {
   'inner' => object(TestApp\Error\Thing\DebuggableThing) id:1 {}
 }
 eos;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -714,7 +714,7 @@ eos;
         Debugger::setOutputMask(['password' => '[**********]']);
         $result = Debugger::exportVar(['password' => 'pass1234']);
         $expected = "['password'=>'[**********]']";
-        $this->assertEquals($expected, preg_replace('/\s+/', '', $result));
+        $this->assertSame($expected, preg_replace('/\s+/', '', $result));
     }
 
     /**
@@ -728,7 +728,7 @@ eos;
         $object = new SecurityThing();
         $result = Debugger::exportVar($object);
         $expected = "object(TestApp\\Error\\Thing\\SecurityThing)id:0{password=>'[**********]'}";
-        $this->assertEquals($expected, preg_replace('/\s+/', '', $result));
+        $this->assertSame($expected, preg_replace('/\s+/', '', $result));
     }
 
     /**
@@ -750,7 +750,7 @@ eos;
 EXPECTED;
         $expected = sprintf($expectedText, Debugger::trimPath(__FILE__), __LINE__ - 9);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         $value = '<div>this-is-a-test</div>';
@@ -768,7 +768,7 @@ EXPECTED;
 </div>
 EXPECTED;
         $expected = sprintf($expected, Debugger::trimPath(__FILE__), __LINE__ - 8);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         Debugger::printVar('<div>this-is-a-test</div>', [], true);
@@ -780,7 +780,7 @@ EXPECTED;
 </div>
 EXPECTED;
         $expected = sprintf($expected, Debugger::trimPath(__FILE__), __LINE__ - 8);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         Debugger::printVar('<div>this-is-a-test</div>', ['file' => __FILE__, 'line' => __LINE__], false);
@@ -793,7 +793,7 @@ EXPECTED;
 
 EXPECTED;
         $expected = sprintf($expected, Debugger::trimPath(__FILE__), __LINE__ - 9);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         ob_start();
         Debugger::printVar('<div>this-is-a-test</div>');
@@ -806,7 +806,7 @@ EXPECTED;
 
 EXPECTED;
         $expected = sprintf($expected, Debugger::trimPath(__FILE__), __LINE__ - 8);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -544,7 +544,7 @@ class ErrorHandlerTest extends TestCase
         $logger = $errorHandler->getLogger();
 
         $this->assertInstanceOf(ErrorLoggerInterface::class, $logger);
-        $this->assertEquals('value', $logger->getConfig('key'), 'config should be forwarded.');
+        $this->assertSame('value', $logger->getConfig('key'), 'config should be forwarded.');
         $this->assertSame($logger, $errorHandler->getLogger());
     }
 

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -139,7 +139,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->render();
         $controller = $ExceptionRenderer->__debugInfo()['controller'];
         $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
-        $this->assertEquals(
+        $this->assertSame(
             'Admin' . DIRECTORY_SEPARATOR . 'Error',
             $controller->viewBuilder()->getTemplatePath()
         );
@@ -174,11 +174,11 @@ class ExceptionRendererTest extends TestCase
 
         $result = $ExceptionRenderer->render();
 
-        $this->assertEquals(
+        $this->assertSame(
             'missingWidgetThing',
             $ExceptionRenderer->__debugInfo()['method']
         );
-        $this->assertEquals(
+        $this->assertSame(
             'widget thing is missing',
             (string)$result->getBody(),
             'Method declared in subclass converted to error400'
@@ -273,7 +273,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $response = $ExceptionRenderer->render();
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
         $this->assertFalse(method_exists($ExceptionRenderer, 'missingWidgetThing'), 'no method should exist.');
         $this->assertStringContainsString('coding fail', (string)$response->getBody(), 'Text should show up.');
     }
@@ -289,7 +289,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $result = $ExceptionRenderer->render();
 
-        $this->assertEquals(500, $result->getStatusCode());
+        $this->assertSame(500, $result->getStatusCode());
         $this->assertStringContainsString('foul ball.', (string)$result->getBody(), 'Text should show up as its debug mode.');
     }
 
@@ -308,7 +308,7 @@ class ExceptionRendererTest extends TestCase
         $response = $ExceptionRenderer->render();
         $result = (string)$response->getBody();
 
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
         $this->assertStringNotContainsString('foul ball.', $result, 'Text should no show up.');
         $this->assertStringContainsString('Internal Error', $result, 'Generic message only.');
     }
@@ -325,7 +325,7 @@ class ExceptionRendererTest extends TestCase
         $response = $ExceptionRenderer->render();
         $result = (string)$response->getBody();
 
-        $this->assertEquals(501, $response->getStatusCode());
+        $this->assertSame(501, $response->getStatusCode());
         $this->assertStringContainsString('foul ball.', $result, 'Text should show up as its debug mode.');
     }
 
@@ -347,7 +347,7 @@ class ExceptionRendererTest extends TestCase
         $response = $ExceptionRenderer->render();
         $result = (string)$response->getBody();
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
         $this->assertStringContainsString('<h2>Custom message</h2>', $result);
         $this->assertRegExp("/<strong>'.*?\/posts\/view\/1000'<\/strong>/", $result);
     }
@@ -380,7 +380,7 @@ class ExceptionRendererTest extends TestCase
             'line' => $exceptionLine,
         ];
         $this->assertEquals($expected, json_decode($result, true));
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -438,7 +438,7 @@ class ExceptionRendererTest extends TestCase
 
         $response = $ExceptionRenderer->render();
         $result = (string)$response->getBody();
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
         $this->assertStringContainsString('<h2>An Internal Error Has Occurred.</h2>', $result);
         $this->assertStringContainsString('An Internal Error Has Occurred.</p>', $result);
     }
@@ -475,7 +475,7 @@ class ExceptionRendererTest extends TestCase
 
         $result = (string)$ExceptionRenderer->render()->getBody();
 
-        $this->assertEquals(
+        $this->assertSame(
             'missingController',
             $ExceptionRenderer->__debugInfo()['template']
         );
@@ -499,7 +499,7 @@ class ExceptionRendererTest extends TestCase
 
         $result = (string)$ExceptionRenderer->render()->getBody();
 
-        $this->assertEquals(
+        $this->assertSame(
             'missingController',
             $ExceptionRenderer->__debugInfo()['template']
         );
@@ -874,7 +874,7 @@ class ExceptionRendererTest extends TestCase
         $result = $ExceptionRenderer->render();
 
         $this->assertStringContainsString('Internal Error', (string)$result->getBody());
-        $this->assertEquals(500, $result->getStatusCode());
+        $this->assertSame(500, $result->getStatusCode());
     }
 
     /**
@@ -965,7 +965,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $response = $ExceptionRenderer->render();
 
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
         $result = (string)$response->getBody();
         $this->assertStringContainsString('Database Error', $result);
         $this->assertStringContainsString('There was an error in the SQL query', $result);

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -141,7 +141,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         });
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf('Cake\Http\Response', $result);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
     }
 
@@ -159,7 +159,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         });
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals(302, $result->getStatusCode());
+        $this->assertSame(302, $result->getStatusCode());
         $this->assertEmpty((string)$result->getBody());
         $expected = [
             'location' => ['http://example.org/login'],
@@ -184,7 +184,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals(301, $result->getStatusCode());
+        $this->assertSame(301, $result->getStatusCode());
         $this->assertEmpty('' . $result->getBody());
         $expected = [
             'location' => ['http://example.org/login'],
@@ -210,7 +210,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         });
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf('Cake\Http\Response', $result);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
         $this->assertStringContainsString('"message": "whoops"', (string)$result->getBody());
         $this->assertStringContainsString('application/json', $result->getHeaderLine('Content-type'));
     }
@@ -246,7 +246,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
 
         $logs = $this->logger->read();
@@ -279,7 +279,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!', null, $previous);
         });
         $result = $middleware->process($request, $handler);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
 
         $logs = $this->logger->read();
@@ -314,7 +314,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
         $this->assertStringContainsString('was not found', '' . $result->getBody());
 
         $this->assertCount(0, $this->logger->read());
@@ -333,7 +333,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new MissingControllerException(['class' => 'Articles']);
         });
         $result = $middleware->process($request, $handler);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertSame(404, $result->getStatusCode());
 
         $logs = $this->logger->read();
         $this->assertStringContainsString(
@@ -371,7 +371,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new \Cake\Http\Exception\ServiceUnavailableException('whoops');
         });
         $response = $middleware->process($request, $handler);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('An Internal Server Error Occurred', '' . $response->getBody());
     }
 }

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -90,7 +90,7 @@ class ConditionDecoratorTest extends TestCase
         ]);
 
         EventManager::instance()->dispatch($event);
-        $this->assertEquals(2, $event->getData('counter'));
+        $this->assertSame(2, $event->getData('counter'));
     }
 
     /**

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -73,7 +73,7 @@ class FileTest extends TestCase
 
         $result = $this->File->name;
         $expecting = basename($file);
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         $result = $this->File->info();
         $expecting = [
@@ -98,7 +98,7 @@ class FileTest extends TestCase
 
         $result = $this->File->name();
         $expecting = 'LICENSE';
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
 
         $result = $this->File->md5();
         $expecting = md5_file($file);
@@ -156,7 +156,7 @@ class FileTest extends TestCase
             // Check the name after running __construct()
             $result = $File->name;
             $expecting = basename($path);
-            $this->assertEquals($expecting, $result);
+            $this->assertSame($expecting, $result);
         }
 
         // Check name()
@@ -168,10 +168,10 @@ class FileTest extends TestCase
             $File->info(); // to set and unset 'extension' in bellow
             unset($File->info['extension']);
 
-            $this->assertEquals(basename($path), $File->name());
+            $this->assertSame(basename($path), (string)$File->name());
         } else {
             $File->info['extension'] = $suffix;
-            $this->assertEquals(basename($path, '.' . $suffix), $File->name());
+            $this->assertSame(basename($path, '.' . $suffix), $File->name());
         }
     }
 
@@ -223,7 +223,7 @@ class FileTest extends TestCase
         $expecting = decoct(0664 & ~umask());
         $File = new File($file, true);
         $result = $File->perms();
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
         $File->delete();
 
         umask(0022);
@@ -231,7 +231,7 @@ class FileTest extends TestCase
         $expecting = decoct(0644 & ~umask());
         $File = new File($file, true);
         $result = $File->perms();
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
         $File->delete();
 
         umask(0422);
@@ -239,7 +239,7 @@ class FileTest extends TestCase
         $expecting = decoct(0244 & ~umask());
         $File = new File($file, true);
         $result = $File->perms();
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
         $File->delete();
 
         umask(0444);
@@ -247,7 +247,7 @@ class FileTest extends TestCase
         $expecting = decoct(0222 & ~umask());
         $File = new File($file, true);
         $result = $File->perms();
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
         $File->delete();
 
         umask($old);
@@ -271,18 +271,18 @@ class FileTest extends TestCase
         $this->File->lock = true;
         $result = $this->File->read();
         $expecting = file_get_contents(__FILE__);
-        $this->assertEquals(trim($expecting), $result);
+        $this->assertSame(trim($expecting), $result);
         $this->File->lock = null;
 
         $data = $expecting;
         $expecting = substr($data, 0, 3);
         $result = $this->File->read(3);
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
         $this->assertIsResource($this->File->handle);
 
         $expecting = substr($data, 3, 3);
         $result = $this->File->read(3);
-        $this->assertEquals($expecting, $result);
+        $this->assertSame($expecting, $result);
     }
 
     /**
@@ -311,7 +311,7 @@ class FileTest extends TestCase
         $expected = substr($data, 5, 3);
         $result = $this->File->read(3);
         $this->assertTrue($success);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->File->offset();
         $expected = 5 + 3;
@@ -358,7 +358,7 @@ class FileTest extends TestCase
         $this->File->handle = fopen(__FILE__, 'r');
         $this->assertIsResource($this->File->handle);
         $this->assertTrue($this->File->close());
-        $this->assertFalse(is_resource($this->File->handle));
+        $this->assertIsResource($this->File->handle);
     }
 
     /**

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -56,7 +56,7 @@ class FilesystemTest extends TestCase
     {
         $path = $this->vfsPath . DS . 'tests' . DS . 'first' . DS . 'second' . DS . 'third';
         $this->fs->mkdir($path);
-        $this->assertTrue(is_dir($path));
+        $this->assertDirectoryExists($path);
     }
 
     /**

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -75,15 +75,15 @@ class FolderTest extends TestCase
         $Folder = new Folder($path);
 
         $result = $Folder->pwd();
-        $this->assertEquals($path, $result);
+        $this->assertSame($path, $result);
 
         $result = Folder::addPathElement($path, 'test');
         $expected = $path . DS . 'test';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Folder->cd(ROOT);
         $expected = ROOT;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Folder->cd(ROOT . DS . 'non-existent');
         $this->assertFalse($result);
@@ -101,7 +101,7 @@ class FolderTest extends TestCase
         $Base = new Folder($basePath);
 
         $result = $Base->pwd();
-        $this->assertEquals($basePath, $result);
+        $this->assertSame($basePath, $result);
 
         // is "/" in "/tests/test_app/"
         $result = $Base->inPath(realpath(DS), true);
@@ -315,7 +315,7 @@ class FolderTest extends TestCase
 
         $expected = $new . ' is a file';
         $result = $Folder->errors();
-        $this->assertEquals($expected, $result[0]);
+        $this->assertSame($expected, $result[0]);
 
         $new = TMP . 'tests' . DS . 'test_folder_new';
         $result = $Folder->create($new);
@@ -415,21 +415,21 @@ class FolderTest extends TestCase
         $expected = DS . 'some' . DS . 'dir' . DS . 'another_path';
 
         $result = Folder::addPathElement(DS . 'some' . DS . 'dir', 'another_path');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, 'another_path');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Folder::addPathElement(DS . 'some' . DS . 'dir', ['another_path']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, ['another_path']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = DS . 'some' . DS . 'dir' . DS . 'another_path' . DS . 'and' . DS . 'another';
 
         $result = Folder::addPathElement(DS . 'some' . DS . 'dir', ['another_path', 'and', 'another']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -692,17 +692,17 @@ class FolderTest extends TestCase
         $path = '/path/to\file';
         $expected = '/path/to/file';
         $result = Folder::normalizeFullPath($path);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $path = '\\path\\to\file';
         $expected = '/path/to/file';
         $result = Folder::normalizeFullPath($path);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $path = 'C:\\path/to/file';
         $expected = 'C:\\path\\to\\file';
         $result = Folder::normalizeFullPath($path);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -858,7 +858,7 @@ class FolderTest extends TestCase
         $File->create();
         $File->write('something here');
         $File->close();
-        $this->assertEquals(14, $Folder->dirSize());
+        $this->assertSame(14, $Folder->dirSize());
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -89,15 +89,15 @@ class BaseApplicationTest extends TestCase
         $plugin = $app->getPlugins()->get('PluginJs');
         $this->assertInstanceOf(BasePlugin::class, $plugin);
 
-        $this->assertEquals(
+        $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS,
             $plugin->getPath()
         );
-        $this->assertEquals(
+        $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS . 'config' . DS,
             $plugin->getConfigPath()
         );
-        $this->assertEquals(
+        $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS . 'src' . DS,
             $plugin->getClassPath()
         );

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -88,7 +88,7 @@ class StreamTest extends TestCase
         $responses = $stream->send($request, []);
         $this->assertInstanceOf(Response::class, $responses[0]);
 
-        $this->assertEquals(20000, strlen($responses[0]->getStringBody()));
+        $this->assertSame(20000, strlen($responses[0]->getStringBody()));
     }
 
     /**
@@ -145,7 +145,7 @@ class StreamTest extends TestCase
             'Cookie: a=b; c=do%20it',
             'Connection: close',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
+        $this->assertSame(implode("\r\n", $expected), $result['header']);
         $this->assertSame(0, $result['max_redirects']);
         $this->assertTrue($result['ignore_errors']);
     }
@@ -175,7 +175,7 @@ class StreamTest extends TestCase
             'Connection: close',
             'User-Agent: CakePHP',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
+        $this->assertSame(implode("\r\n", $expected), $result['header']);
         $this->assertEquals($content, $result['content']);
     }
 
@@ -344,11 +344,11 @@ class StreamTest extends TestCase
         $this->assertSame('close', $responses[0]->getHeaderLine('Connection'));
         $this->assertSame('', (string)$responses[0]->getBody());
         $this->assertSame('', (string)$responses[1]->getBody());
-        $this->assertEquals($content, (string)$responses[2]->getBody());
+        $this->assertSame($content, (string)$responses[2]->getBody());
 
-        $this->assertEquals(302, $responses[0]->getStatusCode());
-        $this->assertEquals(302, $responses[1]->getStatusCode());
-        $this->assertEquals(200, $responses[2]->getStatusCode());
+        $this->assertSame(302, $responses[0]->getStatusCode());
+        $this->assertSame(302, $responses[1]->getStatusCode());
+        $this->assertSame(200, $responses[2]->getStatusCode());
 
         $this->assertSame('value', $responses[0]->getCookie('first'));
         $this->assertNull($responses[0]->getCookie('second'));

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -496,7 +496,7 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
             urldecode($result)
         );
         $expected = 0;
-        $this->assertEquals($expected, ftell($passphrase));
+        $this->assertSame($expected, ftell($passphrase));
     }
 
     /**
@@ -538,6 +538,6 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
             urldecode($result)
         );
         $expected = 0;
-        $this->assertEquals($expected, ftell($passphrase));
+        $this->assertSame($expected, ftell($passphrase));
     }
 }

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -35,7 +35,7 @@ class FormDataTest extends TestCase
         $this->assertRegExp('/^[a-f0-9]{32}$/', $result);
 
         $result2 = $data->boundary();
-        $this->assertEquals($result, $result2);
+        $this->assertSame($result, $result2);
     }
 
     /**
@@ -68,7 +68,7 @@ class FormDataTest extends TestCase
         $boundary = $data->boundary();
         $result = (string)$data;
         $expected = 'test=value&empty=&int=1&float=2.3&password=%40secret';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -89,7 +89,7 @@ class FormDataTest extends TestCase
         $this->assertCount(4, $data);
         $result = (string)$data;
         $expected = 'key=value&empty=&int=1&float=2.3';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -118,7 +118,7 @@ class FormDataTest extends TestCase
             '--' . $boundary . '--',
             '',
         ];
-        $this->assertEquals(implode("\r\n", $expected), (string)$data);
+        $this->assertSame(implode("\r\n", $expected), (string)$data);
     }
 
     /**
@@ -137,7 +137,7 @@ class FormDataTest extends TestCase
         $result = (string)$data;
         $expected = 'Article%5Btitle%5D=first+post&Article%5Bpublished%5D=Y&' .
             'Article%5Btags%5D%5B0%5D=blog&Article%5Btags%5D%5B1%5D=cakephp';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -164,7 +164,7 @@ class FormDataTest extends TestCase
             '--' . $boundary . '--',
             '',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result);
+        $this->assertSame(implode("\r\n", $expected), $result);
     }
 
     /**
@@ -194,7 +194,7 @@ class FormDataTest extends TestCase
             '--' . $boundary . '--',
             '',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result);
+        $this->assertSame(implode("\r\n", $expected), $result);
     }
 
     /**
@@ -208,7 +208,7 @@ class FormDataTest extends TestCase
         $data->add('key', 'value');
         $result = $data->contentType();
         $expected = 'application/x-www-form-urlencoded';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $file = CORE_PATH . 'VERSION.txt';
         $data = new FormData();
@@ -216,6 +216,6 @@ class FormDataTest extends TestCase
         $boundary = $data->boundary();
         $result = $data->contentType();
         $expected = 'multipart/form-data; boundary=' . $boundary;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 }

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -41,11 +41,11 @@ class ResponseTest extends TestCase
         $this->assertSame('1.0', $response->getProtocolVersion());
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('OK', $response->getReasonPhrase());
-        $this->assertEquals(
+        $this->assertSame(
             'text/html;charset="UTF-8"',
             $response->getHeaderLine('content-type')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Tue, 25 Dec 2012 04:43:47 GMT',
             $response->getHeaderLine('Date')
         );
@@ -68,16 +68,16 @@ class ResponseTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('1.0', $response->getProtocolVersion());
-        $this->assertEquals(
+        $this->assertSame(
             'text/html;charset="UTF-8"',
             $response->getHeaderLine('content-type')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Tue, 25 Dec 2012 04:43:47 GMT',
             $response->getHeaderLine('Date')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'text/html;charset="UTF-8"',
             $response->getHeaderLine('Content-Type')
         );
@@ -115,7 +115,7 @@ class ResponseTest extends TestCase
         ];
         $encoded = json_encode($data);
         $response = new Response([], $encoded);
-        $this->assertEquals($data['property'], $response->getJson()['property']);
+        $this->assertSame($data['property'], $response->getJson()['property']);
 
         $data = '';
         $response = new Response([], $data);
@@ -356,7 +356,7 @@ XML;
         $this->assertSame('soon', $result['value']);
         $this->assertTrue($result['httponly']);
         $this->assertTrue($result['secure']);
-        $this->assertEquals(
+        $this->assertSame(
             strtotime('Wed, 09-Jun-2021 10:18:14 GMT'),
             $result['expires']
         );

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
         $http = new Client($config);
         $result = $http->getConfig();
         foreach ($config as $key => $val) {
-            $this->assertEquals($val, $result[$key]);
+            $this->assertSame($val, $result[$key]);
         }
 
         $result = $http->setConfig([
@@ -59,7 +59,7 @@ class ClientTest extends TestCase
             'protocolVersion' => '1.1',
         ];
         foreach ($expected as $key => $val) {
-            $this->assertEquals($val, $result[$key]);
+            $this->assertSame($val, $result[$key]);
         }
     }
 
@@ -186,7 +186,7 @@ class ClientTest extends TestCase
         $http = new Client();
 
         $result = $http->buildUrl($url, $query, (array)$opts);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -214,12 +214,12 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('2', $request->getProtocolVersion());
                 $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
                 $this->assertSame('split=value', $request->getHeaderLine('Cookie'));
-                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
-                $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
+                $this->assertSame($headers['Content-Type'], $request->getHeaderLine('content-type'));
+                $this->assertSame($headers['Connection'], $request->getHeaderLine('connection'));
 
                 return true;
             }))
@@ -248,9 +248,9 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) {
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertEmpty($request->getHeaderLine('Content-Type'), 'Should have no content-type set');
-                $this->assertEquals(
+                $this->assertSame(
                     'http://cakephp.org/search',
                     $request->getUri() . ''
                 );
@@ -282,8 +282,8 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) {
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-                $this->assertEquals(
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(
                     'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
                     $request->getUri() . ''
                 );
@@ -318,7 +318,7 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) {
-                $this->assertEquals(
+                $this->assertSame(
                     'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
                     $request->getUri() . ''
                 );
@@ -355,7 +355,7 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) {
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/search', '' . $request->getUri());
                 $this->assertSame('some data', '' . $request->getBody());
 
@@ -415,10 +415,10 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/', '' . $request->getUri());
-                $this->assertEquals($headers['Authorization'], $request->getHeaderLine('Authorization'));
-                $this->assertEquals($headers['Proxy-Authorization'], $request->getHeaderLine('Proxy-Authorization'));
+                $this->assertSame($headers['Authorization'], $request->getHeaderLine('Authorization'));
+                $this->assertSame($headers['Proxy-Authorization'], $request->getHeaderLine('Proxy-Authorization'));
 
                 return true;
             }))
@@ -470,7 +470,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($method) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
-                $this->assertEquals($method, $request->getMethod());
+                $this->assertSame($method, $request->getMethod());
                 $this->assertSame('http://cakephp.org/projects/add', '' . $request->getUri());
 
                 return true;
@@ -521,9 +521,9 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
-                $this->assertEquals(Request::METHOD_POST, $request->getMethod());
-                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
-                $this->assertEquals($headers['Accept'], $request->getHeaderLine('Accept'));
+                $this->assertSame(Request::METHOD_POST, $request->getMethod());
+                $this->assertSame($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
+                $this->assertSame($headers['Accept'], $request->getHeaderLine('Accept'));
 
                 return true;
             }))
@@ -552,7 +552,7 @@ class ClientTest extends TestCase
         $mock->expects($this->any())
             ->method('send')
             ->with($this->callback(function ($request) use ($data) {
-                $this->assertEquals($data, '' . $request->getBody());
+                $this->assertSame($data, '' . $request->getBody());
                 $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
 
                 return true;
@@ -705,7 +705,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
-                $this->assertEquals(Request::METHOD_HEAD, $request->getMethod());
+                $this->assertSame(Request::METHOD_HEAD, $request->getMethod());
                 $this->assertSame('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
 
                 return true;
@@ -745,7 +745,7 @@ class ClientTest extends TestCase
             ->with(
                 $this->callback(function ($request) use ($url) {
                     $this->assertInstanceOf(Request::class, $request);
-                    $this->assertEquals($url, $request->getUri());
+                    $this->assertSame($url, (string)$request->getUri());
 
                     return true;
                 }),
@@ -767,7 +767,7 @@ class ClientTest extends TestCase
             ->with(
                 $this->callback(function ($request) use ($url) {
                     $this->assertInstanceOf(Request::class, $request);
-                    $this->assertEquals($url . '/redirect1?foo=bar', $request->getUri());
+                    $this->assertSame($url . '/redirect1?foo=bar', (string)$request->getUri());
 
                     return true;
                 }),
@@ -786,7 +786,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($url) {
                 $this->assertInstanceOf(Request::class, $request);
-                $this->assertEquals($url . '/redirect2#foo', $request->getUri());
+                $this->assertSame($url . '/redirect2#foo', (string)$request->getUri());
 
                 return true;
             }))
@@ -830,10 +830,10 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->callback(function ($request) use ($headers) {
                 $this->assertInstanceOf('Laminas\Diactoros\Request', $request);
-                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
-                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
-                $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
+                $this->assertSame($headers['Content-Type'], $request->getHeaderLine('content-type'));
+                $this->assertSame($headers['Connection'], $request->getHeaderLine('connection'));
 
                 return true;
             }))

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -88,7 +88,7 @@ class CookieTest extends TestCase
         $result = $cookie->toHeaderValue();
 
         $expected = 'cakephp=cakephp-rocks; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org; samesite=Strict; secure; httponly';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Http/CorsBuilderTest.php
+++ b/tests/TestCase/Http/CorsBuilderTest.php
@@ -171,7 +171,7 @@ class CorsBuilderTest extends TestCase
     protected function assertHeader($expected, Response $response, $header)
     {
         $this->assertTrue($response->hasHeader($header), 'Header key not found.');
-        $this->assertEquals($expected, $response->getHeaderLine($header), 'Header value not found.');
+        $this->assertSame($expected, $response->getHeaderLine($header), 'Header value not found.');
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -136,7 +136,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
         $cookies = CookieCollection::createFromHeader($response->getHeader('Set-Cookie'));
         $this->assertTrue($cookies->has('ninja'));
-        $this->assertEquals(
+        $this->assertSame(
             'shuriken',
             $this->_decrypt($cookies->get('ninja')->getValue(), 'aes')
         );
@@ -157,7 +157,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         });
         $response = $this->middleware->process($request, $handler);
         $this->assertNotSame('shuriken', $response->getCookie('ninja'));
-        $this->assertEquals(
+        $this->assertSame(
             'shuriken',
             $this->_decrypt($response->getCookie('ninja')['value'], 'aes')
         );

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -76,7 +76,7 @@ class ResponseTest extends TestCase
         $this->assertSame('UTF-8', $response->getCharset());
         $this->assertSame('text/html', $response->getType());
         $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $options = [
             'body' => 'This is the body',
@@ -89,7 +89,7 @@ class ResponseTest extends TestCase
         $this->assertSame('my-custom-charset', $response->getCharset());
         $this->assertSame('audio/mpeg', $response->getType());
         $this->assertSame('audio/mpeg', $response->getHeaderLine('Content-Type'));
-        $this->assertEquals(203, $response->getStatusCode());
+        $this->assertSame(203, $response->getStatusCode());
     }
 
     /**
@@ -119,15 +119,15 @@ class ResponseTest extends TestCase
         $response = new Response();
         $this->assertSame('text/html', $response->getType());
 
-        $this->assertEquals(
+        $this->assertSame(
             'application/pdf',
             $response->withType('pdf')->getType()
         );
-        $this->assertEquals(
+        $this->assertSame(
             'custom/stuff',
             $response->withType('custom/stuff')->getType()
         );
-        $this->assertEquals(
+        $this->assertSame(
             'application/json',
             $response->withType('json')->getType()
         );
@@ -165,7 +165,7 @@ class ResponseTest extends TestCase
     public function testWithTypeAlias()
     {
         $response = new Response();
-        $this->assertEquals(
+        $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
             'Default content-type should match'
@@ -194,17 +194,17 @@ class ResponseTest extends TestCase
     public function withTypeFull()
     {
         $response = new Response();
-        $this->assertEquals(
+        $this->assertSame(
             'application/json',
             $response->withType('application/json')->getHeaderLine('Content-Type'),
             'Should not add charset to explicit type'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'custom/stuff',
             $response->withType('custom/stuff')->getHeaderLine('Content-Type'),
             'Should allow arbitrary types'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'text/html; charset=UTF-8',
             $response->withType('text/html; charset=UTF-8')->getHeaderLine('Content-Type'),
             'Should allow charset types'
@@ -325,9 +325,9 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Date'));
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
-        $this->assertEquals(gmdate('D, j M Y G:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
-        $this->assertEquals(gmdate('D, j M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Last-Modified'));
-        $this->assertEquals(gmdate('D, j M Y H:i:s', $time) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame(gmdate('D, j M Y G:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
+        $this->assertSame(gmdate('D, j M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate('D, j M Y H:i:s', $time) . ' GMT', $new->getHeaderLine('Expires'));
         $this->assertSame('public, max-age=0', $new->getHeaderLine('Cache-Control'));
     }
 
@@ -370,7 +370,7 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Content-Disposition'), 'No mutation');
 
         $expected = 'attachment; filename="myfile.mp3"';
-        $this->assertEquals($expected, $new->getHeaderLine('Content-Disposition'));
+        $this->assertSame($expected, $new->getHeaderLine('Content-Disposition'));
     }
 
     /**
@@ -482,15 +482,15 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Expires'));
 
         $now->setTimeZone(new \DateTimeZone('UTC'));
-        $this->assertEquals($now->format($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame($now->format($format) . ' GMT', $new->getHeaderLine('Expires'));
 
         $now = time();
         $new = $response->withExpires($now);
-        $this->assertEquals(gmdate($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame(gmdate($format) . ' GMT', $new->getHeaderLine('Expires'));
 
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $new = $response->withExpires('+1 day');
-        $this->assertEquals($time->format($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame($time->format($format) . ' GMT', $new->getHeaderLine('Expires'));
     }
 
     /**
@@ -507,19 +507,19 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
         $now->setTimeZone(new \DateTimeZone('UTC'));
-        $this->assertEquals($now->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame($now->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
 
         $now = time();
         $new = $response->withModified($now);
-        $this->assertEquals(gmdate($format, $now) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate($format, $now) . ' GMT', $new->getHeaderLine('Last-Modified'));
 
         $now = new \DateTimeImmutable();
         $new = $response->withModified($now);
-        $this->assertEquals(gmdate($format, $now->getTimestamp()) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate($format, $now->getTimestamp()) . ' GMT', $new->getHeaderLine('Last-Modified'));
 
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $new = $response->withModified('+1 day');
-        $this->assertEquals($time->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame($time->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
     }
 
     /**
@@ -650,7 +650,7 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Content-Length'));
         $this->assertFalse($response->hasHeader('Modified'));
         $this->assertEmpty((string)$response->getBody());
-        $this->assertEquals(304, $response->getStatusCode());
+        $this->assertSame(304, $response->getStatusCode());
     }
 
     /**
@@ -842,7 +842,7 @@ class ResponseTest extends TestCase
         $this->assertSame('abc123', $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', 99));
-        $this->assertEquals(99, $new->getCookie('testing')['value']);
+        $this->assertSame(99, $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', false));
         $this->assertFalse($new->getCookie('testing')['value']);
@@ -950,7 +950,7 @@ class ResponseTest extends TestCase
 
         $expiredCookie = $response->withExpiredCookie($cookie);
 
-        $this->assertEquals($expected['expires'], $response->getCookie('testing')['expires']);
+        $this->assertSame($expected['expires'], (string)$response->getCookie('testing')['expires']);
         $this->assertLessThan(FrozenTime::createFromTimestamp(1), (string)$expiredCookie->getCookie('testing')['expires']);
     }
 
@@ -1158,16 +1158,16 @@ class ResponseTest extends TestCase
                 'download' => true,
             ]
         );
-        $this->assertEquals(
+        $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
             'No mutation'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'text/css; charset=UTF-8',
             $new->getHeaderLine('Content-Type')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="something_special.css"',
             $new->getHeaderLine('Content-Disposition')
         );
@@ -1177,9 +1177,9 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf('Laminas\Diactoros\Stream', $body);
 
         $expected = '/* this is the test asset css file */';
-        $this->assertEquals($expected, trim($body->getContents()));
+        $this->assertSame($expected, trim($body->getContents()));
         $file = $new->getFile()->openFile();
-        $this->assertEquals($expected, trim($file->fread(100)));
+        $this->assertSame($expected, trim($file->fread(100)));
     }
 
     /**
@@ -1192,14 +1192,14 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withFile(CONFIG . 'no_section.ini');
         $this->assertSame('text/html; charset=UTF-8', $new->getHeaderLine('Content-Type'));
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="no_section.ini"',
             $new->getHeaderLine('Content-Disposition')
         );
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $body = $new->getBody();
         $expected = "some_key = some_value\nbool_key = 1\n";
-        $this->assertEquals($expected, $body->getContents());
+        $this->assertSame($expected, $body->getContents());
     }
 
     /**
@@ -1214,7 +1214,7 @@ class ResponseTest extends TestCase
 
         $new = $response->withFile(CONFIG . 'no_section.ini');
         $this->assertSame('application/octet-stream', $new->getHeaderLine('Content-Type'));
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="no_section.ini"',
             $new->getHeaderLine('Content-Disposition')
         );
@@ -1245,7 +1245,7 @@ class ResponseTest extends TestCase
         $new = $response->withFile(CONFIG . 'no_section.ini', [
             'download' => false,
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'text/html; charset=UTF-8',
             $new->getHeaderLine('Content-Type')
         );
@@ -1311,7 +1311,7 @@ class ResponseTest extends TestCase
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
             ['download' => true]
         );
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
@@ -1335,7 +1335,7 @@ class ResponseTest extends TestCase
             ['download' => true]
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
@@ -1343,7 +1343,7 @@ class ResponseTest extends TestCase
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertSame('18', $new->getHeaderLine('Content-Length'));
         $this->assertSame('bytes 8-25/38', $new->getHeaderLine('Content-Range'));
-        $this->assertEquals(206, $new->getStatusCode());
+        $this->assertSame(206, $new->getStatusCode());
     }
 
     /**
@@ -1381,7 +1381,7 @@ class ResponseTest extends TestCase
             ['download' => true]
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
@@ -1389,7 +1389,7 @@ class ResponseTest extends TestCase
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertSame('38', $new->getHeaderLine('Content-Length'));
         $this->assertSame('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
-        $this->assertEquals(206, $new->getStatusCode());
+        $this->assertSame(206, $new->getStatusCode());
     }
 
     /**
@@ -1406,14 +1406,14 @@ class ResponseTest extends TestCase
             ['download' => true]
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename="test_asset.css"',
             $new->getHeaderLine('Content-Disposition')
         );
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertSame('bytes 0-37/38', $new->getHeaderLine('Content-Range'));
-        $this->assertEquals(416, $new->getStatusCode());
+        $this->assertSame(416, $new->getStatusCode());
     }
 
     /**
@@ -1472,18 +1472,18 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $statusCode = $response->getStatusCode();
-        $this->assertEquals(200, $statusCode);
+        $this->assertSame(200, $statusCode);
 
         $response2 = $response->withStatus(404);
         $statusCode = $response2->getStatusCode();
-        $this->assertEquals(404, $statusCode);
+        $this->assertSame(404, $statusCode);
 
         $statusCode = $response->getStatusCode();
-        $this->assertEquals(200, $statusCode);
+        $this->assertSame(200, $statusCode);
         $this->assertNotEquals($response, $response2);
 
         $response3 = $response->withStatus(111);
-        $this->assertEquals(111, $response3->getStatusCode());
+        $this->assertSame(111, $response3->getStatusCode());
         $this->assertSame('', $response3->getReasonPhrase());
     }
 
@@ -1687,9 +1687,9 @@ class ResponseTest extends TestCase
 
         $result = $response->getHeaderLine('Accept');
         $expected = 'application/json,application/xml';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         $result = $response->getHeaderLine('accept');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -1292,7 +1292,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame('born on.txt', $uploads['birth_cert']->getClientFilename());
         $this->assertSame(0, $uploads['birth_cert']->getError());
         $this->assertSame('application/octet-stream', $uploads['birth_cert']->getClientMediaType());
-        $this->assertEquals(123, $uploads['birth_cert']->getSize());
+        $this->assertSame(123, $uploads['birth_cert']->getSize());
     }
 
     /**
@@ -1319,7 +1319,7 @@ class ServerRequestFactoryTest extends TestCase
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
-        $this->assertEquals($files[0]['name'], $uploads[0]->getClientFilename());
+        $this->assertSame($files[0]['name'], $uploads[0]->getClientFilename());
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1024,8 +1024,8 @@ class ServerRequestTest extends TestCase
         $new = $request->withHeader('Content-Length', 999);
         $this->assertNotSame($new, $request);
 
-        $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
-        $this->assertEquals(999, $new->getHeaderLine('Content-length'), 'new request is correct');
+        $this->assertSame('1337', $request->getHeaderLine('Content-length'), 'old request is unchanged');
+        $this->assertSame('999', $new->getHeaderLine('Content-length'), 'new request is correct');
 
         $new = $request->withHeader('Double', ['a']);
         $this->assertEquals(['a'], $new->getHeader('Double'), 'List values are overwritten');
@@ -1075,7 +1075,7 @@ class ServerRequestTest extends TestCase
         $new = $request->withoutHeader('Content-Length');
         $this->assertNotSame($new, $request);
 
-        $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
+        $this->assertSame('1337', $request->getHeaderLine('Content-length'), 'old request is unchanged');
         $this->assertSame('', $new->getHeaderLine('Content-length'), 'new request is correct');
     }
 
@@ -1591,7 +1591,7 @@ XML;
         $this->deprecated(function () use ($request) {
             $result = $request->input('Cake\Utility\Xml::build', ['return' => 'domdocument']);
             $this->assertInstanceOf('DOMDocument', $result);
-            $this->assertEquals(
+            $this->assertSame(
                 'Test',
                 $result->getElementsByTagName('title')->item(0)->childNodes->item(0)->wholeText
             );
@@ -1989,11 +1989,11 @@ XML;
             ],
         ]);
         $result = $request->withData('Model.field.new_value', 'new value');
-        $this->assertEquals(
+        $this->assertSame(
             'new value',
             $result->getData('Model.field.new_value')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'new value',
             $result->getData()['Model']['field']['new_value']
         );
@@ -2135,7 +2135,7 @@ XML;
             ],
             'base' => '/basedir',
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             '/articles/view/1?comments=1&open=0',
             $request->getRequestTarget(),
             'Should not include basedir.'
@@ -2143,7 +2143,7 @@ XML;
 
         $new = $request->withRequestTarget('/articles/view/3');
         $this->assertNotSame($new, $request);
-        $this->assertEquals(
+        $this->assertSame(
             '/articles/view/1?comments=1&open=0',
             $request->getRequestTarget(),
             'should be unchanged.'

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -112,12 +112,12 @@ class ServerTest extends TestCase
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
         $res = $server->run($request);
-        $this->assertEquals(
+        $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
             'Input response is carried through out middleware'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'request header',
             $res->getHeaderLine('X-pass'),
             'Request is used in middleware'
@@ -151,12 +151,12 @@ class ServerTest extends TestCase
 
         $server = new Server($app);
         $res = $server->run($request);
-        $this->assertEquals(
+        $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
             'Input response is carried through out middleware'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'request header',
             $res->getHeaderLine('X-pass'),
             'Request is used in middleware'
@@ -176,7 +176,7 @@ class ServerTest extends TestCase
         $server = new Server($app);
 
         $res = $server->run();
-        $this->assertEquals(
+        $this->assertSame(
             'globalvalue',
             $res->getHeaderLine('X-pass'),
             'Default request is made from server'

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -127,7 +127,7 @@ class DatabaseSessionTest extends TestCase
 
         $result = $this->storage->read('foo');
         $expected = 'Some value';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->storage->read('made up value');
         $this->assertSame('', $result);
@@ -176,6 +176,6 @@ class DatabaseSessionTest extends TestCase
         $entity->value = 'something';
         $result = $this->storage->write('key', serialize($entity));
         $data = $this->getTableLocator()->get('Sessions')->get('key')->data;
-        $this->assertEquals(serialize($entity), stream_get_contents($data));
+        $this->assertSame(serialize($entity), stream_get_contents($data));
     }
 }

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -219,7 +219,7 @@ class SessionTest extends TestCase
             'three' => ['something'],
             'null' => null,
         ]);
-        $this->assertEquals(1, $session->read('one'));
+        $this->assertSame(1, $session->read('one'));
         $this->assertEquals(['something'], $session->read('three'));
         $this->assertNull($session->read('null'));
     }
@@ -567,7 +567,7 @@ class SessionTest extends TestCase
 
         new Session($config);
         $this->assertSame('0', ini_get('session.cookie_lifetime'));
-        $this->assertEquals(400 * 60, ini_get('session.gc_maxlifetime'));
+        $this->assertSame(400 * 60, (int)ini_get('session.gc_maxlifetime'));
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -78,11 +78,11 @@ class DateTest extends TestCase
         $time = '2015-01-22';
         $frozen = new FrozenDate($time);
         $subject = new $class($frozen);
-        $this->assertEquals($time, $subject->format('Y-m-d'), 'frozen date construction');
+        $this->assertSame($time, $subject->format('Y-m-d'), 'frozen date construction');
 
         $mut = new Date($time);
         $subject = new $class($mut);
-        $this->assertEquals($time, $subject->format('Y-m-d'), 'mutable date construction');
+        $this->assertSame($time, $subject->format('Y-m-d'), 'mutable date construction');
     }
 
     /**
@@ -96,16 +96,16 @@ class DateTest extends TestCase
         $time = new $class('Thu Jan 14 13:59:28 2010');
         $result = $time->i18nFormat();
         $expected = '1/14/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $format = [\IntlDateFormatter::NONE, \IntlDateFormatter::SHORT];
         $result = $time->i18nFormat($format);
         $expected = '12:00 AM';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $time->i18nFormat('HH:mm:ss', 'Australia/Sydney');
         $expected = '00:00:00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $class::setDefaultLocale('fr-FR');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
@@ -178,10 +178,10 @@ class DateTest extends TestCase
         $class::setJsonEncodeFormat(static function ($d) {
             return $d->format(DATE_ATOM);
         });
-        $this->assertEquals('"2015-11-06T00:00:00+00:00"', json_encode($date));
+        $this->assertSame('"2015-11-06T00:00:00+00:00"', json_encode($date));
 
         $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");
-        $this->assertEquals('"2015-11-06T00:00:00Z"', json_encode($date));
+        $this->assertSame('"2015-11-06T00:00:00Z"', json_encode($date));
     }
 
     /**
@@ -389,7 +389,7 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = 'at least 8 years ago';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('+4 months +2 weeks +3 days');
         $result = $date->timeAgoInWords([
@@ -398,7 +398,7 @@ class DateTest extends TestCase
             'end' => '+2 months',
         ]);
         $expected = 'exactly on ' . date('n/j/y', strtotime('+4 months +2 weeks +3 days'));
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -415,7 +415,7 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $date->timeAgoInWords([
@@ -423,7 +423,7 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $date->timeAgoInWords([
@@ -431,7 +431,7 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months, 2 weeks';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $date->timeAgoInWords([
@@ -439,7 +439,7 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months, 2 weeks, 3 days';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('+1 years +5 weeks');
         $result = $date->timeAgoInWords([
@@ -447,14 +447,14 @@ class DateTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '1 year';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('now');
         $result = $date->timeAgoInWords([
             'accuracy' => 'day',
         ]);
         $expected = 'today';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -513,7 +513,7 @@ class DateTest extends TestCase
         $date = new $class('-3 years -12 months');
         $result = $date->timeAgoInWords();
         $expected = 'on ' . $date->format('n/j/y');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('-1 month -1 week -6 days');
         $result = $date->timeAgoInWords(
@@ -526,7 +526,7 @@ class DateTest extends TestCase
             ['accuracy' => ['year' => 'year']]
         );
         $expected = 'on ' . $date->format('n/j/y');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $date = new $class('-13 months -5 days');
         $result = $date->timeAgoInWords(['end' => '2 years']);

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -69,8 +69,8 @@ class I18nTest extends TestCase
     {
         $newLocale = 'de_DE';
         I18n::setLocale($newLocale);
-        $this->assertEquals($newLocale, I18n::getLocale());
-        $this->assertEquals($this->locale, I18n::getDefaultLocale());
+        $this->assertSame($newLocale, I18n::getLocale());
+        $this->assertSame($this->locale, I18n::getDefaultLocale());
     }
 
     /**
@@ -183,13 +183,13 @@ class I18nTest extends TestCase
         ]);
 
         $translator = I18n::getTranslator('test_plugin');
-        $this->assertEquals(
+        $this->assertSame(
             'Plural Rule 1 (from plugin)',
             $translator->translate('Plural Rule 1')
         );
 
         $translator = I18n::getTranslator('company/test_plugin_three');
-        $this->assertEquals(
+        $this->assertSame(
             'String 1 (from plugin three)',
             $translator->translate('String 1')
         );
@@ -205,7 +205,7 @@ class I18nTest extends TestCase
     {
         $this->loadPlugins(['TestTheme']);
         $translator = I18n::getTranslator('test_theme');
-        $this->assertEquals(
+        $this->assertSame(
             'translated',
             $translator->translate('A Message')
         );
@@ -437,20 +437,20 @@ class I18nTest extends TestCase
         $this->assertSame('The letters A and B', __x('character', 'letters', 'A', 'B'));
         $this->assertSame('The letter A', __x('character', 'letter', 'A'));
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __x('communication', 'letters', ['Thomas', 'Sara'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __x('communication', 'letter', ['Thomas'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __x('communication', 'letters', 'Thomas', 'Sara')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __x('communication', 'letter', 'Thomas')
         );
@@ -539,20 +539,20 @@ class I18nTest extends TestCase
         $this->assertSame('The letters A and B', __xn('character', 'letter', 'letters', 2, ['A', 'B']));
         $this->assertSame('The letter A', __xn('character', 'letter', 'letters', 1, ['A']));
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __xn('communication', 'letter', 'letters', 2, ['Thomas', 'Sara'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __xn('communication', 'letter', 'letters', 1, ['Thomas'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __xn('communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __xn('communication', 'letter', 'letters', 1, 'Thomas')
         );
@@ -594,20 +594,20 @@ class I18nTest extends TestCase
         $this->assertSame('The letters A and B', __dx('custom', 'character', 'letters', ['A', 'B']));
         $this->assertSame('The letter A', __dx('custom', 'character', 'letter', ['A']));
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __dx('custom', 'communication', 'letters', ['Thomas', 'Sara'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __dx('custom', 'communication', 'letter', ['Thomas'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __dx('custom', 'communication', 'letters', 'Thomas', 'Sara')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __dx('custom', 'communication', 'letter', 'Thomas')
         );
@@ -645,29 +645,29 @@ class I18nTest extends TestCase
 
             return $package;
         }, 'en_US');
-        $this->assertEquals(
+        $this->assertSame(
             'The letters A and B',
             __dxn('custom', 'character', 'letter', 'letters', 2, ['A', 'B'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'The letter A',
             __dxn('custom', 'character', 'letter', 'letters', 1, ['A'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __dxn('custom', 'communication', 'letter', 'letters', 2, ['Thomas', 'Sara'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __dxn('custom', 'communication', 'letter', 'letters', 1, ['Thomas'])
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas and Sara',
             __dxn('custom', 'communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'She wrote a letter to Thomas',
             __dxn('custom', 'communication', 'letter', 'letters', 1, 'Thomas')
         );

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -76,35 +76,35 @@ class NumberTest extends TestCase
 
         $result = $this->Number->format($value);
         $expected = '100,100,100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->format($value, ['before' => '#']);
         $expected = '#100,100,100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->format($value, ['places' => 3]);
         $expected = '100,100,100.000';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->format($value, ['locale' => 'es_VE']);
         $expected = '100.100.100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = 0.00001;
         $result = $this->Number->format($value, ['places' => 1, 'before' => '$']);
         $expected = '$0.0';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = -0.00001;
         $result = $this->Number->format($value, ['places' => 1, 'before' => '$']);
         $expected = '$-0.0';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = 1.23;
         $options = ['locale' => 'fr_FR', 'after' => ' €'];
         $result = $this->Number->format($value, $options);
         $expected = '1,23 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -118,18 +118,18 @@ class NumberTest extends TestCase
         $value = '1.234.567,891';
         $result = $this->Number->parseFloat($value);
         $expected = 1234567.891;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         I18n::setLocale('pt_BR');
         $value = '1.234,37';
         $result = $this->Number->parseFloat($value);
         $expected = 1234.37;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = '1,234.37';
         $result = $this->Number->parseFloat($value, ['locale' => 'en_US']);
         $expected = 1234.37;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -143,38 +143,38 @@ class NumberTest extends TestCase
 
         $result = $this->Number->formatDelta($value, ['places' => 0]);
         $expected = '+100,100,100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->formatDelta($value, ['before' => '', 'after' => '']);
         $expected = '+100,100,100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->formatDelta($value, ['before' => '[', 'after' => ']']);
         $expected = '[+100,100,100]';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->formatDelta(-$value, ['before' => '[', 'after' => ']']);
         $expected = '[-100,100,100]';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->formatDelta(-$value, ['before' => '[ ', 'after' => ' ]']);
         $expected = '[ -100,100,100 ]';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = 0;
         $result = $this->Number->formatDelta($value, ['places' => 1, 'before' => '[', 'after' => ']']);
         $expected = '[0.0]';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = 0.0001;
         $result = $this->Number->formatDelta($value, ['places' => 1, 'before' => '[', 'after' => ']']);
         $expected = '[0.0]';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $value = 9876.1234;
         $result = $this->Number->formatDelta($value, ['places' => 1, 'locale' => 'de_DE']);
         $expected = '+9.876,1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -188,44 +188,44 @@ class NumberTest extends TestCase
 
         $result = $this->Number->currency($value);
         $expected = '$100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'USD');
         $expected = '$100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'EUR');
         $expected = '€100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'EUR', ['locale' => 'de_DE']);
         $expected = '100.100.100,00 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'USD', ['locale' => 'de_DE']);
         $expected = '100.100.100,00 $';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'USD', ['locale' => 'en_US']);
         $expected = '$100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'USD', ['locale' => 'en_CA']);
         $expected = 'US$100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['locale' => 'en_IN', 'pattern' => "Rs'.' #,##,###"];
         $result = $this->Number->currency($value, 'INR', $options);
         $expected = 'Rs. 10,01,00,100';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'GBP');
         $expected = '£100,100,100.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'GBP', ['locale' => 'da_DK']);
         $expected = '100.100.100,00 £';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['locale' => 'fr_FR', 'pattern' => 'EUR #,###.00'];
         $result = $this->Number->currency($value, 'EUR', $options);
@@ -246,50 +246,50 @@ class NumberTest extends TestCase
 
         $result = $this->Number->currency(0.5, 'USD', ['locale' => 'en_US', 'fractionSymbol' => 'c']);
         $expected = '50c';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['fractionSymbol' => ' cents'];
         $result = $this->Number->currency(0.2, 'USD', $options);
         $expected = '20 cents';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['fractionSymbol' => 'cents ', 'fractionPosition' => 'before'];
         $result = $this->Number->currency(0.2, null, $options);
         $expected = 'cents 20';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency(0.2, 'EUR');
         $expected = '€0.20';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['fractionSymbol' => false, 'fractionPosition' => 'before'];
         $result = $this->Number->currency(0.5, null, $options);
         $expected = '$0.50';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency(0, 'GBP');
         $expected = '£0.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency(0, 'GBP', ['pattern' => '¤#,###.00;¤-#,###.00']);
         $expected = '£.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency(0, 'GBP', ['pattern' => '¤#,##0.00;¤-#,##0.00']);
         $expected = '£0.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency(0.00000, 'GBP');
         $expected = '£0.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency('0.00000', 'GBP');
         $expected = '£0.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency('22.389', 'CAD');
         $expected = 'CA$22.39';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -302,19 +302,19 @@ class NumberTest extends TestCase
     {
         $result = $this->Number->currency('1.23', 'EUR', ['locale' => 'de_DE', 'places' => 3]);
         $expected = '1,230 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency('0.23', 'GBP', ['places' => 3, 'fractionSymbol' => 'p']);
         $expected = '23p';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency('0.001', 'GBP', ['places' => 3, 'fractionSymbol' => 'p']);
         $expected = '0p';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency('1.23', 'EUR', ['locale' => 'de_DE', 'precision' => 1]);
         $expected = '1,2 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -326,14 +326,14 @@ class NumberTest extends TestCase
     public function testDefaultCurrency()
     {
         $this->deprecated(function () {
-            $this->assertEquals('USD', $this->Number->defaultCurrency());
+            $this->assertSame('USD', $this->Number->defaultCurrency());
 
             $this->Number->defaultCurrency(false);
             I18n::setLocale('es_ES');
-            $this->assertEquals('EUR', $this->Number->defaultCurrency());
+            $this->assertSame('EUR', $this->Number->defaultCurrency());
 
             $this->Number->defaultCurrency('JPY');
-            $this->assertEquals('JPY', $this->Number->defaultCurrency());
+            $this->assertSame('JPY', $this->Number->defaultCurrency());
         });
     }
 
@@ -344,7 +344,7 @@ class NumberTest extends TestCase
      */
     public function testGetDefaultCurrency()
     {
-        $this->assertEquals('USD', $this->Number->getDefaultCurrency());
+        $this->assertSame('USD', $this->Number->getDefaultCurrency());
     }
 
     /**
@@ -356,10 +356,10 @@ class NumberTest extends TestCase
     {
         $this->Number->setDefaultCurrency();
         I18n::setLocale('es_ES');
-        $this->assertEquals('EUR', $this->Number->getDefaultCurrency());
+        $this->assertSame('EUR', $this->Number->getDefaultCurrency());
 
         $this->Number->setDefaultCurrency('JPY');
-        $this->assertEquals('JPY', $this->Number->getDefaultCurrency());
+        $this->assertSame('JPY', $this->Number->getDefaultCurrency());
     }
 
     /**
@@ -369,7 +369,7 @@ class NumberTest extends TestCase
      */
     public function testGetDefaultCurrencyFormat()
     {
-        $this->assertEquals('currency', $this->Number->getDefaultCurrencyFormat());
+        $this->assertSame('currency', $this->Number->getDefaultCurrencyFormat());
     }
 
     /**
@@ -380,9 +380,9 @@ class NumberTest extends TestCase
     public function testSetDefaultCurrencyFormat()
     {
         $this->Number->setDefaultCurrencyFormat(Number::FORMAT_CURRENCY_ACCOUNTING);
-        $this->assertEquals('currency_accounting', $this->Number->getDefaultCurrencyFormat());
+        $this->assertSame('currency_accounting', $this->Number->getDefaultCurrencyFormat());
 
-        $this->assertEquals('($123.45)', $this->Number->currency(-123.45));
+        $this->assertSame('($123.45)', $this->Number->currency(-123.45));
     }
 
     /**
@@ -396,11 +396,11 @@ class NumberTest extends TestCase
 
         $result = $this->Number->currency($value, 'EUR', ['locale' => 'de_DE']);
         $expected = '-0,99 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'USD', ['fractionSymbol' => 'c']);
         $expected = '-99c';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -414,11 +414,11 @@ class NumberTest extends TestCase
 
         $result = $this->Number->currency($value, 'USD');
         $expected = '$0.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'EUR', ['locale' => 'fr_FR']);
         $expected = '0,00 €';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -432,11 +432,11 @@ class NumberTest extends TestCase
 
         $result = $this->Number->currency($value, null, ['before' => 'Total: ']);
         $expected = 'Total: $1,234,567.89';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, null, ['after' => ' in Total']);
         $expected = '$1,234,567.89 in Total';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -450,15 +450,15 @@ class NumberTest extends TestCase
         $value = '123';
         $result = $this->Number->currency($value, 'USD', ['useIntlCode' => true]);
         $expected = 'USD 123.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'EUR', ['useIntlCode' => true]);
         $expected = 'EUR 123.00';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->currency($value, 'EUR', ['useIntlCode' => true, 'locale' => 'da_DK']);
         $expected = '123,00 EUR';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -482,55 +482,55 @@ class NumberTest extends TestCase
     {
         $result = $this->Number->toPercentage(45, 0);
         $expected = '45%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(45, 2);
         $expected = '45.00%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0, 0);
         $expected = '0%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0, 4);
         $expected = '0.0000%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(45, 0, ['multiply' => false]);
         $expected = '45%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(45, 2, ['multiply' => false]);
         $expected = '45.00%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0, 0, ['multiply' => false]);
         $expected = '0%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0, 4, ['multiply' => false]);
         $expected = '0.0000%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0.456, 0, ['multiply' => true]);
         $expected = '46%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0.456, 2, ['multiply' => true]);
         $expected = '45.60%';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0.456, 2, ['locale' => 'de-DE', 'multiply' => true]);
         $expected = '45,60 %';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(13, 0, ['locale' => 'fi_FI']);
         $expected = '13 %';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toPercentage(0.13, 0, ['locale' => 'fi_FI', 'multiply' => true]);
         $expected = '13 %';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -542,63 +542,63 @@ class NumberTest extends TestCase
     {
         $result = $this->Number->toReadableSize(0);
         $expected = '0 Bytes';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1);
         $expected = '1 Byte';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(45);
         $expected = '45 Bytes';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1023);
         $expected = '1,023 Bytes';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024);
         $expected = '1 KB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 + 123);
         $expected = '1.12 KB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 512);
         $expected = '512 KB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 - 1);
         $expected = '1 MB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024);
         $expected = '512.05 MB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 - 1);
         $expected = '1 GB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 512);
         $expected = '512 GB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 - 1);
         $expected = '1 TB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 512);
         $expected = '512 TB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 - 1);
         $expected = '1,024 TB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 * 1024);
         $expected = '1,048,576 TB';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -84,19 +84,19 @@ class TimeTest extends TestCase
         $time = '2015-01-22 10:33:44.123456';
         $frozen = new FrozenTime($time, 'America/Chicago');
         $subject = new $class($frozen);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'frozen time construction');
+        $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'frozen time construction');
 
         $mut = new Time($time, 'America/Chicago');
         $subject = new $class($mut);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
+        $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
 
         $mut = new Chronos($time, 'America/Chicago');
         $subject = new $class($mut);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
+        $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
 
         $mut = new \DateTime($time, new \DateTimeZone('America/Chicago'));
         $subject = new $class($mut);
-        $this->assertEquals($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
+        $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'mutable time construction');
     }
 
     /**
@@ -242,7 +242,7 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = 'at least 8 years ago';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
@@ -251,7 +251,7 @@ class TimeTest extends TestCase
             'end' => '+2 months',
         ]);
         $expected = 'exactly on ' . date('n/j/y', strtotime('+4 months +2 weeks +3 days'));
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -268,7 +268,7 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
@@ -276,7 +276,7 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
@@ -284,7 +284,7 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months, 2 weeks';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
@@ -292,7 +292,7 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '8 years, 4 months, 2 weeks, 3 days';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+1 years +5 weeks');
         $result = $time->timeAgoInWords([
@@ -300,21 +300,21 @@ class TimeTest extends TestCase
             'end' => '+10 years',
         ]);
         $expected = '1 year';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+58 minutes');
         $result = $time->timeAgoInWords([
             'accuracy' => 'hour',
         ]);
         $expected = 'in about an hour';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+23 hours');
         $result = $time->timeAgoInWords([
             'accuracy' => 'day',
         ]);
         $expected = 'in about a day';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('+20 days');
         $result = $time->timeAgoInWords(['accuracy' => 'month']);
@@ -373,7 +373,7 @@ class TimeTest extends TestCase
         $time = new $class('-3 years -12 months');
         $result = $time->timeAgoInWords();
         $expected = 'on ' . $time->format('n/j/y');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('-1 month -1 week -6 days');
         $result = $time->timeAgoInWords(
@@ -386,7 +386,7 @@ class TimeTest extends TestCase
             ['accuracy' => ['year' => 'year']]
         );
         $expected = 'on ' . $time->format('n/j/y');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $time = new $class('-13 months -5 days');
         $result = $time->timeAgoInWords(['end' => '2 years']);
@@ -784,10 +784,10 @@ class TimeTest extends TestCase
         $class::setJsonEncodeFormat(static function ($t) {
             return $t->format(DATE_ATOM);
         });
-        $this->assertEquals('"2014-04-20T10:10:10+00:00"', json_encode($time));
+        $this->assertSame('"2014-04-20T10:10:10+00:00"', json_encode($time));
 
         $class::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssZZZZZ");
-        $this->assertEquals('"2014-04-20T10:10:10Z"', json_encode($time));
+        $this->assertSame('"2014-04-20T10:10:10Z"', json_encode($time));
     }
 
     /**

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -75,7 +75,7 @@ class ConsoleLogTest extends TestCase
             'stream' => $output,
             'outputAs' => ConsoleOutput::RAW,
         ]);
-        $this->assertEquals(ConsoleOutput::RAW, $log->getConfig('outputAs'));
+        $this->assertSame(ConsoleOutput::RAW, $log->getConfig('outputAs'));
     }
 
     /**

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -167,21 +167,21 @@ class FileLogTest extends TestCase
         $log->log('warning', 'Test warning one');
         $result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
         $expected = '0666';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         unlink($path . 'error.log');
 
         $log = new FileLog(['path' => $path, 'mask' => 0644]);
         $log->log('warning', 'Test warning two');
         $result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
         $expected = '0644';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         unlink($path . 'error.log');
 
         $log = new FileLog(['path' => $path, 'mask' => 0640]);
         $log->log('warning', 'Test warning three');
         $result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
         $expected = '0640';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         unlink($path . 'error.log');
     }
 

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1006,10 +1006,10 @@ class EmailTest extends TestCase
         $this->assertEquals($config['from'], $result);
 
         $result = $this->Email->getSubject();
-        $this->assertEquals($config['subject'], $result);
+        $this->assertSame($config['subject'], $result);
 
         $result = $this->Email->viewBuilder()->getTheme();
-        $this->assertEquals($config['theme'], $result);
+        $this->assertSame($config['theme'], $result);
 
         $result = $this->Email->getTransport();
         $this->assertInstanceOf('Cake\Mailer\Transport\DebugTransport', $result);
@@ -1059,7 +1059,7 @@ class EmailTest extends TestCase
         $this->assertEquals($expected, array_keys($result));
         $expected = "Here is my body, with multi lines.\r\nThis is the second line.\r\n\r\nAnd the last.\r\n\r\n";
 
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertStringContainsString('Date: ', $result['headers']);
         $this->assertStringContainsString('Message-ID: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);
@@ -1933,7 +1933,7 @@ class EmailTest extends TestCase
         $configs = ['from' => 'root@cakephp.org', 'message' => 'Message from configs', 'transport' => 'debug'];
         $instance = Email::deliver('all@cakephp.org', 'About', null, $configs, true);
         $message = $instance->message();
-        $this->assertEquals($configs['message'], $message[0]);
+        $this->assertSame($configs['message'], $message[0]);
     }
 
     /**
@@ -2048,7 +2048,7 @@ class EmailTest extends TestCase
         $this->assertEquals($configs['from'], $result);
 
         $result = $this->Email->getSubject();
-        $this->assertEquals($configs['subject'], $result);
+        $this->assertSame($configs['subject'], $result);
 
         $result = $this->Email->getTransport();
         $this->assertInstanceOf('Cake\Mailer\Transport\DebugTransport', $result);
@@ -2078,7 +2078,7 @@ class EmailTest extends TestCase
         $template = $this->Email->viewBuilder()->getTemplate();
         $layout = $this->Email->viewBuilder()->getLayout();
         $this->assertNull($template);
-        $this->assertEquals($configs['layout'], $layout);
+        $this->assertSame($configs['layout'], $layout);
     }
 
     /**
@@ -2105,7 +2105,7 @@ class EmailTest extends TestCase
         $this->assertEquals($configs['from'], $result);
 
         $result = $this->Email->getSubject();
-        $this->assertEquals($configs['subject'], $result);
+        $this->assertSame($configs['subject'], $result);
 
         $result = $this->Email->getTransport();
         $this->assertInstanceOf('Cake\Mailer\Transport\DebugTransport', $result);
@@ -2531,7 +2531,7 @@ class EmailTest extends TestCase
         $result = $this->Email->send($message);
         $expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('x', Message::LINE_LENGTH_MUST - 26) . "\r\n" .
             str_repeat('x', 26) . "\r\n</a>\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $str1 = 'a ';
@@ -2541,21 +2541,21 @@ class EmailTest extends TestCase
 
         $result = $this->Email->send($message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length) . $str2;
 
         $result = $this->Email->send($message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . $str2;
 
         $result = $this->Email->send($message);
         $expected = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . sprintf("\r\n%s\r\n\r\n", trim($str2));
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -2584,7 +2584,7 @@ HTML;
         $message = str_replace("\r\n", "\n", substr($message, 0, -9));
         $message = str_replace("\n", "\r\n", $message);
         $expected = "{$message}\r\nxxxxxxxxx\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -2608,7 +2608,7 @@ HTML;
         $result = $this->Email->send($message);
         $message = substr($message, 0, -1);
         $expected = "{$message}\r\nx\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -2633,7 +2633,7 @@ HTML;
         $this->Email->setHeaderCharset('iso-2022-jp');
         $result = $this->Email->send($message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
     }
 
     /**
@@ -2670,7 +2670,7 @@ HTML;
         $this->Email->setSubject('Wordwrap Test');
         $result = $this->Email->send($message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -198,7 +198,7 @@ class MailerTest extends TestCase
         $this->assertEquals($configs['from'], $result);
 
         $result = $this->mailer->getSubject();
-        $this->assertEquals($configs['subject'], $result);
+        $this->assertSame($configs['subject'], $result);
 
         $result = $this->mailer->getTransport();
         $this->assertInstanceOf(DebugTransport::class, $result);
@@ -228,7 +228,7 @@ class MailerTest extends TestCase
         $template = $this->mailer->viewBuilder()->getTemplate();
         $layout = $this->mailer->viewBuilder()->getLayout();
         $this->assertNull($template);
-        $this->assertEquals($configs['layout'], $layout);
+        $this->assertSame($configs['layout'], $layout);
     }
 
     /**
@@ -255,7 +255,7 @@ class MailerTest extends TestCase
         $this->assertEquals($configs['from'], $result);
 
         $result = $this->mailer->getSubject();
-        $this->assertEquals($configs['subject'], $result);
+        $this->assertSame($configs['subject'], $result);
 
         $result = $this->mailer->getTransport();
         $this->assertInstanceOf('Cake\Mailer\Transport\DebugTransport', $result);
@@ -334,10 +334,10 @@ class MailerTest extends TestCase
         $this->assertEquals($config['from'], $result);
 
         $result = $this->mailer->getSubject();
-        $this->assertEquals($config['subject'], $result);
+        $this->assertSame($config['subject'], $result);
 
         $result = $this->mailer->viewBuilder()->getTheme();
-        $this->assertEquals($config['theme'], $result);
+        $this->assertSame($config['theme'], $result);
 
         $result = $this->mailer->getTransport();
         $this->assertInstanceOf(DebugTransport::class, $result);
@@ -490,7 +490,7 @@ class MailerTest extends TestCase
         $this->assertEquals($expected, array_keys($result));
         $expected = "Here is my body, with multi lines.\r\nThis is the second line.\r\n\r\nAnd the last.\r\n\r\n";
 
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertStringContainsString('Date: ', $result['headers']);
         $this->assertStringContainsString('Message-ID: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);
@@ -1207,7 +1207,7 @@ class MailerTest extends TestCase
             ->will($this->returnValue([]));
 
         $mailer->send('test', ['foo', 'bar']);
-        $this->assertEquals('test', $mailer->viewBuilder()->getTemplate());
+        $this->assertSame('test', $mailer->viewBuilder()->getTemplate());
     }
 
     /**
@@ -1266,7 +1266,7 @@ class MailerTest extends TestCase
 
         $result = $this->mailer->deliver($message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
     }
 
     /**
@@ -1414,7 +1414,7 @@ class MailerTest extends TestCase
         $this->assertEquals($expected, array_keys($result));
         $expected = "Here is my body, with multi lines.\r\nThis is the second line.\r\n\r\nAnd the last.\r\n\r\n";
 
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertStringContainsString('Date: ', $result['headers']);
         $this->assertStringContainsString('Message-ID: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -140,7 +140,7 @@ class MessageTest extends TestCase
 
         $expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('x', Message::LINE_LENGTH_MUST - 26) . "\r\n" .
             str_repeat('x', 26) . "\r\n</a>\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $str1 = 'a ';
@@ -152,7 +152,7 @@ class MessageTest extends TestCase
 
         $result = $transort->send($this->message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length) . $str2;
@@ -161,7 +161,7 @@ class MessageTest extends TestCase
 
         $result = $transort->send($this->message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
 
         $message = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . $str2;
@@ -170,7 +170,7 @@ class MessageTest extends TestCase
 
         $result = $transort->send($this->message);
         $expected = $str1 . str_repeat('x', Message::LINE_LENGTH_MUST - $length + 1) . sprintf("\r\n%s\r\n\r\n", trim($str2));
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -199,7 +199,7 @@ HTML;
         $message = str_replace("\r\n", "\n", substr($message, 0, -9));
         $message = str_replace("\n", "\r\n", $message);
         $expected = "{$message}\r\nxxxxxxxxx\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -222,7 +222,7 @@ HTML;
         $result = (new DebugTransport())->send($this->message);
         $message = substr($message, 0, -1);
         $expected = "{$message}\r\nx\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
         $this->assertLineLengths($result['message']);
     }
 
@@ -246,7 +246,7 @@ HTML;
 
         $result = (new DebugTransport())->send($this->message);
         $expected = "{$message}\r\n\r\n";
-        $this->assertEquals($expected, $result['message']);
+        $this->assertSame($expected, $result['message']);
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -74,7 +74,7 @@ class DebugTransportTest extends TestCase
 
         $result = $this->DebugTransport->send($message);
 
-        $this->assertEquals($headers, $result['headers']);
-        $this->assertEquals($data, $result['message']);
+        $this->assertSame($headers, $result['headers']);
+        $this->assertSame($data, $result['message']);
     }
 }

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -462,7 +462,7 @@ class SmtpTransportTest extends TestCase
         ]);
         $expected = $this->SmtpTransport->getConfig();
 
-        $this->assertEquals(666, $expected['port']);
+        $this->assertSame(666, $expected['port']);
 
         $this->SmtpTransport->setConfig([]);
         $result = $this->SmtpTransport->getConfig();

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -511,7 +511,7 @@ class SocketTest extends TestCase
 
         $this->assertTrue($result['ssl']['verify_peer']);
         $this->assertFalse($result['ssl']['allow_self_signed']);
-        $this->assertEquals(5, $result['ssl']['verify_depth']);
+        $this->assertSame(5, $result['ssl']['verify_depth']);
         $this->assertSame('smtp.gmail.com', $result['ssl']['CN_match']);
         $this->assertArrayNotHasKey('ssl_verify_peer', $socket->getConfig());
         $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->getConfig());

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -72,7 +72,7 @@ class AssetTest extends TestCase
         Configure::write('Foo.bar', 'test');
         Configure::write('Asset.timestamp', false);
         $result = Asset::assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', false);
@@ -81,7 +81,7 @@ class AssetTest extends TestCase
         $this->assertSame('/%3Cb%3E/cake.generic.css', $result);
 
         $result = Asset::assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', true);
@@ -94,7 +94,7 @@ class AssetTest extends TestCase
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
         $result = Asset::assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
 
         $request = Router::getRequest()->withAttribute('webroot', '/some/dir/');
         Router::setRequest($request);
@@ -112,13 +112,13 @@ class AssetTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $result = Asset::url('js/post.js', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
 
         $result = Asset::url('foo.jpg', ['pathPrefix' => 'img/']);
         $this->assertSame('/img/foo.jpg', $result);
 
         $result = Asset::url('foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/foo.jpg', $result);
 
         $result = Asset::url('style', ['ext' => '.css']);
         $this->assertSame('/style.css', $result);
@@ -175,7 +175,7 @@ class AssetTest extends TestCase
 
         $result = Asset::url('img/cake.icon.png', ['fullBase' => true]);
         $expected = Configure::read('App.fullBaseUrl') . '/cake_dev/app/webroot/img/cake.icon.png';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -204,7 +204,7 @@ class AssetTest extends TestCase
     public function testAssetUrlFullBase()
     {
         $result = Asset::url('img/foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = Asset::url('img/foo.jpg', ['fullBase' => 'https://xyz/']);
         $this->assertSame('https://xyz/img/foo.jpg', $result);
@@ -234,7 +234,7 @@ class AssetTest extends TestCase
         $timestamp = false;
 
         $result = Asset::assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $timestamp);
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
     }
 
     /**
@@ -273,7 +273,7 @@ class AssetTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $result = Asset::scriptUrl('post.js', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
     }
 
     /**
@@ -300,7 +300,7 @@ class AssetTest extends TestCase
         $timestamp = false;
 
         $result = Asset::scriptUrl('script.js', ['timestamp' => $timestamp]);
-        $this->assertEquals('/' . Configure::read('App.jsBaseUrl') . 'script.js', $result);
+        $this->assertSame('/' . Configure::read('App.jsBaseUrl') . 'script.js', $result);
     }
 
     /**
@@ -314,7 +314,7 @@ class AssetTest extends TestCase
         $this->assertSame('/img/foo.jpg', $result);
 
         $result = Asset::imageUrl('foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = Asset::imageUrl('dir/sub dir/my image.jpg');
         $this->assertSame('/img/dir/sub%20dir/my%20image.jpg', $result);
@@ -406,16 +406,16 @@ class AssetTest extends TestCase
     {
         $result = Asset::webroot('/img/cake.power.gif');
         $expected = '/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Asset::webroot('/img/cake.power.gif', ['theme' => 'TestTheme']);
         $expected = '/test_theme/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Asset::setInflectionType('dasherize');
         $result = Asset::webroot('/img/test.jpg', ['theme' => 'TestTheme']);
         $expected = '/test-theme/img/test.jpg';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Asset::setInflectionType('underscore');
 
         $webRoot = Configure::read('App.wwwRoot');
@@ -423,19 +423,19 @@ class AssetTest extends TestCase
 
         $result = Asset::webroot('/img/cake.power.gif', ['theme' => 'TestTheme']);
         $expected = '/test_theme/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Asset::webroot('/img/test.jpg', ['theme' => 'TestTheme']);
         $expected = '/test_theme/img/test.jpg';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Asset::webroot('/img/cake.icon.gif', ['theme' => 'TestTheme']);
         $expected = '/img/cake.icon.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Asset::webroot('/img/cake.icon.gif?some=param', ['theme' => 'TestTheme']);
         $expected = '/img/cake.icon.gif?some=param';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Configure::write('App.wwwRoot', $webRoot);
     }

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -66,7 +66,7 @@ class AssetMiddlewareTest extends TestCase
 
         $body = $res->getBody()->getContents();
         $this->assertSame('', $body);
-        $this->assertEquals(304, $res->getStatusCode());
+        $this->assertSame(304, $res->getStatusCode());
         $this->assertNotEmpty($res->getHeaderLine('Last-Modified'));
     }
 
@@ -152,23 +152,23 @@ class AssetMiddlewareTest extends TestCase
         $middleware = new AssetMiddleware(['cacheTime' => '+4 hours']);
         $res = $middleware->process($request, $handler);
 
-        $this->assertEquals(
+        $this->assertSame(
             'application/javascript',
             $res->getHeaderLine('Content-Type')
         );
-        $this->assertEquals(
+        $this->assertSame(
             gmdate('D, j M Y G:i:s ', $time) . 'GMT',
             $res->getHeaderLine('Date')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'public,max-age=' . ($expires - $time),
             $res->getHeaderLine('Cache-Control')
         );
-        $this->assertEquals(
+        $this->assertSame(
             gmdate('D, j M Y G:i:s ', $modified) . 'GMT',
             $res->getHeaderLine('Last-Modified')
         );
-        $this->assertEquals(
+        $this->assertSame(
             gmdate('D, j M Y G:i:s ', $expires) . 'GMT',
             $res->getHeaderLine('Expires')
         );

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -69,7 +69,7 @@ class RoutingMiddlewareTest extends TestCase
         $middleware = new RoutingMiddleware($this->app());
         $response = $middleware->process($request, $handler);
 
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
         $this->assertSame('http://localhost/subdir/pages', $response->getHeaderLine('Location'));
     }
 
@@ -90,7 +90,7 @@ class RoutingMiddlewareTest extends TestCase
         $middleware = new RoutingMiddleware($this->app());
         $response = $middleware->process($request, $handler);
 
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
         $this->assertSame('http://localhost/pages', $response->getHeaderLine('Location'));
     }
 

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -117,7 +117,7 @@ class DashedRouteTest extends TestCase
             1,
         ]);
         $expected = '/admin/subscriptions/edit-admin-e/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $route = new DashedRoute('/:controller/:action-:id');
         $result = $route->match([
@@ -207,7 +207,7 @@ class DashedRouteTest extends TestCase
             'action' => 'actionName',
         ]);
         $expectedUrl = '/plugin/controller-name/action-name';
-        $this->assertEquals($expectedUrl, $url);
+        $this->assertSame($expectedUrl, $url);
         $result = $route->parse($expectedUrl, 'GET');
         $this->assertSame('ControllerName', $result['controller']);
         $this->assertSame('actionName', $result['action']);

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -117,7 +117,7 @@ class InflectedRouteTest extends TestCase
             1,
         ]);
         $expected = '/admin/subscriptions/edit_admin_e/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $route = new InflectedRoute('/:controller/:action-:id');
         $result = $route->match([
@@ -222,7 +222,7 @@ class InflectedRouteTest extends TestCase
             'action' => 'action_name',
         ]);
         $expectedUrl = '/plugin/controller_name/action_name';
-        $this->assertEquals($expectedUrl, $url);
+        $this->assertSame($expectedUrl, $url);
         $result = $route->parse($expectedUrl, 'GET');
         $this->assertSame('ControllerName', $result['controller']);
         $this->assertSame('action_name', $result['action']);

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -249,6 +249,6 @@ class RedirectRouteTest extends TestCase
         $route = new RedirectRoute('/home', ['controller' => 'posts']);
         $result = $route->setStatus(302);
         $this->assertSame($result, $route);
-        $this->assertEquals(302, $route->options['status']);
+        $this->assertSame(302, $route->options['status']);
     }
 }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -82,7 +82,7 @@ class RouteTest extends TestCase
         $route = new Route('/', ['controller' => 'pages', 'action' => 'display', 'home']);
         $result = $route->compile();
         $expected = '#^/*$#';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         $this->assertEquals([], $route->keys);
 
         $route = new Route('/:controller/:action', ['controller' => 'posts']);
@@ -348,7 +348,7 @@ class RouteTest extends TestCase
     {
         $route = new ProtectedRoute('/:controller/:action/*', [], ['_ext' => $ext]);
         [$outUrl, $outExt] = $route->parseExtension($url);
-        $this->assertEquals($url, $outUrl);
+        $this->assertSame($url, $outUrl);
         $this->assertNull($outExt);
     }
 
@@ -630,7 +630,7 @@ class RouteTest extends TestCase
         $url = ['controller' => 'subscribe', 'prefix' => 'admin', 'action' => 'edit', 1];
         $result = $route->match($url);
         $expected = '/admin/subscriptions/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $url = [
             'controller' => 'subscribe',
@@ -640,7 +640,7 @@ class RouteTest extends TestCase
         ];
         $result = $route->match($url);
         $expected = '/admin/subscriptions/edit_admin_e/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1045,7 +1045,7 @@ class RouteTest extends TestCase
             'action' => 'view',
             'id' => "\xC4\x81",
         ]);
-        $this->assertEquals("/articles/view/\xC4\x81", $result);
+        $this->assertSame("/articles/view/\xC4\x81", $result);
     }
 
     /**
@@ -1063,7 +1063,7 @@ class RouteTest extends TestCase
             'controller' => 'Articles',
             'action' => 'foo',
         ]);
-        $this->assertEquals('/anything', $result);
+        $this->assertSame('/anything', $result);
     }
 
     /**
@@ -1089,7 +1089,7 @@ class RouteTest extends TestCase
             ],
         ]);
         $expected = '/posts/index/0?test=var&amp;var2=test2&amp;more=test+data';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         ini_set('arg_separator.output', $restore);
     }
 
@@ -1431,7 +1431,7 @@ class RouteTest extends TestCase
 
         $result = $route->match($url);
         $expected = '/foo/bar';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1449,7 +1449,7 @@ class RouteTest extends TestCase
             $id,
         ]);
         $expected = '/pages/test/%20spaces/%E6%BC%A2%E5%AD%97/la%E2%80%A0%C3%AEn';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -223,7 +223,7 @@ class RouteBuilderTest extends TestCase
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
-        $this->assertEquals($url, '/' . $this->collection->match($expected, []));
+        $this->assertSame($url, '/' . $this->collection->match($expected, []));
     }
 
     /**
@@ -247,7 +247,7 @@ class RouteBuilderTest extends TestCase
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
-        $this->assertEquals($url, '/' . $this->collection->match($expected, []));
+        $this->assertSame($url, '/' . $this->collection->match($expected, []));
     }
 
     /**
@@ -270,7 +270,7 @@ class RouteBuilderTest extends TestCase
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
-        $this->assertEquals($url, '/' . $this->collection->match($expected, []));
+        $this->assertSame($url, '/' . $this->collection->match($expected, []));
     }
 
     /**
@@ -294,7 +294,7 @@ class RouteBuilderTest extends TestCase
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
-        $this->assertEquals($url, '/' . $this->collection->match($expected, []));
+        $this->assertSame($url, '/' . $this->collection->match($expected, []));
     }
 
     /**
@@ -599,7 +599,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('Articles', $all[0]->defaults['controller']);
         $this->assertSame('/api/posts', $all[0]->template);
         $this->assertSame('/api/posts/:id', $all[2]->template);
-        $this->assertEquals(
+        $this->assertSame(
             '/api/posts/:article_id/comments',
             $all[6]->template,
             'parameter name should reflect resource name'

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -235,7 +235,7 @@ class RouterTest extends TestCase
             '_method' => 'GET',
         ]);
         $expected = '/posts';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'controller' => 'Posts',
@@ -244,15 +244,15 @@ class RouterTest extends TestCase
             'id' => '10',
         ]);
         $expected = '/posts/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'Posts', 'action' => 'add', '_method' => 'POST']);
         $expected = '/posts';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'Posts', 'action' => 'edit', '_method' => 'PUT', 'id' => '10']);
         $expected = '/posts/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'controller' => 'Posts',
@@ -261,7 +261,7 @@ class RouterTest extends TestCase
             'id' => '10',
         ]);
         $expected = '/posts/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'controller' => 'Posts',
@@ -270,7 +270,7 @@ class RouterTest extends TestCase
             'id' => '10',
         ]);
         $expected = '/posts/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -285,16 +285,16 @@ class RouterTest extends TestCase
         $expected = '/users/logout';
 
         $result = Router::normalize('/users/logout/');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::normalize('//users//logout//');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::normalize('users/logout');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::normalize(['controller' => 'users', 'action' => 'logout']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::normalize('/');
         $this->assertSame('/', $result);
@@ -454,7 +454,7 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
         $result = Router::url(['controller' => 'pages', 'action' => 'display', 'about']);
         $expected = '/pages/about';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:plugin/:id/*', ['controller' => 'posts', 'action' => 'view'], ['id' => $ID]);
@@ -466,7 +466,7 @@ class RouterTest extends TestCase
             'id' => '1',
         ]);
         $expected = '/cake_plugin/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => 'cake_plugin',
@@ -476,26 +476,26 @@ class RouterTest extends TestCase
             '0',
         ]);
         $expected = '/cake_plugin/1/0';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller/:action/:id', [], ['id' => $ID]);
 
         $result = Router::url(['controller' => 'posts', 'action' => 'view', 'id' => '1']);
         $expected = '/posts/view/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller/:id', ['action' => 'view']);
 
         $result = Router::url(['controller' => 'posts', 'action' => 'view', 'id' => '1']);
         $expected = '/posts/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::connect('/view/*', ['controller' => 'posts', 'action' => 'view']);
         $result = Router::url(['controller' => 'posts', 'action' => 'view', '1']);
         $expected = '/view/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller/:action');
@@ -510,7 +510,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['action' => 'login']);
         $expected = '/users/login';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/contact/:action', ['plugin' => 'contact', 'controller' => 'contact']);
@@ -522,7 +522,7 @@ class RouterTest extends TestCase
         ]);
 
         $expected = '/contact/me';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller', ['action' => 'index']);
@@ -537,7 +537,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'myothercontroller']);
         $expected = '/myothercontroller';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -551,7 +551,7 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
         $result = Router::url(['controller' => 'Articles', 'action' => 'view', 'id' => 10]);
         $expected = '/articles/10';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -569,7 +569,7 @@ class RouterTest extends TestCase
             '?' => ['var' => 'test', 'var2' => 'test2'],
         ]);
         $expected = '/posts/index/0?var=test&var2=test2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'posts', '0', '?' => ['var' => null]]);
         $this->assertSame('/posts/index/0', $result);
@@ -584,7 +584,7 @@ class RouterTest extends TestCase
             '#' => 'unencoded string %',
         ]);
         $expected = '/posts/index/0?var=test&var2=test2#unencoded string %';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -614,11 +614,11 @@ class RouterTest extends TestCase
 
         $result = Router::url(['admin' => false, 'language' => 'dan', 'action' => 'index', 'controller' => 'galleries']);
         $expected = '/dan/galleries';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['admin' => false, 'language' => 'eng', 'action' => 'index', 'controller' => 'galleries']);
         $expected = '/eng/galleries';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect(
@@ -630,14 +630,14 @@ class RouterTest extends TestCase
 
         $result = Router::url(['language' => 'eng', 'action' => 'index', 'controller' => 'pages']);
         $expected = '/eng/pages';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['language' => 'eng', 'controller' => 'pages']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['language' => 'eng', 'controller' => 'pages', 'action' => 'add']);
         $expected = '/eng/pages/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect(
@@ -655,7 +655,7 @@ class RouterTest extends TestCase
             'min-forestilling',
         ]);
         $expected = '/forestillinger/10/2007/min-forestilling';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect(
@@ -667,7 +667,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'min-forestilling']);
         $expected = '/kalender/min-forestilling';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => 'shows',
@@ -678,7 +678,7 @@ class RouterTest extends TestCase
             'min-forestilling',
         ]);
         $expected = '/kalender/10/2007/min-forestilling';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -710,7 +710,7 @@ class RouterTest extends TestCase
 
         $result = Router::url([]);
         $expected = '/admin/registrations/index';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/subscriptions/:action/*', ['controller' => 'Subscribe', 'prefix' => 'Admin']);
@@ -731,11 +731,11 @@ class RouterTest extends TestCase
 
         $result = Router::url(['action' => 'edit', 1]);
         $expected = '/magazine/admin/subscriptions/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['prefix' => 'Admin', 'controller' => 'users', 'action' => 'login']);
         $expected = '/magazine/admin/users/login';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         $request = new ServerRequest([
@@ -754,7 +754,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['prefix' => 'admin', 'controller' => 'pages', 'action' => 'view', 'my-page']);
         $expected = '/page/my-page';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
@@ -773,7 +773,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
         $expected = '/admin/pages/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
@@ -791,7 +791,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
         $expected = '/admin/pages/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/:controller/:action/:id', ['prefix' => 'admin'], ['id' => '[0-9]+']);
@@ -809,7 +809,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'id' => '284']);
         $expected = '/admin/pages/edit/284';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
@@ -824,7 +824,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
         $expected = '/admin/pages/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
@@ -839,7 +839,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 284]);
         $expected = '/admin/pages/edit/284';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/admin/posts/*', ['controller' => 'posts', 'action' => 'index', 'prefix' => 'admin']);
@@ -854,7 +854,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['all']);
         $expected = '/admin/posts/all';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -877,7 +877,7 @@ class RouterTest extends TestCase
             2,
         ]);
         $expected = '/admin/my-plugin/forms/edit/2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -898,7 +898,7 @@ class RouterTest extends TestCase
             'action' => 'home',
         ]);
         $expected = '/admin/backoffice/dashboards/home';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -919,7 +919,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
         ]);
         $expected = '/articles/add.json';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
@@ -928,7 +928,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
         ]);
         $expected = '/articles/add.json';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
@@ -938,7 +938,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
         ]);
         $expected = '/articles.json';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
@@ -948,7 +948,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
         ]);
         $expected = '/articles.json?id=testing';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -973,7 +973,7 @@ class RouterTest extends TestCase
             1,
         ]);
         $expected = '/tasks/view/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'controller' => 'Tasks',
@@ -982,7 +982,7 @@ class RouterTest extends TestCase
             '_ext' => 'json',
         ]);
         $expected = '/tasks/view/1.json';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1102,7 +1102,7 @@ class RouterTest extends TestCase
         });
         $result = Router::url(['controller' => 'tasks', 'action' => 'edit']);
         $this->assertSame('/en/tasks/edit/1234', $result);
-        $this->assertEquals(2, $calledCount);
+        $this->assertSame(2, $calledCount);
     }
 
     /**
@@ -1203,15 +1203,15 @@ class RouterTest extends TestCase
     {
         $mailto = 'mailto:mark@example.com';
         $result = Router::url($mailto);
-        $this->assertEquals($mailto, $result);
+        $this->assertSame($mailto, $result);
 
         $js = 'javascript:alert("hi")';
         $result = Router::url($js);
-        $this->assertEquals($js, $result);
+        $this->assertSame($js, $result);
 
         $hash = '#first';
         $result = Router::url($hash);
-        $this->assertEquals($hash, $result);
+        $this->assertSame($hash, $result);
     }
 
     /**
@@ -1606,7 +1606,7 @@ class RouterTest extends TestCase
             'extra' => null,
         ]);
         $expected = '/page/this_is_the_slug';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url([
             'admin' => null,
@@ -1617,7 +1617,7 @@ class RouterTest extends TestCase
             'extra' => 'some_extra',
         ]);
         $expected = '/some_extra/page/this_is_the_slug';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1858,39 +1858,39 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'images', 'action' => 'add']);
         $expected = '/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'protected']);
         $expected = '/protected/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add_protected_test', 'prefix' => 'protected']);
         $expected = '/protected/images/add_protected_test';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'edit', 1]);
         $expected = '/images/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'edit', 1, 'prefix' => 'protected']);
         $expected = '/protected/images/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'protectededit', 1, 'prefix' => 'protected']);
         $expected = '/protected/images/protectededit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'edit', 1, 'prefix' => 'protected']);
         $expected = '/protected/images/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'others', 'action' => 'edit', 1]);
         $expected = '/others/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'others', 'action' => 'edit', 1, 'prefix' => 'protected']);
         $expected = '/protected/others/edit/1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1976,15 +1976,15 @@ class RouterTest extends TestCase
 
         $result = Router::url(['prefix' => 'protected', 'controller' => 'images', 'action' => 'add']);
         $expected = '/protected/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add']);
         $expected = '/protected/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => false]);
         $expected = '/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2007,7 +2007,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'admin']);
         $expected = '/admin/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $request = new ServerRequest([
             'url' => '/admin/images/index',
@@ -2018,7 +2018,7 @@ class RouterTest extends TestCase
         Router::setRequest($request);
         $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'protected']);
         $expected = '/protected/images/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2032,7 +2032,7 @@ class RouterTest extends TestCase
 
         $url = Router::url(['prefix' => '0', 'plugin' => '1', 'controller' => '0', 'action' => '1', 'test']);
         $expected = '/cache/test';
-        $this->assertEquals($expected, $url);
+        $this->assertSame($expected, $url);
 
         try {
             Router::url(['controller' => '0', 'action' => '1', 'test']);
@@ -2068,11 +2068,11 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'my_controller', 'action' => 'my_action']);
         $expected = '/base/my_controller/my_action';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'my_controller', 'action' => 'my_action', '_base' => false]);
         $expected = '/my_controller/my_action';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2361,7 +2361,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['prefix' => 'admin', 'controller' => 'posts']);
         $expected = '/base/admin/posts';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Router::reload();
 
@@ -2390,7 +2390,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['prefix' => 'members', 'controller' => 'users', 'action' => 'add']);
         $expected = '/base/members/users/add';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2405,7 +2405,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'users', 'action' => 'login', 'prefix' => 'company']);
         $expected = '/company/users/login';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $request = new ServerRequest([
             'url' => '/',
@@ -2420,7 +2420,7 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'users', 'action' => 'login', 'prefix' => false]);
         $expected = '/login';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2465,15 +2465,15 @@ class RouterTest extends TestCase
 
         $result = Router::url(['controller' => 'pages', 'action' => 'display', 1, 'whatever']);
         $expected = '/test/whatever';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'pages', 'action' => 'display', 2, 'whatever']);
         $expected = '/test2/whatever';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['controller' => 'pages', 'action' => 'display', 'home', 'whatever']);
         $expected = '/test-passed/whatever';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2520,11 +2520,11 @@ class RouterTest extends TestCase
 
         $result = Router::url(['action' => 'test_another_action', 'locale' => 'eng']);
         $expected = '/eng/test/test_another_action';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'test_another_action']);
         $expected = '/';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2635,7 +2635,7 @@ class RouterTest extends TestCase
         ]);
         $result = Router::reverse($request);
         $expected = '/eng/posts/view/1?test=value';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testReverseFull()
@@ -2675,7 +2675,7 @@ class RouterTest extends TestCase
         ]);
         $result = Router::reverse($request);
         $expected = '/posts/view/1.json';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testReverseToArrayQuery()
@@ -2760,7 +2760,7 @@ class RouterTest extends TestCase
         Router::connect($route);
 
         $result = Router::url(['controller' => 'posts', 'action' => 'view', 1]);
-        $this->assertEquals($url, $result);
+        $this->assertSame($url, $result);
     }
 
     /**
@@ -2771,38 +2771,38 @@ class RouterTest extends TestCase
     public function testUrlProtocol()
     {
         $url = 'http://example.com';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = 'ed2k://example.com';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = 'svn+ssh://example.com';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = '://example.com';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = '//example.com';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = 'javascript:void(0)';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = 'tel:012345-678';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = 'sms:012345-678';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = '#here';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = '?param=0';
-        $this->assertEquals($url, Router::url($url));
+        $this->assertSame($url, Router::url($url));
 
         $url = '/posts/index#here';
         $expected = Configure::read('App.fullBaseUrl') . '/posts/index#here';
-        $this->assertEquals($expected, Router::url($url, true));
+        $this->assertSame($expected, Router::url($url, true));
     }
 
     /**
@@ -3151,27 +3151,27 @@ class RouterTest extends TestCase
 
         $result = Router::pathUrl('Articles::index');
         $expected = '/articles';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $result = Router::pathUrl('Articles::view', [3]);
         $expected = '/articles/view/3';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $result = Router::pathUrl('Articles::read', ['slug' => 'title']);
         $expected = '/article/title';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $result = Router::pathUrl('Admin/Articles::index');
         $expected = '/admin/articles';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $result = Router::pathUrl('Cms.Admin/Articles::index');
         $expected = '/cms/admin/articles';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $result = Router::pathUrl('Cms.Articles::index');
         $expected = '/cms/articles';
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
     }
 
     /**
@@ -3201,33 +3201,33 @@ class RouterTest extends TestCase
 
         $expected = '/articles';
         $result = Router::pathUrl('Articles::index');
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
         $result = Router::url(['_path' => 'Articles::index']);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $expected = '/articles/view/3';
         $result = Router::pathUrl('Articles::view', [3]);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
         $result = Router::url(['_path' => 'Articles::view', 3]);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $expected = '/admin/articles';
         $result = Router::pathUrl('Admin/Articles::index');
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
         $result = Router::url(['_path' => 'Admin/Articles::index']);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $expected = '/cms/admin/articles';
         $result = Router::pathUrl('Cms.Admin/Articles::index');
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
         $result = Router::url(['_path' => 'Cms.Admin/Articles::index']);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
 
         $expected = '/cms/articles';
         $result = Router::pathUrl('Cms.Articles::index');
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
         $result = Router::url(['_path' => 'Cms.Articles::index']);
-        $this->assertEquals($result, $expected);
+        $this->assertSame($result, $expected);
     }
 
     /**

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -105,7 +105,7 @@ class XmlTest extends TestCase
         $xml = CORE_TESTS . 'Fixture/sample.xml';
         $obj = Xml::build($xml, ['readFile' => true]);
         $this->assertSame('tags', $obj->getName());
-        $this->assertSame(2, count($obj));
+        $this->assertCount(2, $obj);
 
         $this->assertEquals(
             Xml::build($xml, ['readFile' => true]),
@@ -340,7 +340,7 @@ close to 5 million globally.
         $obj = Xml::fromArray($xml, ['format' => 'attributes']);
         $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
         $this->assertSame('tags', $obj->getName());
-        $this->assertSame(2, count($obj));
+        $this->assertCount(2, $obj);
         $xmlText = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <tags>
@@ -353,7 +353,7 @@ XML;
         $obj = Xml::fromArray($xml);
         $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
         $this->assertSame('tags', $obj->getName());
-        $this->assertSame(2, count($obj));
+        $this->assertCount(2, $obj);
         $xmlText = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <tags>
@@ -388,7 +388,7 @@ XML;
             ],
         ];
         $obj = Xml::fromArray($xml, ['format' => 'tags']);
-        $this->assertSame(6, count($obj));
+        $this->assertCount(6, $obj);
         $this->assertSame((string)$obj->bool, '1');
         $this->assertSame((string)$obj->int, '1');
         $this->assertSame((string)$obj->float, '10.2');

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -165,7 +165,7 @@ class ValidationSetTest extends TestCase
             $this->assertInstanceOf('Cake\Validation\ValidationRule', $rule);
             $i++;
         }
-        $this->assertEquals(3, $i);
+        $this->assertSame(3, $i);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2962,7 +2962,7 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($rule, "Rule was not found for $method");
         $this->assertNull($rule->get('message'), 'Message is present when it should not be');
         $this->assertNull($rule->get('on'), 'On clause is present when it should not be');
-        $this->assertEquals($name, $rule->get('rule'), 'Rule name does not match');
+        $this->assertSame($name, $rule->get('rule'), 'Rule name does not match');
         $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');
         $this->assertSame('default', $rule->get('provider'), 'Provider does not match');
 

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -84,7 +84,7 @@ class CellTest extends TestCase
 
         $cell = $this->View->cell('Cello');
         $this->assertInstanceOf('TestApp\View\Cell\CelloCell', $cell);
-        $this->assertEquals("Cellos\n", $cell->render());
+        $this->assertSame("Cellos\n", $cell->render());
     }
 
     /**
@@ -111,7 +111,7 @@ class CellTest extends TestCase
     {
         $capture = function ($errno, $msg) {
             restore_error_handler();
-            $this->assertEquals(E_USER_WARNING, $errno);
+            $this->assertSame(E_USER_WARNING, $errno);
             $this->assertStringContainsString('Could not render cell - Cell template file', $msg);
         };
         set_error_handler($capture);
@@ -164,7 +164,7 @@ class CellTest extends TestCase
 
         $this->assertStringContainsString('Articles subdir custom_template_path template', "{$appCell}");
         $this->assertSame('custom_template_path', $appCell->viewBuilder()->getTemplate());
-        $this->assertEquals(Cell::TEMPLATE_FOLDER . '/Articles/Subdir', $appCell->viewBuilder()->getTemplatePath());
+        $this->assertSame(Cell::TEMPLATE_FOLDER . '/Articles/Subdir', $appCell->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -346,7 +346,7 @@ class CellTest extends TestCase
     public function testCellOptions()
     {
         $cell = $this->View->cell('Articles', [], ['limit' => 10, 'nope' => 'nope']);
-        $this->assertEquals(10, $cell->limit);
+        $this->assertSame(10, $cell->limit);
         $this->assertObjectNotHasAttribute('nope', $cell, 'Not a valid option');
     }
 
@@ -412,10 +412,10 @@ class CellTest extends TestCase
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
         $expected = "dummy\n";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::read('cell_test_app_view_cell_articles_cell_display_default', 'default');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
         Cache::drop('default');
     }
 
@@ -431,7 +431,7 @@ class CellTest extends TestCase
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
         $result = $cell->render();
-        $this->assertEquals('from cache', $result);
+        $this->assertSame('from cache', $result);
         Cache::drop('default');
     }
 
@@ -449,7 +449,7 @@ class CellTest extends TestCase
             'cache' => ['key' => 'my_key', 'config' => 'cell'],
         ]);
         $result = $cell->render();
-        $this->assertEquals('from cache', $result);
+        $this->assertSame('from cache', $result);
         Cache::drop('cell');
     }
 
@@ -483,10 +483,10 @@ class CellTest extends TestCase
         Cache::setConfig('default', ['className' => 'Array']);
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => ['key' => 'celltest']]);
         $result = $cell->render();
-        $this->assertEquals(1, $cell->counter);
+        $this->assertSame(1, $cell->counter);
         $cell->render();
 
-        $this->assertEquals(1, $cell->counter);
+        $this->assertSame(1, $cell->counter);
         $this->assertStringContainsString('This is the alternate template', $result);
         Cache::drop('default');
     }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -469,7 +469,7 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
         $result = $context->val('title');
-        $this->assertEquals('Invalid title', $result);
+        $this->assertSame('Invalid title', $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -218,7 +218,7 @@ class BreadcrumbsHelperTest extends TestCase
         $this->breadcrumbs->add('Products', '/products');
 
         $crumbs = $this->breadcrumbs->getCrumbs();
-        $this->assertEquals(count($crumbs), 2);
+        $this->assertCount(2, $crumbs);
 
         $this->breadcrumbs->reset();
         $actual = $this->breadcrumbs->getCrumbs();

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -127,7 +127,7 @@ class FlashHelperTest extends TestCase
 
         $expected = '<div id="classy-message">Recorded</div>';
         $result = $this->Flash->render('classy');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Flash->render('notification');
         $expected = [
@@ -184,7 +184,7 @@ class FlashHelperTest extends TestCase
 
         $result = $this->Flash->render('flash', ['element' => 'TestPlugin.flash/plugin_element']);
         $expected = 'this is the plugin element';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -319,7 +319,7 @@ class FormHelperTest extends TestCase
         $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->Form->addContextProvider('test', function ($request, $data) use ($context, $stub) {
             $this->assertInstanceOf('Cake\Http\ServerRequest', $request);
-            $this->assertEquals($context, $data['entity']);
+            $this->assertSame($context, $data['entity']);
 
             return $stub;
         });
@@ -2419,7 +2419,7 @@ class FormHelperTest extends TestCase
         $this->Form->text('Article.title');
 
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
-        $this->assertEquals(1, $result['Article.id'], 'Hidden input should be secured.');
+        $this->assertSame('1', $result['Article.id'], 'Hidden input should be secured.');
         $this->assertContains('Article.title', $result, 'Field should be secured.');
 
         $this->Form->unlockField('Article.title');
@@ -2452,7 +2452,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $this->Form->hidden('Contact.id', ['value' => 1]);
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
-        $this->assertEquals(1, $result['Contact.id'], 'Hidden input should be secured.');
+        $this->assertSame('1', $result['Contact.id'], 'Hidden input should be secured.');
     }
 
     /**
@@ -7099,7 +7099,7 @@ class FormHelperTest extends TestCase
         $this->assertStringContainsString($hash, $result, 'Should contain the correct hash.');
         $reflect = new ReflectionProperty($this->Form, '_lastAction');
         $reflect->setAccessible(true);
-        $this->assertEquals('/articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
+        $this->assertSame('/articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
     }
 
     /**
@@ -8340,17 +8340,17 @@ class FormHelperTest extends TestCase
 
         $expected = '2';
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->Form->setValueSources(['data']);
         $expected = '1';
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->Form->setValueSources(['query', 'data']);
         $expected = '2';
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testValueSourcesValidation()

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -601,7 +601,7 @@ class HtmlHelperTest extends TestCase
         $this->assertSame('display:none; margin:10px;', $result);
 
         $result = $this->Html->style(['display' => 'none', 'margin' => '10px'], false);
-        $this->assertEquals("display:none;\nmargin:10px;", $result);
+        $this->assertSame("display:none;\nmargin:10px;", $result);
     }
 
     /**
@@ -1826,7 +1826,7 @@ class HtmlHelperTest extends TestCase
         ];
         $result = $this->Html->tableCells($tr, ['class' => 'odd'], ['class' => 'even']);
         $expected = "<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $tr = [
             ['td content 1', 'td content 2', 'td content 3'],
@@ -1836,7 +1836,7 @@ class HtmlHelperTest extends TestCase
         ];
         $result = $this->Html->tableCells($tr, ['class' => 'odd'], ['class' => 'even']);
         $expected = "<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $tr = [
             ['td content 1', 'td content 2', 'td content 3'],
@@ -1846,7 +1846,7 @@ class HtmlHelperTest extends TestCase
         $this->Html->tableCells($tr, ['class' => 'odd'], ['class' => 'even']);
         $result = $this->Html->tableCells($tr, ['class' => 'odd'], ['class' => 'even'], false, false);
         $expected = "<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $tr = [
             'td content 1',
@@ -1902,7 +1902,7 @@ class HtmlHelperTest extends TestCase
         $options = [$evilKey => 'some value'];
         $result = $this->Html->div('class-name', '', $options);
         $expected = '<div &gt;&lt;script&gt;alert(1)&lt;/script&gt;="some value" class="class-name"></div>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -667,7 +667,7 @@ class PaginatorHelperTest extends TestCase
     {
         $result = $this->Paginator->sortDir();
         $expected = 'asc';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->setPagingParams([
             'Article' => [
@@ -990,7 +990,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->generateUrl([], null, $url);
         $expected = '/members/Posts/index?page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->sort('name', null, ['url' => $url]);
         $expected = [
@@ -1027,13 +1027,13 @@ class PaginatorHelperTest extends TestCase
         ];
         $result = $this->Paginator->generateUrl($options, null, $url);
         $expected = '/members/Posts/index?sort=name&amp;direction=desc&amp;page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $options = ['sort' => 'Article.name', 'direction' => 'desc'];
         $url = ['controller' => 'Posts'];
         $result = $this->Paginator->generateUrl($options, null, $url);
         $expected = '/Posts/index?sort=Article.name&amp;direction=desc&amp;page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1062,19 +1062,19 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->generateUrl();
         $expected = '/members/posts/index?page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->generateUrl([], null, ['prefix' => 'members']);
         $expected = '/members/posts/index?page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->generateUrl([], null, ['prefix' => false]);
         $expected = '/posts/index?page=2';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->Paginator->options(['url' => ['prefix' => false]]);
         $result = $this->Paginator->generateUrl();
-        $this->assertEquals($expected, $result, 'Setting prefix in options should work too.');
+        $this->assertSame($expected, $result, 'Setting prefix in options should work too.');
     }
 
     /**
@@ -1105,7 +1105,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->generateUrl([]);
         $expected = '/Posts/index?article%5Bpage%5D=3';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->sort('name');
         $expected = [
@@ -1137,11 +1137,11 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->generateUrl(['sort' => 'name']);
         $expected = '/Posts/index?article%5Bsort%5D=name&amp;article%5Bpage%5D=3';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->generateUrl([], null, ['#' => 'foo']);
         $expected = '/Posts/index?article%5Bpage%5D=3#foo';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1178,11 +1178,11 @@ class PaginatorHelperTest extends TestCase
 
         $result = $paginator->generateUrl(['sort' => 'name']);
         $expected = '/Posts/index?article%5Bsort%5D=name&amp;article%5Bpage%5D=3&amp;article%5Bpuppy%5D=no';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $paginator->generateUrl([]);
         $expected = '/Posts/index?article%5Bpage%5D=3&amp;article%5Bpuppy%5D=no';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1570,13 +1570,13 @@ class PaginatorHelperTest extends TestCase
             'model' => 'Client',
         ]);
         $expected = '<li class="prev disabled"><a href="" onclick="return false;">Prev</a></li>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->next('Next', [
             'model' => 'Server',
         ]);
         $expected = '<li class="next disabled"><a href="" onclick="return false;">Next</a></li>';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->prev('Prev', [
             'model' => 'Server',
@@ -2686,7 +2686,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->last();
         $expected = '';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2733,7 +2733,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->first();
         $expected = '';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -2996,15 +2996,15 @@ class PaginatorHelperTest extends TestCase
         $expected = 'Page 1 of 5, showing 3 records out of 13 total, starting on record 1, ';
         $expected .= 'ending on 3';
         $result = $this->Paginator->counter($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->counter('pages');
         $expected = '1 of 5';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->counter('range');
         $expected = '1 - 3 of 13';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Paginator->counter('Showing {{page}} of {{pages}} {{model}}');
         $this->assertSame('Showing 1 of 5 clients', $result);
@@ -3040,13 +3040,13 @@ class PaginatorHelperTest extends TestCase
         $expected = 'Page 1,523 of 1,600, showing 3,000 records out of 4,800,001 total, ';
         $expected .= 'starting on record 4,566,001, ending on 4,569,001';
         $result = $this->Paginator->counter($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         I18n::setLocale('de-DE');
         $expected = 'Page 1.523 of 1.600, showing 3.000 records out of 4.800.001 total, ';
         $expected .= 'starting on record 4.566.001, ending on 4.569.001';
         $result = $this->Paginator->counter($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -3127,7 +3127,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertSame($params['Article']['page'], $result);
 
         $result = $this->Paginator->current('Incorrect');
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     /**
@@ -3208,7 +3208,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->counter('pages');
         $expected = '0 of 1';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -3482,7 +3482,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $paginator->counter();
         // counter() sets `pageCount` to 1 if empty.
-        $this->assertEquals('1 of 1', $result);
+        $this->assertSame('1 of 1', $result);
 
         $result = $paginator->total();
         $this->assertSame(0, $result);

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -152,12 +152,12 @@ class TextHelperTest extends TestCase
     {
         $text = 'The AWWWARD show happened today';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($text, $result);
+        $this->assertSame($text, $result);
 
         $text = 'This is a test text';
         $expected = 'This is a test text';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a partial www.cakephp.org URL and test@cakephp.org email address';
         $result = $this->Text->autoLink($text);
@@ -167,47 +167,47 @@ class TextHelperTest extends TestCase
         $text = 'This is a test text with URL http://www.cakephp.org';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL http://www.cakephp.org and some more text';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a> and some more text';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = "This is a test text with URL http://www.cakephp.org\tand some more text";
         $expected = "This is a test text with URL <a href=\"http://www.cakephp.org\">http://www.cakephp.org</a>\tand some more text";
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL http://www.cakephp.org(and some more text)';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>(and some more text)';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL (http://www.cakephp.org/page/4) in brackets';
         $expected = 'This is a test text with URL (<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>) in brackets';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL [http://www.cakephp.org/page/4] in square brackets';
         $expected = 'This is a test text with URL [<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>] in square brackets';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL [http://www.example.com?aParam[]=value1&aParam[]=value2&aParam[]=value3] in square brackets';
         $expected = 'This is a test text with URL [<a href="http://www.example.com?aParam[]=value1&amp;aParam[]=value2&amp;aParam[]=value3">http://www.example.com?aParam[]=value1&amp;aParam[]=value2&amp;aParam[]=value3</a>] in square brackets';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL ;http://www.cakephp.org/page/4; semi-colon';
         $expected = 'This is a test text with URL ;<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>; semi-colon';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL (http://www.cakephp.org/page/4/other(thing)) brackets';
         $expected = 'This is a test text with URL (<a href="http://www.cakephp.org/page/4/other(thing)">http://www.cakephp.org/page/4/other(thing)</a>) brackets';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -221,7 +221,7 @@ class TextHelperTest extends TestCase
         $expected = 'Text with a url/email <a href="http://example.com/store?email=mark@example.com">' .
             'http://example.com/store?email=mark@example.com</a> and email.';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -234,12 +234,12 @@ class TextHelperTest extends TestCase
         $text = 'This is a test text with URL http://www.cakephp.org';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link">http://www.cakephp.org</a>';
         $result = $this->Text->autoLink($text, ['class' => 'link']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a test text with URL http://www.cakephp.org';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link" id="MyLink">http://www.cakephp.org</a>';
         $result = $this->Text->autoLink($text, ['class' => 'link', 'id' => 'MyLink']);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -252,12 +252,12 @@ class TextHelperTest extends TestCase
         $text = 'This is a <b>test</b> text with URL http://www.cakephp.org';
         $expected = 'This is a &lt;b&gt;test&lt;/b&gt; text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
         $result = $this->Text->autoLink($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'This is a <b>test</b> text with URL http://www.cakephp.org';
         $expected = 'This is a <b>test</b> text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
         $result = $this->Text->autoLink($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'test <ul>
 		<li>lorem: http://example.org?some</li>
@@ -268,7 +268,7 @@ class TextHelperTest extends TestCase
 		<li>ipsum: <a href="http://othersite.com/abc">http://othersite.com/abc</a></li>
 		</ul> test';
         $result = $this->Text->autoLink($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -426,47 +426,47 @@ class TextHelperTest extends TestCase
         $text = 'Text with a partial <a href="http://www.example.com">http://www.example.com</a> link';
         $expected = 'Text with a partial <a href="http://www.example.com">http://www.example.com</a> link';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a partial <a href="http://www.example.com">www.example.com</a> link';
         $expected = 'Text with a partial <a href="http://www.example.com">www.example.com</a> link';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a partial <a href="http://www.cakephp.org">link</a> link';
         $expected = 'Text with a partial <a href="http://www.cakephp.org">link</a> link';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
         $expected = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
         $expected = 'Text with a partial &lt;iframe src=&quot;http://www.cakephp.org&quot; /&gt; link';
         $result = $this->Text->autoLinkUrls($text, ['escape' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
         $expected = 'Text with a url &lt;a href=&quot;http://www.not-working-www.com&quot;&gt;www.not-working-www.com&lt;/a&gt; and more';
         $result = $this->Text->autoLinkUrls($text, ['escape' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a url www.not-working-www.com and more';
         $expected = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a url http://www.not-working-www.com and more';
         $expected = 'Text with a url <a href="http://www.not-working-www.com">http://www.not-working-www.com</a> and more';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $text = 'Text with a url http://www.www.not-working-www.com and more';
         $expected = 'Text with a url <a href="http://www.www.not-working-www.com">http://www.www.not-working-www.com</a> and more';
         $result = $this->Text->autoLinkUrls($text, ['escape' => false]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -479,7 +479,7 @@ class TextHelperTest extends TestCase
         $text = 'Text with a partial http://www.cakephp.org?product_id=123&foo=bar link';
         $expected = 'Text with a partial <a href="http://www.cakephp.org?product_id=123&amp;foo=bar">http://www.cakephp.org?product_id=123&amp;foo=bar</a> link';
         $result = $this->Text->autoLinkUrls($text);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -561,7 +561,7 @@ class TextHelperTest extends TestCase
     public function testAutoLinkEmails($text, $expected, $attrs = [])
     {
         $result = $this->Text->autoLinkEmails($text, $attrs);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -573,7 +573,7 @@ class TextHelperTest extends TestCase
     {
         $result = $this->Text->autoLinkEmails('this is a myaddress@gmx-de test');
         $expected = 'this is a myaddress@gmx-de test';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -207,7 +207,7 @@ class TimeHelperTest extends TestCase
     public function testToAtom()
     {
         $dateTime = new \DateTime();
-        $this->assertEquals($dateTime->format($dateTime::ATOM), $this->Time->toAtom($dateTime->getTimestamp()));
+        $this->assertSame($dateTime->format($dateTime::ATOM), $this->Time->toAtom($dateTime->getTimestamp()));
     }
 
     /**
@@ -221,7 +221,7 @@ class TimeHelperTest extends TestCase
         $dateTime = new Time();
         $vancouver = clone $dateTime;
         $vancouver->timezone('America/Vancouver');
-        $this->assertEquals($vancouver->format(Time::ATOM), $this->Time->toAtom($vancouver));
+        $this->assertSame($vancouver->format(Time::ATOM), $this->Time->toAtom($vancouver));
     }
 
     /**
@@ -233,14 +233,14 @@ class TimeHelperTest extends TestCase
     {
         $date = '2012-08-12 12:12:45';
         $time = strtotime($date);
-        $this->assertEquals(date('r', $time), $this->Time->toRss($time));
+        $this->assertSame(date('r', $time), $this->Time->toRss($time));
 
         $timezones = ['Europe/London', 'Europe/Brussels', 'UTC', 'America/Denver', 'America/Caracas', 'Asia/Kathmandu'];
         foreach ($timezones as $timezone) {
             $yourTimezone = new \DateTimeZone($timezone);
             $yourTime = new \DateTime($date, $yourTimezone);
             $time = $yourTime->format('U');
-            $this->assertEquals($yourTime->format('r'), $this->Time->toRss($time, $timezone), "Failed on $timezone");
+            $this->assertSame($yourTime->format('r'), $this->Time->toRss($time, $timezone), "Failed on $timezone");
         }
     }
 
@@ -256,7 +256,7 @@ class TimeHelperTest extends TestCase
         $vancouver = clone $dateTime;
         $vancouver->timezone('America/Vancouver');
 
-        $this->assertEquals($vancouver->format('r'), $this->Time->toRss($vancouver));
+        $this->assertSame($vancouver->format('r'), $this->Time->toRss($vancouver));
     }
 
     /**
@@ -266,7 +266,7 @@ class TimeHelperTest extends TestCase
      */
     public function testGmt()
     {
-        $this->assertEquals(1397980800, $this->Time->gmt('2014-04-20 08:00:00'));
+        $this->assertSame('1397980800', $this->Time->gmt('2014-04-20 08:00:00'));
     }
 
     /**
@@ -523,7 +523,7 @@ class TimeHelperTest extends TestCase
 
         $result = $this->Time->format('invalid date', null, 'Date invalid');
         $expected = 'Date invalid';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         I18n::setLocale('fr_FR');
         Time::setDefaultLocale('fr_FR');
@@ -609,7 +609,7 @@ class TimeHelperTest extends TestCase
      */
     public function assertTimeFormat($expected, $result)
     {
-        $this->assertEquals(
+        $this->assertSame(
             str_replace([',', '(', ')', ' at', ' à'], '', $expected),
             str_replace([',', '(', ')', ' at', ' à'], '', $result)
         );
@@ -627,6 +627,6 @@ class TimeHelperTest extends TestCase
 
         $fallback = 'Date invalid or not set';
         $result = $this->Time->format(null, \IntlDateFormatter::FULL, $fallback);
-        $this->assertEquals($fallback, $result);
+        $this->assertSame($fallback, $result);
     }
 }

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -137,7 +137,7 @@ class UrlHelperTest extends TestCase
         Router::setRequest($request);
 
         $this->assertSame('/magazine/subscribe', $this->Helper->build());
-        $this->assertEquals(
+        $this->assertSame(
             '/magazine/articles/add',
             $this->Helper->build(['controller' => 'articles', 'action' => 'add'])
         );
@@ -187,7 +187,7 @@ class UrlHelperTest extends TestCase
         Configure::write('Foo.bar', 'test');
         Configure::write('Asset.timestamp', false);
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', false);
@@ -196,7 +196,7 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/%3Cb%3E/cake.generic.css', $result);
 
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
         Configure::write('Asset.timestamp', true);
         Configure::write('debug', true);
@@ -209,7 +209,7 @@ class UrlHelperTest extends TestCase
         $this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam');
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css?someparam', $result);
 
         $request = $this->View->getRequest()->withAttribute('webroot', '/some/dir/');
         $this->View->setRequest($request);
@@ -227,13 +227,13 @@ class UrlHelperTest extends TestCase
     {
         $this->Helper->webroot = '';
         $result = $this->Helper->assetUrl('js/post.js', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg', ['pathPrefix' => 'img/']);
         $this->assertSame('img/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('style', ['ext' => '.css']);
         $this->assertSame('style.css', $result);
@@ -290,7 +290,7 @@ class UrlHelperTest extends TestCase
 
         $result = $this->Helper->assetUrl('img/cake.icon.png', ['fullBase' => true]);
         $expected = Configure::read('App.fullBaseUrl') . '/cake_dev/app/webroot/img/cake.icon.png';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -320,7 +320,7 @@ class UrlHelperTest extends TestCase
     public function testAssetUrlFullBase()
     {
         $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => 'https://xyz/']);
         $this->assertSame('https://xyz/img/foo.jpg', $result);
@@ -352,7 +352,7 @@ class UrlHelperTest extends TestCase
         $timestamp = false;
 
         $result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $timestamp);
-        $this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
+        $this->assertSame(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
     }
 
     /**
@@ -390,7 +390,7 @@ class UrlHelperTest extends TestCase
             'post.js',
             ['fullBase' => true]
         );
-        $this->assertEquals(Router::fullBaseUrl() . '/js/post.js', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
     }
 
     /**
@@ -418,7 +418,7 @@ class UrlHelperTest extends TestCase
         $timestamp = false;
 
         $result = $this->Helper->script('script.js', ['timestamp' => $timestamp]);
-        $this->assertEquals(Configure::read('App.jsBaseUrl') . 'script.js', $result);
+        $this->assertSame(Configure::read('App.jsBaseUrl') . 'script.js', $result);
     }
 
     /**
@@ -432,7 +432,7 @@ class UrlHelperTest extends TestCase
         $this->assertSame('img/foo.jpg', $result);
 
         $result = $this->Helper->image('foo.jpg', ['fullBase' => true]);
-        $this->assertEquals(Router::fullBaseUrl() . '/img/foo.jpg', $result);
+        $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
 
         $result = $this->Helper->image('dir/sub dir/my image.jpg');
         $this->assertSame('img/dir/sub%20dir/my%20image.jpg', $result);
@@ -529,36 +529,36 @@ class UrlHelperTest extends TestCase
         Router::setRequest($request);
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->Helper->getView()->setTheme('TestTheme');
 
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/test_theme/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Helper->webroot('/img/test.jpg');
         $expected = '/test_theme/img/test.jpg';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $webRoot = Configure::read('App.wwwRoot');
         Configure::write('App.wwwRoot', TEST_APP . 'TestApp/webroot/');
 
         $result = $this->Helper->webroot('/img/cake.power.gif');
         $expected = '/test_theme/img/cake.power.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Helper->webroot('/img/test.jpg');
         $expected = '/test_theme/img/test.jpg';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Helper->webroot('/img/cake.icon.gif');
         $expected = '/img/cake.icon.gif';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $this->Helper->webroot('/img/cake.icon.gif?some=param');
         $expected = '/img/cake.icon.gif?some=param';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Configure::write('App.wwwRoot', $webRoot);
     }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -123,7 +123,7 @@ class HelperTest extends TestCase
         $resultB = $Helper->Html;
 
         $resultA->testprop = 1;
-        $this->assertEquals($resultA->testprop, $resultB->testprop);
+        $this->assertSame($resultA->testprop, $resultB->testprop);
     }
 
     /**

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -48,7 +48,7 @@ class StringTemplateTest extends TestCase
             'link' => '<a href="{{url}}">{{text}}</a>',
         ];
         $template = new StringTemplate($templates);
-        $this->assertEquals($templates['link'], $template->get('link'));
+        $this->assertSame($templates['link'], $template->get('link'));
     }
 
     /**
@@ -68,7 +68,7 @@ class StringTemplateTest extends TestCase
             'The same instance should be returned'
         );
 
-        $this->assertEquals($templates['link'], $this->template->get('link'));
+        $this->assertSame($templates['link'], $this->template->get('link'));
     }
 
     /**
@@ -222,14 +222,14 @@ class StringTemplateTest extends TestCase
     {
         $attrs = ['disabled' => true, 'selected' => 1, 'checked' => '1', 'multiple' => 'multiple'];
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             ' disabled="disabled" selected="selected" checked="checked" multiple="multiple"',
             $result
         );
 
         $attrs = ['disabled' => false, 'selected' => 0, 'checked' => '0', 'multiple' => null];
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $result
         );
@@ -244,28 +244,28 @@ class StringTemplateTest extends TestCase
     {
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>', 'spellcheck' => 'true'];
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             ' name="bruce" data-hero="&lt;batman&gt;" spellcheck="true"',
             $result
         );
 
         $attrs = ['escape' => false, 'name' => 'bruce', 'data-hero' => '<batman>'];
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             ' name="bruce" data-hero="<batman>"',
             $result
         );
 
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>'];
         $result = $this->template->formatAttributes($attrs, ['name']);
-        $this->assertEquals(
+        $this->assertSame(
             ' data-hero="&lt;batman&gt;"',
             $result
         );
 
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>', 'templateVars' => ['foo' => 'bar']];
         $result = $this->template->formatAttributes($attrs, ['name']);
-        $this->assertEquals(
+        $this->assertSame(
             ' data-hero="&lt;batman&gt;"',
             $result
         );
@@ -274,7 +274,7 @@ class StringTemplateTest extends TestCase
         $attrs = [$evilKey => 'some value'];
 
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             ' &gt;&lt;script&gt;alert(1)&lt;/script&gt;="some value"',
             $result
         );
@@ -289,7 +289,7 @@ class StringTemplateTest extends TestCase
     {
         $attrs = ['name' => ['bruce', 'wayne']];
         $result = $this->template->formatAttributes($attrs);
-        $this->assertEquals(
+        $this->assertSame(
             ' name="bruce wayne"',
             $result
         );

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -97,7 +97,7 @@ class StringTemplateTraitTest extends TestCase
         $result = $this->Template->formatTemplate('text', [
             'text' => 'CakePHP',
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             '<p>CakePHP</p>',
             $result
         );

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -168,11 +168,11 @@ class ViewTest extends TestCase
 
         $expected = Plugin::path('TestPlugin') . 'templates' . DS . 'Tests' . DS . 'index.php';
         $result = $View->getTemplateFileName('index');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $expected = Plugin::path('TestPlugin') . 'templates' . DS . 'layout' . DS . 'default.php';
         $result = $View->getLayoutFileName();
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -658,14 +658,14 @@ class ViewTest extends TestCase
         $this->assertSame('this is the test element', $result);
 
         $result = $this->View->element('TestPlugin.plugin_element');
-        $this->assertEquals("Element in the TestPlugin\n", $result);
+        $this->assertSame("Element in the TestPlugin\n", $result);
 
         $this->View->setRequest($this->View->getRequest()->withParam('plugin', 'TestPlugin'));
         $result = $this->View->element('plugin_element');
-        $this->assertEquals("Element in the TestPlugin\n", $result);
+        $this->assertSame("Element in the TestPlugin\n", $result);
 
         $result = $this->View->element('plugin_element', [], ['plugin' => false]);
-        $this->assertEquals("Plugin element overridden in app\n", $result);
+        $this->assertSame("Plugin element overridden in app\n", $result);
     }
 
     /**
@@ -736,7 +736,7 @@ class ViewTest extends TestCase
         $events->on('View.afterRender', $callback);
 
         $this->View->element('test_element', [], ['callbacks' => true]);
-        $this->assertEquals(2, $count);
+        $this->assertSame(2, $count);
     }
 
     /**
@@ -791,16 +791,16 @@ class ViewTest extends TestCase
 
         $result = $View->element('test_element', [], ['cache' => true]);
         $expected = 'this is the test element';
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::read('element__test_element', 'test_view');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $View->element('test_element', ['param' => 'one', 'foo' => 'two'], ['cache' => true]);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = Cache::read('element__test_element_param_foo', 'test_view');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $View->element('test_element', [
             'param' => 'one',
@@ -809,7 +809,7 @@ class ViewTest extends TestCase
             'cache' => ['key' => 'custom_key'],
         ]);
         $result = Cache::read('element_custom_key', 'test_view');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $View->setElementCache('default');
         $View->element('test_element', [
@@ -819,7 +819,7 @@ class ViewTest extends TestCase
             'cache' => ['config' => 'test_view'],
         ]);
         $result = Cache::read('element__test_element_param_foo', 'test_view');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Cache::clear('test_view');
         Cache::drop('test_view');
@@ -846,10 +846,10 @@ class ViewTest extends TestCase
 
         $result = $View->element('subfolder/test_element', [], ['cache' => true]);
         $expected = 'this is the test element in subfolder';
-        $this->assertEquals($expected, trim($result));
+        $this->assertSame($expected, trim($result));
 
         $result = Cache::read('element__subfolder_test_element', 'test_view');
-        $this->assertEquals($expected, trim($result));
+        $this->assertSame($expected, trim($result));
     }
 
     /**
@@ -867,15 +867,15 @@ class ViewTest extends TestCase
         $View->getEventManager()->on($listener);
 
         $View->render('index');
-        $this->assertEquals(View::TYPE_TEMPLATE, $listener->beforeRenderViewType);
-        $this->assertEquals(View::TYPE_TEMPLATE, $listener->afterRenderViewType);
+        $this->assertSame(View::TYPE_TEMPLATE, $listener->beforeRenderViewType);
+        $this->assertSame(View::TYPE_TEMPLATE, $listener->afterRenderViewType);
 
-        $this->assertEquals($View->getCurrentType(), View::TYPE_TEMPLATE);
+        $this->assertSame($View->getCurrentType(), View::TYPE_TEMPLATE);
         $View->element('test_element', [], ['callbacks' => true]);
-        $this->assertEquals($View->getCurrentType(), View::TYPE_TEMPLATE);
+        $this->assertSame($View->getCurrentType(), View::TYPE_TEMPLATE);
 
-        $this->assertEquals(View::TYPE_ELEMENT, $listener->beforeRenderViewType);
-        $this->assertEquals(View::TYPE_ELEMENT, $listener->afterRenderViewType);
+        $this->assertSame(View::TYPE_ELEMENT, $listener->beforeRenderViewType);
+        $this->assertSame(View::TYPE_ELEMENT, $listener->afterRenderViewType);
     }
 
     /**
@@ -1496,7 +1496,7 @@ class ViewTest extends TestCase
         $this->assertSame($this->View, $result);
 
         $result = $this->View->fetch('test');
-        $this->assertEquals($value . 'Block', $result);
+        $this->assertSame($value . 'Block', $result);
     }
 
     /**
@@ -1621,7 +1621,7 @@ This is the first parent.
 This is the first template.
 Sidebar Content.
 TEXT;
-        $this->assertEquals($expected, $content);
+        $this->assertSame($expected, $content);
     }
 
     /**
@@ -1669,7 +1669,7 @@ Parent Element.
 Element content.
 
 TEXT;
-        $this->assertEquals($expected, $content);
+        $this->assertSame($expected, $content);
     }
 
     /**
@@ -1688,7 +1688,7 @@ Parent Element.
 Prefix Element content.
 
 TEXT;
-        $this->assertEquals($expected, $content);
+        $this->assertSame($expected, $content);
     }
 
     /**
@@ -1719,7 +1719,7 @@ Parent View.
 this is the test elementThe view
 
 TEXT;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1737,7 +1737,7 @@ Parent View.
 this is the test prefix elementThe view
 
 TEXT;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1757,8 +1757,8 @@ TEXT;
         }
 
         $this->assertNotNull($e);
-        $this->assertEquals('Exception with open buffers', $e->getMessage());
-        $this->assertEquals($bufferLevel, ob_get_level());
+        $this->assertSame('Exception with open buffers', $e->getMessage());
+        $this->assertSame($bufferLevel, ob_get_level());
     }
 
     /**
@@ -1797,8 +1797,8 @@ TEXT;
         Cache::drop('test_view');
 
         $this->assertNotNull($e);
-        $this->assertEquals('Exception with open buffers', $e->getMessage());
-        $this->assertEquals($bufferLevel, ob_get_level());
+        $this->assertSame('Exception with open buffers', $e->getMessage());
+        $this->assertSame($bufferLevel, ob_get_level());
     }
 
     /**
@@ -1834,12 +1834,12 @@ TEXT;
     {
         $default = 'Default';
         $result = $this->View->fetch('title', $default);
-        $this->assertEquals($default, $result);
+        $this->assertSame($default, $result);
 
         $expected = 'My Title';
         $this->View->assign('title', $expected);
         $result = $this->View->fetch('title', $default);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -1851,12 +1851,12 @@ TEXT;
     {
         $default = 'Default';
         $result = $this->View->get('title', $default);
-        $this->assertEquals($default, $result);
+        $this->assertSame($default, $result);
 
         $expected = 'Back to the Future';
         $this->View->set('title', $expected);
         $result = $this->View->get('title', $default);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and make assertion value equals checking strict.