### PR TITLE
Fix tmpdir path

### DIFF
--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -86,7 +86,7 @@ class FileLog extends BaseLog
     {
         parent::__construct($config);
 
-        $this->_path = $this->getConfig('path', sys_get_temp_dir());
+        $this->_path = $this->getConfig('path', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
         if (Configure::read('debug') && !is_dir($this->_path)) {
             mkdir($this->_path, 0775, true);
         }


### PR DESCRIPTION
Fixes on linux/unix OS:

> Warning Error: file_put_contents(/tmperror.log): failed to open stream: Permission denied
In [/.../vendor/cakephp/cakephp/src/Log/Engine/FileLog.php, line 131]

when no path is yet configured, and it uses the system default tmp dir (which has no trailing slash).
This should be `/tmp/error.log` etc.