### PR TITLE
Fix: Type Missmatch in HtmlHelper::tableCells()

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -729,7 +729,7 @@ class HtmlHelper extends Helper
         bool $continueOddEven = true
     ): string {
         if (is_string($data) || empty($data[0]) || !is_array($data[0])) {
-            $data = [$data];
+            $data = [[$data]];
         }
 
         if ($oddTrOptions === true) {


### PR DESCRIPTION
TableCells() allow $data to be of type string. If so, it will be warped into an array an later unpacked in a foreach loop, and passed as string to _renderCells(). But _renderCells() aspects the argument $line to be an array.

Double warp it as array should fix this.