### PR TITLE
Make sure debug as string doesn't throw error.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -166,7 +166,7 @@ abstract class BaseErrorHandler
             'line' => $line,
         ];
 
-        $debug = Configure::read('debug');
+        $debug = (bool)Configure::read('debug');
         if ($debug) {
             // By default trim 3 frames off for the public and protected methods
             // used by ErrorHandler instances.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -608,7 +608,7 @@ class FormHelper extends Helper
             $this->formProtector->addField($field, true, $value);
         }
 
-        $debugSecurity = Configure::read('debug');
+        $debugSecurity = (bool)Configure::read('debug');
         if (isset($secureAttributes['debugSecurity'])) {
             $debugSecurity = $debugSecurity && $secureAttributes['debugSecurity'];
             unset($secureAttributes['debugSecurity']);


### PR DESCRIPTION
The default app template (especially of existing apps) uses

    'debug' => filter_var(env('DEBUG', false), FILTER_VALIDATE_BOOLEAN),

Some might also still use

     'debug' => env('DEBUG', false),

or alike.

So it can also come in from env using strings, e.g. empty string or `'0'` for false or `'1'` for true.

A stringish debug value here creates a fatal error though down the line:

> [TypeError] Argument 2 passed to Cake\Error\ErrorHandler::_displayError() must be of the type boolean, string given

in  `protected function _displayError(array $error, bool $debug): void` part.

I propose casting here where the code depends on the bool value for logic/comparison.