### PR TITLE
Update PHP 8 build job on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 php:
   - 7.4
-  - nightly
+  - '8.0snapshot'
 
 env:
   matrix:
@@ -44,12 +44,14 @@ before_install:
 
   - |
       phpenv config-rm xdebug.ini
-      if [[ $TRAVIS_PHP_VERSION != 'nightly' ]]; then
+
+      if [[ $TRAVIS_PHP_VERSION != '8.0snapshot' ]]; then
         echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
       fi
+
+      echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+      echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+      echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
   - sudo locale-gen da_DK.UTF-8
 
@@ -57,7 +59,7 @@ install:
   - |
       if [[ $PREFER_LOWEST == 1 ]]; then
         composer update --prefer-lowest --prefer-stable --no-interaction
-      elif [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then
+      elif [[ $TRAVIS_PHP_VERSION == '8.0snapshot' ]]; then
         composer install --no-interaction --ignore-platform-reqs
       else
         composer install --no-interaction


### PR DESCRIPTION
`8.0snapshot` has all the additional extensions we need except `memcached` but it's using an older PHP 8 snapshot than `nightly`. I have left a comment on Travis' forum so waiting for it to get sorted out.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
