### PR TITLE
Change _runOperation to runPerFixture

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -25,6 +25,7 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FixtureInterface;
 use Cake\TestSuite\TestCase;
+use Closure;
 use PDOException;
 use RuntimeException;
 use UnexpectedValueException;
@@ -284,20 +285,19 @@ class FixtureManager
         }
 
         try {
-            $createTables = function (ConnectionInterface $db, array $fixtures) use ($test): void {
-                /** @var \Cake\Datasource\FixtureInterface[] $fixtures */
-                $tables = $db->getSchemaCollection()->listTables();
-                $configName = $db->configName();
-                if (!isset($this->_insertionMap[$configName])) {
-                    $this->_insertionMap[$configName] = [];
-                }
-
-                foreach ($fixtures as $fixture) {
-                    if (!$fixture instanceof ConstraintsInterface) {
-                        continue;
+            $this->runPerFixture(
+                $fixtures,
+                function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) use ($test) {
+                    $configName = $db->configName();
+                    if (!isset($this->_insertionMap[$configName])) {
+                        $this->_insertionMap[$configName] = [];
                     }
 
-                    if (in_array($fixture->sourceName(), $tables, true)) {
+                    if (!$fixture instanceof ConstraintsInterface) {
+                        return;
+                    }
+
+                    if (in_array($fixture->sourceName(), $tableCache, true)) {
                         try {
                             $fixture->dropConstraints($db);
                         } catch (PDOException $e) {
@@ -311,18 +311,25 @@ class FixtureManager
                         }
                     }
                 }
+            );
 
-                foreach ($fixtures as $fixture) {
+            $this->runPerFixture(
+                $fixtures,
+                function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) use ($test) {
+                    $configName = $db->configName();
                     if (!in_array($fixture, $this->_insertionMap[$configName], true)) {
-                        $this->_setupTable($fixture, $db, $tables, $test->dropTables);
+                        $this->_setupTable($fixture, $db, $tableCache, $test->dropTables);
                     } else {
                         $fixture->truncate($db);
                     }
                 }
+            );
 
-                foreach ($fixtures as $fixture) {
+            $this->runPerFixture(
+                $fixtures,
+                function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) use ($test) {
                     if (!$fixture instanceof ConstraintsInterface) {
-                        continue;
+                        return;
                     }
 
                     try {
@@ -337,12 +344,11 @@ class FixtureManager
                         throw new Exception($msg, null, $e);
                     }
                 }
-            };
-            $this->_runOperation($fixtures, $createTables);
+            );
 
-            // Use a separate transaction because of postgres.
-            $insert = function (ConnectionInterface $db, array $fixtures) use ($test): void {
-                foreach ($fixtures as $fixture) {
+            $this->runPerFixture(
+                $fixtures,
+                function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) use ($test) {
                     try {
                         $fixture->insert($db);
                     } catch (PDOException $e) {
@@ -355,8 +361,7 @@ class FixtureManager
                         throw new Exception($msg, null, $e);
                     }
                 }
-            };
-            $this->_runOperation($fixtures, $insert);
+            );
         } catch (PDOException $e) {
             $msg = sprintf(
                 'Unable to insert fixtures for "%s" test case. %s',
@@ -370,25 +375,30 @@ class FixtureManager
     /**
      * Run a function on each connection and collection of fixtures.
      *
-     * @param string[] $fixtures A list of fixtures to operate on.
-     * @param callable $operation The operation to run on each connection + fixture set.
+     * @param string[] $names Test fixture names
+     * @param \Closure $callback Callback that is run per fixture
      * @return void
      */
-    protected function _runOperation(array $fixtures, callable $operation): void
+    protected function runPerFixture(array $names, Closure $callback): void
     {
-        $dbs = $this->_fixtureConnections($fixtures);
+        $dbs = $this->groupFixturesByConnection($names);
         foreach ($dbs as $connection => $fixtures) {
             $db = ConnectionManager::get($connection);
-            $logQueries = $db->isQueryLoggingEnabled();
 
+            $logQueries = $db->isQueryLoggingEnabled();
             if ($logQueries && !$this->_debug) {
                 $db->disableQueryLogging();
             }
-            $db->transactional(function (ConnectionInterface $db) use ($fixtures, $operation): void {
-                $db->disableConstraints(function (ConnectionInterface $db) use ($fixtures, $operation): void {
-                    $operation($db, $fixtures);
+
+            $tableCache = $db->getSchemaCollection()->listTables();
+            $db->transactional(function (ConnectionInterface $db) use ($fixtures, $callback, $tableCache) {
+                $db->disableConstraints(function (ConnectionInterface $db) use ($fixtures, $callback, $tableCache) {
+                    foreach ($fixtures as $fixture) {
+                        $callback($db, $fixture, $tableCache);
+                    }
                 });
             });
+
             if ($logQueries) {
                 $db->enableQueryLogging(true);
             }
@@ -396,15 +406,15 @@ class FixtureManager
     }
 
     /**
-     * Get the unique list of connections that a set of fixtures contains.
+     * Groups fixtures by connection name.
      *
-     * @param string[] $fixtures The array of fixtures a list of connections is needed from.
-     * @return array An array of connection names.
+     * @param string[] $names Test fixture names.
+     * @return array
      */
-    protected function _fixtureConnections(array $fixtures): array
+    protected function groupFixturesByConnection(array $names): array
     {
         $dbs = [];
-        foreach ($fixtures as $name) {
+        foreach ($names as $name) {
             if (!empty($this->_loaded[$name])) {
                 $fixture = $this->_loaded[$name];
                 $dbs[$fixture->connection()][$name] = $fixture;
@@ -426,19 +436,18 @@ class FixtureManager
         if (!$fixtures) {
             return;
         }
-        $truncate = function (ConnectionInterface $db, array $fixtures): void {
-            $configName = $db->configName();
 
-            foreach ($fixtures as $name => $fixture) {
+        $this->runPerFixture(
+            $fixtures,
+            function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) {
                 if (
-                    $this->isFixtureSetup($configName, $fixture)
+                    $this->isFixtureSetup($db->configName(), $fixture)
                     && $fixture instanceof ConstraintsInterface
                 ) {
                     $fixture->dropConstraints($db);
                 }
             }
-        };
-        $this->_runOperation($fixtures, $truncate);
+        );
     }
 
     /**
@@ -487,18 +496,17 @@ class FixtureManager
      */
     public function shutDown(): void
     {
-        $shutdown = function (ConnectionInterface $db, array $fixtures): void {
-            $connection = $db->configName();
-            /** @var \Cake\Datasource\FixtureInterface $fixture */
-            foreach ($fixtures as $fixture) {
+        $this->runPerFixture(
+            array_keys($this->_loaded),
+            function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) {
+                $connection = $db->configName();
                 if ($this->isFixtureSetup($connection, $fixture)) {
                     $fixture->drop($db);
                     $index = array_search($fixture, $this->_insertionMap[$connection], true);
                     unset($this->_insertionMap[$connection][$index]);
                 }
             }
-        };
-        $this->_runOperation(array_keys($this->_loaded), $shutdown);
+        );
     }
 
     /**

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -381,10 +381,10 @@ class FixtureManagerTest extends TestCase
             ->willReturn(['core.Products']);
 
         $manager = $this->getMockBuilder(FixtureManager::class)
-            ->onlyMethods(['_runOperation'])
+            ->onlyMethods(['runPerFixture'])
             ->getMock();
         $manager->expects($this->any())
-            ->method('_runOperation')
+            ->method('runPerFixture')
             ->will($this->returnCallback(function () {
                 throw new PDOException('message');
             }));
@@ -430,10 +430,10 @@ class FixtureManagerTest extends TestCase
 
         /** @var \Cake\TestSuite\Fixture\FixtureManager|\PHPUnit\Framework\MockObject\MockObject $manager */
         $manager = $this->getMockBuilder(FixtureManager::class)
-            ->onlyMethods(['_fixtureConnections'])
+            ->onlyMethods(['groupFixturesByConnection'])
             ->getMock();
         $manager->expects($this->any())
-            ->method('_fixtureConnections')
+            ->method('groupFixturesByConnection')
             ->will($this->returnValue([
                 'test' => $fixtures,
             ]));


### PR DESCRIPTION
Port some of the refactor cleanup from debugging php 8 transaction issue. This is to improve code clarity for future work.

- The `_runOperation()` wrapper is renamed to `runPerFixture()` and runs the callback per-fixture in the same transaction.
- The `_fixtureConnections()` helper is renamed to `groupFixturesByConnection()`.

There only runtime change is in `FixtureManager::load()` where the `dropContraints()`, `create()/drop()/truncate()` and `createConstraints()` calls are run in separate transactions.
