### PR TITLE
Convenience instance factory for TableLocator instance.

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -79,6 +79,16 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     }
 
     /**
+     * @param array|null $locations
+     *
+     * @return static
+     */
+    public static function instance(array $locations = null)
+    {
+        return new static($locations);
+    }
+
+    /**
      * @inheritDoc
      */
     public function setConfig($alias, $options = null)

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -62,6 +62,17 @@ class TableLocatorTest extends TestCase
     }
 
     /**
+     * Test TableLocator::instance()->...() factory.
+     *
+     * @return void
+     */
+    public function testInstance(): void
+    {
+        $instance = TableLocator::instance();
+        $this->assertInstanceOf(TableLocator::class, $instance);
+    }
+
+    /**
      * Test getConfig() method.
      *
      * @return void


### PR DESCRIPTION
Psalm reports
```
ERROR: DeprecatedClass - src/TableFinderTrait.php:175:18 - Cake\ORM\TableRegistry is marked deprecated (see https://psalm.dev/098)
        $table = TableRegistry::getTableLocator()->get($className);
```


When trying to resolve the deprecations in existing 4.x app or plugin code, you can into really weird issues.
```diff
Index: src/TableFinderTrait.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- src/TableFinderTrait.php	(revision 64e49fb5f0cffb5772fac3a18f755b555232542c)
+++ src/TableFinderTrait.php	(date 1598257246628)
@@ -18,7 +18,6 @@
 use Cake\Database\Schema\CollectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Filesystem\Filesystem;
-use Cake\ORM\TableRegistry;
 use FilesystemIterator;
 use ReflectionClass;
 
@@ -172,7 +171,7 @@
             return $tables;
         }
 
-        $table = TableRegistry::getTableLocator()->get($className);
+        $table = $this->getTableLocator()->get($className);
         foreach ($table->associations()->keys() as $key) {
             /** @psalm-suppress PossiblyNullReference */
             if ($table->associations()->get($key)->type() === 'belongsToMany') {
```
wouldn't work, as traits cannot easily reuse other traits.
One could use `(new ...)->` etc, but that is also not too convenient now.

I really liked the TableRegistry static factory call, but I understand that it should go away.
Would it make sense so simplify it back to a static factory method though inside the new class?

e.g:
```
TableRegistry::get('Queue.QueuedJobs')->do();
// becomes
TableLocator::instance()->get('Queue.QueuedJobs')->do();
```