### PR TITLE
Fix operator extraction from expression keys

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -737,7 +737,7 @@ class QueryExpression implements ExpressionInterface, Countable
         $spaces = substr_count($field, ' ');
         if ($spaces > 1) {
             $parts = explode(' ', $field);
-            if (preg_match('/(is not|not in)$/i', $field)) {
+            if (preg_match('/(is not|not \w+)$/i', $field)) {
                 $last = array_pop($parts);
                 $second = array_pop($parts);
                 array_push($parts, strtolower("{$second} {$last}"));

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -735,6 +735,7 @@ class QueryExpression implements ExpressionInterface, Countable
         $expression = $field;
 
         $spaces = substr_count($field, ' ');
+        // Handle operators with a space in them like `is not` and `not like`
         if ($spaces > 1) {
             $parts = explode(' ', $field);
             if (preg_match('/(is not|not \w+)$/i', $field)) {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -722,7 +722,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * generating the placeholders and replacing the values by them, while storing
      * the value elsewhere for future binding.
      *
-     * @param string $field The value from with the actual field and operator will
+     * @param string $field The value from which the actual field and operator will
      * be extracted.
      * @param mixed $value The value to be bound to a placeholder for the field
      * @return string|\Cake\Database\ExpressionInterface
@@ -730,16 +730,26 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     protected function _parseCondition(string $field, $value)
     {
+        $field = trim($field);
         $operator = '=';
         $expression = $field;
-        $parts = explode(' ', trim($field), 2);
 
-        if (count($parts) > 1) {
+        $spaces = substr_count($field, ' ');
+        if ($spaces > 1) {
+            $parts = explode(' ', $field);
+            if (preg_match('/(is not|not in)$/i', $field)) {
+                $last = array_pop($parts);
+                $second = array_pop($parts);
+                array_push($parts, strtolower("{$second} {$last}"));
+            }
+            $operator = array_pop($parts);
+            $expression = implode(' ', $parts);
+        } elseif ($spaces == 1) {
+            $parts = explode(' ', $field, 2);
             [$expression, $operator] = $parts;
+            $operator = strtolower(trim($operator));
         }
-
-        $type = $this->getTypeMap()->type($expression);
-        $operator = strtolower(trim($operator));
+        $type = $this->getTypeMap() ->type($expression);
 
         $typeMultiple = (is_string($type) && strpos($type, '[]') !== false);
         if (in_array($operator, ['in', 'not in']) || $typeMultiple) {

--- a/src/Database/PostgresCompiler.php
+++ b/src/Database/PostgresCompiler.php
@@ -41,7 +41,7 @@ class PostgresCompiler extends QueryCompiler
     protected $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
-        'group' => ' GROUP BY %s ',
+        'group' => ' GROUP BY %s',
         'order' => ' %s',
         'limit' => ' LIMIT %s',
         'offset' => ' OFFSET %s',
@@ -88,6 +88,6 @@ class PostgresCompiler extends QueryCompiler
             }
         }
 
-        return sprintf('HAVING %s', implode(', ', $parts));
+        return sprintf(' HAVING %s', implode(', ', $parts));
     }
 }

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -39,7 +39,7 @@ class SqlserverCompiler extends QueryCompiler
     protected $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
-        'group' => ' GROUP BY %s ',
+        'group' => ' GROUP BY %s',
         'order' => ' %s',
         'offset' => ' OFFSET %s ROWS',
         'epilog' => ' %s',
@@ -155,6 +155,6 @@ class SqlserverCompiler extends QueryCompiler
             }
         }
 
-        return sprintf('HAVING %s', implode(', ', $parts));
+        return sprintf(' HAVING %s', implode(', ', $parts));
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2303,6 +2303,33 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test having casing with string expressions
+     *
+     * @return void
+     */
+    public function testHavingAliasCasingStringExpression()
+    {
+        $this->loadFixtures('Authors');
+        $query = new Query($this->connection);
+        $query
+            ->select(['id'])
+            ->from(['Authors' => 'authors'])
+            ->where([
+                'FUNC( Authors.id) =' => 1,
+                'FUNC( Authors.id) IS NOT' => null,
+            ])
+            ->having(['COUNT(DISTINCT Authors.id) =' => 1]);
+
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <authors> <Authors> WHERE ' .
+            '\(FUNC\( <Authors>\.<id>\) = :c0 AND \(FUNC\( <Authors>\.<id>\)\) IS NOT NULL\) ' .
+            'HAVING COUNT\(DISTINCT <Authors>\.<id>\) = :c1',
+            $query->sql(),
+            !$this->autoQuote
+        );
+    }
+
+    /**
      * Tests selecting rows using a limit clause
      *
      * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2309,7 +2309,7 @@ class QueryTest extends TestCase
      */
     public function testHavingAliasCasingStringExpression()
     {
-        $this->loadFixtures('Authors');
+        $this->skipIf($this->autoQuote, 'Does not work when autoquoting is enabled.');
         $query = new Query($this->connection);
         $query
             ->select(['id'])
@@ -2320,12 +2320,11 @@ class QueryTest extends TestCase
             ])
             ->having(['COUNT(DISTINCT Authors.id) =' => 1]);
 
-        $this->assertQuotedQuery(
-            'SELECT <id> FROM <authors> <Authors> WHERE ' .
-            '\(FUNC\( <Authors>\.<id>\) = :c0 AND \(FUNC\( <Authors>\.<id>\)\) IS NOT NULL\) ' .
-            'HAVING COUNT\(DISTINCT <Authors>\.<id>\) = :c1',
-            $query->sql(),
-            !$this->autoQuote
+        $this->assertSame(
+            'SELECT id FROM authors Authors WHERE ' .
+            '(FUNC( Authors.id) = :c0 AND (FUNC( Authors.id)) IS NOT NULL) ' .
+            'HAVING COUNT(DISTINCT Authors.id) = :c1',
+            trim($query->sql())
         );
     }
 


### PR DESCRIPTION
Fix the operator extraction on expression key values. Previously we were
not handling functions with spaces well which resulted in conditions
being lowercased.

Fixes #15008