### PR TITLE
Fix test failing on PHP 8.

### DIFF
--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -88,10 +88,9 @@ class IcuFormatterTest extends TestCase
      *
      * @return void
      */
-    public function testBadMessageFormatPHP7()
+    public function testBadMessageFormat()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Constructor failed');
 
         $formatter = new IcuFormatter();
         $formatter->format('en_US', '{crazy format', ['some', 'vars']);


### PR DESCRIPTION
PHP 8 throws a different error message and checking the exact message
isn't really necessary in this case.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
