### PR TITLE
Name acronyms correctly

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -53,7 +53,7 @@
         <!-- Postgres
         <env name="DB_URL" value="postgres://localhost/cake_test?timezone=UTC"/>
         -->
-        <!-- Mysql
+        <!-- MySQL
         <env name="DB_URL" value="mysql://localhost/cake_test?timezone=UTC"/>
         -->
         <!-- SQL Server

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -68,7 +68,7 @@ class Cache
     use StaticConfigTrait;
 
     /**
-     * An array mapping url schemes to fully qualified caching engine
+     * An array mapping URL schemes to fully qualified caching engine
      * class names.
      *
      * @var string[]

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -52,8 +52,8 @@ class MemcachedEngine extends CacheEngine
      *    the same persistent value will share a single underlying connection.
      * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     * - `serialize` The serializer engine used to serialize data. Available engines are php,
-     *    igbinary and json. Beside php, the memcached extension must be compiled with the
+     * - `serialize` The serializer engine used to serialize data. Available engines are 'php',
+     *    'igbinary' and 'json'. Beside 'php', the memcached extension must be compiled with the
      *    appropriate serializer support.
      * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
      *    them as a pool.
@@ -80,7 +80,7 @@ class MemcachedEngine extends CacheEngine
     /**
      * List of available serializer engines
      *
-     * Memcached must be compiled with json and igbinary support to use these engines
+     * Memcached must be compiled with JSON and igbinary support to use these engines
      *
      * @var array
      */

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -46,7 +46,7 @@ class RedisEngine extends CacheEngine
      * - `port` port number to the Redis server.
      * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     * - `server` URL or ip to the Redis server host.
+     * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
      *

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -267,7 +267,7 @@ class ConsoleInputOption
     }
 
     /**
-     * Append the option's xml into the parent.
+     * Append the option's XML into the parent.
      *
      * @param \SimpleXMLElement $parent The parent element.
      * @return \SimpleXMLElement The parent with this option appended.

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -741,7 +741,7 @@ class ConsoleOptionParser
      *
      * @param string|null $subcommand If present and a valid subcommand that has a linked parser.
      *    That subcommands help will be shown instead.
-     * @param string $format Define the output format, can be text or xml
+     * @param string $format Define the output format, can be text or XML
      * @param int $width The width to format user content to. Defaults to 72
      * @return string Generated help.
      */

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -206,7 +206,7 @@ class HelpFormatter
     }
 
     /**
-     * Get the help as an xml string.
+     * Get the help as an XML string.
      *
      * @param bool $string Return the SimpleXml object or a string. Defaults to true.
      * @return string|\SimpleXMLElement See $string

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -387,7 +387,7 @@ class Shell
      *      'extra' => ['param' => 'value']
      * ]);`
      *
-     * @return int The cli command exit code. 0 is success.
+     * @return int The CLI command exit code. 0 is success.
      * @link https://book.cakephp.org/4/en/console-and-shells.html#invoking-other-shells-from-your-shell
      */
     public function dispatchShell(): int

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -26,7 +26,7 @@ use Cake\Shell\Task\CommandTask;
 use Cake\Utility\Inflector;
 
 /**
- * Shell dispatcher handles dispatching cli commands.
+ * Shell dispatcher handles dispatching CLI commands.
  *
  * Consult /bin/cake.php for how this class is used in practice.
  *
@@ -172,7 +172,7 @@ class ShellDispatcher
      * Built-in extra parameter is :
      *
      * - `requested` : if used, will prevent the Shell welcome message to be displayed
-     * @return int The cli command exit code. 0 is success.
+     * @return int The CLI command exit code. 0 is success.
      */
     public function dispatch(array $extra = []): int
     {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -380,7 +380,7 @@ class RequestHandlerComponent extends Component
      *
      * ### Usage:
      *
-     * Render the response as an 'AJAX' response.
+     * Render the response as an 'ajax' response.
      *
      * ```
      * $this->RequestHandler->renderAs($this, 'ajax');

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -63,7 +63,7 @@ class RequestHandlerComponent extends Component
      *
      * - `checkHttpCache` - Whether to check for HTTP cache. Default `true`.
      * - `viewClassMap` - Mapping between type and view classes. If undefined
-     *   json, xml, and ajax will be mapped. Defining any types will omit the defaults.
+     *   json, XML, and ajax will be mapped. Defining any types will omit the defaults.
      *
      * @var array
      */
@@ -244,7 +244,7 @@ class RequestHandlerComponent extends Component
      * $this->RequestHandler->accepts('xml');
      * ```
      *
-     * Returns true if the client accepts xml.
+     * Returns true if the client accepts XML.
      *
      * @param string|array|null $type Can be null (or no parameter), a string type name, or an
      *   array of types
@@ -386,7 +386,7 @@ class RequestHandlerComponent extends Component
      * $this->RequestHandler->renderAs($this, 'ajax');
      * ```
      *
-     * Render the response as an xml file and force the result as a file download.
+     * Render the response as an XML file and force the result as a file download.
      *
      * ```
      * $this->RequestHandler->renderAs($this, 'xml', ['attachment' => 'myfile.xml'];

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -63,7 +63,7 @@ class RequestHandlerComponent extends Component
      *
      * - `checkHttpCache` - Whether to check for HTTP cache. Default `true`.
      * - `viewClassMap` - Mapping between type and view classes. If undefined
-     *   json, XML, and ajax will be mapped. Defining any types will omit the defaults.
+     *   JSON, XML, and ajax will be mapped. Defining any types will omit the defaults.
      *
      * @var array
      */

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -63,7 +63,7 @@ class RequestHandlerComponent extends Component
      *
      * - `checkHttpCache` - Whether to check for HTTP cache. Default `true`.
      * - `viewClassMap` - Mapping between type and view classes. If undefined
-     *   JSON, XML, and ajax will be mapped. Defining any types will omit the defaults.
+     *   JSON, XML, and AJAX will be mapped. Defining any types will omit the defaults.
      *
      * @var array
      */
@@ -380,7 +380,7 @@ class RequestHandlerComponent extends Component
      *
      * ### Usage:
      *
-     * Render the response as an 'ajax' response.
+     * Render the response as an 'AJAX' response.
      *
      * ```
      * $this->RequestHandler->renderAs($this, 'ajax');

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -154,7 +154,7 @@ if (!function_exists('pr')) {
 
 if (!function_exists('pj')) {
     /**
-     * json pretty print convenience function.
+     * JSON pretty print convenience function.
      *
      * In terminals this will act similar to using json_encode() with JSON_PRETTY_PRINT directly, when not run on CLI
      * will also wrap <pre> tags around the output of given variable. Similar to pr().

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -128,7 +128,7 @@ if (!function_exists('pr')) {
     /**
      * print_r() convenience function.
      *
-     * In terminals this will act similar to using print_r() directly, when not run on cli
+     * In terminals this will act similar to using print_r() directly, when not run on CLI
      * print_r() will also wrap <pre> tags around the output of given variable. Similar to debug().
      *
      * This function returns the same variable that was passed.
@@ -156,7 +156,7 @@ if (!function_exists('pj')) {
     /**
      * json pretty print convenience function.
      *
-     * In terminals this will act similar to using json_encode() with JSON_PRETTY_PRINT directly, when not run on cli
+     * In terminals this will act similar to using json_encode() with JSON_PRETTY_PRINT directly, when not run on CLI
      * will also wrap <pre> tags around the output of given variable. Similar to pr().
      *
      * This function returns the same variable that was passed.

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -25,7 +25,7 @@ use Cake\Database\StatementInterface;
 use PDO;
 
 /**
- * Class Mysql
+ * MySQL Driver
  */
 class Mysql extends Driver
 {

--- a/src/Database/Statement/MysqlStatement.php
+++ b/src/Database/Statement/MysqlStatement.php
@@ -19,7 +19,7 @@ namespace Cake\Database\Statement;
 use PDO;
 
 /**
- * Statement class meant to be used by a Mysql PDO driver
+ * Statement class meant to be used by a MySQL PDO driver
  *
  * @internal
  */

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -21,9 +21,9 @@ use InvalidArgumentException;
 use PDO;
 
 /**
- * Json type converter.
+ * JSON type converter.
  *
- * Use to convert json data between PHP and the database types.
+ * Use to convert JSON data between PHP and the database types.
  */
 class JsonType extends BaseType implements BatchCastingInterface
 {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -54,7 +54,7 @@ trait EntityTrait
     /**
      * List of computed or virtual fields that **should** be included in JSON or array
      * representations of this Entity. If a field is present in both _hidden and _virtual
-     * the field will **not** be in the array/json versions of the entity.
+     * the field will **not** be in the array/JSON versions of the entity.
      *
      * @var string[]
      */

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -827,7 +827,7 @@ class Debugger
      *   Gets the following templates: `id`, `context`
      * - 'links' - An array of HTML links that are used for creating links to other resources.
      *   Typically this is used to create javascript links to open other sections.
-     *   Link keys, are: `code`, `context`, `help`. See the js output format for an
+     *   Link keys, are: `code`, `context`, `help`. See the JS output format for an
      *   example.
      * - 'traceLine' - Used for creating lines in the stacktrace. Gets the following
      *   template variables: `reference`, `path`, `line`

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -66,7 +66,7 @@ use SimpleXMLElement;
  * ```
  * // Get as XML
  * $content = $response->getXml()
- * // Get as json
+ * // Get as JSON
  * $content = $response->getJson()
  * ```
  *

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -64,7 +64,7 @@ use SimpleXMLElement;
  * as SimpleXML nodes:
  *
  * ```
- * // Get as xml
+ * // Get as XML
  * $content = $response->getXml()
  * // Get as json
  * $content = $response->getJson()

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -793,7 +793,7 @@ class Cookie implements CookieInterface
      * Implode method to keep keys are multidimensional arrays
      *
      * @param array $array Map of key and values
-     * @return string A json encoded string.
+     * @return string A JSON encoded string.
      */
     protected function _flatten(array $array): string
     {

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -54,7 +54,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      *
      * ### Options
      *
-     * - `json` Set to false to disable json body parsing.
+     * - `json` Set to false to disable JSON body parsing.
      * - `xml` Set to true to enable XML parsing. Defaults to false, as XML
      *   handling requires more care than JSON does.
      * - `methods` The HTTP methods to parse on. Defaults to PUT, POST, PATCH DELETE.

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -25,7 +25,7 @@ use SessionHandlerInterface;
 /**
  * This class is a wrapper for the native PHP session functions. It provides
  * several defaults for the most common session configuration
- * via external handlers and helps with using session in cli without any warnings.
+ * via external handlers and helps with using session in CLI without any warnings.
  *
  * Sessions can be created from the defaults using `Session::create()` or you can get
  * an instance of a new session by just instantiating this class and passing the complete

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -435,7 +435,7 @@ trait DateFormatTrait
     }
 
     /**
-     * Returns a string that should be serialized when converting this object to json
+     * Returns a string that should be serialized when converting this object to JSON
      *
      * @return string|int
      */

--- a/src/I18n/I18nDateTimeInterface.php
+++ b/src/I18n/I18nDateTimeInterface.php
@@ -128,7 +128,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
     public static function setToStringFormat($format): void;
 
     /**
-     * Sets the default format used when converting this object to json
+     * Sets the default format used when converting this object to JSON
      *
      * The format should be either the formatting constants from IntlDateFormatter as
      * described in (https://secure.php.net/manual/en/class.intldateformatter.php) or a pattern

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -347,7 +347,7 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
-     * Sets the "sender" address. See rfc link below for full explanation.
+     * Sets the "sender" address. See RFC link below for full explanation.
      *
      * @param string|array $email String with email,
      *   Array with email as key, name as value or email as value (without name)
@@ -362,7 +362,7 @@ class Message implements JsonSerializable, Serializable
     }
 
     /**
-     * Gets the "sender" address. See rfc link below for full explanation.
+     * Gets the "sender" address. See RFC link below for full explanation.
      *
      * @return array
      * @link https://tools.ietf.org/html/rfc2822.html#section-3.6.2

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -88,7 +88,7 @@ trait ConsoleIntegrationTestTrait
     protected $_in;
 
     /**
-     * Runs cli integration test
+     * Runs CLI integration test
      *
      * @param string $command Command to run
      * @param array $input Input values to pass to an interactive shell

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -156,7 +156,7 @@ trait CookieCryptTrait
      * Implode method to keep keys are multidimensional arrays
      *
      * @param array $array Map of key and values
-     * @return string A json encoded string.
+     * @return string A JSON encoded string.
      */
     protected function _implode(array $array): string
     {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1089,7 +1089,7 @@ class Validation
      * The regex checks for the following component parts:
      *
      * - a valid, optional, scheme
-     * - a valid ip address OR
+     * - a valid IP address OR
      *   a valid domain name as defined by section 2.3.1 of https://www.ietf.org/rfc/rfc1035.txt
      *   with an optional port number
      * - an optional valid path

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1332,7 +1332,7 @@ class FormHelper extends Helper
     }
 
     /**
-     * Set required attribute and custom validity js.
+     * Set required attribute and custom validity JS.
      *
      * @param string $fieldName The name of the field to generate options for.
      * @param array $options Options list.

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -59,7 +59,7 @@ use RuntimeException;
 class JsonView extends SerializedView
 {
     /**
-     * JSON layouts are located in the json sub directory of `Layouts/`
+     * JSON layouts are located in the JSON sub directory of `Layouts/`
      *
      * @var string
      */

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -61,7 +61,7 @@ use Cake\Utility\Xml;
 class XmlView extends SerializedView
 {
     /**
-     * XML layouts are located in the 'xml' sub directory of `Layouts/`
+     * XML layouts are located in the `layouts/xml/` sub directory
      *
      * @var string
      */

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -61,7 +61,7 @@ use Cake\Utility\Xml;
 class XmlView extends SerializedView
 {
     /**
-     * XML layouts are located in the xml sub directory of `Layouts/`
+     * XML layouts are located in the 'xml' sub directory of `Layouts/`
      *
      * @var string
      */

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1002,7 +1002,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * Test json encoding
+     * Test JSON encoding
      *
      * @return void
      */

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -537,7 +537,7 @@ xml;
     }
 
     /**
-     * Test xml help as object
+     * Test XML help as object
      *
      * @return void
      */

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1165,7 +1165,7 @@ class AuthComponentTest extends TestCase
     }
 
     /**
-     * test ajax unauthenticated
+     * test AJAX unauthenticated
      *
      * @return void
      * @triggers Controller.startup $this->Controller

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -360,7 +360,7 @@ class RequestHandlerComponentTest extends TestCase
     }
 
     /**
-     * Verify that isAjax is set on the request params for ajax requests
+     * Verify that isAjax is set on the request params for AJAX requests
      *
      * @return void
      * @triggers Controller.startup $this->Controller

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -151,7 +151,7 @@ class JsonConfigTest extends TestCase
     }
 
     /**
-     * Test dumping data to json format.
+     * Test dumping data to JSON format.
      *
      * @return void
      */

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 use PDO;
 
 /**
- * Tests Mysql driver
+ * Tests MySQL driver
  */
 class MysqlTest extends TestCase
 {
@@ -40,7 +40,7 @@ class MysqlTest extends TestCase
     }
 
     /**
-     * Test connecting to Mysql with default configuration
+     * Test connecting to MySQL with default configuration
      *
      * @return void
      */
@@ -82,7 +82,7 @@ class MysqlTest extends TestCase
     }
 
     /**
-     * Test connecting to Mysql with custom configuration
+     * Test connecting to MySQL with custom configuration
      *
      * @return void
      */

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4490,7 +4490,7 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests that the json type can save and get data symmetrically
+     * Tests that the JSON type can save and get data symmetrically
      *
      * @return void
      */

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 use PDO;
 
 /**
- * Test case for Mysql Schema Dialect.
+ * Test case for MySQL Schema Dialect.
  */
 class MysqlSchemaTest extends TestCase
 {
@@ -322,7 +322,7 @@ SQL;
     }
 
     /**
-     * Test describing a table with Mysql
+     * Test describing a table with MySQL
      *
      * @return void
      */
@@ -423,7 +423,7 @@ SQL;
     }
 
     /**
-     * Test describing a table with indexes in Mysql
+     * Test describing a table with indexes in MySQL
      *
      * @return void
      */
@@ -1353,7 +1353,7 @@ SQL;
     }
 
     /**
-     * Tests JSON column parsing on Mysql 5.7+
+     * Tests JSON column parsing on MySQL 5.7+
      *
      * @return void
      */

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1353,7 +1353,7 @@ SQL;
     }
 
     /**
-     * Tests json column parsing on Mysql 5.7+
+     * Tests JSON column parsing on Mysql 5.7+
      *
      * @return void
      */

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -232,7 +232,7 @@ SQL;
                 ['type' => 'DOUBLE PRECISION'],
                 ['type' => 'float', 'length' => null],
             ],
-            // Json
+            // JSON
             [
                 ['type' => 'JSON'],
                 ['type' => 'json', 'length' => null],

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -60,7 +60,7 @@ class JsonTypeTest extends TestCase
     }
 
     /**
-     * Test converting json strings to PHP values.
+     * Test converting JSON strings to PHP values.
      *
      * @return void
      */

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -49,7 +49,7 @@ class ResultSetDecoratorTest extends TestCase
     }
 
     /**
-     * Tests json encoding method
+     * Tests JSON encoding method
      *
      * @return void
      */

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -353,7 +353,7 @@ class ExceptionRendererTest extends TestCase
     }
 
     /**
-     * testerror400 method when returning as json
+     * testerror400 method when returning as JSON
      *
      * @return void
      */

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -104,7 +104,7 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * Test accessor for json
+     * Test accessor for JSON
      *
      * @return void
      */
@@ -139,7 +139,7 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * Test accessor for json when set with PSR7 methods.
+     * Test accessor for JSON when set with PSR7 methods.
      *
      * @return void
      */

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -155,7 +155,7 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * Test accessor for xml
+     * Test accessor for XML
      *
      * @return void
      */

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -527,7 +527,7 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test is() with json and xml.
+     * Test is() with json and XML.
      *
      * @return void
      */

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -762,7 +762,7 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test ajax, flash and friends
+     * Test AJAX, flash and friends
      *
      * @return void
      */

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -231,7 +231,7 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test parsing json PUT data into the object.
+     * Test parsing JSON PUT data into the object.
      *
      * @return void
      * @group deprecated
@@ -527,7 +527,7 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test is() with json and XML.
+     * Test is() with JSON and XML.
      *
      * @return void
      */

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -166,7 +166,7 @@ class DateTest extends TestCase
     }
 
     /**
-     * Tests change json encoding format
+     * Tests change JSON encoding format
      *
      * @dataProvider classNameProvider
      * @return void

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -731,7 +731,7 @@ class TimeTest extends TestCase
     }
 
     /**
-     * Tests encoding a Time object as json
+     * Tests encoding a Time object as JSON
      *
      * @dataProvider classNameProvider
      * @return void
@@ -772,7 +772,7 @@ class TimeTest extends TestCase
     }
 
     /**
-     * Tests change json encoding format
+     * Tests change JSON encoding format
      *
      * @dataProvider classNameProvider
      * @return void

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -728,7 +728,7 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests serializing an entity as json
+     * Tests serializing an entity as JSON
      *
      * @return void
      */

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -162,7 +162,7 @@ class ResultSetTest extends TestCase
     }
 
     /**
-     * Test converting resultsets into json
+     * Test converting resultsets into JSON
      *
      * @return void
      */

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -291,7 +291,7 @@ close to 5 million globally.
     }
 
     /**
-     * test loadHtml with a empty html string
+     * test loadHtml with a empty HTML string
      *
      * @return void
      */

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -668,7 +668,7 @@ XML;
     }
 
     /**
-     * Test that there are not unterminated errors when building xml
+     * Test that there are not unterminated errors when building XML
      *
      * @return void
      */

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2570,7 +2570,7 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * Tests the ip proxy methods
+     * Tests the IP proxy methods
      *
      * @return void
      */

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -862,7 +862,7 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test base form URL when url param is passed with multiple parameters (&)
+     * Test base form URL when 'url' param is passed with multiple parameters (&)
      */
     public function testCreateQueryStringRequest()
     {

--- a/tests/test_app/Plugin/TestTheme/webroot/js/one/theme_one.js
+++ b/tests/test_app/Plugin/TestTheme/webroot/js/one/theme_one.js
@@ -1,1 +1,1 @@
-// nested theme js file
+// nested theme JS file

--- a/tests/test_app/Plugin/TestTheme/webroot/js/theme.js
+++ b/tests/test_app/Plugin/TestTheme/webroot/js/theme.js
@@ -1,1 +1,1 @@
-// root theme js file
+// root theme JS file

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -26,7 +26,7 @@ use Cake\Controller\Controller;
 class RequestHandlerTestController extends Controller
 {
     /**
-     * test method for ajax redirection
+     * test method for AJAX redirection
      *
      * @return void
      */
@@ -37,7 +37,7 @@ class RequestHandlerTestController extends Controller
     }
 
     /**
-     * test method for ajax redirection + parameter parsing
+     * test method for AJAX redirection + parameter parsing
      *
      * @param string|null $one
      * @param string|null $two


### PR DESCRIPTION
To improve the readability/clarity about common acronyms, either name them correctly, e.g. all in caps or use quotes.