### PR TITLE
Fix visibility of $helpers property of helper classes.

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -34,7 +34,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Url'];
+    protected $helpers = ['Url'];
 
     /**
      * Default config for the helper.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -55,7 +55,7 @@ class FormHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Url', 'Html'];
+    protected $helpers = ['Url', 'Html'];
 
     /**
      * Default config for the helper.

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -43,7 +43,7 @@ class PaginatorHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Url', 'Number', 'Html', 'Form'];
+    protected $helpers = ['Url', 'Number', 'Html', 'Form'];
 
     /**
      * Default config for this class

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -39,7 +39,7 @@ class TextHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Html'];
+    protected $helpers = ['Html'];
 
     /**
      * Default config for this class


### PR DESCRIPTION
Helper::$helpers is already protected.

This fix could probably go into `master` itself but since it's not a big issue made the change for `4.next`.