### PR TITLE
Add Core/ContainerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",
+        "league/container": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -40,10 +40,10 @@ interface ContainerInterface extends PsrInterface
      * @param mixed $concrete Either the classname an interface or name resolves to.
      *   Can also be a constructed object, Closure, or null. When null, the `$id` parameter will
      *   be used as the concrete class name.
-     * @param bool|null $shared Set to true to make a service shared.
+     * @param ?bool $shared Set to true to make a service shared.
      * @return \League\Container\Definition\DefinitionInterface
      */
-    public function add(string $id, $concrete = null, bool $shared = null): DefinitionInterface;
+    public function add(string $id, $concrete = null, ?bool $shared = null): DefinitionInterface;
 
     /**
      * Add a service provider to the container

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
-use League\Container\DefinitionInterface;
+use League\Container\Definition\DefinitionInterface;
 use Psr\Container\ContainerInterface as PsrInterface;
 
 /**
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface as PsrInterface;
  * The methods defined in this interface use the conventions provided
  * by league/container as that is the library that CakePHP uses.
  *
- * @experimental This interface is not final and can have additional 
+ * @experimental This interface is not final and can have additional
  *   methods and parameters added in future minor releases.
  */
 interface ContainerInterface extends PsrInterface
@@ -38,17 +38,17 @@ interface ContainerInterface extends PsrInterface
      *
      * @param string $id The class name or name of the service being registered.
      * @param mixed $concrete Either the classname an interface or name resolves to.
-     *   Can also be a constructed object, or null. When null, the `$id` parameter will
+     *   Can also be a constructed object, Closure, or null. When null, the `$id` parameter will
      *   be used as the concrete class name.
-     * @param boolean $shared Set to true to make a service shared.
-     * @return \League\Container\DefinitionInterface
+     * @param bool|null $shared Set to true to make a service shared.
+     * @return \League\Container\Definition\DefinitionInterface
      */
     public function add(string $id, $concrete = null, bool $shared = null): DefinitionInterface;
 
     /**
      * Add a service provider to the container
      *
-     * @param \League\Container\ServiceProviderInterface $provider The service provider to add.
+     * @param \League\Container\ServiceProvider\ServiceProviderInterface $provider The service provider to add.
      * @return $this
      */
     public function addServiceProvider($provider);

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use League\Container\DefinitionInterface;
+use Psr\Container\ContainerInterface as PsrInterface;
+
+/**
+ * Interface for the Dependency Injection Container in CakePHP applications
+ *
+ * This interface extends the PSR-11 container interface and adds
+ * methods to add services and service providers to the container.
+ *
+ * The methods defined in this interface use the conventions provided
+ * by league/container as that is the library that CakePHP uses.
+ *
+ * @experimental This interface is not final and can have additional 
+ *   methods and parameters added in future minor releases.
+ */
+interface ContainerInterface extends PsrInterface
+{
+    /**
+     * Add an item to the container.
+     *
+     * @param string $id The class name or name of the service being registered.
+     * @param mixed $concrete Either the classname an interface or name resolves to.
+     *   Can also be a constructed object, or null. When null, the `$id` parameter will
+     *   be used as the concrete class name.
+     * @param boolean $shared Set to true to make a service shared.
+     * @return \League\Container\DefinitionInterface
+     */
+    public function add(string $id, $concrete = null, bool $shared = null): DefinitionInterface;
+
+    /**
+     * Add a service provider to the container
+     *
+     * @param \League\Container\ServiceProviderInterface $provider The service provider to add.
+     * @return $this
+     */
+    public function addServiceProvider($provider);
+}


### PR DESCRIPTION
Add a DI container interface to give us an interface that applications and plugins can use when registering services. The PSR interfaces do not provide methods to register services. However, for us to have a useful container interface we need those methods as plugins and applications will want a stable interface. Should we need to change off of league/container this interface is small enough that we could adapt it to a new container implementation. This interface will also allow ambitious applications to use an alternative container implementation and not break their plugins.

Refs #14865
