### PR TITLE
Speed up file existence checks where feasible.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -365,7 +365,7 @@ class FileEngine extends CacheEngine
             $this->_File->getBasename() !== $key ||
             $this->_File->valid() === false
         ) {
-            $exists = file_exists($path->getPathname());
+            $exists = is_file($path->getPathname());
             try {
                 $this->_File = $path->openFile('c+');
             } catch (Exception $e) {

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -257,7 +257,7 @@ class BasePlugin implements PluginInterface
     public function routes(RouteBuilder $routes): void
     {
         $path = $this->getConfigPath() . 'routes.php';
-        if (file_exists($path)) {
+        if (is_file($path)) {
             require $path;
         }
     }
@@ -268,7 +268,7 @@ class BasePlugin implements PluginInterface
     public function bootstrap(PluginApplicationInterface $app): void
     {
         $bootstrap = $this->getConfigPath() . 'bootstrap.php';
-        if (file_exists($bootstrap)) {
+        if (is_file($bootstrap)) {
             require $bootstrap;
         }
     }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -421,7 +421,7 @@ class Configure
         }
 
         $path = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'config/config.php';
-        if (file_exists($path)) {
+        if (is_file($path)) {
             $config = require $path;
             static::write($config);
 

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -94,9 +94,9 @@ class PluginCollection implements Iterator, Countable
             return;
         }
         $vendorFile = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
-        if (!file_exists($vendorFile)) {
+        if (!is_file($vendorFile)) {
             $vendorFile = dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
-            if (!file_exists($vendorFile)) {
+            if (!is_file($vendorFile)) {
                 Configure::write(['plugins' => []]);
 
                 return;

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -133,7 +133,7 @@ class FileLog extends BaseLog
             return;
         }
 
-        $exists = file_exists($pathname);
+        $exists = is_file($pathname);
         file_put_contents($pathname, $output, FILE_APPEND);
         static $selfError = false;
 
@@ -184,7 +184,7 @@ class FileLog extends BaseLog
         clearstatcache(true, $filePath);
 
         if (
-            !file_exists($filePath) ||
+            !is_file($filePath) ||
             filesize($filePath) < $this->_size
         ) {
             return null;

--- a/src/Routing/Asset.php
+++ b/src/Routing/Asset.php
@@ -249,7 +249,7 @@ class Asset
                 urldecode($path)
             );
             $webrootPath = Configure::read('App.wwwRoot') . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
-            if (file_exists($webrootPath)) {
+            if (is_file($webrootPath)) {
                 return $path . '?' . filemtime($webrootPath);
             }
             // Check for plugins and org prefixed plugins.
@@ -265,7 +265,7 @@ class Asset
                     . 'webroot'
                     . DIRECTORY_SEPARATOR
                     . implode(DIRECTORY_SEPARATOR, $segments);
-                if (file_exists($pluginPath)) {
+                if (is_file($pluginPath)) {
                     return $path . '?' . filemtime($pluginPath);
                 }
             }
@@ -304,12 +304,12 @@ class Asset
                 $file = str_replace('/', '\\', $file);
             }
 
-            if (file_exists(Configure::read('App.wwwRoot') . $theme . $file)) {
+            if (is_file(Configure::read('App.wwwRoot') . $theme . $file)) {
                 $webPath = $requestWebroot . $theme . $asset[0];
             } else {
                 $themePath = Plugin::path($themeName);
                 $path = $themePath . 'webroot/' . $file;
-                if (file_exists($path)) {
+                if (is_file($path)) {
                     $webPath = $requestWebroot . $theme . $asset[0];
                 }
             }

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -73,7 +73,7 @@ class AssetMiddleware implements MiddlewareInterface
         }
 
         $assetFile = $this->_getAssetFile($url);
-        if ($assetFile === null || !file_exists($assetFile)) {
+        if ($assetFile === null || !is_file($assetFile)) {
             return $handler->handle($request);
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1346,7 +1346,7 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
         $paths = $this->_paths($plugin);
         foreach ($paths as $path) {
-            if (file_exists($path . $name)) {
+            if (is_file($path . $name)) {
                 return $this->_checkFilePath($path . $name, $path);
             }
         }
@@ -1440,7 +1440,7 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
 
         foreach ($this->getLayoutPaths($plugin) as $path) {
-            if (file_exists($path . $name)) {
+            if (is_file($path . $name)) {
                 return $this->_checkFilePath($path . $name, $path);
             }
         }
@@ -1483,7 +1483,7 @@ class View implements EventDispatcherInterface
 
         $name .= $this->_ext;
         foreach ($this->getElementPaths($plugin) as $path) {
-            if (file_exists($path . $name)) {
+            if (is_file($path . $name)) {
                 return $path . $name;
             }
         }


### PR DESCRIPTION
file_exists() is a lot slower than is_file() / is_dir().
Refs: https://bugs.php.net/bug.php?id=78285

`is_file()` doesn't check if the file is actually accessible but if there are file permission issues one if going to have problems one way or another anyway.