### PR TITLE
Rename Validator's setProvider() to addProvider()

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -295,10 +295,12 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $name The name under which the provider should be set.
      * @param object|string $object Provider object or class name.
      * @return $this
-     * @deprecated In favour of addProvider()
+     * @deprecated 4.2.0 Use `addProvider()` instead
      */
     public function setProvider(string $name, $object)
     {
+        deprecationWarning('Validator::setProvider() is deprecated; use addProvider() instead.');
+
         return $this->addProvider($name, $object);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -295,8 +295,24 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $name The name under which the provider should be set.
      * @param object|string $object Provider object or class name.
      * @return $this
+     * @deprecated In favour of addProvider()
      */
     public function setProvider(string $name, $object)
+    {
+        return $this->addProvider($name, $object);
+    }
+
+    /**
+     * Associates an object to a name so it can be used as a provider. Providers are
+     * objects or class names that can contain methods used during validation of for
+     * deciding whether a validation rule can be applied. All validation methods,
+     * when called will receive the full list of providers stored in this validator.
+     *
+     * @param string $name The name under which the provider should be set.
+     * @param object|string $object Provider object or class name.
+     * @return $this
+     */
+    public function addProvider(string $name, $object)
     {
         $this->_providers[$name] = $object;
 
@@ -535,7 +551,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             }
             foreach ($this->providers() as $provider) {
                 /** @psalm-suppress PossiblyNullArgument */
-                $validator->setProvider($provider, $this->getProvider($provider));
+                $validator->addProvider($provider, $this->getProvider($provider));
             }
             $errors = $validator->validate($value, $context['newRecord']);
 
@@ -578,7 +594,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             }
             foreach ($this->providers() as $provider) {
                 /** @psalm-suppress PossiblyNullArgument */
-                $validator->setProvider($provider, $this->getProvider($provider));
+                $validator->addProvider($provider, $this->getProvider($provider));
             }
             $errors = [];
             foreach ($value as $i => $row) {

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -157,7 +157,7 @@ trait ValidatorAwareTrait
      */
     public function setValidator(string $name, Validator $validator)
     {
-        $validator->setProvider(static::VALIDATOR_PROVIDER_NAME, $this);
+        $validator->addProvider(static::VALIDATOR_PROVIDER_NAME, $this);
         $this->_validators[$name] = $validator;
 
         return $this;

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -599,7 +599,7 @@ class EntityContext implements ContextInterface
 
         if (isset($this->_validator[$key])) {
             /** @psalm-suppress PossiblyInvalidArgument */
-            $this->_validator[$key]->setProvider('entity', $entity);
+            $this->_validator[$key]->addProvider('entity', $entity);
 
             return $this->_validator[$key];
         }
@@ -619,7 +619,7 @@ class EntityContext implements ContextInterface
 
         $validator = $table->getValidator($method);
         /** @psalm-suppress PossiblyInvalidArgument */
-        $validator->setProvider('entity', $entity);
+        $validator->addProvider('entity', $entity);
 
         return $this->_validator[$key] = $validator;
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6203,7 +6203,7 @@ class TableTest extends TestCase
         $table = $this->getTableLocator()->get('Users');
         $validator = new Validator();
         $validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
-        $validator->setProvider('table', $table);
+        $validator->addProvider('table', $table);
 
         $data = ['username' => ['larry', 'notthere']];
         $this->assertNotEmpty($validator->validate($data));
@@ -6243,7 +6243,7 @@ class TableTest extends TestCase
             'rule' => ['validateUnique', ['derp' => 'erp', 'scope' => 'id']],
             'provider' => 'table',
         ]);
-        $validator->setProvider('table', $table);
+        $validator->addProvider('table', $table);
         $data = ['username' => 'larry', 'id' => 3];
         $this->assertNotEmpty($validator->validate($data));
 
@@ -6283,7 +6283,7 @@ class TableTest extends TestCase
             'provider' => 'table',
             'message' => 'Must be unique.',
         ]);
-        $validator->setProvider('table', $table);
+        $validator->addProvider('table', $table);
 
         $data = ['site_id' => 1, 'author_id' => null, 'title' => 'Null dupe'];
         $expected = ['site_id' => ['unique' => 'Must be unique.']];

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -129,7 +129,7 @@ class ValidatorTest extends TestCase
     public function testAddNestedSingleProviders()
     {
         $validator = new Validator();
-        $validator->setProvider('test', $this);
+        $validator->addProvider('test', $this);
 
         $inner = new Validator();
         $inner->add('username', 'not-blank', ['rule' => function () use ($inner, $validator) {
@@ -196,7 +196,7 @@ class ValidatorTest extends TestCase
     public function testAddNestedManyProviders()
     {
         $validator = new Validator();
-        $validator->setProvider('test', $this);
+        $validator->addProvider('test', $this);
 
         $inner = new Validator();
         $inner->add('comment', 'not-blank', ['rule' => function () use ($inner, $validator) {
@@ -1780,12 +1780,12 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $object = new \stdClass();
-        $this->assertSame($validator, $validator->setProvider('foo', $object));
+        $this->assertSame($validator, $validator->addProvider('foo', $object));
         $this->assertSame($object, $validator->getProvider('foo'));
         $this->assertNull($validator->getProvider('bar'));
 
         $another = new \stdClass();
-        $this->assertSame($validator, $validator->setProvider('bar', $another));
+        $this->assertSame($validator, $validator->addProvider('bar', $another));
         $this->assertSame($another, $validator->getProvider('bar'));
 
         $this->assertEquals(new \Cake\Validation\RulesProvider(), $validator->getProvider('default'));
@@ -1851,7 +1851,7 @@ class ValidatorTest extends TestCase
                 return "That ain't cool, yo";
             }));
 
-        $validator->setProvider('thing', $thing);
+        $validator->addProvider('thing', $thing);
         $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
         $expected = [
             'email' => ['alpha' => 'The provided value is invalid'],
@@ -1898,7 +1898,7 @@ class ValidatorTest extends TestCase
 
                 return "That ain't cool, yo";
             }));
-        $validator->setProvider('thing', $thing);
+        $validator->addProvider('thing', $thing);
         $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
         $expected = [
             'title' => ['cool' => "That ain't cool, yo"],
@@ -2124,7 +2124,7 @@ class ValidatorTest extends TestCase
     public function testDebugInfo()
     {
         $validator = new Validator();
-        $validator->setProvider('test', $this);
+        $validator->addProvider('test', $this);
         $validator->add('title', 'not-empty', ['rule' => 'notBlank']);
         $validator->requirePresence('body');
         $validator->allowEmptyString('published');

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1772,23 +1772,46 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Test the provider() method
+     * Run test cases for setProvider() and addProvider().
      *
+     * @param string $method Name of method to call.
      * @return void
      */
-    public function testProvider()
+    protected function runProviderTest(string $method)
     {
         $validator = new Validator();
         $object = new \stdClass();
-        $this->assertSame($validator, $validator->addProvider('foo', $object));
+        $this->assertSame($validator, $validator->$method('foo', $object));
         $this->assertSame($object, $validator->getProvider('foo'));
         $this->assertNull($validator->getProvider('bar'));
 
         $another = new \stdClass();
-        $this->assertSame($validator, $validator->addProvider('bar', $another));
+        $this->assertSame($validator, $validator->$method('bar', $another));
         $this->assertSame($another, $validator->getProvider('bar'));
 
         $this->assertEquals(new \Cake\Validation\RulesProvider(), $validator->getProvider('default'));
+    }
+
+    /**
+     * Test the addProvider() method.
+     *
+     * @return void
+     */
+    public function testAddProvider()
+    {
+        $this->runProviderTest('addProvider');
+    }
+
+    /**
+     * Test the deprecated setProvider() method.
+     *
+     * @return void
+     */
+    public function testSetProvider()
+    {
+        $this->deprecated(function () {
+            $this->runProviderTest('setProvider');
+        });
     }
 
     /**


### PR DESCRIPTION
A while back, when I needed to add two custom validation providers to a certain table, I found the terminology `setProvider()` confusing, as "setting" something _usually_ infers that that something has been changed once and cannot be added to, unless changed completely (e.g. `$this->Email->setViewRenderer(...)` and `$view->setTemplatePath(...)`).  To clarify, the name of the method does not lend itself to describing something actually being added to an indexed list behind the scenes, in spite of the first parameter actually being the key itself.

This PR serves as an implemented proposal to rename `setProvider()` to `addProvider()`, and marking `setProvider()` as soft-deprecated.