### PR TITLE
Preferred indentation style for .neon files is using tabs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[*.neon]
+indent_style = tab

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,22 +1,22 @@
 includes:
-    - phpstan-baseline.neon
+	- phpstan-baseline.neon
 
 parameters:
-    level: 6
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
-    treatPhpDocTypesAsCertain: false
-    bootstrapFiles:
-        - tests/bootstrap.php
-    paths:
-        - src/
-    earlyTerminatingMethodCalls:
-        Cake\Console\Shell:
-            - abort
+	level: 6
+	checkMissingIterableValueType: false
+	checkGenericClassInNonGenericObjectType: false
+	treatPhpDocTypesAsCertain: false
+	bootstrapFiles:
+		- tests/bootstrap.php
+	paths:
+		- src/
+	earlyTerminatingMethodCalls:
+		Cake\Console\Shell:
+			- abort
 
 services:
-    -
-        class: Cake\PHPStan\AssociationTableMixinClassReflectionExtension
-        tags:
-            - phpstan.broker.methodsClassReflectionExtension
-            - phpstan.broker.propertiesClassReflectionExtension
+	-
+		class: Cake\PHPStan\AssociationTableMixinClassReflectionExtension
+		tags:
+			- phpstan.broker.methodsClassReflectionExtension
+			- phpstan.broker.propertiesClassReflectionExtension


### PR DESCRIPTION
This harmonizes the identation style of phpstan.neon and auto generated phpstan-baseline.neon
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
