### PR TITLE
Fix sorting of path segments by length.

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -187,7 +187,9 @@ class RouteCollection
 
         // Sort path segments matching longest paths first.
         $paths = array_keys($this->_paths);
-        rsort($paths);
+        usort($paths, function ($value1, $value2) {
+            return mb_strlen($value2) - mb_strlen($value1);
+        });
 
         foreach ($paths as $path) {
             if (strpos($urlPath, $path) !== 0) {


### PR DESCRIPTION
`rsort()` doesn't achieve what the comment `Sort path segments matching longest paths first.` says is being done. Plus we only need length based sorting here, not alphabetical.

https://3v4l.org/gBbCs