### PR TITLE
Make TestShell compatible with PHP 7.4

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -291,8 +291,8 @@ class TestShell extends Shell {
 	public function available() {
 		$params = $this->_parseArgs();
 		$testCases = CakeTestLoader::generateTestList($params);
-		$app = $params['app'];
-		$plugin = $params['plugin'];
+		$app = isset($params['app']) ? $params['app'] : null;
+		$plugin = isset($params['plugin']) ? $params['plugin'] : null;
 
 		$title = "Core Test Cases:";
 		$category = 'core';


### PR DESCRIPTION
If `$params` is `null`, PHP 7.4 would otherwise throw a warning. 