### PR TITLE
Update Connection parameter names

### DIFF
--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -95,12 +95,12 @@ interface ConnectionInterface extends LoggerAwareInterface
      * });
      * ```
      *
-     * @param callable $transaction The callback to execute within a transaction.
+     * @param callable $callback The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.
      */
-    public function transactional(callable $transaction);
+    public function transactional(callable $callback);
 
     /**
      * Run an operation with constraints disabled.
@@ -115,20 +115,20 @@ interface ConnectionInterface extends LoggerAwareInterface
      * });
      * ```
      *
-     * @param callable $operation The callback to execute within a transaction.
+     * @param callable $callback The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.
      */
-    public function disableConstraints(callable $operation);
+    public function disableConstraints(callable $callback);
 
     /**
      * Enable/disable query logging
      *
-     * @param bool $value Enable/disable query logging
+     * @param bool $enable Enable/disable query logging
      * @return $this
      */
-    public function enableQueryLogging(bool $value = true);
+    public function enableQueryLogging(bool $enable = true);
 
     /**
      * Disable query logging


### PR DESCRIPTION
I left any parameter that is a sql string only as `$sql` and anything that is a string or Query as `$query`. Should we make the string|Query parameters all `$sql` ?