### PR TITLE
Fix sameSite for PHP 7.3+

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -563,15 +563,29 @@ class Response implements ResponseInterface
         );
 
         foreach ($this->_cookies as $cookie) {
-            setcookie(
-                $cookie->getName(),
-                $cookie->getValue(),
-                $cookie->getExpiresTimestamp(),
-                $cookie->getPath(),
-                $cookie->getDomain(),
-                $cookie->isSecure(),
-                $cookie->isHttpOnly()
-            );
+            if (PHP_VERSION_ID >= 70300) {
+                setcookie(
+                    $cookie->getName(),
+                    $cookie->getValue(),
+                    [
+                        'expires' => $cookie->getExpiresTimestamp(),
+                        'path' => $cookie->getPath(),
+                        'domain' => $cookie->getDomain(),
+                        'secure' => $cookie->isSecure(),
+                        'httponly' => $cookie->isHttpOnly(),
+                    ]
+                );
+            } else {
+                setcookie(
+                    $cookie->getName(),
+                    $cookie->getValue(),
+                    $cookie->getExpiresTimestamp(),
+                    $cookie->getPath(),
+                    $cookie->getDomain(),
+                    $cookie->isSecure(),
+                    $cookie->isHttpOnly()
+                );
+            }
         }
     }
 

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -135,6 +135,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => true,
                 'httponly' => false,
+                'samesite' => null,
             ],
             [
                 'name' => 'google',
@@ -144,6 +145,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => false,
                 'httponly' => true,
+                'samesite' => null,
             ],
         ];
         $this->assertEquals($expected, $GLOBALS['mockedCookies']);
@@ -162,6 +164,7 @@ class ResponseEmitterTest extends TestCase
             ->withAddedHeader('Set-Cookie', 'google=not=nice;Path=/accounts; HttpOnly')
             ->withAddedHeader('Set-Cookie', 'a=b;  Expires=Wed, 13 Jan 2021 22:23:01 GMT; Domain=www.example.com;')
             ->withAddedHeader('Set-Cookie', 'list%5B%5D=a%20b%20c')
+            ->withAddedHeader('Set-Cookie', 'x=y;Path=/somepath; SameSite=None')
             ->withHeader('Content-Type', 'text/plain');
         $response->getBody()->write('ok');
 
@@ -184,6 +187,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => true,
                 'httponly' => false,
+                'samesite' => null,
             ],
             [
                 'name' => 'people',
@@ -193,6 +197,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => false,
                 'httponly' => false,
+                'samesite' => null,
             ],
             [
                 'name' => 'google',
@@ -202,6 +207,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => false,
                 'httponly' => true,
+                'samesite' => null,
             ],
             [
                 'name' => 'a',
@@ -211,6 +217,7 @@ class ResponseEmitterTest extends TestCase
                 'domain' => 'www.example.com',
                 'secure' => false,
                 'httponly' => false,
+                'samesite' => null,
             ],
             [
                 'name' => 'list[]',
@@ -220,6 +227,17 @@ class ResponseEmitterTest extends TestCase
                 'domain' => '',
                 'secure' => false,
                 'httponly' => false,
+                'samesite' => null,
+            ],
+            [
+                'name' => 'x',
+                'value' => 'y',
+                'path' => '/somepath',
+                'expire' => 0,
+                'domain' => '',
+                'secure' => false,
+                'httponly' => false,
+                'samesite' => 'None',
             ],
         ];
         $this->assertEquals($expected, $GLOBALS['mockedCookies']);

--- a/tests/TestCase/Http/server_mocks.php
+++ b/tests/TestCase/Http/server_mocks.php
@@ -14,15 +14,39 @@ function header($header)
     $GLOBALS['mockedHeaders'][] = $header;
 }
 
-function setcookie($name, $value, $expire, $path, $domain, $secure = false, $httponly = false)
-{
-    $GLOBALS['mockedCookies'][] = compact(
-        'name',
-        'value',
-        'expire',
-        'path',
-        'domain',
-        'secure',
-        'httponly'
-    );
+if (PHP_VERSION_ID >= 70300) {
+    function setcookie($name, $value, $options)
+    {
+        $GLOBALS['mockedCookies'][] = [
+            'name' => $name,
+            'value' => $value,
+            'expire' => $options['expires'],
+            'path' => $options['path'],
+            'domain' => $options['domain'],
+            'secure' => isset($options['secure']) ? $options['secure'] : false,
+            'httponly' => isset($options['httponly']) ? $options['httponly'] : false,
+            'samesite' => isset($options['samesite']) ? $options['samesite'] : null,
+        ];
+    }
+} else {
+    function setcookie($name, $value, $expire, $path, $domain, $secure = false, $httponly = false)
+    {
+        // We need to parse out sameSite for PHP < 7.3
+        $samesite = null;
+        if (preg_match('/^(.*); SameSite=(.*)$/', $path, $matches) === 1) {
+            $path = $matches[1];
+            $samesite = $matches[2];
+        }
+
+        $GLOBALS['mockedCookies'][] = compact(
+            'name',
+            'value',
+            'expire',
+            'path',
+            'domain',
+            'secure',
+            'httponly',
+            'samesite'
+        );
+    }
 }


### PR DESCRIPTION
We have some webapps that need to set the `sameSite` option for a cookie, which we do by setting the path to `/; SameSite=None`. This works on PHP < 7.3 but breaks on 7.3+.
This PR should add a fix for that.

I saw that on `master` the `Cookie` object has a sameSite property but the 4.x code also changes the path to have `; sameSite=x` in it. I can also submit a PR for `master` if this one seems good.