### PR TITLE
Allow Cake\ORM\Query type in the arguments of epilog()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1820,7 +1820,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * Epliog content is raw SQL and not suitable for use with user supplied data.
      *
-     * @param string|\Cake\Database\Expression\QueryExpression|\Cake\ORM\Query|null $expression The expression to be appended
+     * @param string|\Cake\Database\ExpressionInterface|null $expression The expression to be appended
      * @return $this
      */
     public function epilog($expression = null)

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1820,7 +1820,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * Epliog content is raw SQL and not suitable for use with user supplied data.
      *
-     * @param string|\Cake\Database\Expression\QueryExpression|null $expression The expression to be appended
+     * @param string|\Cake\Database\Expression\QueryExpression|\Cake\ORM\Query|null $expression The expression to be appended
      * @return $this
      */
     public function epilog($expression = null)


### PR DESCRIPTION
`epilog()` can be used as follows.

```php
$query = $this->FooTabls
    ->query()
    ->epilog($this->BarTables->find()->limit(1));
```

But, PHPStan gives the error, `Parameter #1 $expression of method Cake\Database\Query::epilog()  expects Cake\Database\Expression\QueryExpression|string|null, Cake\ORM\Query given. `.

ref: I found the problem on [this](https://github.com/itosho/easy-query/blob/master/src/Model/Behavior/InsertBehavior.php#L98)