### PR TITLE
Add ServiceProvider base class

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -73,6 +73,12 @@
       <code>$request</code>
     </ArgumentTypeCoercion>
   </file>
+  <file src="src/Core/ServiceProvider.php">
+    <MethodSignatureMismatch occurrences="2">
+      <code>ServiceProvider</code>
+      <code>public function getContainer(): ContainerInterface</code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="src/Database/Driver.php">
     <InvalidScalarArgument occurrences="2">
       <code>$value</code>

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -30,8 +30,7 @@ use League\Container\ServiceProvider\BootableServiceProviderInterface;
  * @experimental This class' interface is not stable and may change
  *   in future minor releases.
  */
-abstract class ServiceProvider extends AbstractServiceProvider
-    implements BootableServiceProviderInterface
+abstract class ServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
 {
     /**
      * Delegate to the bootstrap() method

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -47,7 +47,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
         $container = parent::getContainer();
         if (!($container instanceof ContainerInterface)) {
             $message = sprintf(
-                "Unexpected container type. Expected `%s` got `%s` instead.",
+                'Unexpected container type. Expected `%s` got `%s` instead.',
                 ContainerInterface::class,
                 getTypeName($container)
             );

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use League\Container\ServiceProvider\BootableServiceProviderInterface;
+
+/**
+ * Container ServiceProvider
+ *
+ * Service provider bundle related services together helping
+ * to organize your application's dependencies. They also help
+ * improve performance of applications with many services by
+ * allowing service registration to be deferred until services are needed.
+ *
+ * @experimental This class' interface is not stable and may change
+ *   in future minor releases.
+ */
+abstract class ServiceProvider extends AbstractServiceProvider
+    implements BootableServiceProviderInterface
+{
+    /**
+     * Delegate to the bootstrap() method
+     *
+     * This method primarily exists as a shim between the interface
+     * that league/container has and the one we want to offer in CakePHP.
+     *
+     * @return void
+     */
+    public function boot(): void
+    {
+        $this->bootstrap($this->getContainer());
+    }
+
+    /**
+     * Bootstrap hook for ServiceProviders
+     *
+     * This hook should be implemented if your service provider
+     * needs to register additional service providers, load configuration
+     * files or do any other work when the service provider is added to the
+     * container.
+     *
+     * @param \Cake\Core\ContainerInterface $container The container to add services to.
+     * @return void
+     */
+    public function bootstrap(ContainerInterface $container): void
+    {
+    }
+
+    /**
+     * Call the abstract services() method.
+     *
+     * This method primarily exists as a shim between the interface
+     * that league/container has and the one we want to offer in CakePHP.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->services($this->getContainer());
+    }
+
+    /**
+     * Register the services in a provider.
+     *
+     * All services registered in this method should also be included in the $provides
+     * property so that services can be located.
+     *
+     * @param \Cake\Core\ContainerInterface $container The container to add services to.
+     * @return void
+     */
+    abstract public function services(ContainerInterface $container): void;
+}

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -60,8 +60,8 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
     /**
      * Delegate to the bootstrap() method
      *
-     * This method primarily exists as a shim between the interface
-     * that league/container has and the one we want to offer in CakePHP.
+     * This method wraps the league/container function so users
+     * only need to use the CakePHP bootstrap() interface.
      *
      * @return void
      */

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -18,6 +18,7 @@ namespace Cake\Core;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Container\ServiceProvider\BootableServiceProviderInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use RuntimeException;
 
 /**
@@ -36,9 +37,12 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
     /**
      * Get the container.
      *
+     * This method's actual return type and documented return type differ
+     * because PHP 7.2 doesn't support return type narrowing.
+     *
      * @return \Cake\Core\ContainerInterface
      */
-    public function getContainer(): ContainerInterface
+    public function getContainer(): PsrContainerInterface
     {
         $container = parent::getContainer();
         if (!($container instanceof ContainerInterface)) {

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -18,6 +18,7 @@ namespace Cake\Core;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Container\ServiceProvider\BootableServiceProviderInterface;
+use RuntimeException;
 
 /**
  * Container ServiceProvider
@@ -32,6 +33,26 @@ use League\Container\ServiceProvider\BootableServiceProviderInterface;
  */
 abstract class ServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
 {
+    /**
+     * Get the container.
+     *
+     * @return \Cake\Core\ContainerInterface
+     */
+    public function getContainer(): ContainerInterface
+    {
+        $container = parent::getContainer();
+        if (!($container instanceof ContainerInterface)) {
+            $message = sprintf(
+                "Unexpected container type. Expected `%s` got `%s` instead.",
+                ContainerInterface::class,
+                getTypeName($container)
+            );
+            throw new RuntimeException($message);
+        }
+
+        return $container;
+    }
+
     /**
      * Delegate to the bootstrap() method
      *

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -27,7 +27,8 @@
     },
     "suggest": {
         "cakephp/event": "To use PluginApplicationInterface or plugin applications.",
-        "cakephp/cache": "To use Configure::store() and restore()."
+        "cakephp/cache": "To use Configure::store() and restore().",
+        "league/container": "To use Container and ServiceProvider classes"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\Container;
-use TestApp\ServiceProvider\PersonServiceProvider;
 use Cake\TestSuite\TestCase;
+use TestApp\ServiceProvider\PersonServiceProvider;
 
 /**
  * ServiceProviderTest
@@ -27,7 +27,7 @@ class ServiceProviderTest extends TestCase
 {
     public function testBootstrapHook()
     {
-        $container = new Container;
+        $container = new Container();
         $container->addServiceProvider(new PersonServiceProvider());
 
         $this->assertTrue(
@@ -39,10 +39,10 @@ class ServiceProviderTest extends TestCase
 
     public function testServicesHook()
     {
-        $container = new Container;
+        $container = new Container();
         $container->addServiceProvider(new PersonServiceProvider());
 
-        $this->assertTrue( $container->has('sally'), 'Should have service');
+        $this->assertTrue($container->has('sally'), 'Should have service');
         $this->assertSame('sally', $container->get('sally')->name);
     }
 }

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Core;
+
+use Cake\Core\Container;
+use TestApp\ServiceProvider\PersonServiceProvider;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ServiceProviderTest
+ */
+class ServiceProviderTest extends TestCase
+{
+    public function testBootstrapHook()
+    {
+        $container = new Container;
+        $container->addServiceProvider(new PersonServiceProvider());
+
+        $this->assertTrue(
+            $container->has('boot'),
+            'Should have service defined in bootstrap.'
+        );
+        $this->assertSame('boot', $container->get('boot')->name);
+    }
+
+    public function testServicesHook()
+    {
+        $container = new Container;
+        $container->addServiceProvider(new PersonServiceProvider());
+
+        $this->assertTrue( $container->has('sally'), 'Should have service');
+        $this->assertSame('sally', $container->get('sally')->name);
+    }
+}

--- a/tests/test_app/TestApp/ServiceProvider/PersonServiceProvider.php
+++ b/tests/test_app/TestApp/ServiceProvider/PersonServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\ServiceProvider;
+
+use Cake\Core\ContainerInterface;
+use Cake\Core\ServiceProvider;
+
+class PersonServiceProvider extends ServiceProvider
+{
+    protected $provides = ['boot', 'sally'];
+
+    public function bootstrap(ContainerInterface $container): void
+    {
+        $container->add('boot', json_decode('{"name":"boot"}'));
+    }
+
+    public function services(ContainerInterface $container): void
+    {
+        $container->add('sally', json_decode('{"name":"sally"}'));
+    }
+}


### PR DESCRIPTION
To provide consistent method name conventions for users we will need a ServiceProvider subclass. This should also help reduce the number of times that users need to import directly from league.

Refs cakephp/docs#6847