### PR TITLE
Add Application interface and BasePlugin methods

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use Cake\Console\CommandCollection;
-use Cake\Core\ContainerInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
 use InvalidArgumentException;

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use Cake\Console\CommandCollection;
+use Cake\Core\ContainerInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
 use InvalidArgumentException;
@@ -37,11 +38,11 @@ class BasePlugin implements PluginInterface
     protected $bootstrapEnabled = true;
 
     /**
-     * Load routes or not
+     * Console middleware
      *
      * @var bool
      */
-    protected $routesEnabled = true;
+    protected $consoleEnabled = true;
 
     /**
      * Enable middleware
@@ -51,11 +52,18 @@ class BasePlugin implements PluginInterface
     protected $middlewareEnabled = true;
 
     /**
-     * Console middleware
+     * Register container services
      *
      * @var bool
      */
-    protected $consoleEnabled = true;
+    protected $registerEnabled = true;
+
+    /**
+     * Load routes or not
+     *
+     * @var bool
+     */
+    protected $routesEnabled = true;
 
     /**
      * The path to this plugin.
@@ -280,5 +288,16 @@ class BasePlugin implements PluginInterface
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         return $middlewareQueue;
+    }
+
+    /**
+     * Register container services for this plugin.
+     *
+     * @param \Cake\Core\ContainerInterface $container The container to add services to.
+     * @return \Cake\Core\ContainerInterface The updated container
+     */
+    public function register(ContainerInterface $container): ContainerInterface
+    {
+        return $container;
     }
 }

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use League\Container\Container as LeagueContainer;
+
+/**
+ * Dependency Injection container
+ *
+ * Based on the container out of League\Container
+ *
+ * @experimental This class' interface is not stable and may change
+ *   in future minor releases.
+ */
+class Container extends LeagueContainer implements ContainerInterface
+{
+}

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -32,7 +32,7 @@ interface ContainerApplicationInterface
      * on service definitions.
      *
      * @param \Cake\Core\ContainerInterface $container The container to add services to
-     * @return \Cake\Container\ContainerInterface The updated container.
+     * @return \Cake\Core\ContainerInterface The updated container.
      */
     public function register(ContainerInterface $container): ContainerInterface;
 
@@ -42,7 +42,7 @@ interface ContainerApplicationInterface
      * This will `register()` services provided by both the application
      * and any plugins if the application has plugin support.
      *
-     * @return \Cake\Container\ContainerInterface A populated container
+     * @return \Cake\Core\ContainerInterface A populated container
      */
     public function getContainer(): ContainerInterface;
 }

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+/**
+ * Interface for applications that configure and use a dependency injection container.
+ *
+ * @experimental This interface is not final and can have additional
+ *   methods and parameters added in future minor releases.
+ */
+interface ContainerApplicationInterface
+{
+    /**
+     * Register services to the container
+     *
+     * Registered services can have instances fetched out of the container
+     * using `get()`. Dependencies and parameters will be resolved based
+     * on service definitions.
+     *
+     * @param \Cake\Core\ContainerInterface $container The container to add services to
+     * @return \Cake\Container\ContainerInterface The updated container.
+     */
+    public function register(ContainerInterface $container): ContainerInterface;
+
+    /**
+     * Create a new container and register services.
+     *
+     * This will `register()` services provided by both the application
+     * and any plugins if the application has plugin support.
+     *
+     * @return \Cake\Container\ContainerInterface A populated container
+     */
+    public function getContainer(): ContainerInterface;
+}

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -40,10 +40,10 @@ interface ContainerInterface extends PsrInterface
      * @param mixed $concrete Either the classname an interface or name resolves to.
      *   Can also be a constructed object, Closure, or null. When null, the `$id` parameter will
      *   be used as the concrete class name.
-     * @param ?bool $shared Set to true to make a service shared.
+     * @param bool $shared Set to true to make a service shared.
      * @return \League\Container\Definition\DefinitionInterface
      */
-    public function add(string $id, $concrete = null, ?bool $shared = null): DefinitionInterface;
+    public function add(string $id, $concrete = null, bool $shared = false): DefinitionInterface;
 
     /**
      * Add a service provider to the container

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -21,7 +21,8 @@ use Cake\Routing\RouteBuilder;
 /**
  * Plugin Interface
  *
- * @method register(\Cake\Core\ContainerInterface $container): \Cake\Core\ContainerInterface
+ * @method \Cake\Core\ContainerInterface register(\Cake\Core\ContainerInterface $container) Register plugin services to
+ *   the application's container
  */
 interface PluginInterface
 {

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -20,6 +20,8 @@ use Cake\Routing\RouteBuilder;
 
 /**
  * Plugin Interface
+ *
+ * @method register(\Cake\Core\ContainerInterface $container): \Cake\Core\ContainerInterface
  */
 interface PluginInterface
 {
@@ -28,7 +30,7 @@ interface PluginInterface
      *
      * @var string[]
      */
-    public const VALID_HOOKS = ['routes', 'bootstrap', 'console', 'middleware'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'register', 'routes'];
 
     /**
      * Get the name of this plugin.

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Core;
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
+use Cake\Core\Container;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
@@ -59,6 +60,7 @@ class BasePluginTest extends TestCase
         $this->assertFalse($plugin->isEnabled('bootstrap'));
         $this->assertTrue($plugin->isEnabled('console'));
         $this->assertTrue($plugin->isEnabled('middleware'));
+        $this->assertTrue($plugin->isEnabled('register'));
     }
 
     public function testGetName()
@@ -83,11 +85,18 @@ class BasePluginTest extends TestCase
         $this->assertSame($middleware, $plugin->middleware($middleware));
     }
 
-    public function testConsoleNoop()
+    public function testConsole()
     {
         $plugin = new BasePlugin();
         $commands = new CommandCollection();
         $this->assertSame($commands, $plugin->console($commands));
+    }
+
+    public function testRegister()
+    {
+        $plugin = new BasePlugin();
+        $container = new Container();
+        $this->assertSame($container, $plugin->register($container));
     }
 
     public function testConsoleFind()


### PR DESCRIPTION
Add the container interface for applications and BasePlugin method. I've not added the new method to PluginInterface as it could break existing plugins that don't extend BasePlugin. If this isn't a scenario we are concerned about I can update the interface.