### PR TITLE
Update db and generator parameter names

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -187,11 +187,11 @@
   </file>
   <file src="src/TestSuite/Fixture/TestFixture.php">
     <ArgumentTypeCoercion occurrences="5">
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
+      <code>$connection</code>
+      <code>$connection</code>
+      <code>$connection</code>
+      <code>$connection</code>
+      <code>$connection</code>
     </ArgumentTypeCoercion>
   </file>
   <file src="src/TestSuite/IntegrationTestTrait.php">

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -318,12 +318,12 @@ class Connection implements ConnectionInterface
      * connection's driver
      *
      * @param \Cake\Database\Query $query The query to be compiled
-     * @param \Cake\Database\ValueBinder $generator The placeholder generator to use
+     * @param \Cake\Database\ValueBinder $binder Value binder
      * @return string
      */
-    public function compileQuery(Query $query, ValueBinder $generator): string
+    public function compileQuery(Query $query, ValueBinder $binder): string
     {
-        return $this->getDriver()->compileQuery($query, $generator)[1];
+        return $this->getDriver()->compileQuery($query, $binder)[1];
     }
 
     /**

--- a/src/Database/ConstraintsInterface.php
+++ b/src/Database/ConstraintsInterface.php
@@ -31,19 +31,19 @@ interface ConstraintsInterface
      * Build and execute SQL queries necessary to create the constraints for the
      * fixture
      *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
+     * @param \Cake\Datasource\ConnectionInterface $connection An instance of the database
      *  into which the constraints will be created.
      * @return bool on success or if there are no constraints to create, or false on failure
      */
-    public function createConstraints(ConnectionInterface $db): bool;
+    public function createConstraints(ConnectionInterface $connection): bool;
 
     /**
      * Build and execute SQL queries necessary to drop the constraints for the
      * fixture
      *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database
+     * @param \Cake\Datasource\ConnectionInterface $connection An instance of the database
      *  into which the constraints will be dropped.
      * @return bool on success or if there are no constraints to drop, or false on failure
      */
-    public function dropConstraints(ConnectionInterface $db): bool;
+    public function dropConstraints(ConnectionInterface $connection): bool;
 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -296,18 +296,17 @@ class Query implements ExpressionInterface, IteratorAggregate
      * values when the query is executed, hence it is most suitable to use with
      * prepared statements.
      *
-     * @param \Cake\Database\ValueBinder|null $generator A placeholder object that will hold
-     * associated values for expressions
+     * @param \Cake\Database\ValueBinder|null $binder Value binder that generates parameter placeholders
      * @return string
      */
-    public function sql(?ValueBinder $generator = null): string
+    public function sql(?ValueBinder $binder = null): string
     {
-        if (!$generator) {
-            $generator = $this->getValueBinder();
-            $generator->resetCount();
+        if (!$binder) {
+            $binder = $this->getValueBinder();
+            $binder->resetCount();
         }
 
-        return $this->getConnection()->compileQuery($this, $generator);
+        return $this->getConnection()->compileQuery($this, $binder);
     }
 
     /**

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -97,25 +97,25 @@ class QueryCompiler
      * the placeholders for the bound values using the provided generator
      *
      * @param \Cake\Database\Query $query The query that is being compiled
-     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholders
      * @return string
      */
-    public function compile(Query $query, ValueBinder $generator): string
+    public function compile(Query $query, ValueBinder $binder): string
     {
         $sql = '';
         $type = $query->type();
         $query->traverseParts(
-            $this->_sqlCompiler($sql, $query, $generator),
+            $this->_sqlCompiler($sql, $query, $binder),
             $this->{"_{$type}Parts"}
         );
 
         // Propagate bound parameters from sub-queries if the
         // placeholders can be found in the SQL statement.
-        if ($query->getValueBinder() !== $generator) {
+        if ($query->getValueBinder() !== $binder) {
             foreach ($query->getValueBinder()->bindings() as $binding) {
                 $placeholder = ':' . $binding['placeholder'];
                 if (preg_match('/' . $placeholder . '(?:\W|$)/', $sql) > 0) {
-                    $generator->bind($placeholder, $binding['value'], $binding['type']);
+                    $binder->bind($placeholder, $binding['value'], $binding['type']);
                 }
             }
         }

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -24,38 +24,38 @@ interface FixtureInterface
     /**
      * Create the fixture schema/mapping/definition
      *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the connection the fixture should be created on.
+     * @param \Cake\Datasource\ConnectionInterface $connection An instance of the connection the fixture should be created on.
      * @return bool True on success, false on failure.
      */
-    public function create(ConnectionInterface $db): bool;
+    public function create(ConnectionInterface $connection): bool;
 
     /**
      * Run after all tests executed, should remove the table/collection from the connection.
      *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the connection the fixture should be removed from.
+     * @param \Cake\Datasource\ConnectionInterface $connection An instance of the connection the fixture should be removed from.
      * @return bool True on success, false on failure.
      */
-    public function drop(ConnectionInterface $db): bool;
+    public function drop(ConnectionInterface $connection): bool;
 
     /**
      * Run before each test is executed.
      *
      * Should insert all the records into the test database.
      *
-     * @param \Cake\Datasource\ConnectionInterface $db An instance of the connection
+     * @param \Cake\Datasource\ConnectionInterface $connection An instance of the connection
      *   into which the records will be inserted.
      * @return \Cake\Database\StatementInterface|bool on success or if there are no records to insert,
      *  or false on failure.
      */
-    public function insert(ConnectionInterface $db);
+    public function insert(ConnectionInterface $connection);
 
     /**
      * Truncates the current fixture.
      *
-     * @param \Cake\Datasource\ConnectionInterface $db A reference to a db instance
+     * @param \Cake\Datasource\ConnectionInterface $connection A reference to a db instance
      * @return bool
      */
-    public function truncate(ConnectionInterface $db): bool;
+    public function truncate(ConnectionInterface $connection): bool;
 
     /**
      * Get the connection name this fixture should be inserted into.

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1096,13 +1096,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * @inheritDoc
      */
-    public function sql(?ValueBinder $generator = null): string
+    public function sql(?ValueBinder $binder = null): string
     {
         $this->triggerBeforeFind();
 
         $this->_transformQuery();
 
-        return parent::sql($generator);
+        return parent::sql($binder);
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -445,39 +445,39 @@ class FixtureManager
      * Creates a single fixture table and loads data into it.
      *
      * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface|null $db Connection instance or null
+     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
      *  to get a Connection from the fixture.
      * @param bool $dropTables Whether or not tables should be dropped and re-created.
      * @return void
      * @throws \UnexpectedValueException if $name is not a previously loaded class
      */
-    public function loadSingle(string $name, ?ConnectionInterface $db = null, bool $dropTables = true): void
+    public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {
         if (!isset($this->_fixtureMap[$name])) {
             throw new UnexpectedValueException(sprintf('Referenced fixture class %s not found', $name));
         }
 
         $fixture = $this->_fixtureMap[$name];
-        if (!$db) {
-            $db = ConnectionManager::get($fixture->connection());
+        if (!$connection) {
+            $connection = ConnectionManager::get($fixture->connection());
         }
 
-        if (!$this->isFixtureSetup($db->configName(), $fixture)) {
-            $sources = $db->getSchemaCollection()->listTables();
-            $this->_setupTable($fixture, $db, $sources, $dropTables);
+        if (!$this->isFixtureSetup($connection->configName(), $fixture)) {
+            $sources = $connection->getSchemaCollection()->listTables();
+            $this->_setupTable($fixture, $connection, $sources, $dropTables);
         }
 
         if (!$dropTables) {
             if ($fixture instanceof ConstraintsInterface) {
-                $fixture->dropConstraints($db);
+                $fixture->dropConstraints($connection);
             }
-            $fixture->truncate($db);
+            $fixture->truncate($connection);
         }
 
         if ($fixture instanceof ConstraintsInterface) {
-            $fixture->createConstraints($db);
+            $fixture->createConstraints($connection);
         }
-        $fixture->insert($db);
+        $fixture->insert($connection);
     }
 
     /**

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -268,7 +268,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function create(ConnectionInterface $db): bool
+    public function create(ConnectionInterface $connection): bool
     {
         if (empty($this->_schema)) {
             return false;
@@ -279,9 +279,9 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
         }
 
         try {
-            $queries = $this->_schema->createSql($db);
+            $queries = $this->_schema->createSql($connection);
             foreach ($queries as $query) {
-                $stmt = $db->prepare($query);
+                $stmt = $connection->prepare($query);
                 $stmt->execute();
                 $stmt->closeCursor();
             }
@@ -303,20 +303,20 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function drop(ConnectionInterface $db): bool
+    public function drop(ConnectionInterface $connection): bool
     {
         if (empty($this->_schema)) {
             return false;
         }
 
         if (empty($this->import) && empty($this->fields)) {
-            return $this->truncate($db);
+            return $this->truncate($connection);
         }
 
         try {
-            $sql = $this->_schema->dropSql($db);
+            $sql = $this->_schema->dropSql($connection);
             foreach ($sql as $stmt) {
-                $db->execute($stmt)->closeCursor();
+                $connection->execute($stmt)->closeCursor();
             }
         } catch (Exception $e) {
             return false;
@@ -328,11 +328,11 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function insert(ConnectionInterface $db)
+    public function insert(ConnectionInterface $connection)
     {
         if (isset($this->records) && !empty($this->records)) {
             [$fields, $values, $types] = $this->_getRecords();
-            $query = $db->newQuery()
+            $query = $connection->newQuery()
                 ->insert($fields, $types)
                 ->into($this->sourceName());
 
@@ -351,7 +351,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function createConstraints(ConnectionInterface $db): bool
+    public function createConstraints(ConnectionInterface $connection): bool
     {
         if (empty($this->_constraints)) {
             return true;
@@ -361,14 +361,14 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             $this->_schema->addConstraint($name, $data);
         }
 
-        $sql = $this->_schema->addConstraintSql($db);
+        $sql = $this->_schema->addConstraintSql($connection);
 
         if (empty($sql)) {
             return true;
         }
 
         foreach ($sql as $stmt) {
-            $db->execute($stmt)->closeCursor();
+            $connection->execute($stmt)->closeCursor();
         }
 
         return true;
@@ -377,20 +377,20 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function dropConstraints(ConnectionInterface $db): bool
+    public function dropConstraints(ConnectionInterface $connection): bool
     {
         if (empty($this->_constraints)) {
             return true;
         }
 
-        $sql = $this->_schema->dropConstraintSql($db);
+        $sql = $this->_schema->dropConstraintSql($connection);
 
         if (empty($sql)) {
             return true;
         }
 
         foreach ($sql as $stmt) {
-            $db->execute($stmt)->closeCursor();
+            $connection->execute($stmt)->closeCursor();
         }
 
         foreach ($this->_constraints as $name => $data) {
@@ -429,11 +429,11 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * @inheritDoc
      */
-    public function truncate(ConnectionInterface $db): bool
+    public function truncate(ConnectionInterface $connection): bool
     {
-        $sql = $this->_schema->truncateSql($db);
+        $sql = $this->_schema->truncateSql($connection);
         foreach ($sql as $stmt) {
-            $db->execute($stmt)->closeCursor();
+            $connection->execute($stmt)->closeCursor();
         }
 
         return true;

--- a/tests/Fixture/OtherArticlesFixture.php
+++ b/tests/Fixture/OtherArticlesFixture.php
@@ -26,31 +26,31 @@ class OtherArticlesFixture implements FixtureInterface
 {
     public $table = 'other_articles';
 
-    public function create(ConnectionInterface $db): bool
+    public function create(ConnectionInterface $connection): bool
     {
         return true;
     }
 
-    public function drop(ConnectionInterface $db): bool
+    public function drop(ConnectionInterface $connection): bool
     {
         return true;
     }
 
-    public function insert(ConnectionInterface $db)
+    public function insert(ConnectionInterface $connection)
     {
     }
 
-    public function createConstraints(ConnectionInterface $db): bool
-    {
-        return true;
-    }
-
-    public function dropConstraints(ConnectionInterface $db): bool
+    public function createConstraints(ConnectionInterface $connection): bool
     {
         return true;
     }
 
-    public function truncate(ConnectionInterface $db): bool
+    public function dropConstraints(ConnectionInterface $connection): bool
+    {
+        return true;
+    }
+
+    public function truncate(ConnectionInterface $connection): bool
     {
         return true;
     }


### PR DESCRIPTION
Found these working on fixtures. This updates only public interfaces.

The psalm suppression doesn't look good. Why are we passing around `ConnectionInterface` when we can't use it?