### PR TITLE
Add docs for runCommand + container

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -242,6 +242,10 @@ abstract class BaseCommand implements CommandInterface
     /**
      * Execute another command with the provided set of arguments.
      *
+     * If you are using a string command name, that command's dependencies
+     * will not be resolved with the application container. Instead you will
+     * need to pass the command as an object with all of its dependencies.
+     *
      * @param string|\Cake\Console\CommandInterface $command The command class name or command instance.
      * @param array $args The arguments to invoke the command with.
      * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.


### PR DESCRIPTION
Add notes on the limitations of runCommand() and the container. Because commands don't have access to the container they are unable resolve dependencies. Instead commands should be defined in the container and then resolved as dependencies to the calling command.

Refs #14865 