### PR TITLE
Undeprecate class

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -55,9 +55,6 @@ use Cake\ORM\Locator\LocatorInterface;
  * // Prior to 3.6.0
  * $table = TableRegistry::get('Users', $config);
  * ```
- *
- * @deprecated 4.1.0 Use {@see \Cake\ORM\Locator\LocatorAwareTrait::getTableLocator()}
- *   or \Cake\Datasource\FactoryLocator::get('Table') to get the table locator instance instead.
  */
 class TableRegistry
 {


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/pull/14933

now the remaining API is as expected (and documented in the docblock above):

```php
// OK
$table = TableRegistry::getTableLocator()->get('Users', $config);
// same for the setter

// Deprecated
$table = TableRegistry::get('Users', $config);
```