### PR TITLE
Rename register() for container services

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -293,10 +293,9 @@ class BasePlugin implements PluginInterface
      * Register container services for this plugin.
      *
      * @param \Cake\Core\ContainerInterface $container The container to add services to.
-     * @return \Cake\Core\ContainerInterface The updated container
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
-        return $container;
     }
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -55,7 +55,7 @@ class BasePlugin implements PluginInterface
      *
      * @var bool
      */
-    protected $registerEnabled = true;
+    protected $servicesEnabled = true;
 
     /**
      * Load routes or not
@@ -295,7 +295,7 @@ class BasePlugin implements PluginInterface
      * @param \Cake\Core\ContainerInterface $container The container to add services to.
      * @return \Cake\Core\ContainerInterface The updated container
      */
-    public function register(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): ContainerInterface
     {
         return $container;
     }

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -34,7 +34,7 @@ interface ContainerApplicationInterface
      * @param \Cake\Core\ContainerInterface $container The container to add services to
      * @return \Cake\Core\ContainerInterface The updated container.
      */
-    public function register(ContainerInterface $container): ContainerInterface;
+    public function services(ContainerInterface $container): ContainerInterface;
 
     /**
      * Create a new container and register services.

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -32,9 +32,9 @@ interface ContainerApplicationInterface
      * on service definitions.
      *
      * @param \Cake\Core\ContainerInterface $container The container to add services to
-     * @return \Cake\Core\ContainerInterface The updated container.
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface;
+    public function services(ContainerInterface $container): void;
 
     /**
      * Create a new container and register services.

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -21,7 +21,7 @@ use Cake\Routing\RouteBuilder;
 /**
  * Plugin Interface
  *
- * @method \Cake\Core\ContainerInterface register(\Cake\Core\ContainerInterface $container) Register plugin services to
+ * @method \Cake\Core\ContainerInterface services(\Cake\Core\ContainerInterface $container) Register plugin services to
  *   the application's container
  */
 interface PluginInterface
@@ -31,7 +31,7 @@ interface PluginInterface
      *
      * @var string[]
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'register', 'routes'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes','services'];
 
     /**
      * Get the name of this plugin.

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -21,7 +21,7 @@ use Cake\Routing\RouteBuilder;
 /**
  * Plugin Interface
  *
- * @method \Cake\Core\ContainerInterface services(\Cake\Core\ContainerInterface $container) Register plugin services to
+ * @method void services(\Cake\Core\ContainerInterface $container) Register plugin services to
  *   the application's container
  */
 interface PluginInterface
@@ -31,7 +31,7 @@ interface PluginInterface
      *
      * @var string[]
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes','services'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services'];
 
     /**
      * Get the name of this plugin.

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -249,9 +249,9 @@ abstract class BaseApplication implements
         if ($this->container) {
             return $this->container;
         }
-        $container = $this->register(new Container());
-        foreach ($this->plugins->with('register') as $plugin) {
-            $container = $plugin->register($container);
+        $container = $this->services(new Container());
+        foreach ($this->plugins->with('services') as $plugin) {
+            $container = $plugin->services($container);
         }
         $this->container = $container;
 
@@ -259,12 +259,12 @@ abstract class BaseApplication implements
     }
 
     /**
-     * Register application services.
+     * Register application container services.
      *
      * @param \Cake\Core\ContainerInterface $container The Container to update.
      * @return \Cake\Core\ContainerInterface The updated container
      */
-    public function register(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): ContainerInterface
     {
         return $container;
     }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -249,24 +249,24 @@ abstract class BaseApplication implements
         if ($this->container) {
             return $this->container;
         }
-        $container = $this->services(new Container());
-        foreach ($this->plugins->with('services') as $plugin) {
-            $container = $plugin->services($container);
-        }
-        $this->container = $container;
 
-        return $this->container;
+        $container = new Container();
+        $this->services($container);
+        foreach ($this->plugins->with('services') as $plugin) {
+            $plugin->services($container);
+        }
+
+        return $this->container = $container;
     }
 
     /**
      * Register application container services.
      *
      * @param \Cake\Core\ContainerInterface $container The Container to update.
-     * @return \Cake\Core\ContainerInterface The updated container
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
-        return $container;
     }
 
     /**

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -92,7 +92,7 @@ class BasePluginTest extends TestCase
         $this->assertSame($commands, $plugin->console($commands));
     }
 
-    public function testRegister()
+    public function testServices()
     {
         $plugin = new BasePlugin();
         $container = new Container();

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -96,7 +96,7 @@ class BasePluginTest extends TestCase
     {
         $plugin = new BasePlugin();
         $container = new Container();
-        $this->assertSame($container, $plugin->services($container));
+        $this->assertNull($plugin->services($container));
     }
 
     public function testConsoleFind()

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -60,7 +60,7 @@ class BasePluginTest extends TestCase
         $this->assertFalse($plugin->isEnabled('bootstrap'));
         $this->assertTrue($plugin->isEnabled('console'));
         $this->assertTrue($plugin->isEnabled('middleware'));
-        $this->assertTrue($plugin->isEnabled('register'));
+        $this->assertTrue($plugin->isEnabled('services'));
     }
 
     public function testGetName()
@@ -96,7 +96,7 @@ class BasePluginTest extends TestCase
     {
         $plugin = new BasePlugin();
         $container = new Container();
-        $this->assertSame($container, $plugin->register($container));
+        $this->assertSame($container, $plugin->services($container));
     }
 
     public function testConsoleFind()

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -96,12 +96,10 @@ class Application extends BaseApplication
      * Container register hook
      *
      * @param \Cake\Core\ContainerInterface $container The container to update
-     * @return \Cake\Core\ContainerInterface
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
-
-        return $container;
     }
 }

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -98,7 +98,7 @@ class Application extends BaseApplication
      * @param \Cake\Core\ContainerInterface $container The container to update
      * @return \Cake\Core\ContainerInterface
      */
-    public function register(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): ContainerInterface
     {
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
 


### PR DESCRIPTION
Suggest not using a core function name for optional feature.

If php had proper function overloading, then we could just do it that way.