### PR TITLE
Add FixtureManager test for unmanaged fixtures

### DIFF
--- a/tests/Fixture/UnmanagedFixture.php
+++ b/tests/Fixture/UnmanagedFixture.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture that wraps a pre-existing table
+ * without importing and with no fields.
+ */
+class UnmanagedFixture extends TestFixture
+{
+    /**
+     * @inheritDoc
+     */
+    public $table = 'unmanaged';
+
+    /**
+     * @inheritDoc
+     */
+    public $records = [
+        ['title' => 'a title', 'body' => 'a body'],
+        ['title' => 'another title', 'body' => 'another body'],
+    ];
+}

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\Fixture\FixtureManager;
-use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use PDOException;
 
@@ -49,8 +48,9 @@ class FixtureManagerTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        Log::reset();
         $this->clearPlugins();
+        Log::reset();
+        ConnectionManager::get('test')->disableQueryLogging();
     }
 
     /**
@@ -79,16 +79,13 @@ class FixtureManagerTest extends TestCase
      */
     public function testLogSchemaWithDebug()
     {
+        Log::setConfig('queries', ['className' => 'Array']);
+
         $db = ConnectionManager::get('test');
         $restore = $db->isQueryLoggingEnabled();
         $db->enableQueryLogging(true);
 
         $this->manager->setDebug(true);
-        $buffer = new ConsoleOutput();
-        Log::setConfig('testQueryLogger', [
-            'className' => 'Console',
-            'stream' => $buffer,
-        ]);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
@@ -102,7 +99,7 @@ class FixtureManagerTest extends TestCase
         $this->manager->shutdown();
 
         $db->enableQueryLogging($restore);
-        $this->assertStringContainsString('CREATE TABLE', implode('', $buffer->messages()));
+        $this->assertStringContainsString('CREATE TABLE', implode('', Log::engine('queries')->read()));
     }
 
     /**
@@ -113,16 +110,13 @@ class FixtureManagerTest extends TestCase
      */
     public function testResetDbIfTableExists()
     {
+        Log::setConfig('queries', ['className' => 'Array']);
+
         $db = ConnectionManager::get('test');
         $restore = $db->isQueryLoggingEnabled();
         $db->enableQueryLogging(true);
 
         $this->manager->setDebug(true);
-        $buffer = new ConsoleOutput();
-        Log::setConfig('testQueryLogger', [
-            'className' => 'Console',
-            'stream' => $buffer,
-        ]);
 
         $table = new TableSchema('articles', [
             'id' => ['type' => 'integer', 'unsigned' => true],
@@ -142,7 +136,7 @@ class FixtureManagerTest extends TestCase
         $this->manager->load($test);
 
         $db->enableQueryLogging($restore);
-        $this->assertStringContainsString('DROP TABLE', implode('', $buffer->messages()));
+        $this->assertStringContainsString('DROP TABLE', implode('', Log::engine('queries')->read()));
     }
 
     /**
@@ -307,29 +301,25 @@ class FixtureManagerTest extends TestCase
             ])
             ->execute();
 
-        $buffer = new ConsoleOutput();
-        Log::setConfig('testQueryLogger', [
-            'className' => 'Console',
-            'stream' => $buffer,
-        ]);
+        Log::setConfig('queries', ['className' => 'Array']);
+        $conn->enableQueryLogging(true);
 
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
             ->method('getFixtures')
             ->willReturn(['core.Unmanaged']);
 
-        $conn->enableQueryLogging(true);
         $this->manager->setDebug(true);
         $this->manager->fixturize($test);
         $this->manager->load($test);
-        $this->assertStringNotContainsString('DROP TABLE', implode('', $buffer->messages()));
+        $this->assertStringNotContainsString('DROP TABLE', implode('', Log::engine('queries')->read()));
 
         $stmt = $conn->newQuery()->select(['title', 'body'])->from('unmanaged')->execute();
         $rows = $stmt->fetchAll();
         $this->assertCount(2, $rows);
 
         $this->manager->shutDown();
-        $this->assertStringNotContainsString('DROP TABLE', implode('', $buffer->messages()));
+        $this->assertStringNotContainsString('DROP TABLE', implode('', Log::engine('queries')->read()));
         $this->assertContains('unmanaged', $conn->getSchemaCollection()->listTables());
 
         foreach ($schema->dropSql($conn) as $sql) {


### PR DESCRIPTION
This confirms the current setup will only delete then insert records.
