### PR TITLE
Allow TimeType to marshal H:i format

### DIFF
--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -35,6 +35,7 @@ class TimeType extends DateTimeType
      */
     protected $_marshalFormats = [
         'H:i:s',
+        'H:i',
     ];
 
     /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -146,13 +146,13 @@ class TimeTypeTest extends TestCase
             ['', null],
             ['derpy', null],
             ['16-nope!', null],
-            ['14:15', null],
             ['2014-02-14 13:14:15', null],
 
             // valid string types
             ['1392387900', $date],
             [1392387900, $date],
             ['13:10:10', new Time('13:10:10')],
+            ['14:15', new Time('14:15:00')],
 
             // valid array types
             [


### PR DESCRIPTION
This aligns the behavior of TimeType with the values accepted by Validation::time(). Doing so will prevent tedious to diagnose problems where validation passes but no value is set in the entity.

The x:y format could also be marshaled as I:S but we already accept Y-m-d H:i in the DateTimeType and having consistency is important.

Fixes #14957