### PR TITLE
Fixtures not truncated when both $import and $fields aren't set

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -310,7 +310,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
         }
 
         if (empty($this->import) && empty($this->fields)) {
-            return true;
+            return $this->truncate($db);
         }
 
         try {

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -178,7 +178,6 @@ class TestFixtureTest extends TestCase
         $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
 
         $db = $this->getMockBuilder('Cake\Database\Connection')
-            ->onlyMethods(['prepare', 'execute'])
             ->disableOriginalConstructor()
             ->getMock();
         $db->expects($this->never())


### PR DESCRIPTION
Issue #14958

When both `$fixture->import` and `$fixture->fields` are not set, the fixture uses the structure of an existing table. When setting up the table, the fixture manager was using `$fixture->drop()` and `$fixture->create()` when it should be using `$fixture->truncate()` in this case. The drop and create methods just return true right away with this setup.
