### PR TITLE
Disable xdebug for php8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ before_install:
       fi
 
   - |
+      phpenv config-rm xdebug.ini
       if [[ $TRAVIS_PHP_VERSION != 'nightly' ]]; then
-        phpenv config-rm xdebug.ini
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
This fixes the memory corruption error showing up.