### PR TITLE
Restrict Validation::time() so it requires minutes not just hours

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -627,7 +627,7 @@ class Validation
 
     /**
      * Time validation, determines if the string passed is a valid time.
-     * Validates time as 24hr (HH[:MM][:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
+     * Validates time as 24hr (HH:MM[:SS][.FFFFFF]) or am/pm ([H]H:MM[a|p]m)
      *
      * Seconds and fractional seconds (microseconds) are allowed but optional
      * in 24hr format.
@@ -649,7 +649,7 @@ class Validation
         }
 
         $meridianClockRegex = '^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$';
-        $standardClockRegex = '^([01]\d|2[0-3])((:[0-5]\d){0,2}|(:[0-5]\d){2}\.\d{0,6})$';
+        $standardClockRegex = '^([01]\d|2[0-3])((:[0-5]\d){1,2}|(:[0-5]\d){2}\.\d{0,6})$';
 
         return static::_check($check, '%' . $meridianClockRegex . '|' . $standardClockRegex . '%');
     }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1650,13 +1650,12 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::time('1:00pm'));
         $this->assertFalse(Validation::time('13:00pm'));
         $this->assertFalse(Validation::time('9:00'));
-        $this->assertTrue(Validation::time('00'));
+        $this->assertFalse(Validation::time('00'));
         $this->assertFalse(Validation::time('0'));
-        $this->assertTrue(Validation::time('09'));
+        $this->assertFalse(Validation::time('09'));
         $this->assertFalse(Validation::time('9'));
-        $this->assertTrue(Validation::time('10'));
-        $this->assertTrue(Validation::time('23'));
-        $this->assertFalse(Validation::time('24'));
+        $this->assertFalse(Validation::time('10'));
+        $this->assertFalse(Validation::time('23'));
     }
 
     /**


### PR DESCRIPTION
I am proposing this as the alternative to https://github.com/cakephp/cakephp/pull/14930. I don't think most users expect hours only to pass validation in a 24-hour format.

PHP DateTime will not parse hours-only when passed to the constructor so it would require a custom format for users that want to accept this input.

https://3v4l.org/iYb3Q

Did not adjust the am/pm (meridian) format which will validate something like "1 pm". These formats are never marshaled so I don't know when users expect to use them.