### PR TITLE
Update distinct on column test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
         REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       run: |
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.2' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.2' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.4' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
-        if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"'; fi
+        if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
 
         if [[ ${{ matrix.php-version }} == '7.2' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ php:
 
 env:
   matrix:
-    - DB=mysql DB_URL='mysql://root@127.0.0.1/cakephp_test?init[]=SET sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    - DB=mysql DB_URL='mysql://root@127.0.0.1/cakephp_test'
     - DB=pgsql DB_URL='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite DB_URL='sqlite:///:memory:'
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2136,8 +2136,7 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests that it is possible to select distinct rows, even filtering by one column
-     * this is testing that there is a specific implementation for DISTINCT ON
+     * Tests distinct on a specific column reduces rows based on that column.
      *
      * @return void
      */
@@ -2146,14 +2145,13 @@ class QueryTest extends TestCase
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
-            ->select(['id', 'author_id'])
+            ->select(['author_id'])
             ->distinct(['author_id'])
             ->from(['a' => 'articles'])
             ->order(['author_id' => 'ASC'])
             ->execute();
         $this->assertCount(2, $result);
         $results = $result->fetchAll('assoc');
-        $this->assertEquals(['id', 'author_id'], array_keys($results[0]));
         $this->assertEquals(
             [3, 1],
             collection($results)->sortBy('author_id')->extract('author_id')->toList()
@@ -2161,14 +2159,13 @@ class QueryTest extends TestCase
 
         $query = new Query($this->connection);
         $result = $query
-            ->select(['id', 'author_id'])
+            ->select(['author_id'])
             ->distinct('author_id')
             ->from(['a' => 'articles'])
             ->order(['author_id' => 'ASC'])
             ->execute();
         $this->assertCount(2, $result);
         $results = $result->fetchAll('assoc');
-        $this->assertEquals(['id', 'author_id'], array_keys($results[0]));
         $this->assertEquals(
             [3, 1],
             collection($results)->sortBy('author_id')->extract('author_id')->toList()


### PR DESCRIPTION
This removes the custom init for mysql and mariadb. 

Columns used in select clause must be in the group by (distinct) clause for most databases. MySQL requires this by default since 5.7. I think the only db that supports it natively still is SQLite.

This does not deprecate the feature yet, but we don't need to test the support because we don't provide any transformations to avoid the scenario.