### PR TITLE
Change return type of ContainerApplicationInterface::services() to avoid.

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -293,10 +293,9 @@ class BasePlugin implements PluginInterface
      * Register container services for this plugin.
      *
      * @param \Cake\Core\ContainerInterface $container The container to add services to.
-     * @return \Cake\Core\ContainerInterface The updated container
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
-        return $container;
     }
 }

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -32,9 +32,9 @@ interface ContainerApplicationInterface
      * on service definitions.
      *
      * @param \Cake\Core\ContainerInterface $container The container to add services to
-     * @return \Cake\Core\ContainerInterface The updated container.
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface;
+    public function services(ContainerInterface $container): void;
 
     /**
      * Create a new container and register services.

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -21,7 +21,7 @@ use Cake\Routing\RouteBuilder;
 /**
  * Plugin Interface
  *
- * @method \Cake\Core\ContainerInterface services(\Cake\Core\ContainerInterface $container) Register plugin services to
+ * @method void services(\Cake\Core\ContainerInterface $container) Register plugin services to
  *   the application's container
  */
 interface PluginInterface
@@ -31,7 +31,7 @@ interface PluginInterface
      *
      * @var string[]
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes','services'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services'];
 
     /**
      * Get the name of this plugin.

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -249,24 +249,24 @@ abstract class BaseApplication implements
         if ($this->container) {
             return $this->container;
         }
-        $container = $this->services(new Container());
-        foreach ($this->plugins->with('services') as $plugin) {
-            $container = $plugin->services($container);
-        }
-        $this->container = $container;
 
-        return $this->container;
+        $container = new Container();
+        $this->services($container);
+        foreach ($this->plugins->with('services') as $plugin) {
+            $plugin->services($container);
+        }
+
+        return $this->container = $container;
     }
 
     /**
      * Register application container services.
      *
      * @param \Cake\Core\ContainerInterface $container The Container to update.
-     * @return \Cake\Core\ContainerInterface The updated container
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
-        return $container;
     }
 
     /**

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -92,7 +92,7 @@ class BasePluginTest extends TestCase
         $this->assertSame($commands, $plugin->console($commands));
     }
 
-    public function testRegister()
+    public function testServices()
     {
         $plugin = new BasePlugin();
         $container = new Container();

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -96,7 +96,7 @@ class BasePluginTest extends TestCase
     {
         $plugin = new BasePlugin();
         $container = new Container();
-        $this->assertSame($container, $plugin->services($container));
+        $this->assertNull($plugin->services($container));
     }
 
     public function testConsoleFind()

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -96,12 +96,10 @@ class Application extends BaseApplication
      * Container register hook
      *
      * @param \Cake\Core\ContainerInterface $container The container to update
-     * @return \Cake\Core\ContainerInterface
+     * @return void
      */
-    public function services(ContainerInterface $container): ContainerInterface
+    public function services(ContainerInterface $container): void
     {
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
-
-        return $container;
     }
 }


### PR DESCRIPTION
The services() hooks should just mutate the provided instance,
no return value is necessary.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
