### PR TITLE
Throw exception if loadFixtures() is called when auto fixtures enabled

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -252,9 +252,13 @@ abstract class TestCase extends BaseTestCase
      */
     public function loadFixtures(): void
     {
+        if ($this->autoFixtures) {
+            throw new RuntimeException('Cannot use `loadFixtures()` with `$autoFixtures` enabled.');
+        }
         if ($this->fixtureManager === null) {
             throw new RuntimeException('No fixture manager to load the test fixture');
         }
+
         $args = func_get_args();
         foreach ($args as $class) {
             $this->fixtureManager->loadSingle($class, null, $this->dropTables);

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -316,7 +316,7 @@ class ConnectionTest extends TestCase
             !($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite),
             'Only required for SQLite driver which does not support buffered results natively'
         );
-        $this->loadFixtures('Things');
+
         $statement = $this->connection->query('SELECT * FROM things LIMIT 3');
 
         $collection = new Collection($statement);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3215,8 +3215,6 @@ class QueryTest extends TestCase
         // Sqlite only supports maximum 16 digits for decimals.
         $this->skipIf($this->connection->getDriver() instanceof Sqlite);
 
-        $this->loadFixtures('Datatypes');
-
         $big = '1234567890123456789.2';
         $table = $this->getTableLocator()->get('Datatypes');
         $entity = $table->newEntity([]);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3940,8 +3940,6 @@ class QueryTest extends TestCase
             'The current driver does not support window functions.'
         );
 
-        $this->loadFixtures('Articles');
-
         $table = $this->getTableLocator()->get('Articles');
 
         $cteQuery = $table


### PR DESCRIPTION
In preparation for FixtureManager clean-up. This is just an extra check that shouldn't occur in existing tests.