### PR TITLE
Return all possible form context attributes.

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -317,7 +317,10 @@ class ArrayContext implements ContextInterface
             $schema = Hash::get($this->_context['schema'], $this->stripNesting($field));
         }
 
-        return (array)$schema;
+        return array_intersect_key(
+            (array)$schema,
+            array_flip(static::VALID_ATTRIBUTES)
+        );
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -316,9 +316,8 @@ class ArrayContext implements ContextInterface
         if ($schema === null) {
             $schema = Hash::get($this->_context['schema'], $this->stripNesting($field));
         }
-        $allowed = ['length' => null, 'precision' => null];
 
-        return array_intersect_key((array)$schema, $allowed);
+        return (array)$schema;
     }
 
     /**

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -21,6 +21,8 @@ namespace Cake\View\Form;
  */
 interface ContextInterface
 {
+    public const VALID_ATTRIBUTES = ['length', 'precision', 'comment', 'null', 'default'];
+
     /**
      * Get the fields used in the context as a primary key.
      *

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -711,7 +711,10 @@ class EntityContext implements ContextInterface
             return [];
         }
 
-        return (array)$table->getSchema()->getColumn(array_pop($parts));
+        $column = (array)$table->getSchema()->getColumn(array_pop($parts));
+        $allowed = ['length' => null, 'precision' => null, 'comment' => null, 'null' => null, 'default' => null];
+
+        return array_intersect_key($column, $allowed);
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -711,10 +711,10 @@ class EntityContext implements ContextInterface
             return [];
         }
 
-        $column = (array)$table->getSchema()->getColumn(array_pop($parts));
-        $allowed = ['length' => null, 'precision' => null, 'comment' => null, 'null' => null, 'default' => null];
-
-        return array_intersect_key($column, $allowed);
+        return array_intersect_key(
+            (array)$table->getSchema()->getColumn(array_pop($parts)),
+            array_flip(static::VALID_ATTRIBUTES)
+        );
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -711,10 +711,7 @@ class EntityContext implements ContextInterface
             return [];
         }
 
-        $column = (array)$table->getSchema()->getColumn(array_pop($parts));
-        $allowed = ['length' => null, 'precision' => null];
-
-        return array_intersect_key($column, $allowed);
+        return (array)$table->getSchema()->getColumn(array_pop($parts));
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -202,10 +202,7 @@ class FormContext implements ContextInterface
      */
     public function attributes(string $field): array
     {
-        $column = (array)$this->_form->getSchema()->field($field);
-        $allowed = ['length' => null, 'precision' => null];
-
-        return array_intersect_key($column, $allowed);
+        return (array)$this->_form->getSchema()->field($field);
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -202,7 +202,10 @@ class FormContext implements ContextInterface
      */
     public function attributes(string $field): array
     {
-        return (array)$this->_form->getSchema()->field($field);
+        return array_intersect_key(
+            (array)$this->_form->getSchema()->field($field),
+            array_flip(static::VALID_ATTRIBUTES)
+        );
     }
 
     /**

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -291,11 +291,11 @@ class ArrayContextTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertEquals([], $context->attributes('Comments.id'));
-        $this->assertEquals(['length' => 25], $context->attributes('Comments.0.tags'));
-        $this->assertEquals(['length' => 255], $context->attributes('Comments.comment'));
-        $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.decimal'));
-        $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.floaty'));
+        $this->assertEquals(['type' => 'integer'], $context->attributes('Comments.id'));
+        $this->assertEquals(['length' => 25, 'type' => 'string'], $context->attributes('Comments.0.tags'));
+        $this->assertEquals(['length' => 255, 'type' => 'string'], $context->attributes('Comments.comment'));
+        $this->assertEquals(['precision' => 2, 'length' => 5, 'type' => 'decimal'], $context->attributes('Comments.decimal'));
+        $this->assertEquals(['precision' => 2, 'length' => 5, 'type' => 'float'], $context->attributes('Comments.floaty'));
     }
 
     /**

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -291,11 +291,11 @@ class ArrayContextTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertEquals(['type' => 'integer'], $context->attributes('Comments.id'));
-        $this->assertEquals(['length' => 25, 'type' => 'string'], $context->attributes('Comments.0.tags'));
-        $this->assertEquals(['length' => 255, 'type' => 'string'], $context->attributes('Comments.comment'));
-        $this->assertEquals(['precision' => 2, 'length' => 5, 'type' => 'decimal'], $context->attributes('Comments.decimal'));
-        $this->assertEquals(['precision' => 2, 'length' => 5, 'type' => 'float'], $context->attributes('Comments.floaty'));
+        $this->assertEquals([], $context->attributes('Comments.id'));
+        $this->assertEquals(['length' => 25], $context->attributes('Comments.0.tags'));
+        $this->assertEquals(['length' => 255], $context->attributes('Comments.comment'));
+        $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.decimal'));
+        $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.floaty'));
     }
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -396,8 +396,8 @@ class EntityContextTest extends TestCase
         $this->assertNull($context->type('0.nope'));
 
         $expected = [
-            'length' => 255, 'precision' => null, 'type' => 'string',
-            'null' => null, 'default' => null, 'comment' => null, 'collate' => null,
+            'length' => 255, 'precision' => null,
+            'null' => null, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('0.user.username'));
     }
@@ -1120,26 +1120,26 @@ class EntityContextTest extends TestCase
         ]);
 
         $expected = [
-            'length' => 255, 'precision' => null, 'type' => 'string',
-            'null' => null, 'default' => null, 'comment' => null, 'collate' => null,
+            'length' => 255, 'precision' => null,
+            'null' => null, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('title'));
 
         $expected = [
-            'length' => null, 'precision' => null, 'type' => 'crazy_text',
+            'length' => null, 'precision' => null,
             'null' => null, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('body'));
 
         $expected = [
-            'length' => 10, 'precision' => 3, 'type' => 'decimal',
-            'null' => null, 'default' => null, 'comment' => null, 'unsigned' => null,
+            'length' => 10, 'precision' => 3,
+            'null' => null, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('user.rating'));
 
         $expected = [
-            'length' => 11, 'precision' => null, 'type' => 'integer',
-            'null' => false, 'default' => null, 'comment' => null, 'unsigned' => null, 'autoIncrement' => null,
+            'length' => 11, 'precision' => null,
+            'null' => false, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('tags.0._joinData.article_id'));
     }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -395,7 +395,10 @@ class EntityContextTest extends TestCase
         $this->assertSame('string', $context->type('99.title'));
         $this->assertNull($context->type('0.nope'));
 
-        $expected = ['length' => 255, 'precision' => null];
+        $expected = [
+            'length' => 255, 'precision' => null, 'type' => 'string',
+            'null' => null, 'default' => null, 'comment' => null, 'collate' => null,
+        ];
         $this->assertEquals($expected, $context->attributes('0.user.username'));
     }
 
@@ -1117,22 +1120,26 @@ class EntityContextTest extends TestCase
         ]);
 
         $expected = [
-            'length' => 255, 'precision' => null,
+            'length' => 255, 'precision' => null, 'type' => 'string',
+            'null' => null, 'default' => null, 'comment' => null, 'collate' => null,
         ];
         $this->assertEquals($expected, $context->attributes('title'));
 
         $expected = [
-            'length' => null, 'precision' => null,
+            'length' => null, 'precision' => null, 'type' => 'crazy_text',
+            'null' => null, 'default' => null, 'comment' => null,
         ];
         $this->assertEquals($expected, $context->attributes('body'));
 
         $expected = [
-            'length' => 10, 'precision' => 3,
+            'length' => 10, 'precision' => 3, 'type' => 'decimal',
+            'null' => null, 'default' => null, 'comment' => null, 'unsigned' => null,
         ];
         $this->assertEquals($expected, $context->attributes('user.rating'));
 
         $expected = [
-            'length' => 11, 'precision' => null,
+            'length' => 11, 'precision' => null, 'type' => 'integer',
+            'null' => false, 'default' => null, 'comment' => null, 'unsigned' => null, 'autoIncrement' => null,
         ];
         $this->assertEquals($expected, $context->attributes('tags.0._joinData.article_id'));
     }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -233,11 +233,11 @@ class FormContextTest extends TestCase
         ]);
         $this->assertEquals([], $context->attributes('id'));
         $this->assertEquals(
-            ['length' => 10, 'precision' => null, 'type' => 'string', 'default' => null],
+            ['length' => 10, 'precision' => null, 'default' => null],
             $context->attributes('email')
         );
         $this->assertEquals(
-            ['precision' => 2, 'length' => 5, 'type' => 'decimal', 'default' => null],
+            ['precision' => 2, 'length' => 5, 'default' => null],
             $context->attributes('amount')
         );
     }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -232,8 +232,14 @@ class FormContextTest extends TestCase
             'entity' => $form,
         ]);
         $this->assertEquals([], $context->attributes('id'));
-        $this->assertEquals(['length' => 10, 'precision' => null], $context->attributes('email'));
-        $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('amount'));
+        $this->assertEquals(
+            ['length' => 10, 'precision' => null, 'type' => 'string', 'default' => null],
+            $context->attributes('email')
+        );
+        $this->assertEquals(
+            ['precision' => 2, 'length' => 5, 'type' => 'decimal', 'default' => null],
+            $context->attributes('amount')
+        );
     }
 
     /**


### PR DESCRIPTION
Additional attributes could be for e.g. useful in custom widgets.

For e.g. `comment` attribute of a table column could be used to auto generate help text below a form input.