### PR TITLE
Validation last=true regressions

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -201,7 +201,6 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * The first failing one will abort then per rule.
      *
      * @param bool $stopOnFailure If to apply last flag.
-     *
      * @return $this
      */
     public function stopOnFailure(bool $stopOnFailure = true)

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -197,8 +197,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
-     * Whether to apply last flag to generated rule(s).
-     * The first failing one will abort then per rule.
+     * Whether to stop validation rule evaluation on the first failed rule.
+     *
+     * When enabled the first failing rule per field will cause validation to stop.
+     * When disabled all rules will be run even if there are failures.
      *
      * @param bool $stopOnFailure If to apply last flag.
      * @return $this

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -181,12 +181,34 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     protected $_allowEmptyFlags = [];
 
     /**
+     * Whether to apply last flag to generated rule(s).
+     *
+     * @var bool
+     */
+    protected $_stopOnFailure = false;
+
+    /**
      * Constructor
      */
     public function __construct()
     {
         $this->_useI18n = function_exists('__d');
         $this->_providers = self::$_defaultProviders;
+    }
+
+    /**
+     * Whether to apply last flag to generated rule(s).
+     * The first failing one will abort then per rule.
+     *
+     * @param bool $stopOnFailure If to apply last flag.
+     *
+     * @return $this
+     */
+    public function stopOnFailure(bool $stopOnFailure = true)
+    {
+        $this->_stopOnFailure = $stopOnFailure;
+
+        return $this;
     }
 
     /**
@@ -479,7 +501,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
         foreach ($rules as $name => $rule) {
             if (is_array($rule)) {
-                $rule += ['rule' => $name];
+                $rule += [
+                    'rule' => $name,
+                    'last' => $this->_stopOnFailure,
+                ];
             }
             if (!is_string($name)) {
                 /** @psalm-suppress PossiblyUndefinedMethod */
@@ -2715,6 +2740,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             '_allowEmptyMessages' => $this->_allowEmptyMessages,
             '_allowEmptyFlags' => $this->_allowEmptyFlags,
             '_useI18n' => $this->_useI18n,
+            '_stopOnFailure' => $this->_stopOnFailure,
             '_providers' => array_keys($this->_providers),
             '_fields' => $fields,
         ];

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -205,7 +205,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param bool $stopOnFailure If to apply last flag.
      * @return $this
      */
-    public function stopOnFailure(bool $stopOnFailure = true)
+    public function setStopOnFailure(bool $stopOnFailure = true)
     {
         $this->_stopOnFailure = $stopOnFailure;
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1926,6 +1926,27 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests that setting last globally will stop validating the rest of the rules
+     *
+     * @return void
+     */
+    public function testErrorsWithLastRuleGlobal(): void
+    {
+        $validator = new Validator();
+        $validator->stopOnFailure()
+            ->notBlank('email', 'Fill something in!')
+            ->email('email', false, 'Y u no write email?');
+        $errors = $validator->validate(['email' => '']);
+        $expected = [
+            'email' => [
+                'notBlank' => 'Fill something in!',
+            ],
+        ];
+
+        $this->assertEquals($expected, $errors);
+    }
+
+    /**
      * Tests that setting last to a rule will stop validating the rest of the rules
      *
      * @return void
@@ -2155,6 +2176,7 @@ class ValidatorTest extends TestCase
                 'published' => Validator::EMPTY_STRING,
             ],
             '_useI18n' => true,
+            '_stopOnFailure' => false,
         ];
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1933,7 +1933,7 @@ class ValidatorTest extends TestCase
     public function testErrorsWithLastRuleGlobal(): void
     {
         $validator = new Validator();
-        $validator->stopOnFailure()
+        $validator->setStopOnFailure()
             ->notBlank('email', 'Fill something in!')
             ->email('email', false, 'Y u no write email?');
         $errors = $validator->validate(['email' => '']);


### PR DESCRIPTION
While upgrading an app from 3.x to 4.x I ran into a few hard blockers.
One was the hidden behavior change of validation rules being applied differently now.
See https://github.com/cakephp/cakephp/issues/14815#issuecomment-678568430

An additional problem seems to be that a rule setup as baked like this does not allow setting last in any way:

		$validator
			->requirePresence('email', 'create')
			->notBlank('email')
			->email('email');

### Part 1 of 2

This resolves this at least in a way that you can now extend the validator on project level and globally set it to true, or invoke the flag method enableLast() for it in the specific tables and retain the old 3.x behavior again.

I targeted master here since this is quite a blocker for apps trying to upgrade, and this seems to be fully BC since you need do enable this new flag.

PS: We could also make this a static call, so it could be done from bootstrapping process, rather than inline.
Or allow `(bool)Configure::read('Validation.last')` to read it in the constructor, this way it would be easier to configure without having to overwrite/extend so much.

--- 

 Part 2 of 2 will then be an API cleanup in 4.next to allow the convenience wrappers, e.g. notBlank() email() etc to accept an additional extra argument to also set the last flag per rule (which currently seems also impossible now.