### PR TITLE
Use exception code as http code for HttpException only

### DIFF
--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -61,20 +61,16 @@ class Exception extends RuntimeException
      *
      * @param string|array $message Either the string of the error message, or an array of attributes
      *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
-     * @param int|null $code The code of the error, is also the HTTP status code for the error.
+     * @param int|null $code The error code
      * @param \Throwable|null $previous the previous exception.
      */
     public function __construct($message = '', ?int $code = null, ?Throwable $previous = null)
     {
-        if ($code === null) {
-            $code = $this->_defaultCode;
-        }
-
         if (is_array($message)) {
             $this->_attributes = $message;
             $message = vsprintf($this->_messageTemplate, $message);
         }
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $code ?? $this->_defaultCode, $previous);
     }
 
     /**

--- a/src/Datasource/Exception/InvalidPrimaryKeyException.php
+++ b/src/Datasource/Exception/InvalidPrimaryKeyException.php
@@ -23,8 +23,4 @@ use Cake\Core\Exception\Exception;
  */
 class InvalidPrimaryKeyException extends Exception
 {
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 404;
 }

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -305,7 +305,8 @@ class ExceptionRenderer implements ExceptionRendererInterface
             $baseClass = substr($baseClass, 0, -9);
         }
 
-        $method = Inflector::variable($baseClass) ?: 'error500';
+        // $baseClass would be an empty string if the exception class is \Exception.
+        $method = $baseClass === '' ? 'error500' : Inflector::variable($baseClass);
 
         return $this->method = $method;
     }
@@ -339,24 +340,15 @@ class ExceptionRenderer implements ExceptionRendererInterface
      * Get template for rendering exception info.
      *
      * @param \Throwable $exception Exception instance.
-     * @param string $method Method name.
+     * @param string $template Template name.
      * @param int $code Error code.
      * @return string Template name
      */
-    protected function _template(Throwable $exception, string $method, int $code): string
+    protected function _template(Throwable $exception, string $template, int $code): string
     {
-        $isHttpException = $exception instanceof HttpException;
-
-        if (!Configure::read('debug') && !$isHttpException || $isHttpException) {
-            $template = 'error500';
-            if ($code < 500) {
-                $template = 'error400';
-            }
-
-            return $this->template = $template;
+        if ($exception instanceof HttpException || !Configure::read('debug')) {
+            return $this->template = $code < 500 ? 'error400' : 'error500';
         }
-
-        $template = $method ?: 'error500';
 
         if ($exception instanceof PDOException) {
             $template = 'pdo_error';

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -340,21 +340,21 @@ class ExceptionRenderer implements ExceptionRendererInterface
      * Get template for rendering exception info.
      *
      * @param \Throwable $exception Exception instance.
-     * @param string $template Template name.
+     * @param string $method Method name.
      * @param int $code Error code.
      * @return string Template name
      */
-    protected function _template(Throwable $exception, string $template, int $code): string
+    protected function _template(Throwable $exception, string $method, int $code): string
     {
         if ($exception instanceof HttpException || !Configure::read('debug')) {
             return $this->template = $code < 500 ? 'error400' : 'error500';
         }
 
         if ($exception instanceof PDOException) {
-            $template = 'pdo_error';
+            return $this->template = 'pdo_error';
         }
 
-        return $this->template = $template;
+        return $this->template = $method;
     }
 
     /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -23,7 +23,6 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\Exception\MissingPluginException;
-use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -108,7 +107,6 @@ class ExceptionRenderer implements ExceptionRendererInterface
         // Controller exceptions
         MissingActionException::class => 404,
         // Datasource exceptions
-        InvalidPrimaryKeyException::class => 404,
         PageOutOfBoundsException::class => 404,
         RecordNotFoundException::class => 404,
         // Http exceptions

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -95,6 +95,15 @@ class ExceptionRenderer implements ExceptionRendererInterface
      */
     protected $request;
 
+    /**
+     * Map of exceptions to http status codes.
+     *
+     * This can be customized for users that don't want specific exceptions to throw 404 errors
+     * or want their application exceptions to be automatically converted.
+     *
+     * @var array
+     * @psalm-var array<class-string<\Throwable>, int>
+     */
     protected $exceptionHttpCodes = [
         // Controller exceptions
         MissingActionException::class => 404,

--- a/src/Mailer/Exception/MissingActionException.php
+++ b/src/Mailer/Exception/MissingActionException.php
@@ -25,9 +25,4 @@ class MissingActionException extends Exception
      * @inheritDoc
      */
     protected $_messageTemplate = 'Mail %s::%s() could not be found, or is not accessible.';
-
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 404;
 }

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -320,7 +320,7 @@ class ExceptionRendererTest extends TestCase
      */
     public function testUnknownExceptionTypeWithCodeHigherThan500()
     {
-        $exception = new \OutOfBoundsException('foul ball.', 501);
+        $exception = new HttpException('foul ball.', 501);
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $response = $ExceptionRenderer->render();
         $result = (string)$response->getBody();
@@ -611,7 +611,7 @@ class ExceptionRendererTest extends TestCase
                     '/Missing Method in UserMailer/',
                     '/<em>UserMailer::welcome\(\)<\/em>/',
                 ],
-                404,
+                500,
             ],
             [
                 new Exception('boom'),

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -172,7 +172,7 @@ class ExceptionsTest extends TestCase
             ['Cake\Datasource\Exception\MissingModelException', 500],
             ['Cake\Datasource\Exception\PageOutOfBoundsException', 404],
             ['Cake\Datasource\Exception\RecordNotFoundException', 404],
-            ['Cake\Mailer\Exception\MissingActionException', 404],
+            ['Cake\Mailer\Exception\MissingActionException', 500],
             ['Cake\Mailer\Exception\MissingMailerException', 500],
             ['Cake\Http\Exception\BadRequestException', 400],
             ['Cake\Http\Exception\ConflictException', 409],

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -166,7 +166,7 @@ class ExceptionsTest extends TestCase
             ['Cake\Database\Exception\MissingDriverException', 500],
             ['Cake\Database\Exception\MissingExtensionException', 500],
             ['Cake\Database\Exception\NestedTransactionRollbackException', 500],
-            ['Cake\Datasource\Exception\InvalidPrimaryKeyException', 404],
+            ['Cake\Datasource\Exception\InvalidPrimaryKeyException', 500],
             ['Cake\Datasource\Exception\MissingDatasourceConfigException', 500],
             ['Cake\Datasource\Exception\MissingDatasourceException', 500],
             ['Cake\Datasource\Exception\MissingModelException', 500],


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/14897

ExceptionRenderer now maps certain non-http exceptions to their http status codes instead of requiring exceptions to extend HttpException or require core Exception to implement http status codes.

~A few exceptions that were returning 404 now return 500.~