### PR TITLE
Fix UUID warning for invalid ones.

### DIFF
--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -36,15 +36,20 @@ class BinaryUuidType extends BaseType
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-     * @return string|resource
+     * @return string|resource|null
      */
     public function toDatabase($value, DriverInterface $driver)
     {
-        if (is_string($value)) {
-            return $this->convertStringToBinaryUuid($value);
+        if (!is_string($value)) {
+            return $value;
         }
 
-        return $value;
+        $length = strlen($value);
+        if ($length !== 36 && $length !== 32) {
+            return null;
+        }
+
+        return $this->convertStringToBinaryUuid($value);
     }
 
     /**
@@ -126,7 +131,7 @@ class BinaryUuidType extends BaseType
     }
 
     /**
-     * Converts a string uuid to a binary representation
+     * Converts a string UUID (36 or 32 char) to a binary representation.
      *
      * @param string $string The value to convert.
      * @return string Converted value.

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -104,6 +104,18 @@ class BinaryUuidTypeTest extends TestCase
     }
 
     /**
+     * Test converting to database format fails
+     *
+     * @return void
+     */
+    public function testToDatabaseInvalid()
+    {
+        $value = 'mUMPWUxCpaCi685A9fEwJZ';
+        $result = $this->type->toDatabase($value, $this->driver);
+        $this->assertNull($result);
+    }
+
+    /**
      * Test that the PDO binding type is correct.
      *
      * @return void


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/14942

Seems like the only way to prevent the notice is to prevent people from allowing non UUID strings to be inserted into that conversion method.
So length 36 or 32 are valid, the rest cannot.