### PR TITLE
Default to string if no SQLite type is defined

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -52,6 +52,10 @@ class SqliteSchemaDialect extends SchemaDialect
      */
     protected function _convertColumn(string $column): array
     {
+        if (empty($column)) {
+            return ['type' => TableSchema::TYPE_STRING, 'length' => null];
+        }
+
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
             throw new Exception(sprintf('Unable to parse column type from "%s"', $column));

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -52,8 +52,8 @@ class SqliteSchemaDialect extends SchemaDialect
      */
     protected function _convertColumn(string $column): array
     {
-        if (empty($column)) {
-            return ['type' => TableSchema::TYPE_STRING, 'length' => null];
+        if ($column === '') {
+            return ['type' => TableSchema::TYPE_TEXT, 'length' => null];
         }
 
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -413,7 +413,7 @@ SQL;
                 'precision' => null,
                 'comment' => null,
                 'collate' => null,
-            ]
+            ],
         ];
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
         foreach ($expected as $field => $definition) {

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -417,7 +417,7 @@ SQL;
         ];
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->getColumn($field));
+            $this->assertSame($definition, $result->getColumn($field));
         }
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -392,6 +392,11 @@ SQL;
         }
     }
 
+    /**
+     * Tests SQLite views
+     *
+     * @return void
+     */
     public function testDescribeView()
     {
         $connection = ConnectionManager::get('test');

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -406,7 +406,7 @@ SQL;
         $result = $schema->describe('view_schema_articles');
         $expected = [
             'total' => [
-                'type' => 'string',
+                'type' => 'text',
                 'length' => null,
                 'null' => true,
                 'default' => null,

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -270,7 +270,15 @@ CREATE TABLE schema_composite (
     PRIMARY KEY("id", "site_id")
 );
 SQL;
+
         $connection->execute($sql);
+
+        $view = <<<SQL
+CREATE VIEW view_schema_articles AS
+    SELECT count(*) as total FROM schema_articles
+SQL;
+
+        $connection->execute($view);
     }
 
     /**
@@ -379,6 +387,30 @@ SQL;
         ];
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
         $this->assertEquals(['id'], $result->getPrimaryKey());
+        foreach ($expected as $field => $definition) {
+            $this->assertEquals($definition, $result->getColumn($field));
+        }
+    }
+
+    public function testDescribeView()
+    {
+        $connection = ConnectionManager::get('test');
+        $this->_createTables($connection);
+
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('view_schema_articles');
+        $expected = [
+            'total' => [
+                'type' => 'string',
+                'length' => null,
+                'null' => true,
+                'default' => null,
+                'precision' => null,
+                'comment' => null,
+                'collate' => null,
+            ]
+        ];
+        $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
         foreach ($expected as $field => $definition) {
             $this->assertEquals($definition, $result->getColumn($field));
         }


### PR DESCRIPTION
See #15075. This PR defaults column type to `string` if no type is defined by SQLite.