### PR TITLE
Clarify version map

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ a starting point. For existing applications you can run the following:
 $ composer require cakephp/cakephp
 ```
 
+For details on the (minimum/maximum) PHP version see [version map](https://github.com/cakephp/cakephp/wiki#version-map).
+
 ## Running Tests
 
 Assuming you have PHPUnit installed system wide using one of the methods stated


### PR DESCRIPTION
The next weeks there will a lot more tickets for PHP 8 and other PHP version related issues coming in
We can clarify it a bit more using the version map I put into the wiki - until we have a good and graphically clear roadmap on supported PHP versions in docs at least.