### PR TITLE
Logs RedisException message to error log on connection failure.

### DIFF
--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -88,7 +88,7 @@ class CacheRegistry extends ObjectRegistry
         if (!$instance->init($config)) {
             throw new RuntimeException(
                 sprintf(
-                    'Cache engine %s is not properly configured. Check log for additional information.',
+                    'Cache engine %s is not properly configured. Check error log for additional information.',
                     get_class($instance)
                 )
             );

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -87,7 +87,10 @@ class CacheRegistry extends ObjectRegistry
 
         if (!$instance->init($config)) {
             throw new RuntimeException(
-                sprintf('Cache engine %s is not properly configured.', get_class($instance))
+                sprintf(
+                    'Cache engine %s is not properly configured. Check log for additional information.',
+                    get_class($instance)
+                )
             );
         }
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -118,7 +118,7 @@ class RedisEngine extends CacheEngine
             }
         } catch (RedisException $e) {
             if (class_exists(Log::class)) {
-                Log::error('RedisEngine RedisException: ' . $e->getMessage());
+                Log::error('RedisEngine could not connect. Got error: ' . $e->getMessage());
             }
 
             return false;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -118,6 +118,7 @@ class RedisEngine extends CacheEngine
             }
         } catch (RedisException $e) {
             Log::error('RedisEngine RedisException: ' . $e->getMessage());
+
             return false;
         }
         if ($return && $this->_config['password']) {

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -117,7 +117,9 @@ class RedisEngine extends CacheEngine
                 );
             }
         } catch (RedisException $e) {
-            Log::error('RedisEngine RedisException: ' . $e->getMessage());
+            if (class_exists(Log::class)) {
+                Log::error('RedisEngine RedisException: ' . $e->getMessage());
+            }
 
             return false;
         }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
+use Cake\Log\Log;
 use Redis;
 use RedisException;
 use RuntimeException;
@@ -116,6 +117,7 @@ class RedisEngine extends CacheEngine
                 );
             }
         } catch (RedisException $e) {
+            Log::error('RedisEngine RedisException: ' . $e->getMessage());
             return false;
         }
         if ($return && $this->_config['password']) {


### PR DESCRIPTION
On a connection failure to the Redis server cake currently displays the following warning:

> Cache engine %s is not properly configured.

This is not particularly useful in determining the problem. This PR adds the RedisException message to the error log and informs the user to check there. Probably some better ways of going about this, but this is a step in the right direction IMO.