### PR TITLE
4.2 - Fix variadic routing parameters not being set during invoke

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -140,6 +140,9 @@ class ControllerFactory implements ControllerFactoryInterface
                 );
             }
         }
+        if (count($passed)) {
+            $args = array_merge($args, $passed);
+        }
         $controller->invokeAction($action, $args);
 
         $result = $controller->shutdownProcess();

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -583,4 +583,29 @@ class ControllerFactoryTest extends TestCase
         $this->assertSame($data->str, 'two');
         $this->assertSame('value', $data->dep->key);
     }
+
+    /**
+     * Test that routing parameters are passed into variadic controller functions
+     *
+     * @return void
+     */
+    public function testInvokeInjectPassedParametersVariadic()
+    {
+        $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/optionalDep',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'variadic',
+                'pass' => ['one', 'two'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+        $result = $this->factory->invoke($controller);
+        $data = json_decode((string)$result->getBody());
+
+        $this->assertNotNull($data);
+        $this->assertSame(['one', 'two'], $data->args);
+    }
 }

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -591,13 +591,36 @@ class ControllerFactoryTest extends TestCase
      */
     public function testInvokeInjectPassedParametersVariadic()
     {
-        $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/optionalDep',
             'params' => [
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'variadic',
+                'pass' => ['one', 'two'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+        $result = $this->factory->invoke($controller);
+        $data = json_decode((string)$result->getBody());
+
+        $this->assertNotNull($data);
+        $this->assertSame(['one', 'two'], $data->args);
+    }
+
+    /**
+     * Test that routing parameters are passed into controller action using spread operator
+     *
+     * @return void
+     */
+    public function testInvokeInjectPassedParametersSpread()
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/optionalDep',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'spread',
                 'pass' => ['one', 'two'],
             ],
         ]);

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -41,4 +41,9 @@ class DependenciesController extends Controller
     {
         return $this->response->withStringBody(json_encode(['args' => func_get_args()]));
     }
+
+    public function spread(...$args)
+    {
+        return $this->response->withStringBody(json_encode(['args' => $args]));
+    }
 }

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -36,4 +36,9 @@ class DependenciesController extends Controller
     {
         return $this->response->withStringBody(json_encode(compact('dep', 'any', 'str')));
     }
+
+    public function variadic()
+    {
+        return $this->response->withStringBody(json_encode(['args' => func_get_args()]));
+    }
 }


### PR DESCRIPTION
These would not be captured during the reflection merge as there are no parameters to read during reflection.