### PR TITLE
Set default error code to 500 for HttpException only

### DIFF
--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -26,9 +26,4 @@ class MissingActionException extends Exception
      * @inheritDoc
      */
     protected $_messageTemplate = 'Action %s::%s() could not be found, or is not accessible.';
-
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 404;
 }

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -51,7 +51,7 @@ class Exception extends RuntimeException
      *
      * @var int
      */
-    protected $_defaultCode = 500;
+    protected $_defaultCode = 0;
 
     /**
      * Constructor.

--- a/src/Datasource/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Exception/PageOutOfBoundsException.php
@@ -25,9 +25,4 @@ class PageOutOfBoundsException extends Exception
      * @inheritDoc
      */
     protected $_messageTemplate = 'Page number %s could not be found.';
-
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 404;
 }

--- a/src/Datasource/Exception/RecordNotFoundException.php
+++ b/src/Datasource/Exception/RecordNotFoundException.php
@@ -23,8 +23,4 @@ use Cake\Core\Exception\Exception;
  */
 class RecordNotFoundException extends Exception
 {
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 404;
 }

--- a/src/Error/ConsoleErrorHandler.php
+++ b/src/Error/ConsoleErrorHandler.php
@@ -61,9 +61,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
     {
         $this->_displayException($exception);
         $this->logException($exception);
-        $code = $exception->getCode();
-        $code = $code && is_int($code) ? $code : 1;
-        $this->_stop($code);
+        $this->_stop(1);
     }
 
     /**

--- a/src/Error/ConsoleErrorHandler.php
+++ b/src/Error/ConsoleErrorHandler.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Error;
 
+use Cake\Command\Command;
 use Cake\Console\ConsoleOutput;
+use Cake\Console\Exception\ConsoleException;
 use Throwable;
 
 /**
@@ -61,7 +63,12 @@ class ConsoleErrorHandler extends BaseErrorHandler
     {
         $this->_displayException($exception);
         $this->logException($exception);
-        $this->_stop(1);
+
+        $exitCode = Command::CODE_ERROR;
+        if ($exception instanceof ConsoleException) {
+            $exitCode = (int)$exception->getCode();
+        }
+        $this->_stop($exitCode);
     }
 
     /**

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -26,4 +26,8 @@ use Cake\Core\Exception\Exception;
  */
 class HttpException extends Exception
 {
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultCode = 500;
 }

--- a/src/Network/Exception/SocketException.php
+++ b/src/Network/Exception/SocketException.php
@@ -22,8 +22,4 @@ use Cake\Core\Exception\Exception;
  */
 class SocketException extends Exception
 {
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 0;
 }

--- a/src/Utility/Exception/XmlException.php
+++ b/src/Utility/Exception/XmlException.php
@@ -22,8 +22,4 @@ use Cake\Core\Exception\Exception;
  */
 class XmlException extends Exception
 {
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultCode = 0;
 }

--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -16,9 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Error;
 
+use Cake\Console\Exception\ConsoleException;
 use Cake\Controller\Exception\MissingActionException;
-use Cake\Http\Exception\InternalErrorException;
-use Cake\Http\Exception\NotFoundException;
 use Cake\Log\Log;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
@@ -126,33 +125,28 @@ class ConsoleErrorHandlerTest extends TestCase
     {
         $exception = new \InvalidArgumentException('Too many parameters.');
 
+        $this->Error->expects($this->once())
+            ->method('_stop')
+            ->with(1);
+
         $this->Error->handleException($exception);
         $this->assertStringContainsString('Too many parameters', $this->stderr->messages()[0]);
     }
 
     /**
-     * test a Error404 exception.
+     * Test error code is used as exit code for ConsoleException.
      *
      * @return void
      */
-    public function testError404Exception()
+    public function testConsoleExceptions()
     {
-        $exception = new NotFoundException("don't use me in cli.");
+        $exception = new ConsoleException('Test ConsoleException', 2);
+
+        $this->Error->expects($this->once())
+            ->method('_stop')
+            ->with(2);
 
         $this->Error->handleException($exception);
-        $this->assertStringContainsString("don't use me in cli", $this->stderr->messages()[0]);
-    }
-
-    /**
-     * test a Error500 exception.
-     *
-     * @return void
-     */
-    public function testError500Exception()
-    {
-        $exception = new InternalErrorException("don't use me in cli.");
-
-        $this->Error->handleException($exception);
-        $this->assertStringContainsString("don't use me in cli", $this->stderr->messages()[0]);
+        $this->assertStringContainsString('Test ConsoleException', $this->stderr->messages()[0]);
     }
 }

--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Error;
 
 use Cake\Controller\Exception\MissingActionException;
-use Cake\Core\Exception\Exception;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Log\Log;
@@ -109,7 +108,8 @@ class ConsoleErrorHandlerTest extends TestCase
         $message = sprintf("<error>Exception:</error> Missing action\nIn [%s, line %s]\n", $exception->getFile(), $exception->getLine());
 
         $this->Error->expects($this->once())
-            ->method('_stop');
+            ->method('_stop')
+            ->with(1);
 
         $this->Error->handleException($exception);
 
@@ -154,27 +154,5 @@ class ConsoleErrorHandlerTest extends TestCase
 
         $this->Error->handleException($exception);
         $this->assertStringContainsString("don't use me in cli", $this->stderr->messages()[0]);
-    }
-
-    /**
-     * test a exception with non-integer code
-     *
-     * @return void
-     */
-    public function testNonIntegerExceptionCode()
-    {
-        $exception = new Exception('Non-integer exception code');
-
-        $class = new \ReflectionClass('Exception');
-        $property = $class->getProperty('code');
-        $property->setAccessible(true);
-        $property->setValue($exception, '42S22');
-
-        $this->Error->expects($this->once())
-            ->method('_stop')
-            ->with(1);
-
-        $this->Error->handleException($exception);
-        $this->assertStringContainsString('Non-integer exception code', $this->stderr->messages()[0]);
     }
 }

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -69,13 +69,6 @@ class ExceptionsTest extends TestCase
         $this->assertSame(__FILE__, $exception->getFile());
         $this->assertSame(1, $exception->getLine());
         $this->assertSame($previous, $exception->getPrevious());
-
-        $exception = new FatalErrorException('message', null, __FILE__, 1, $previous);
-        $this->assertSame('message', $exception->getMessage());
-        $this->assertSame(500, $exception->getCode());
-        $this->assertSame(__FILE__, $exception->getFile());
-        $this->assertSame(1, $exception->getLine());
-        $this->assertSame($previous, $exception->getPrevious());
     }
 
     /**
@@ -93,11 +86,6 @@ class ExceptionsTest extends TestCase
         $this->assertSame(100, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
         $this->assertSame($entity, $exception->getEntity());
-
-        $exception = new PersistenceFailedException(new Entity(), 'message', null, $previous);
-        $this->assertSame('message', $exception->getMessage());
-        $this->assertSame(500, $exception->getCode());
-        $this->assertSame($previous, $exception->getPrevious());
     }
 
     /**
@@ -156,24 +144,24 @@ class ExceptionsTest extends TestCase
             ['Cake\Console\Exception\MissingTaskException', 1],
             ['Cake\Console\Exception\StopException', 1],
             ['Cake\Controller\Exception\AuthSecurityException', 400],
-            ['Cake\Controller\Exception\MissingActionException', 404],
-            ['Cake\Controller\Exception\MissingComponentException', 500],
+            ['Cake\Controller\Exception\MissingActionException', 0],
+            ['Cake\Controller\Exception\MissingComponentException', 0],
             ['Cake\Controller\Exception\SecurityException', 400],
-            ['Cake\Core\Exception\Exception', 500],
-            ['Cake\Core\Exception\MissingPluginException', 500],
-            ['Cake\Database\Exception', 500],
-            ['Cake\Database\Exception\MissingConnectionException', 500],
-            ['Cake\Database\Exception\MissingDriverException', 500],
-            ['Cake\Database\Exception\MissingExtensionException', 500],
-            ['Cake\Database\Exception\NestedTransactionRollbackException', 500],
-            ['Cake\Datasource\Exception\InvalidPrimaryKeyException', 500],
-            ['Cake\Datasource\Exception\MissingDatasourceConfigException', 500],
-            ['Cake\Datasource\Exception\MissingDatasourceException', 500],
-            ['Cake\Datasource\Exception\MissingModelException', 500],
-            ['Cake\Datasource\Exception\PageOutOfBoundsException', 404],
-            ['Cake\Datasource\Exception\RecordNotFoundException', 404],
-            ['Cake\Mailer\Exception\MissingActionException', 500],
-            ['Cake\Mailer\Exception\MissingMailerException', 500],
+            ['Cake\Core\Exception\Exception', 0],
+            ['Cake\Core\Exception\MissingPluginException', 0],
+            ['Cake\Database\Exception', 0],
+            ['Cake\Database\Exception\MissingConnectionException', 0],
+            ['Cake\Database\Exception\MissingDriverException', 0],
+            ['Cake\Database\Exception\MissingExtensionException', 0],
+            ['Cake\Database\Exception\NestedTransactionRollbackException', 0],
+            ['Cake\Datasource\Exception\InvalidPrimaryKeyException', 0],
+            ['Cake\Datasource\Exception\MissingDatasourceConfigException', 0],
+            ['Cake\Datasource\Exception\MissingDatasourceException', 0],
+            ['Cake\Datasource\Exception\MissingModelException', 0],
+            ['Cake\Datasource\Exception\PageOutOfBoundsException', 0],
+            ['Cake\Datasource\Exception\RecordNotFoundException', 0],
+            ['Cake\Mailer\Exception\MissingActionException', 0],
+            ['Cake\Mailer\Exception\MissingMailerException', 0],
             ['Cake\Http\Exception\BadRequestException', 400],
             ['Cake\Http\Exception\ConflictException', 409],
             ['Cake\Http\Exception\ForbiddenException', 403],
@@ -190,18 +178,18 @@ class ExceptionsTest extends TestCase
             ['Cake\Http\Exception\UnauthorizedException', 401],
             ['Cake\Http\Exception\UnavailableForLegalReasonsException', 451],
             ['Cake\Network\Exception\SocketException', 0],
-            ['Cake\ORM\Exception\MissingBehaviorException', 500],
-            ['Cake\ORM\Exception\MissingEntityException', 500],
-            ['Cake\ORM\Exception\MissingTableClassException', 500],
-            ['Cake\ORM\Exception\RolledbackTransactionException', 500],
-            ['Cake\Routing\Exception\DuplicateNamedRouteException', 500],
-            ['Cake\Routing\Exception\MissingDispatcherFilterException', 500],
-            ['Cake\Routing\Exception\MissingRouteException', 500],
+            ['Cake\ORM\Exception\MissingBehaviorException', 0],
+            ['Cake\ORM\Exception\MissingEntityException', 0],
+            ['Cake\ORM\Exception\MissingTableClassException', 0],
+            ['Cake\ORM\Exception\RolledbackTransactionException', 0],
+            ['Cake\Routing\Exception\DuplicateNamedRouteException', 0],
+            ['Cake\Routing\Exception\MissingDispatcherFilterException', 0],
+            ['Cake\Routing\Exception\MissingRouteException', 0],
             ['Cake\Routing\Exception\RedirectException', 302],
             ['Cake\Utility\Exception\XmlException', 0],
-            ['Cake\View\Exception\MissingCellException', 500],
-            ['Cake\View\Exception\MissingHelperException', 500],
-            ['Cake\View\Exception\MissingViewException', 500],
+            ['Cake\View\Exception\MissingCellException', 0],
+            ['Cake\View\Exception\MissingHelperException', 0],
+            ['Cake\View\Exception\MissingViewException', 0],
         ];
     }
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/14998 https://github.com/cakephp/cakephp/issues/14897

Moves the default 500 error code to HttpException only. Now that only HttpException uses the error code as http code, this makes sure we don't imply it anywhere else.

The default for Exception is now the original default of 0.