### PR TITLE
Fix call_user_func_array() named arguments on PHP 8

### DIFF
--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -126,7 +126,7 @@ abstract class ObjectCollection {
 		}
 		$result = null;
 		foreach ($list as $name) {
-			$result = call_user_func_array(array($this->_loaded[$name], $callback), array_filter(compact('subject')) + $params);
+			$result = call_user_func_array(array($this->_loaded[$name], $callback), array_values(array_filter(compact('subject')) + $params));
 			if ($options['collectReturn'] === true) {
 				$collected[] = $result;
 			}


### PR DESCRIPTION
On PHP 8, call_user_func_array support named arguments.

https://wiki.php.net/rfc/named_params 