### PR TITLE
Fix TypeError  in str_replace() call

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -236,7 +236,7 @@ class Text
         /** @var array<string, mixed> $dataReplacements */
         $dataReplacements = array_combine($hashKeys, array_values($data));
         foreach ($dataReplacements as $tmpHash => $tmpValue) {
-            $tmpValue = is_string($tmpValue) ? $tmpValue  : '';
+            $tmpValue = is_array($tmpValue) ? '' : (string) $tmpValue;
             $str = str_replace($tmpHash, $tmpValue, $str);
         }
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -236,7 +236,7 @@ class Text
         /** @var array<string, mixed> $dataReplacements */
         $dataReplacements = array_combine($hashKeys, array_values($data));
         foreach ($dataReplacements as $tmpHash => $tmpValue) {
-            $tmpValue = is_array($tmpValue) ? '' : $tmpValue;
+            $tmpValue = is_string($tmpValue) ? $tmpValue  : '';
             $str = str_replace($tmpHash, $tmpValue, $str);
         }
 


### PR DESCRIPTION
Fix issue #15020 

According to code $tmpValue must be only string in the other case it must be a empty string
so i simply check if $tmpValue is string then return $tmpValue else return empty string

In my case it fixes problem  issue #15020 
