### PR TITLE
Allow the Reply-to header of e-mail contain more than one e-mail address

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -95,6 +95,7 @@ use InvalidArgumentException;
  * @method array getSender() Gets "sender" address. {@see \Cake\Mailer\Message::getSender()}
  * @method $this setReplyTo($email, $name = null) Sets "Reply-To" address. {@see \Cake\Mailer\Message::setReplyTo()}
  * @method array getReplyTo() Gets "Reply-To" address. {@see \Cake\Mailer\Message::getReplyTo()}
+ * @method $this addReplyTo($email, $name = null) Add "Reply-To" address. {@see \Cake\Mailer\Message::addReplyTo()}
  * @method $this setReadReceipt($email, $name = null) Sets Read Receipt (Disposition-Notification-To header).
  *   {@see \Cake\Mailer\Message::setReadReceipt()}
  * @method array getReadReceipt() Gets Read Receipt (Disposition-Notification-To header).

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -95,7 +95,6 @@ use InvalidArgumentException;
  * @method array getSender() Gets "sender" address. {@see \Cake\Mailer\Message::getSender()}
  * @method $this setReplyTo($email, $name = null) Sets "Reply-To" address. {@see \Cake\Mailer\Message::setReplyTo()}
  * @method array getReplyTo() Gets "Reply-To" address. {@see \Cake\Mailer\Message::getReplyTo()}
- * @method $this addReplyTo($email, $name = null) Add "Reply-To" address. {@see \Cake\Mailer\Message::addReplyTo()}
  * @method $this setReadReceipt($email, $name = null) Sets Read Receipt (Disposition-Notification-To header).
  *   {@see \Cake\Mailer\Message::setReadReceipt()}
  * @method array getReadReceipt() Gets Read Receipt (Disposition-Notification-To header).

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -101,7 +101,7 @@ class Message implements JsonSerializable, Serializable
     protected $sender = [];
 
     /**
-     * List of email's that the recipient will reply to
+     * List of email(s) that the recipient will reply to
      *
      * @var array
      */

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -395,19 +395,6 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
-     * Add "Reply-To" address.
-     *
-     * @param string|array $email Null to get, String with email,
-     *   Array with email as key, name as value or email as value (without name)
-     * @param string|null $name Name
-     * @return $this
-     */
-    public function addReplyTo($email, ?string $name = null)
-    {
-        return $this->addEmail('replyTo', $email, $name);
-    }
-
-    /**
      * Sets Read Receipt (Disposition-Notification-To header).
      *
      * @param string|array $email String with email,

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -457,13 +457,12 @@ class EmailTest extends TestCase
         $this->Email->setTo('to@cakephp.org', 'To, CakePHP');
         $this->Email->setCc('cc@cakephp.org', 'Cc CakePHP');
         $this->Email->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
-        $this->Email->addReplyTo('replyto2@cakephp.org', 'ReplyTo2 CakePHP');
         $this->Email->addTo('to2@cakephp.org', 'To2 CakePHP');
         $this->Email->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
         $this->Email->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
 
         $this->assertSame($this->Email->getFrom(), ['cake@cakephp.org' => 'CakePHP']);
-        $this->assertSame($this->Email->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $this->assertSame($this->Email->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP']);
         $this->assertSame($this->Email->getReadReceipt(), ['readreceipt@cakephp.org' => 'ReadReceipt CakePHP']);
         $this->assertSame($this->Email->getReturnPath(), ['returnpath@cakephp.org' => 'ReturnPath CakePHP']);
         $this->assertSame($this->Email->getTo(), ['to@cakephp.org' => 'To, CakePHP', 'to2@cakephp.org' => 'To2 CakePHP']);
@@ -472,12 +471,17 @@ class EmailTest extends TestCase
 
         $headers = $this->Email->getHeaders(array_fill_keys(['from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'], true));
         $this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
-        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
         $this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
         $this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
         $this->assertSame($headers['To'], '"To, CakePHP" <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');
         $this->assertSame($headers['Cc'], 'Cc CakePHP <cc@cakephp.org>, Cc2 CakePHP <cc2@cakephp.org>');
         $this->assertSame($headers['Bcc'], 'Bcc CakePHP <bcc@cakephp.org>, Bcc2 CakePHP <bcc2@cakephp.org>');
+
+        $this->Email->setReplyTo(['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $this->assertSame($this->Email->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $headers = $this->Email->getHeaders(array_fill_keys(['replyTo'], true));
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -457,12 +457,13 @@ class EmailTest extends TestCase
         $this->Email->setTo('to@cakephp.org', 'To, CakePHP');
         $this->Email->setCc('cc@cakephp.org', 'Cc CakePHP');
         $this->Email->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
+        $this->Email->addReplyTo('replyto2@cakephp.org', 'ReplyTo2 CakePHP');
         $this->Email->addTo('to2@cakephp.org', 'To2 CakePHP');
         $this->Email->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
         $this->Email->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
 
         $this->assertSame($this->Email->getFrom(), ['cake@cakephp.org' => 'CakePHP']);
-        $this->assertSame($this->Email->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP']);
+        $this->assertSame($this->Email->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
         $this->assertSame($this->Email->getReadReceipt(), ['readreceipt@cakephp.org' => 'ReadReceipt CakePHP']);
         $this->assertSame($this->Email->getReturnPath(), ['returnpath@cakephp.org' => 'ReturnPath CakePHP']);
         $this->assertSame($this->Email->getTo(), ['to@cakephp.org' => 'To, CakePHP', 'to2@cakephp.org' => 'To2 CakePHP']);
@@ -471,7 +472,7 @@ class EmailTest extends TestCase
 
         $headers = $this->Email->getHeaders(array_fill_keys(['from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'], true));
         $this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
-        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
         $this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
         $this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
         $this->assertSame($headers['To'], '"To, CakePHP" <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -708,12 +708,13 @@ HTML;
         $this->message->setTo('to@cakephp.org', 'To, CakePHP');
         $this->message->setCc('cc@cakephp.org', 'Cc CakePHP');
         $this->message->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
+        $this->message->addReplyTo('replyto2@cakephp.org', 'ReplyTo2 CakePHP');
         $this->message->addTo('to2@cakephp.org', 'To2 CakePHP');
         $this->message->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
         $this->message->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
 
         $this->assertSame($this->message->getFrom(), ['cake@cakephp.org' => 'CakePHP']);
-        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP']);
+        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
         $this->assertSame($this->message->getReadReceipt(), ['readreceipt@cakephp.org' => 'ReadReceipt CakePHP']);
         $this->assertSame($this->message->getReturnPath(), ['returnpath@cakephp.org' => 'ReturnPath CakePHP']);
         $this->assertSame($this->message->getTo(), ['to@cakephp.org' => 'To, CakePHP', 'to2@cakephp.org' => 'To2 CakePHP']);
@@ -722,7 +723,7 @@ HTML;
 
         $headers = $this->message->getHeaders(array_fill_keys(['from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'], true));
         $this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
-        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
         $this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
         $this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
         $this->assertSame($headers['To'], '"To, CakePHP" <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -708,13 +708,12 @@ HTML;
         $this->message->setTo('to@cakephp.org', 'To, CakePHP');
         $this->message->setCc('cc@cakephp.org', 'Cc CakePHP');
         $this->message->setBcc('bcc@cakephp.org', 'Bcc CakePHP');
-        $this->message->addReplyTo('replyto2@cakephp.org', 'ReplyTo2 CakePHP');
         $this->message->addTo('to2@cakephp.org', 'To2 CakePHP');
         $this->message->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
         $this->message->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
 
         $this->assertSame($this->message->getFrom(), ['cake@cakephp.org' => 'CakePHP']);
-        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP']);
         $this->assertSame($this->message->getReadReceipt(), ['readreceipt@cakephp.org' => 'ReadReceipt CakePHP']);
         $this->assertSame($this->message->getReturnPath(), ['returnpath@cakephp.org' => 'ReturnPath CakePHP']);
         $this->assertSame($this->message->getTo(), ['to@cakephp.org' => 'To, CakePHP', 'to2@cakephp.org' => 'To2 CakePHP']);
@@ -723,12 +722,17 @@ HTML;
 
         $headers = $this->message->getHeaders(array_fill_keys(['from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'], true));
         $this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
-        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
         $this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
         $this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
         $this->assertSame($headers['To'], '"To, CakePHP" <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');
         $this->assertSame($headers['Cc'], 'Cc CakePHP <cc@cakephp.org>, Cc2 CakePHP <cc2@cakephp.org>');
         $this->assertSame($headers['Bcc'], 'Bcc CakePHP <bcc@cakephp.org>, Bcc2 CakePHP <bcc2@cakephp.org>');
+
+        $this->message->setReplyTo(['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $this->assertSame($this->message->getReplyTo(), ['replyto@cakephp.org' => 'ReplyTo CakePHP', 'replyto2@cakephp.org' => 'ReplyTo2 CakePHP']);
+        $headers = $this->message->getHeaders(array_fill_keys(['replyTo'], true));
+        $this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>, ReplyTo2 CakePHP <replyto2@cakephp.org>');
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -71,6 +71,7 @@ class MailTransportTest extends TestCase
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setReplyTo(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
         $message->setCc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
         $message->setBcc('phpnut@cakephp.org');
         $message->setMessageId('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
@@ -88,6 +89,7 @@ class MailTransportTest extends TestCase
         $encoded .= ' =?UTF-8?B?Rm/DuCBCw6VyIELDqXo=?=';
 
         $data = 'From: CakePHP Test <noreply@cakephp.org>' . PHP_EOL;
+        $data .= 'Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>' . PHP_EOL;
         $data .= 'Return-Path: CakePHP Return <pleasereply@cakephp.org>' . PHP_EOL;
         $data .= 'Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>' . PHP_EOL;
         $data .= 'Bcc: phpnut@cakephp.org' . PHP_EOL;

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -404,6 +404,7 @@ class SmtpTransportTest extends TestCase
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setReplyTo(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
         $message->setCc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
         $message->setBcc('phpnut@cakephp.org');
         $message->setMessageId('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
@@ -413,6 +414,7 @@ class SmtpTransportTest extends TestCase
         $message->setBody(['text' => "First Line\nSecond Line\n.Third Line"]);
 
         $data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
+        $data .= "Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";
         $data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>\r\n";
         $data .= "To: CakePHP <cake@cakephp.org>\r\n";
         $data .= "Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";


### PR DESCRIPTION
The [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822.txt) says:

> an optional reply-to field MAY also be
> included, which contains the field name "Reply-To" and a
> comma-separated list of one or more addresses.
> ...
> reply-to        =       "Reply-To:" address-list CRLF

In CakePHP, if you try to set more than one reply-to, an InvalidArgumentException is thrown.

This pull request is to allow more than 1 e-mail address as reply-to.