### PR TITLE
Don't allow PluginLoadCommand to add invalid plugins

### DIFF
--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -74,7 +74,7 @@ class PluginLoadCommand extends Command
         try {
             Plugin::getCollection()->findPath($plugin);
         } catch (MissingPluginException $e) {
-            $this->io->err('Could not find plugin <info>NopeNotThere</info>');
+            $this->io->err($e->getMessage());
             $this->io->err('Ensure you have the correct spelling and casing.');
 
             return static::CODE_ERROR;

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -19,6 +19,8 @@ namespace Cake\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Plugin;
+use Cake\Core\Exception\MissingPluginException;
 
 /**
  * Command for loading plugins.
@@ -65,6 +67,15 @@ class PluginLoadCommand extends Command
         if (!$plugin) {
             $this->io->err('You must provide a plugin name in CamelCase format.');
             $this->io->err('To load an "Example" plugin, run `cake plugin load Example`.');
+
+            return static::CODE_ERROR;
+        }
+
+        try {
+            Plugin::getCollection()->findPath($plugin);
+        } catch (MissingPluginException $e) {
+            $this->io->err('Could not find plugin <info>NopeNotThere</info>');
+            $this->io->err('Ensure you have the correct spelling and casing.');
 
             return static::CODE_ERROR;
         }

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -19,8 +19,8 @@ namespace Cake\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Core\Plugin;
 use Cake\Core\Exception\MissingPluginException;
+use Cake\Core\Plugin;
 
 /**
  * Command for loading plugins.

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -77,16 +77,31 @@ class PluginLoadCommandTest extends TestCase
     }
 
     /**
-     * Test loading the app
+     * Test loading a plugin modifies the app
      *
      * @return void
      */
-    public function testLoadApp()
+    public function testLoadModifiesApplication()
     {
         $this->exec('plugin load TestPlugin');
         $this->assertExitCode(Command::CODE_SUCCESS);
 
         $contents = file_get_contents($this->app);
         $this->assertStringContainsString("\$this->addPlugin('TestPlugin');", $contents);
+    }
+
+    /**
+     * Test loading an unknown plugin
+     *
+     * @return void
+     */
+    public function testLoadUnknownPlugin()
+    {
+        $this->exec('plugin load NopeNotThere');
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Could not find plugin <info>NopeNotThere</info>');
+
+        $contents = file_get_contents($this->app);
+        $this->assertStringNotContainsString("\$this->addPlugin('NopeNotThere');", $contents);
     }
 }

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -99,7 +99,7 @@ class PluginLoadCommandTest extends TestCase
     {
         $this->exec('plugin load NopeNotThere');
         $this->assertExitCode(Command::CODE_ERROR);
-        $this->assertErrorContains('Could not find plugin <info>NopeNotThere</info>');
+        $this->assertErrorContains('Plugin NopeNotThere could not be found');
 
         $contents = file_get_contents($this->app);
         $this->assertStringNotContainsString("\$this->addPlugin('NopeNotThere');", $contents);


### PR DESCRIPTION
Catch mistakes earlier on as users can easily make typos when adding plugins to their applications.

Fixes #14870