### PR TITLE
Add StringExpression with collation support

### DIFF
--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\StringExpression;
 use Cake\Database\PostgresCompiler;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
@@ -223,6 +224,7 @@ class Postgres extends Driver
     {
         return [
             FunctionExpression::class => '_transformFunctionExpression',
+            StringExpression::class => '_transformStringExpression',
         ];
     }
 
@@ -289,6 +291,18 @@ class Postgres extends Driver
                     ->add([') + (1' => 'literal']); // Postgres starts on index 0 but Sunday should be 1
                 break;
         }
+    }
+
+    /**
+     * Changes string expression into postgresql format.
+     *
+     * @param \Cake\Database\Expression\StringExpression $expression The string expression to tranform.
+     * @return void
+     */
+    protected function _transformStringExpression(StringExpression $expression): void
+    {
+        // use trim() to work around expression being transformed multiple times
+        $expression->setCollation('"' . trim($expression->getCollation(), '"') . '"');
     }
 
     /**

--- a/src/Database/Expression/StringExpression.php
+++ b/src/Database/Expression/StringExpression.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+use Closure;
+
+/**
+ * String expression with collation.
+ */
+class StringExpression implements ExpressionInterface
+{
+    /**
+     * @var string
+     */
+    protected $string;
+
+    /**
+     * @var string
+     */
+    protected $collation;
+
+    /**
+     * @param string $string String value
+     * @param string $collation String collation
+     */
+    public function __construct(string $string, string $collation)
+    {
+        $this->string = $string;
+        $this->collation = $collation;
+    }
+
+    /**
+     * Sets the string collation.
+     *
+     * @param string $collation String collation
+     * @return void
+     */
+    public function setCollation(string $collation): void
+    {
+        $this->collation = $collation;
+    }
+
+    /**
+     * Returns the string collation.
+     *
+     * @return string
+     */
+    public function getCollation(): string
+    {
+        return $this->collation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        $placeholder = $binder->placeholder('c');
+        $binder->bind($placeholder, $this->string, 'string');
+
+        return $placeholder . ' COLLATE ' . $this->collation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback)
+    {
+        return $this;
+    }
+}

--- a/tests/TestCase/Database/Expression/StringExpressionTest.php
+++ b/tests/TestCase/Database/Expression/StringExpressionTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\StringExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests StringExpression class
+ */
+class StringExpressionTest extends TestCase
+{
+    public function testCollation()
+    {
+        $expr = new StringExpression('testString', 'utf8_general_ci');
+
+        $binder = new ValueBinder();
+        $this->assertSame(':c0 COLLATE utf8_general_ci', $expr->sql($binder));
+        $this->assertSame('testString', $binder->bindings()[':c0']['value']);
+        $this->assertSame('string', $binder->bindings()[':c0']['type']);
+    }
+}

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -16,14 +16,20 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database;
 
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Expression\StringExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\Statement\StatementDecorator;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeFactory;
 use Cake\Database\TypeMap;
+use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use DateTimeImmutable;
@@ -4950,6 +4956,44 @@ class QueryTest extends TestCase
         $statement = $query->execute();
         $results = $statement->fetchColumn(3);
         $this->assertFalse($results);
+        $statement->closeCursor();
+    }
+
+    /**
+     * Tests creating StringExpression.
+     *
+     * @return void
+     */
+    public function testStringExpression()
+    {
+        $driver = $this->connection->getDriver();
+        if ($driver instanceof Mysql) {
+            if (version_compare($this->connection->getDriver()->version(), '5.7.0', '<')) {
+                $collation = 'utf8_general_ci';
+            } else {
+                $collation = 'utf8mb4_general_ci';
+            }
+        } elseif ($driver instanceof Postgres) {
+            $collation = 'en_US.utf8';
+        } elseif ($driver instanceof Sqlite) {
+            $collation = 'BINARY';
+        } elseif ($driver instanceof Sqlserver) {
+            $collation = 'Latin1_general_CI_AI';
+        }
+
+        $query = new Query($this->connection);
+        if ($driver instanceof Postgres) {
+            // Older postgres versions throw an error on the parameter type without a cast
+            $query->select(['test_string' => $query->func()->cast(new StringExpression('testString', $collation), 'text')]);
+            $expected = "SELECT \(CAST\(:c0 COLLATE \"${collation}\" AS text\)\) AS <test_string>";
+        } else {
+            $query->select(['test_string' => new StringExpression('testString', $collation)]);
+            $expected = "SELECT \(:c0 COLLATE ${collation}\) AS <test_string>";
+        }
+        $this->assertRegExpSql($expected, $query->sql(new ValueBinder()), !$this->autoQuote);
+
+        $statement = $query->execute();
+        $this->assertSame('testString', $statement->fetchColumn(0));
         $statement->closeCursor();
     }
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/14546

`Query::newString()` helps simplify code instead of having to called `new StringExpression` everywhere.

If we want to support changing the collation of columns in an expression, that should be done through `IdentifierExpression`.