### PR TITLE
Add a way to restore 3.x behavior for last=true

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1255,16 +1255,17 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
+     * @param array $extra Extra arguments, e.g. last.
      * @see \Cake\Validation\Validation::notBlank()
      * @return $this
      */
-    public function notBlank(string $field, ?string $message = null, $when = null)
+    public function notBlank(string $field, ?string $message = null, $when = null, array $extra = [])
     {
-        $extra = array_filter(['on' => $when, 'message' => $message]);
+        $extra = array_filter(['on' => $when, 'message' => $message]) + $extra;
 
-        return $this->add($field, 'notBlank', $extra + [
+        return $this->add($field, 'notBlank', [
             'rule' => 'notBlank',
-        ]);
+        ] + $extra);
     }
 
     /**
@@ -1825,16 +1826,17 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
+     * @param array $extra Extra arguments, e.g. last.
      * @see \Cake\Validation\Validation::email()
      * @return $this
      */
-    public function email(string $field, bool $checkMX = false, ?string $message = null, $when = null)
+    public function email(string $field, bool $checkMX = false, ?string $message = null, $when = null, array $extra = [])
     {
-        $extra = array_filter(['on' => $when, 'message' => $message]);
+        $extra = array_filter(['on' => $when, 'message' => $message]) + $extra;
 
-        return $this->add($field, 'email', $extra + [
+        return $this->add($field, 'email', [
             'rule' => ['email', $checkMX],
-        ]);
+        ] + $extra);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1947,6 +1947,27 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests that setting last to a rule will stop validating the rest of the rules
+     *
+     * @return void
+     */
+    public function testErrorsWithLastRuleOnWrapperMethods(): void
+    {
+        $validator = new Validator();
+        $validator
+            ->notBlank('email', null, null, ['last' => true])
+            ->email('email', false, 'Y u no write email?', ['last' => true]);
+        $errors = $validator->validate(['email' => '']);
+        $expected = [
+            'email' => [
+                'notBlank' => 'The provided value is invalid',
+            ],
+        ];
+
+        $this->assertEquals($expected, $errors);
+    }
+
+    /**
      * Tests it is possible to get validation sets for a field using an array interface
      *
      * @return void


### PR DESCRIPTION
Follows https://github.com/cakephp/cakephp/pull/14943

It basically, independent from the global setting for last, allows overwriting it on a per rule base from the convenience wrappers.
In 5.x we should clean up the API and remove some of the many args that can just be added into $extra array.

These are the baked rules, and it would be quite annoying to have to completely rewrite them only to have the flag set (and possibly other options).

WIP
so far only changed
- notBlank()
- email()

wrappers as showcase, the rest can be done once this is OK with everyone.