### PR TITLE
Add container support to CommandFactory

### DIFF
--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Console;
 
+use Cake\Core\ContainerInterface;
 use InvalidArgumentException;
 
 /**
@@ -25,11 +26,31 @@ use InvalidArgumentException;
 class CommandFactory implements CommandFactoryInterface
 {
     /**
+     * @var \Cake\Core\ContainerInterface|null
+     */
+    protected $container;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Core\ContainerInterface $container The container to use if available.
+     */
+    public function __construct(?ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
      * @inheritDoc
      */
     public function create(string $className)
     {
-        $command = new $className();
+        if ($this->container && $this->container->has($className)) {
+            $command = $this->container->get($className);
+        } else {
+            $command = new $className();
+        }
+
         if (!($command instanceof CommandInterface) && !($command instanceof Shell)) {
             /** @psalm-suppress DeprecatedClass */
             $valid = implode('` or `', [Shell::class, CommandInterface::class]);

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -33,7 +33,7 @@ class CommandFactory implements CommandFactoryInterface
     /**
      * Constructor
      *
-     * @param \Cake\Core\ContainerInterface $container The container to use if available.
+     * @param \Cake\Core\ContainerInterface|null $container The container to use if available.
      */
     public function __construct(?ContainerInterface $container = null)
     {

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -50,7 +50,7 @@ class CommandRunner implements EventDispatcherInterface
     /**
      * The application console commands are being run for.
      *
-     * @var \Cake\Console\CommandFactoryInterface
+     * @var \Cake\Console\CommandFactoryInterface|null
      */
     protected $factory;
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -21,6 +21,7 @@ use Cake\Console\Command\HelpCommand;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;
+use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -81,7 +82,7 @@ class CommandRunner implements EventDispatcherInterface
     ) {
         $this->app = $app;
         $this->root = $root;
-        $this->factory = $factory ?: new CommandFactory();
+        $this->factory = $factory;
         $this->aliases = [
             '--version' => 'version',
             '--help' => 'help',
@@ -368,6 +369,14 @@ class CommandRunner implements EventDispatcherInterface
      */
     protected function createCommand(string $className, ConsoleIo $io)
     {
+        if (!$this->factory) {
+            $container = null;
+            if ($this->app instanceof ContainerApplicationInterface) {
+                $container = $this->app->getContainer();
+            }
+            $this->factory = new CommandFactory($container);
+        }
+
         $shell = $this->factory->create($className);
         if ($shell instanceof Shell) {
             $shell->setIo($io);

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -16,9 +16,12 @@ namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\CommandFactory;
 use Cake\Console\CommandInterface;
+use Cake\Core\Container;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use stdClass;
 use TestApp\Command\DemoCommand;
+use TestApp\Command\DependencyCommand;
 use TestApp\Shell\SampleShell;
 
 class CommandFactoryTest extends TestCase
@@ -30,6 +33,19 @@ class CommandFactoryTest extends TestCase
         $command = $factory->create(DemoCommand::class);
         $this->assertInstanceOf(DemoCommand::class, $command);
         $this->assertInstanceOf(CommandInterface::class, $command);
+    }
+
+    public function testCreateCommandDependencies()
+    {
+        $container = new Container();
+        $container->add(stdClass::class, json_decode('{"key":"value"}'));
+        $container->add(DependencyCommand::class)
+            ->addArgument(stdClass::class);
+        $factory = new CommandFactory($container);
+
+        $command = $factory->create(DependencyCommand::class);
+        $this->assertInstanceOf(DependencyCommand::class, $command);
+        $this->assertInstanceOf(stdClass::class, $command->inject);
     }
 
     public function testCreateShell()

--- a/tests/test_app/TestApp/Command/DependencyCommand.php
+++ b/tests/test_app/TestApp/Command/DependencyCommand.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use stdClass;
+
+class DependencyCommand extends Command
+{
+    public $inject;
+
+    public function __construct(stdClass $inject)
+    {
+        parent::__construct();
+        $this->inject = $inject;
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $io->out('Dependency Command');
+        $io->out('constructor inject: ' . get_class($this->inject));
+
+        return static::CODE_SUCCESS;
+    }
+}


### PR DESCRIPTION
This enables commands to have dependencies injected as constructor arguments.

Refs #14865
Refs #14945 

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
