### PR TITLE
Added package name to each base exception class

### DIFF
--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -18,7 +18,7 @@ namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 
 /**
@@ -80,13 +80,13 @@ class ControllerAuthorize extends BaseAuthorize
      *
      * @param array|\ArrayAccess $user Active user data
      * @param \Cake\Http\ServerRequest $request Request instance.
-     * @throws \Cake\Core\Exception\Exception If controller does not have method `isAuthorized()`.
+     * @throws \Cake\Core\Exception\CakeException If controller does not have method `isAuthorized()`.
      * @return bool
      */
     public function authorize($user, ServerRequest $request): bool
     {
         if (!method_exists($this->_Controller, 'isAuthorized')) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 '%s does not implement an isAuthorized() method.',
                 get_class($this->_Controller)
             ));

--- a/src/Cache/InvalidArgumentException.php
+++ b/src/Cache/InvalidArgumentException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Cache;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Psr\SimpleCache\InvalidArgumentException as InvalidArgumentInterface;
 
 /**
  * Exception raised when cache keys are invalid.
  */
-class InvalidArgumentException extends Exception implements InvalidArgumentInterface
+class InvalidArgumentException extends CakeException implements InvalidArgumentInterface
 {
 }

--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 namespace Cake\Console\Exception;
 
 use Cake\Console\CommandInterface;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception class for Console libraries. This exception will be thrown from Console library
  * classes when they encounter an error.
  */
-class ConsoleException extends Exception
+class ConsoleException extends CakeException
 {
     /**
      * Default exception code

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -19,7 +19,7 @@ namespace Cake\Console;
 use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Filesystem\Filesystem;
 use Cake\Log\LogTrait;
@@ -874,7 +874,7 @@ class Shell
             $fs->dumpFile($path, $contents);
 
             $this->_io->out(sprintf('<success>Wrote</success> `%s`', $path));
-        } catch (Exception $e) {
+        } catch (CakeException $e) {
             $this->_io->err(sprintf('<error>Could not write to `%s`</error>.', $path), 2);
 
             return false;

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -134,7 +134,7 @@ class ShellDispatcher
      * Defines current working environment.
      *
      * @return void
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _initEnvironment(): void
     {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -22,7 +22,7 @@ use Cake\Auth\Storage\StorageInterface;
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
@@ -342,7 +342,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * @param \Cake\Controller\Controller $controller A reference to the controller object.
      * @return \Cake\Http\Response|null Null if current action is login action
      *   else response object returned by authenticate object or Controller::redirect().
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _unauthenticated(Controller $controller): ?Response
     {
@@ -352,7 +352,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
         $response = $controller->getResponse();
         $auth = end($this->_authenticateObjects);
         if ($auth === false) {
-            throw new Exception('At least one authenticate object must be available.');
+            throw new CakeException('At least one authenticate object must be available.');
         }
         $result = $auth->unauthenticated($controller->getRequest(), $response);
         if ($result !== null) {
@@ -513,7 +513,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * Loads the authorization objects configured.
      *
      * @return array|null The loaded authorization objects, or null when authorize is empty.
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function constructAuthorize(): ?array
     {
@@ -536,10 +536,10 @@ class AuthComponent extends Component implements EventDispatcherInterface
             }
             $className = App::className($class, 'Auth', 'Authorize');
             if ($className === null) {
-                throw new Exception(sprintf('Authorization adapter "%s" was not found.', $class));
+                throw new CakeException(sprintf('Authorization adapter "%s" was not found.', $class));
             }
             if (!method_exists($className, 'authorize')) {
-                throw new Exception('Authorization objects must implement an authorize() method.');
+                throw new CakeException('Authorization objects must implement an authorize() method.');
             }
             $config = (array)$config + $global;
             $this->_authorizeObjects[$alias] = new $className($this->_registry, $config);
@@ -808,7 +808,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * Loads the configured authentication objects.
      *
      * @return array|null The loaded authorization objects, or null on empty authenticate value.
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function constructAuthenticate(): ?array
     {
@@ -831,10 +831,10 @@ class AuthComponent extends Component implements EventDispatcherInterface
             }
             $className = App::className($class, 'Auth', 'Authenticate');
             if ($className === null) {
-                throw new Exception(sprintf('Authentication adapter "%s" was not found.', $class));
+                throw new CakeException(sprintf('Authentication adapter "%s" was not found.', $class));
             }
             if (!method_exists($className, 'authenticate')) {
-                throw new Exception('Authentication objects must implement an authenticate() method.');
+                throw new CakeException('Authentication objects must implement an authenticate() method.');
             }
             $config = array_merge($global, (array)$config);
             $this->_authenticateObjects[$alias] = new $className($this->_registry, $config);
@@ -873,7 +873,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
         }
         $className = App::className($class, 'Auth/Storage', 'Storage');
         if ($className === null) {
-            throw new Exception(sprintf('Auth storage adapter "%s" was not found.', $class));
+            throw new CakeException(sprintf('Auth storage adapter "%s" was not found.', $class));
         }
         $request = $this->getController()->getRequest();
         $response = $this->getController()->getResponse();

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -18,7 +18,7 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -61,7 +61,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     public function getController(): Controller
     {
         if ($this->_Controller === null) {
-            throw new Exception('Controller not set for ComponentRegistry');
+            throw new CakeException('Controller not set for ComponentRegistry');
         }
 
         return $this->_Controller;

--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  */
 namespace Cake\Controller\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Missing Action exception - used when a controller action
  * cannot be found, or when the controller's isAction() method returns false.
  */
-class MissingActionException extends Exception
+class MissingActionException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Controller/Exception/MissingComponentException.php
+++ b/src/Controller/Exception/MissingComponentException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Controller\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a component cannot be found.
  */
-class MissingComponentException extends Exception
+class MissingComponentException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -19,7 +19,7 @@ namespace Cake\Core;
 use Cake\Cache\Cache;
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
 use RuntimeException;
 
@@ -368,13 +368,13 @@ class Configure
      * @param string[] $keys The name of the top-level keys you want to dump.
      *   This allows you save only some data stored in Configure.
      * @return bool Success
-     * @throws \Cake\Core\Exception\Exception if the adapter does not implement a `dump` method.
+     * @throws \Cake\Core\Exception\CakeException if the adapter does not implement a `dump` method.
      */
     public static function dump(string $key, string $config = 'default', array $keys = []): bool
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
-            throw new Exception(sprintf('There is no "%s" config engine.', $config));
+            throw new CakeException(sprintf('There is no "%s" config engine.', $config));
         }
         $values = static::$_values;
         if (!empty($keys)) {

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -94,7 +94,7 @@ class IniConfig implements ConfigEngineInterface
      * @param string $key The identifier to read from. If the key has a . it will be treated
      *  as a plugin prefix. The chosen file must be on the engine's path.
      * @return array Parsed configuration values.
-     * @throws \Cake\Core\Exception\Exception when files don't exist.
+     * @throws \Cake\Core\Exception\CakeException when files don't exist.
      *  Or when files contain '..' as this could lead to abusive reads.
      */
     public function read(string $key): array

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -18,7 +18,7 @@ namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\FileConfigTrait;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * JSON engine allows Configure to load configuration values from
@@ -71,7 +71,7 @@ class JsonConfig implements ConfigEngineInterface
      * @param string $key The identifier to read from. If the key has a . it will be treated
      *   as a plugin prefix.
      * @return array Parsed configuration values.
-     * @throws \Cake\Core\Exception\Exception When files don't exist or when
+     * @throws \Cake\Core\Exception\CakeException When files don't exist or when
      *   files contain '..' (as this could lead to abusive reads) or when there
      *   is an error parsing the JSON string.
      */
@@ -81,14 +81,14 @@ class JsonConfig implements ConfigEngineInterface
 
         $values = json_decode(file_get_contents($file), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 'Error parsing JSON string fetched from config file "%s.json": %s',
                 $key,
                 json_last_error_msg()
             ));
         }
         if (!is_array($values)) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 'Decoding JSON config file "%s.json" did not return an array',
                 $key
             ));

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -18,7 +18,7 @@ namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\FileConfigTrait;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * PHP engine allows Configure to load configuration values from
@@ -77,7 +77,7 @@ class PhpConfig implements ConfigEngineInterface
      * @param string $key The identifier to read from. If the key has a . it will be treated
      *  as a plugin prefix.
      * @return array Parsed configuration values.
-     * @throws \Cake\Core\Exception\Exception when files don't exist or they don't contain `$config`.
+     * @throws \Cake\Core\Exception\CakeException when files don't exist or they don't contain `$config`.
      *  Or when files contain '..' as this could lead to abusive reads.
      */
     public function read(string $key): array
@@ -91,7 +91,7 @@ class PhpConfig implements ConfigEngineInterface
             return $return;
         }
 
-        throw new Exception(sprintf('Config file "%s" did not return an array', $key . '.php'));
+        throw new CakeException(sprintf('Config file "%s" did not return an array', $key . '.php'));
     }
 
     /**

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Core\Configure;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
 
 /**
@@ -38,13 +38,13 @@ trait FileConfigTrait
      *  as a plugin prefix.
      * @param bool $checkExists Whether to check if file exists. Defaults to false.
      * @return string Full file path
-     * @throws \Cake\Core\Exception\Exception When files don't exist or when
+     * @throws \Cake\Core\Exception\CakeException When files don't exist or when
      *  files contain '..' as this could lead to abusive reads.
      */
     protected function _getFilePath(string $key, bool $checkExists = false): string
     {
         if (strpos($key, '..') !== false) {
-            throw new Exception('Cannot load/dump configuration files with ../ in them.');
+            throw new CakeException('Cannot load/dump configuration files with ../ in them.');
         }
 
         [$plugin, $key] = pluginSplit($key);
@@ -66,6 +66,6 @@ trait FileConfigTrait
             return $realPath;
         }
 
-        throw new Exception(sprintf('Could not load configuration file: %s', $file));
+        throw new CakeException(sprintf('Could not load configuration file: %s', $file));
     }
 }

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -115,5 +115,5 @@ class CakeException extends RuntimeException
 }
 
 // phpcs:disable
-class_exists('Cake\Core\Exception\Exception');
+class_exists('Cake\Core\Exception\CakeException');
 // phpcs:enable

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -115,5 +115,5 @@ class CakeException extends RuntimeException
 }
 
 // phpcs:disable
-class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');
+class_exists('Cake\Core\Exception\Exception');
 // phpcs:enable

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Base class that all CakePHP Exceptions extend.
+ *
+ * @method int getCode() Gets the Exception code.
+ */
+class CakeException extends RuntimeException
+{
+    /**
+     * Array of attributes that are passed in from the constructor, and
+     * made available in the view when a development error is displayed.
+     *
+     * @var array
+     */
+    protected $_attributes = [];
+
+    /**
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
+     */
+    protected $_messageTemplate = '';
+
+    /**
+     * Array of headers to be passed to Cake\Http\Response::header()
+     *
+     * @var array|null
+     */
+    protected $_responseHeaders;
+
+    /**
+     * Default exception code
+     *
+     * @var int
+     */
+    protected $_defaultCode = 0;
+
+    /**
+     * Constructor.
+     *
+     * Allows you to create exceptions that are treated as framework errors and disabled
+     * when debug mode is off.
+     *
+     * @param string|array $message Either the string of the error message, or an array of attributes
+     *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
+     * @param int|null $code The error code
+     * @param \Throwable|null $previous the previous exception.
+     */
+    public function __construct($message = '', ?int $code = null, ?Throwable $previous = null)
+    {
+        if (is_array($message)) {
+            $this->_attributes = $message;
+            $message = vsprintf($this->_messageTemplate, $message);
+        }
+        parent::__construct($message, $code ?? $this->_defaultCode, $previous);
+    }
+
+    /**
+     * Get the passed in attributes
+     *
+     * @return array
+     */
+    public function getAttributes(): array
+    {
+        return $this->_attributes;
+    }
+
+    /**
+     * Get/set the response header to be used
+     *
+     * See also Cake\Http\Response::withHeader()
+     *
+     * @param string|array|null $header A single header string or an associative
+     *   array of "header name" => "header value"
+     * @param string|null $value The header value.
+     * @return array|null
+     * @deprecated 4.2.0 Use `HttpException::setHeaders()` instead. Response headers
+     *   should be set for HttpException only.
+     */
+    public function responseHeader($header = null, $value = null): ?array
+    {
+        if ($header === null) {
+            return $this->_responseHeaders;
+        }
+
+        deprecationWarning(
+            'Setting HTTP response headers from Exception directly is deprecated. ' .
+            'If your exceptions extend Exception, they must now extend HttpException. ' .
+            'You should only set HTTP headers on HttpException instances via the `setHeaders()` method.'
+        );
+        if (is_array($header)) {
+            return $this->_responseHeaders = $header;
+        }
+
+        return $this->_responseHeaders = [$header => $value];
+    }
+}
+
+// phpcs:disable
+class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');
+// phpcs:enable

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -13,4 +13,4 @@ declare(strict_types=1);
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
-class_exists('Cake\Core\Exception\CakeException');
+class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');

--- a/src/Core/Exception/MissingPluginException.php
+++ b/src/Core/Exception/MissingPluginException.php
@@ -17,7 +17,7 @@ namespace Cake\Core\Exception;
 /**
  * Exception raised when a plugin could not be found
  */
-class MissingPluginException extends Exception
+class MissingPluginException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
 
@@ -68,7 +68,7 @@ trait InstanceConfigTrait
      * @param mixed|null $value The value to set.
      * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return $this
-     * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
+     * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
      */
     public function setConfig($key, $value = null, $merge = true)
     {
@@ -222,7 +222,7 @@ trait InstanceConfigTrait
      * @param bool|string $merge True to merge recursively, 'shallow' for simple merge,
      *   false to overwrite, defaults to false.
      * @return void
-     * @throws \Cake\Core\Exception\Exception if attempting to clobber existing config
+     * @throws \Cake\Core\Exception\CakeException if attempting to clobber existing config
      */
     protected function _configWrite($key, $value, $merge = false): void
     {
@@ -262,7 +262,7 @@ trait InstanceConfigTrait
 
         foreach ($stack as $k) {
             if (!is_array($update)) {
-                throw new Exception(sprintf('Cannot set %s value', $key));
+                throw new CakeException(sprintf('Cannot set %s value', $key));
             }
 
             if (!isset($update[$k])) {
@@ -280,7 +280,7 @@ trait InstanceConfigTrait
      *
      * @param string $key Key to delete.
      * @return void
-     * @throws \Cake\Core\Exception\Exception if attempting to clobber existing config
+     * @throws \Cake\Core\Exception\CakeException if attempting to clobber existing config
      */
     protected function _configDelete(string $key): void
     {
@@ -296,7 +296,7 @@ trait InstanceConfigTrait
 
         foreach ($stack as $i => $k) {
             if (!is_array($update)) {
-                throw new Exception(sprintf('Cannot unset %s value', $key));
+                throw new CakeException(sprintf('Cannot unset %s value', $key));
             }
 
             if (!isset($update[$k])) {

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -6,21 +6,11 @@ declare(strict_types=1);
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         4.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Database;
 
-use Cake\Core\Exception\Exception as CakeException;
-
-/**
- * Exception for the database package.
- */
-class Exception extends CakeException
-{
-}
+class_exists('Cake\Database\Exception\DatabaseException');

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -13,4 +13,4 @@ declare(strict_types=1);
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
-class_exists('Cake\Database\Exception\DatabaseException');
+class_alias('Cake\Database\Exception\DatabaseException', 'Cake\Database\Exception');

--- a/src/Database/Exception/DatabaseException.php
+++ b/src/Database/Exception/DatabaseException.php
@@ -26,5 +26,5 @@ class DatabaseException extends CakeException
 }
 
 // phpcs:disable
-class_alias('Cake\Database\Exception\DatabaseException', 'Cake\Database\Exception');
+class_exists('Cake\Database\Exception');
 // phpcs:enable

--- a/src/Database/Exception/DatabaseException.php
+++ b/src/Database/Exception/DatabaseException.php
@@ -6,11 +6,25 @@ declare(strict_types=1);
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         4.2.0
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+namespace Cake\Database\Exception;
 
-class_exists('Cake\Core\Exception\CakeException');
+use Cake\Core\Exception\CakeException;
+
+/**
+ * Exception for the database package.
+ */
+class DatabaseException extends CakeException
+{
+}
+
+// phpcs:disable
+class_alias('Cake\Database\Exception\DatabaseException', 'Cake\Database\Exception');
+// phpcs:enable

--- a/src/Database/Exception/MissingConnectionException.php
+++ b/src/Database/Exception/MissingConnectionException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Class MissingConnectionException
  */
-class MissingConnectionException extends Exception
+class MissingConnectionException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Database/Exception/MissingDriverException.php
+++ b/src/Database/Exception/MissingDriverException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Class MissingDriverException
  */
-class MissingDriverException extends Exception
+class MissingDriverException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Class MissingExtensionException
  */
-class MissingExtensionException extends Exception
+class MissingExtensionException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Database/Exception/NestedTransactionRollbackException.php
+++ b/src/Database/Exception/NestedTransactionRollbackException.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
  * Class NestedTransactionRollbackException
  */
-class NestedTransactionRollbackException extends Exception
+class NestedTransactionRollbackException extends CakeException
 {
     /**
      * Constructor

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Expression;
 
-use Cake\Database\Exception as DatabaseException;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\ValueBinder;

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Expression;
 
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
@@ -83,7 +83,7 @@ class ValuesExpression implements ExpressionInterface
      * @param array|\Cake\Database\Query $values Array of data to append into the insert, or
      *   a query for doing INSERT INTO .. SELECT style commands
      * @return void
-     * @throws \Cake\Database\Exception When mixing array + Query data types.
+     * @throws \Cake\Database\Exception\DatabaseException When mixing array + Query data types.
      */
     public function add($values): void
     {
@@ -97,7 +97,7 @@ class ValuesExpression implements ExpressionInterface
                 is_array($values)
             )
         ) {
-            throw new Exception(
+            throw new DatabaseException(
                 'You cannot mix subqueries and array values in inserts.'
             );
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
@@ -1672,18 +1673,18 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array|\Cake\Database\Query|\Cake\Database\Expression\ValuesExpression $data The data to insert.
      * @return $this
-     * @throws \Cake\Database\Exception if you try to set values before declaring columns.
+     * @throws \Cake\Database\Exception\DatabaseException if you try to set values before declaring columns.
      *   Or if you try to set values on non-insert queries.
      */
     public function values($data)
     {
         if ($this->_type !== 'insert') {
-            throw new Exception(
+            throw new DatabaseException(
                 'You cannot add values before defining columns to use.'
             );
         }
         if (empty($this->_parts['insert'])) {
-            throw new Exception(
+            throw new DatabaseException(
                 'You cannot add values before defining columns to use.'
             );
         }

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Schema;
 
 use Cake\Database\Connection;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use PDOException;
 
 /**
@@ -87,7 +87,7 @@ class Collection implements CollectionInterface
      * @param string $name The name of the table to describe.
      * @param array $options The options to use, see above.
      * @return \Cake\Database\Schema\TableSchema Object with column metadata.
-     * @throws \Cake\Database\Exception when table cannot be described.
+     * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
     public function describe(string $name, array $options = []): TableSchemaInterface
     {
@@ -99,7 +99,7 @@ class Collection implements CollectionInterface
 
         $this->_reflect('Column', $name, $config, $table);
         if (count($table->columns()) === 0) {
-            throw new Exception(sprintf('Cannot describe %s. It has 0 columns.', $name));
+            throw new DatabaseException(sprintf('Cannot describe %s. It has 0 columns.', $name));
         }
 
         $this->_reflect('Index', $name, $config, $table);
@@ -117,7 +117,7 @@ class Collection implements CollectionInterface
      * @param array $config The config data.
      * @param \Cake\Database\Schema\TableSchema $schema The table schema instance.
      * @return void
-     * @throws \Cake\Database\Exception on query failure.
+     * @throws \Cake\Database\Exception\DatabaseException on query failure.
      * @uses \Cake\Database\Schema\SchemaDialect::describeColumnSql
      * @uses \Cake\Database\Schema\SchemaDialect::describeIndexSql
      * @uses \Cake\Database\Schema\SchemaDialect::describeForeignKeySql
@@ -139,7 +139,7 @@ class Collection implements CollectionInterface
         try {
             $statement = $this->_connection->execute($sql, $params);
         } catch (PDOException $e) {
-            throw new Exception($e->getMessage(), 500, $e);
+            throw new DatabaseException($e->getMessage(), 500, $e);
         }
         /** @psalm-suppress PossiblyFalseIterator */
         foreach ($statement->fetchAll('assoc') as $row) {

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -45,7 +45,7 @@ interface CollectionInterface
      * @param string $name The name of the table to describe.
      * @param array $options The options to use, see above.
      * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
-     * @throws \Cake\Database\Exception when table cannot be described.
+     * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
     public function describe(string $name, array $options = []): TableSchemaInterface;
 }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Schema generation/reflection features for MySQL
@@ -82,13 +82,13 @@ class MysqlSchemaDialect extends SchemaDialect
      *
      * @param string $column The column type + length
      * @return array Array of column information.
-     * @throws \Cake\Database\Exception When column type cannot be parsed.
+     * @throws \Cake\Database\Exception\DatabaseException When column type cannot be parsed.
      */
     protected function _convertColumn(string $column): array
     {
         preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);
         if (empty($matches)) {
-            throw new Exception(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Schema management/reflection features for Postgres.
@@ -74,14 +74,14 @@ class PostgresSchemaDialect extends SchemaDialect
      * Cake\Database\TypeFactory can handle.
      *
      * @param string $column The column type + length
-     * @throws \Cake\Database\Exception when column cannot be parsed.
+     * @throws \Cake\Database\Exception\DatabaseException when column cannot be parsed.
      * @return array Array of column information.
      */
     protected function _convertColumn(string $column): array
     {
         preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new Exception(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Schema management/reflection features for Sqlite
@@ -47,7 +47,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * Cake\Database\TypeFactory can handle.
      *
      * @param string $column The column type + length
-     * @throws \Cake\Database\Exception when unable to parse column type
+     * @throws \Cake\Database\Exception\DatabaseException when unable to parse column type
      * @return array Array of column information.
      */
     protected function _convertColumn(string $column): array
@@ -58,7 +58,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new Exception(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
         }
 
         $unsigned = false;
@@ -321,7 +321,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
      * @param string $name The name of the column.
      * @return string SQL fragment.
-     * @throws \Cake\Database\Exception when the column type is unknown
+     * @throws \Cake\Database\Exception\DatabaseException when the column type is unknown
      */
     public function columnSql(TableSchema $schema, string $name): string
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Schema;
 
 use Cake\Database\Connection;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\TypeFactory;
 
 /**
@@ -468,7 +468,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         unset($attrs['references'], $attrs['update'], $attrs['delete']);
 
         if (!in_array($attrs['type'], static::$_validIndexTypes, true)) {
-            throw new Exception(sprintf(
+            throw new DatabaseException(sprintf(
                 'Invalid index type "%s" in index "%s" in table "%s".',
                 $attrs['type'],
                 $name,
@@ -476,7 +476,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             ));
         }
         if (empty($attrs['columns'])) {
-            throw new Exception(sprintf(
+            throw new DatabaseException(sprintf(
                 'Index "%s" in table "%s" must have at least one column.',
                 $name,
                 $this->_table
@@ -492,7 +492,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                     $this->_table,
                     $field
                 );
-                throw new Exception($msg);
+                throw new DatabaseException($msg);
             }
         }
         $this->_indexes[$name] = $attrs;
@@ -559,10 +559,17 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         $attrs = array_intersect_key($attrs, static::$_indexKeys);
         $attrs += static::$_indexKeys;
         if (!in_array($attrs['type'], static::$_validConstraintTypes, true)) {
-            throw new Exception(sprintf('Invalid constraint type "%s" in table "%s".', $attrs['type'], $this->_table));
+            throw new DatabaseException(sprintf(
+                'Invalid constraint type "%s" in table "%s".',
+                $attrs['type'],
+                $this->_table
+            ));
         }
         if (empty($attrs['columns'])) {
-            throw new Exception(sprintf('Constraints in table "%s" must have at least one column.', $this->_table));
+            throw new DatabaseException(sprintf(
+                'Constraints in table "%s" must have at least one column.',
+                $this->_table
+            ));
         }
         $attrs['columns'] = (array)$attrs['columns'];
         foreach ($attrs['columns'] as $field) {
@@ -573,7 +580,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                     $field,
                     $this->_table
                 );
-                throw new Exception($msg);
+                throw new DatabaseException($msg);
             }
         }
 
@@ -637,21 +644,21 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @param array $attrs Attributes to set.
      * @return array
-     * @throws \Cake\Database\Exception When foreign key definition is not valid.
+     * @throws \Cake\Database\Exception\DatabaseException When foreign key definition is not valid.
      */
     protected function _checkForeignKey(array $attrs): array
     {
         if (count($attrs['references']) < 2) {
-            throw new Exception('References must contain a table and column.');
+            throw new DatabaseException('References must contain a table and column.');
         }
         if (!in_array($attrs['update'], static::$_validForeignKeyActions)) {
-            throw new Exception(sprintf(
+            throw new DatabaseException(sprintf(
                 'Update action is invalid. Must be one of %s',
                 implode(',', static::$_validForeignKeyActions)
             ));
         }
         if (!in_array($attrs['delete'], static::$_validForeignKeyActions)) {
-            throw new Exception(sprintf(
+            throw new DatabaseException(sprintf(
                 'Delete action is invalid. Must be one of %s',
                 implode(',', static::$_validForeignKeyActions)
             ));

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -215,7 +215,7 @@ interface TableSchemaInterface extends SchemaInterface
      * @param array|string $attrs The attributes for the index.
      *   If string it will be used as `type`.
      * @return $this
-     * @throws \Cake\Database\Exception
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     public function addIndex(string $name, $attrs);
 
@@ -254,7 +254,7 @@ interface TableSchemaInterface extends SchemaInterface
      * @param array|string $attrs The attributes for the constraint.
      *   If string it will be used as `type`.
      * @return $this
-     * @throws \Cake\Database\Exception
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     public function addConstraint(string $name, $attrs);
 

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Statement;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\DriverInterface;
 use PDO;
 use PDOStatement as Statement;
@@ -112,7 +112,7 @@ class PDOStatement extends StatementDecorator
         }
 
         if (!is_int($type)) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 'Fetch type for PDOStatement must be an integer, found `%s` instead',
                 getTypeName($type)
             ));
@@ -149,7 +149,7 @@ class PDOStatement extends StatementDecorator
         }
 
         if (!is_int($type)) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 'Fetch type for PDOStatement must be an integer, found `%s` instead',
                 getTypeName($type)
             ));

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\DriverInterface;
 use PDO;
 
@@ -48,7 +48,7 @@ class BinaryType extends BaseType
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return resource|null
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function toPHP($value, DriverInterface $driver)
     {
@@ -61,7 +61,7 @@ class BinaryType extends BaseType
         if (is_resource($value)) {
             return $value;
         }
-        throw new Exception(sprintf('Unable to convert %s into binary.', gettype($value)));
+        throw new CakeException(sprintf('Unable to convert %s into binary.', gettype($value)));
     }
 
     /**

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\DriverInterface;
 use Cake\Utility\Text;
 use PDO;
@@ -68,7 +68,7 @@ class BinaryUuidType extends BaseType
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return resource|string|null
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function toPHP($value, DriverInterface $driver)
     {
@@ -82,7 +82,7 @@ class BinaryUuidType extends BaseType
             return $value;
         }
 
-        throw new Exception(sprintf('Unable to convert %s into binary uuid.', gettype($value)));
+        throw new CakeException(sprintf('Unable to convert %s into binary uuid.', gettype($value)));
     }
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -65,7 +65,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return float|null
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function toPHP($value, DriverInterface $driver): ?float
     {

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -75,7 +75,7 @@ class ConnectionManager
      * @param string|array $key The name of the connection config, or an array of multiple configs.
      * @param array|null $config An array of name => config data for adapter.
      * @return void
-     * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
+     * @throws \Cake\Core\Exception\CakeException When trying to modify an existing config.
      * @see \Cake\Core\StaticConfigTrait::config()
      */
     public static function setConfig($key, $config = null): void

--- a/src/Datasource/Exception/InvalidPrimaryKeyException.php
+++ b/src/Datasource/Exception/InvalidPrimaryKeyException.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when the provided primary key does not match the table primary key
  */
-class InvalidPrimaryKeyException extends Exception
+class InvalidPrimaryKeyException extends CakeException
 {
 }

--- a/src/Datasource/Exception/MissingDatasourceConfigException.php
+++ b/src/Datasource/Exception/MissingDatasourceConfigException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception class to be thrown when a datasource configuration is not found
  */
-class MissingDatasourceConfigException extends Exception
+class MissingDatasourceConfigException extends CakeException
 {
     /**
      * @var string

--- a/src/Datasource/Exception/MissingDatasourceException.php
+++ b/src/Datasource/Exception/MissingDatasourceException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a datasource cannot be found.
  */
-class MissingDatasourceException extends Exception
+class MissingDatasourceException extends CakeException
 {
     /**
      * @var string

--- a/src/Datasource/Exception/MissingModelException.php
+++ b/src/Datasource/Exception/MissingModelException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a model cannot be found.
  */
-class MissingModelException extends Exception
+class MissingModelException extends CakeException
 {
     /**
      * @var string

--- a/src/Datasource/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Exception/PageOutOfBoundsException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when requested page number does not exist.
  */
-class PageOutOfBoundsException extends Exception
+class PageOutOfBoundsException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Datasource/Exception/RecordNotFoundException.php
+++ b/src/Datasource/Exception/RecordNotFoundException.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when a particular record was not found
  */
-class RecordNotFoundException extends Exception
+class RecordNotFoundException extends CakeException
 {
 }

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\Exception\PageOutOfBoundsException;
 
@@ -169,7 +169,7 @@ class Paginator implements PaginatorInterface
             $query = $object;
             $object = $query->getRepository();
             if ($object === null) {
-                throw new Exception('No repository set for query.');
+                throw new CakeException('No repository set for query.');
             }
         }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -218,7 +218,7 @@ class Debugger
      * @param mixed|null $value The value to set.
      * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return mixed Config value being read, or the object itself on write operations.
-     * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
+     * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
      */
     public static function configInstance($key = null, $value = null, bool $merge = true)
     {

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Error;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Log\Log;
 use Psr\Http\Message\ServerRequestInterface;
@@ -110,7 +110,7 @@ class ErrorLogger implements ErrorLoggerInterface
         );
         $debug = Configure::read('debug');
 
-        if ($debug && $exception instanceof Exception) {
+        if ($debug && $exception instanceof CakeException) {
             $attributes = $exception->getAttributes();
             if ($attributes) {
                 $message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -22,7 +22,7 @@ use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Container;
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Datasource\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -75,7 +75,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
     protected $controller;
 
     /**
-     * Template to render for Cake\Core\Exception\Exception
+     * Template to render for Cake\Core\Exception\CakeException
      *
      * @var string
      */
@@ -119,7 +119,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
 
     /**
      * Creates the controller to perform rendering on the error response.
-     * If the error is a Cake\Core\Exception\Exception it will be converted to either a 400 or a 500
+     * If the error is a Cake\Core\Exception\CakeException it will be converted to either a 400 or a 500
      * code error depending on the code used to construct the error.
      *
      * @param \Throwable $exception Exception.

--- a/src/Error/FatalErrorException.php
+++ b/src/Error/FatalErrorException.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  */
 namespace Cake\Error;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
  * Represents a fatal error
  */
-class FatalErrorException extends Exception
+class FatalErrorException extends CakeException
 {
     /**
      * Constructor

--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event\Decorator;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventInterface;
 use RuntimeException;
 
@@ -61,7 +61,7 @@ class SubjectFilterDecorator extends AbstractDecorator
 
         try {
             $subject = $event->getSubject();
-        } catch (Exception $e) {
+        } catch (CakeException $e) {
             return false;
         }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Class Event
@@ -103,14 +103,14 @@ class Event implements EventInterface
      * If the event has no subject an exception will be raised.
      *
      * @return object
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @psalm-return TSubject
      * @psalm-suppress LessSpecificImplementedReturnType
      */
     public function getSubject()
     {
         if ($this->_subject === null) {
-            throw new Exception('No subject set for this event');
+            throw new CakeException('No subject set for this event');
         }
 
         return $this->_subject;

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * The event manager is responsible for keeping track of event listeners, passing the correct
@@ -184,7 +184,7 @@ class EventManager implements EventManagerInterface
 
         if (!is_string($eventKey)) {
             if (!is_callable($eventKey)) {
-                throw new Exception(
+                throw new CakeException(
                     'First argument of EventManager::off() must be ' .
                     ' string or EventListenerInterface instance or callable.'
                 );
@@ -472,7 +472,7 @@ class EventManager implements EventManagerInterface
                 try {
                     $subject = $event->getSubject();
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . get_class($subject);
-                } catch (Exception $e) {
+                } catch (CakeException $e) {
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with no subject';
                 }
             }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Filesystem;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use CallbackFilterIterator;
 use FilesystemIterator;
 use Iterator;
@@ -128,7 +128,7 @@ class Filesystem
      * @param string $filename File path.
      * @param string $content Content to dump.
      * @return void
-     * @throws \Cake\Core\Exception\Exception When dumping fails.
+     * @throws \Cake\Core\Exception\CakeException When dumping fails.
      */
     public function dumpFile(string $filename, string $content): void
     {
@@ -148,7 +148,7 @@ class Filesystem
         }
 
         if ($success === false) {
-            throw new Exception(sprintf('Failed dumping content to file `%s`', $dir));
+            throw new CakeException(sprintf('Failed dumping content to file `%s`', $dir));
         }
 
         if (!$exists) {
@@ -162,7 +162,7 @@ class Filesystem
      * @param string $dir Directory path.
      * @param int $mode Octal mode passed to mkdir(). Defaults to 0755.
      * @return void
-     * @throws \Cake\Core\Exception\Exception When directory creation fails.
+     * @throws \Cake\Core\Exception\CakeException When directory creation fails.
      */
     public function mkdir(string $dir, int $mode = 0755): void
     {
@@ -174,7 +174,7 @@ class Filesystem
         // phpcs:ignore
         if (@mkdir($dir, $mode, true) === false) {
             umask($old);
-            throw new Exception(sprintf('Failed to create directory "%s"', $dir));
+            throw new CakeException(sprintf('Failed to create directory "%s"', $dir));
         }
 
         umask($old);
@@ -185,7 +185,7 @@ class Filesystem
      *
      * @param string $path Directory path.
      * @return bool
-     * @throws \Cake\Core\Exception\Exception If path is not a directory.
+     * @throws \Cake\Core\Exception\CakeException If path is not a directory.
      */
     public function deleteDir(string $path): bool
     {
@@ -194,7 +194,7 @@ class Filesystem
         }
 
         if (!is_dir($path)) {
-            throw new Exception(sprintf('"%s" is not a directory', $path));
+            throw new CakeException(sprintf('"%s" is not a directory', $path));
         }
 
         $iterator = new RecursiveIteratorIterator(

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Client\Adapter\Curl;
 use Cake\Http\Client\Adapter\Stream;
@@ -558,7 +558,7 @@ class Client implements ClientInterface
      *
      * @param string $type short type alias or full mimetype.
      * @return string[] Headers to set on the request.
-     * @throws \Cake\Core\Exception\Exception When an unknown type alias is used.
+     * @throws \Cake\Core\Exception\CakeException When an unknown type alias is used.
      * @psalm-return array{Accept: string, Content-Type: string}
      */
     protected function _typeHeaders(string $type): array
@@ -574,7 +574,7 @@ class Client implements ClientInterface
             'xml' => 'application/xml',
         ];
         if (!isset($typeMap[$type])) {
-            throw new Exception("Unknown type alias '$type'.");
+            throw new CakeException("Unknown type alias '$type'.");
         }
 
         return [
@@ -630,7 +630,7 @@ class Client implements ClientInterface
      * @param array $auth The authentication options to use.
      * @param array $options The overall request options to use.
      * @return object Authentication strategy instance.
-     * @throws \Cake\Core\Exception\Exception when an invalid strategy is chosen.
+     * @throws \Cake\Core\Exception\CakeException when an invalid strategy is chosen.
      */
     protected function _createAuth(array $auth, array $options)
     {
@@ -640,7 +640,7 @@ class Client implements ClientInterface
         $name = ucfirst($auth['type']);
         $class = App::className($name, 'Http/Client/Auth');
         if (!$class) {
-            throw new Exception(
+            throw new CakeException(
                 sprintf('Invalid authentication type %s', $name)
             );
         }

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Client\Auth;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\Request;
 use Cake\Utility\Security;
 use Psr\Http\Message\UriInterface;
@@ -39,7 +39,7 @@ class Oauth
      * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return \Cake\Http\Client\Request The updated request.
-     * @throws \Cake\Core\Exception\Exception On invalid signature types.
+     * @throws \Cake\Core\Exception\CakeException On invalid signature types.
      */
     public function authentication(Request $request, array $credentials): Request
     {
@@ -85,7 +85,7 @@ class Oauth
                 break;
 
             default:
-                throw new Exception(sprintf('Unknown Oauth signature method %s', $credentials['method']));
+                throw new CakeException(sprintf('Unknown Oauth signature method %s', $credentials['method']));
         }
 
         return $request->withHeader('Authorization', $value);

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Parent class for all of the HTTP related exceptions in CakePHP.
  * All HTTP status/error related exceptions should extend this class so
  * catch blocks can be specifically typed.
  *
- * You may also use this as a meaningful bridge to Cake\Core\Exception\Exception, e.g.:
+ * You may also use this as a meaningful bridge to Cake\Core\Exception\CakeException, e.g.:
  * throw new \Cake\Network\Exception\HttpException('HTTP Version Not Supported', 505);
  */
-class HttpException extends Exception
+class HttpException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Http/Exception/MissingControllerException.php
+++ b/src/Http/Exception/MissingControllerException.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Missing Controller exception - used when a controller
  * cannot be found.
  */
-class MissingControllerException extends Exception
+class MissingControllerException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Http/Exception/RedirectException.php
+++ b/src/Http/Exception/RedirectException.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * An exception subclass used by routing and application code to
@@ -31,7 +31,7 @@ use Cake\Core\Exception\Exception;
  * Additional headers can also be provided in the constructor, or
  * using the addHeaders() method.
  */
-class RedirectException extends Exception
+class RedirectException extends CakeException
 {
     /**
      * Headers to include in the response.

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -18,7 +18,7 @@ namespace Cake\Http;
 
 use BadMethodCallException;
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
@@ -258,7 +258,7 @@ class ServerRequest implements ServerRequestInterface
 
         if (isset($config['uri'])) {
             if (!$config['uri'] instanceof UriInterface) {
-                throw new Exception('The `uri` key must be an instance of ' . UriInterface::class);
+                throw new CakeException('The `uri` key must be an instance of ' . UriInterface::class);
             }
             $uri = $config['uri'];
         } else {

--- a/src/I18n/Exception/I18nException.php
+++ b/src/I18n/Exception/I18nException.php
@@ -17,11 +17,11 @@ declare(strict_types=1);
  */
 namespace Cake\I18n\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * I18n exception.
  */
-class I18nException extends Exception
+class I18nException extends CakeException
 {
 }

--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Utility class used to determine the plural number to be used for a variable
@@ -200,6 +200,6 @@ class PluralRules
                 return $n % 10 !== 1 || $n % 100 === 11 ? 1 : 0;
         }
 
-        throw new Exception('Unable to find plural rule number.');
+        throw new CakeException('Unable to find plural rule number.');
     }
 }

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 
 /**
@@ -57,7 +57,7 @@ abstract class AbstractTransport
      *
      * @param \Cake\Mailer\Message $message Message instance.
      * @return void
-     * @throws \Cake\Core\Exception\Exception If at least one of to, cc or bcc is not specified.
+     * @throws \Cake\Core\Exception\CakeException If at least one of to, cc or bcc is not specified.
      */
     protected function checkRecipient(Message $message): void
     {
@@ -66,7 +66,7 @@ abstract class AbstractTransport
             && $message->getCc() === []
             && $message->getBcc() === []
         ) {
-            throw new Exception(
+            throw new CakeException(
                 'You must specify at least one recipient.'
                 . ' Use one of `setTo`, `setCc` or `setBcc` to define a recipient.'
             );

--- a/src/Mailer/Exception/MissingActionException.php
+++ b/src/Mailer/Exception/MissingActionException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Missing Action exception - used when a mailer action cannot be found.
  */
-class MissingActionException extends Exception
+class MissingActionException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Mailer/Exception/MissingMailerException.php
+++ b/src/Mailer/Exception/MissingMailerException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a mailer cannot be found.
  */
-class MissingMailerException extends Exception
+class MissingMailerException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Cake\Mailer;
 
 use BadMethodCallException;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\StaticConfigTrait;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventListenerInterface;
@@ -481,7 +481,7 @@ class Mailer implements EventListenerInterface
         } elseif (is_object($name)) {
             $transport = $name;
             if (!$transport instanceof AbstractTransport) {
-                throw new Exception('Transport class must extend Cake\Mailer\AbstractTransport');
+                throw new CakeException('Transport class must extend Cake\Mailer\AbstractTransport');
             }
         } else {
             throw new InvalidArgumentException(sprintf(

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Mailer;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\FormDataPart;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -1914,7 +1914,7 @@ class Message implements JsonSerializable, Serializable
     {
         $array = unserialize($data);
         if (!is_array($array)) {
-            throw new Exception('Unable to unserialize message.');
+            throw new CakeException('Unable to unserialize message.');
         }
 
         $this->createFromArray($array);

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 namespace Cake\Mailer\Transport;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Message;
 
@@ -91,7 +91,7 @@ class MailTransport extends AbstractTransport
         if (!@mail($to, $subject, $message, $headers, $params)) {
             $error = error_get_last();
             $msg = 'Could not send email: ' . ($error['message'] ?? 'unknown');
-            throw new Exception($msg);
+            throw new CakeException($msg);
         }
         // phpcs:enable
     }

--- a/src/Network/Exception/SocketException.php
+++ b/src/Network/Exception/SocketException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Network\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception class for Socket. This exception will be thrown from Socket, Email, HttpSocket
  * SmtpTransport, MailTransport and HttpResponse when it encounters an error.
  */
-class SocketException extends Exception
+class SocketException extends CakeException
 {
 }

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Network;
 
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Network\Exception\SocketException;
 use Cake\Validation\Validation;

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Event\EventListenerInterface;
 use ReflectionClass;
@@ -242,7 +242,7 @@ class Behavior implements EventListenerInterface
      * Checks that implemented keys contain values pointing at callable.
      *
      * @return void
-     * @throws \Cake\Core\Exception\Exception if config are invalid
+     * @throws \Cake\Core\Exception\CakeException if config are invalid
      */
     public function verifyConfig(): void
     {
@@ -254,7 +254,7 @@ class Behavior implements EventListenerInterface
 
             foreach ($this->_config[$key] as $method) {
                 if (!is_callable([$this, $method])) {
-                    throw new Exception(sprintf(
+                    throw new CakeException(sprintf(
                         'The method %s is not callable on class %s',
                         $method,
                         static::class

--- a/src/ORM/Exception/MissingBehaviorException.php
+++ b/src/ORM/Exception/MissingBehaviorException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a behavior cannot be found.
  */
-class MissingBehaviorException extends Exception
+class MissingBehaviorException extends CakeException
 {
     /**
      * @var string

--- a/src/ORM/Exception/MissingEntityException.php
+++ b/src/ORM/Exception/MissingEntityException.php
@@ -18,12 +18,12 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when an Entity could not be found.
  */
-class MissingEntityException extends Exception
+class MissingEntityException extends CakeException
 {
     /**
      * @var string

--- a/src/ORM/Exception/MissingTableClassException.php
+++ b/src/ORM/Exception/MissingTableClassException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when a Table could not be found.
  */
-class MissingTableClassException extends Exception
+class MissingTableClassException extends CakeException
 {
     /**
      * @var string

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\EntityInterface;
 use Cake\Utility\Hash;
 use Throwable;
@@ -22,7 +22,7 @@ use Throwable;
 /**
  * Used when a strict save or delete fails
  */
-class PersistenceFailedException extends Exception
+class PersistenceFailedException extends CakeException
 {
     /**
      * The entity on which the persistence operation failed

--- a/src/ORM/Exception/RolledbackTransactionException.php
+++ b/src/ORM/Exception/RolledbackTransactionException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a transaction was rolled back from a callback event.
  */
-class RolledbackTransactionException extends Exception
+class RolledbackTransactionException extends CakeException
 {
     /**
      * @var string

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -18,7 +18,7 @@ namespace Cake\ORM;
 
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
@@ -219,7 +219,7 @@ class ResultSet implements ResultSetInterface
      *
      * Part of Iterator interface.
      *
-     * @throws \Cake\Database\Exception
+     * @throws \Cake\Database\Exception\DatabaseException
      * @return void
      */
     public function rewind(): void
@@ -231,7 +231,7 @@ class ResultSet implements ResultSetInterface
         if (!$this->_useBuffering) {
             $msg = 'You cannot rewind an un-buffered ResultSet. '
                 . 'Use Query::bufferResults() to get a buffered ResultSet.';
-            throw new Exception($msg);
+            throw new DatabaseException($msg);
         }
 
         $this->_index = 0;
@@ -303,7 +303,7 @@ class ResultSet implements ResultSetInterface
         if (!$this->_useBuffering) {
             $msg = 'You cannot serialize an un-buffered ResultSet. '
                 . 'Use Query::bufferResults() to get a buffered ResultSet.';
-            throw new Exception($msg);
+            throw new DatabaseException($msg);
         }
 
         while ($this->valid()) {

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
  * Exception raised when a route names used twice.
  */
-class DuplicateNamedRouteException extends Exception
+class DuplicateNamedRouteException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Routing/Exception/MissingDispatcherFilterException.php
+++ b/src/Routing/Exception/MissingDispatcherFilterException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when a Dispatcher filter could not be found
  */
-class MissingDispatcherFilterException extends Exception
+class MissingDispatcherFilterException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
  * Exception raised when a URL cannot be reverse routed
  * or when a URL cannot be parsed.
  */
-class MissingRouteException extends Exception
+class MissingRouteException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * An exception subclass used by the routing layer to indicate
@@ -33,7 +33,7 @@ use Cake\Core\Exception\Exception;
  *
  * @deprecated 4.1.0 Use Cake\Http\Exception\RedirectException instead.
  */
-class RedirectException extends Exception
+class RedirectException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -203,7 +203,7 @@ class Router
      *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
      *   custom routing class.
      * @return void
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @see \Cake\Routing\RouteBuilder::connect()
      * @see \Cake\Routing\Router::scope()
      */
@@ -407,7 +407,7 @@ class Router
      * @param bool $full If true, the full base URL will be prepended to the result.
      *   Default is false.
      * @return string Full translated URL with base path.
-     * @throws \Cake\Core\Exception\Exception When the route name is not found
+     * @throws \Cake\Core\Exception\CakeException When the route name is not found
      */
     public static function url($url = null, bool $full = false): string
     {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\ConstraintsInterface;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaAwareInterface;
@@ -274,7 +274,7 @@ class FixtureManager
      *
      * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
      * @return void
-     * @throws \Cake\Core\Exception\Exception When fixture records cannot be inserted.
+     * @throws \Cake\Core\Exception\CakeException When fixture records cannot be inserted.
      * @throws \RuntimeException
      */
     public function load(TestCase $test): void
@@ -307,7 +307,7 @@ class FixtureManager
                                 get_class($test),
                                 $e->getMessage()
                             );
-                            throw new Exception($msg, null, $e);
+                            throw new CakeException($msg, null, $e);
                         }
                     }
                 }
@@ -341,7 +341,7 @@ class FixtureManager
                             get_class($test),
                             $e->getMessage()
                         );
-                        throw new Exception($msg, null, $e);
+                        throw new CakeException($msg, null, $e);
                     }
                 }
             );
@@ -358,7 +358,7 @@ class FixtureManager
                             get_class($test),
                             $e->getMessage()
                         );
-                        throw new Exception($msg, null, $e);
+                        throw new CakeException($msg, null, $e);
                     }
                 },
                 true // Run in transaction

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\ConstraintsInterface;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaAwareInterface;
@@ -97,7 +97,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     /**
      * Instantiate the fixture.
      *
-     * @throws \Cake\Core\Exception\Exception on invalid datasource usage.
+     * @throws \Cake\Core\Exception\CakeException on invalid datasource usage.
      */
     public function __construct()
     {
@@ -212,7 +212,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
      * Build fixture schema from a table in another datasource.
      *
      * @return void
-     * @throws \Cake\Core\Exception\Exception when trying to import from an empty table.
+     * @throws \Cake\Core\Exception\CakeException when trying to import from an empty table.
      */
     protected function _schemaFromImport(): void
     {
@@ -244,7 +244,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
      * Build fixture schema directly from the datasource
      *
      * @return void
-     * @throws \Cake\Core\Exception\Exception when trying to reflect a table that does not exist
+     * @throws \Cake\Core\Exception\CakeException when trying to reflect a table that does not exist
      */
     protected function _schemaFromReflection(): void
     {

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -17,7 +17,7 @@ namespace Cake\TestSuite;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Database\Exception as DatabaseException;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Error\ExceptionRenderer;
 use Cake\Event\EventInterface;
 use Cake\Form\FormProtector;

--- a/src/Utility/Exception/XmlException.php
+++ b/src/Utility/Exception/XmlException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\Utility\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception class for Xml. This exception will be thrown from Xml when it
  * encounters an error.
  */
-class XmlException extends Exception
+class XmlException extends CakeException
 {
 }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use InvalidArgumentException;
 use Transliterator;
 
@@ -1091,7 +1091,7 @@ class Text
     {
         $transliterator = transliterator_create($transliteratorId);
         if ($transliterator === null) {
-            throw new Exception('Unable to create transliterator for id: ' . $transliteratorId);
+            throw new CakeException('Unable to create transliterator for id: ' . $transliteratorId);
         }
 
         static::setTransliterator($transliterator);
@@ -1117,7 +1117,7 @@ class Text
 
         $return = transliterator_transliterate($transliterator, $string);
         if ($return === false) {
-            throw new Exception(sprintf('Unable to transliterate string: %s', $string));
+            throw new CakeException(sprintf('Unable to transliterate string: %s', $string));
         }
 
         return $return;

--- a/src/View/Exception/MissingCellException.php
+++ b/src/View/Exception/MissingCellException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\View\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a cell class file cannot be found.
  */
-class MissingCellException extends Exception
+class MissingCellException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/View/Exception/MissingHelperException.php
+++ b/src/View/Exception/MissingHelperException.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
  */
 namespace Cake\View\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a helper cannot be found.
  */
-class MissingHelperException extends Exception
+class MissingHelperException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  */
 namespace Cake\View\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
  * Used when a template file cannot be found.
  */
-class MissingTemplateException extends Exception
+class MissingTemplateException extends CakeException
 {
     /**
      * @var string

--- a/src/View/Exception/MissingViewException.php
+++ b/src/View/Exception/MissingViewException.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\View\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a view class file cannot be found.
  */
-class MissingViewException extends Exception
+class MissingViewException extends CakeException
 {
     /**
      * @inheritDoc

--- a/src/View/Exception/SerializationFailureException.php
+++ b/src/View/Exception/SerializationFailureException.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\View\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Used when a SerializedView class fails to serialize data.
  */
-class SerializationFailureException extends Exception
+class SerializationFailureException extends CakeException
 {
 }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\View\Helper;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Form\FormProtector;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -673,12 +673,14 @@ class FormHelper extends Helper
      * Get form protector instance.
      *
      * @return \Cake\Form\FormProtector
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function getFormProtector(): FormProtector
     {
         if ($this->formProtector === null) {
-            throw new Exception('FormHelper::create() must be called first for FormProtector instance to be created.');
+            throw new CakeException(
+                'FormHelper::create() must be called first for FormProtector instance to be created.'
+            );
         }
 
         return $this->formProtector;
@@ -1569,13 +1571,13 @@ class FormHelper extends Helper
      * @param string $method Method name / input type to make.
      * @param array $params Parameters for the method call
      * @return string Formatted input method.
-     * @throws \Cake\Core\Exception\Exception When there are no params for the method call.
+     * @throws \Cake\Core\Exception\CakeException When there are no params for the method call.
      */
     public function __call(string $method, array $params)
     {
         $options = [];
         if (empty($params)) {
-            throw new Exception(sprintf('Missing field name for FormHelper::%s', $method));
+            throw new CakeException(sprintf('Missing field name for FormHelper::%s', $method));
         }
         if (isset($params[1])) {
             $options = $params[1];

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\I18n\Number;
 use Cake\View\Helper;
 use Cake\View\View;
@@ -58,7 +58,7 @@ class NumberHelper extends Helper
      *
      * @param \Cake\View\View $view The View this helper is being attached to.
      * @param array $config Configuration settings for the helper
-     * @throws \Cake\Core\Exception\Exception When the engine class could not be found.
+     * @throws \Cake\Core\Exception\CakeException When the engine class could not be found.
      */
     public function __construct(View $view, array $config = [])
     {
@@ -69,7 +69,7 @@ class NumberHelper extends Helper
         /** @psalm-var class-string<\Cake\I18n\Number>|null $engineClass */
         $engineClass = App::className($config['engine'], 'Utility');
         if ($engineClass === null) {
-            throw new Exception(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
         }
 
         $this->_engine = new $engineClass($config);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Security;
 use Cake\Utility\Text;
 use Cake\View\Helper;
@@ -75,7 +75,7 @@ class TextHelper extends Helper
      *
      * @param \Cake\View\View $view the view object the helper is attached to.
      * @param array $config Settings array Settings array
-     * @throws \Cake\Core\Exception\Exception when the engine class could not be found.
+     * @throws \Cake\Core\Exception\CakeException when the engine class could not be found.
      */
     public function __construct(View $view, array $config = [])
     {
@@ -86,7 +86,7 @@ class TextHelper extends Helper
         /** @psalm-var class-string<\Cake\Utility\Text>|null $engineClass */
         $engineClass = App::className($config['engine'], 'Utility');
         if ($engineClass === null) {
-            throw new Exception(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
         }
 
         $this->_engine = new $engineClass($config);

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\View;
 
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Utility\Hash;
 use RuntimeException;
@@ -203,7 +203,7 @@ class StringTemplate
     public function load(string $file): void
     {
         if ($file === '') {
-            throw new Exception('String template filename cannot be an empty string');
+            throw new CakeException('String template filename cannot be an empty string');
         }
 
         $loader = new PhpConfig();

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -742,7 +742,7 @@ class View implements EventDispatcherInterface
      * @param string|null $template Name of template file to use
      * @param string|false|null $layout Layout to use. False to disable.
      * @return string Rendered content.
-     * @throws \Cake\Core\Exception\Exception If there is an error in the view.
+     * @throws \Cake\Core\Exception\CakeException If there is an error in the view.
      * @triggers View.beforeRender $this, [$templateFileName]
      * @triggers View.afterRender $this, [$templateFileName]
      */
@@ -792,7 +792,7 @@ class View implements EventDispatcherInterface
      * @param string $content Content to render in a template, wrapped by the surrounding layout.
      * @param string|null $layout Layout name
      * @return string Rendered output.
-     * @throws \Cake\Core\Exception\Exception if there is an error in the view.
+     * @throws \Cake\Core\Exception\CakeException if there is an error in the view.
      * @triggers View.beforeLayout $this, [$layoutFileName]
      * @triggers View.afterLayout $this, [$layoutFileName]
      */

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\View;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * ViewBlock implements the concept of Blocks or Slots in the View layer.
@@ -82,13 +82,13 @@ class ViewBlock
      * @param string $mode If ViewBlock::OVERRIDE existing content will be overridden by new content.
      *   If ViewBlock::APPEND content will be appended to existing content.
      *   If ViewBlock::PREPEND it will be prepended.
-     * @throws \Cake\Core\Exception\Exception When starting a block twice
+     * @throws \Cake\Core\Exception\CakeException When starting a block twice
      * @return void
      */
     public function start(string $name, string $mode = ViewBlock::OVERRIDE): void
     {
         if (array_key_exists($name, $this->_active)) {
-            throw new Exception(sprintf("A view block with the name '%s' is already/still open.", $name));
+            throw new CakeException(sprintf("A view block with the name '%s' is already/still open.", $name));
         }
         $this->_active[$name] = $mode;
         ob_start();

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -56,7 +56,7 @@ class ControllerAuthorizeTest extends TestCase
      */
     public function testControllerErrorOnMissingMethod(): void
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->auth->controller(new Controller());
         $this->auth->authorize([], new ServerRequest());
     }

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -238,7 +238,7 @@ class AuthComponentTest extends TestCase
      */
     public function testIsAuthorizedMissingFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->Controller->Auth->setConfig('authorize', 'Missing');
         $this->Controller->Auth->isAuthorized(['User' => ['id' => 1]]);
     }
@@ -359,7 +359,7 @@ class AuthComponentTest extends TestCase
      */
     public function testLoadAuthenticateNoFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->Controller->Auth->setConfig('authenticate', 'Missing');
         $this->Controller->Auth->identify(
             $this->Controller->getRequest(),

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -18,7 +18,7 @@ namespace Cake\Test\TestCase\Controller;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Controller\Component\AppleComponent;
@@ -282,7 +282,7 @@ class ComponentTest extends TestCase
      */
     public function testGetControllerException()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Controller not set for ComponentRegistry');
 
         $collection = new ComponentRegistry();

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -167,7 +167,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('no_ini_extension');
     }
@@ -179,7 +179,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('fake_values');
     }
@@ -203,7 +203,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithDots()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -80,7 +80,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('no_json_extension');
     }
@@ -92,7 +92,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('fake_values');
     }
@@ -104,7 +104,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadEmptyFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('config file "empty.json"');
         $engine = new JsonConfig($this->path);
         $config = $engine->read('empty');
@@ -117,7 +117,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithInvalidJson()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Error parsing JSON string fetched from config file "invalid.json"');
         $engine = new JsonConfig($this->path);
         $engine->read('invalid');
@@ -130,7 +130,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithDots()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -80,7 +80,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('no_php_extension');
     }
@@ -92,7 +92,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('fake_values');
     }
@@ -104,7 +104,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadEmptyFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('empty');
     }
@@ -116,7 +116,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithDots()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -531,7 +531,7 @@ class ConfigureTest extends TestCase
      */
     public function testDumpNoAdapter()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         Configure::dump(TMP . 'test.php', 'does_not_exist');
     }
 

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -70,7 +70,7 @@ class BinaryTypeTest extends TestCase
      */
     public function testToPHPFailure()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Unable to convert array into binary.');
         $this->type->toPHP([], $this->driver);
     }

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Type\BinaryUuidType;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
@@ -81,7 +81,7 @@ class BinaryUuidTypeTest extends TestCase
      */
     public function testToPHPFailure()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to convert array into binary uuid.');
 
         $this->type->toPHP([], $this->driver);

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -104,7 +104,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGetFailOnMissingConfig()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "test_variant" was not found.');
         ConnectionManager::get('test_variant');
     }
@@ -132,7 +132,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGetNoAlias()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "other_name" was not found.');
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -20,7 +20,7 @@ use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Datasource\Exception\MissingDatasourceConfigException;
 use Cake\Datasource\Exception\MissingDatasourceException;

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Event;
 
 use ArrayObject;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
 
@@ -54,7 +54,7 @@ class EventTest extends TestCase
         $event = new Event('fake.event', $this);
         $this->assertSame($this, $event->getSubject());
 
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('No subject set for this event');
 
         $event = new Event('fake.event');

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -147,7 +147,7 @@ class ExceptionsTest extends TestCase
             ['Cake\Controller\Exception\MissingActionException', 0],
             ['Cake\Controller\Exception\MissingComponentException', 0],
             ['Cake\Controller\Exception\SecurityException', 400],
-            ['Cake\Core\Exception\Exception', 0],
+            ['Cake\Core\Exception\CakeException', 0],
             ['Cake\Core\Exception\MissingPluginException', 0],
             ['Cake\Database\Exception', 0],
             ['Cake\Database\Exception\MissingConnectionException', 0],

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -68,7 +68,7 @@ class StreamTest extends TestCase
 
         try {
             $responses = $stream->send($request, []);
-        } catch (\Cake\Core\Exception\Exception $e) {
+        } catch (\Cake\Core\Exception\CakeException $e) {
             $this->markTestSkipped('Could not connect to localhost, skipping');
         }
         $this->assertInstanceOf(Response::class, $responses[0]);

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -65,7 +65,7 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      */
     public function testExceptionUnknownSigningMethod()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $auth = new Oauth();
         $creds = [
             'consumerSecret' => 'it is secret',

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -380,7 +380,7 @@ class ClientTest extends TestCase
      */
     public function testInvalidAuthenticationType()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
             ->getMock();
@@ -575,7 +575,7 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnUnknownType()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
             ->getMock();

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Mailer;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Log\Log;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Exception\MissingActionException;
@@ -112,7 +112,7 @@ class MailerTest extends TestCase
      */
     public function testTransportInstanceInvalid()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->mailer->setTransport(new \stdClass());
     }
 

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Mailer\Transport;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Mailer\Message;
 use Cake\TestSuite\TestCase;
 
@@ -53,7 +53,7 @@ class MailTransportTest extends TestCase
      */
     public function testSendWithoutRecipient()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('You must specify at least one recipient. Use one of `setTo`, `setCc` or `setBcc` to define a recipient.');
 
         $message = new Message();

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Behavior\Test2Behavior;
@@ -266,7 +266,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyImplementedFindersInvalid()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method findNotDefined is not callable on class ' . Test2Behavior::class);
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -304,7 +304,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyImplementedMethodsInvalid()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method iDoNotExist is not callable on class ' . Test2Behavior::class);
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Log\QueryLogger;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
@@ -98,7 +98,7 @@ class ResultSetTest extends TestCase
         foreach ($results as $result) {
             $first[] = $result;
         }
-        $this->expectException(Exception::class);
+        $this->expectException(DatabaseException::class);
         foreach ($results as $result) {
             $second[] = $result;
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -18,7 +18,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
 use Cake\Collection\Collection;
-use Cake\Database\Exception;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\StatementInterface;
@@ -1054,7 +1054,7 @@ class TableTest extends TestCase
      */
     public function testUpdateAllFailure()
     {
-        $this->expectException(\Cake\Database\Exception::class);
+        $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
@@ -1069,7 +1069,7 @@ class TableTest extends TestCase
 
         $query->expects($this->once())
             ->method('execute')
-            ->will($this->throwException(new Exception('Not good')));
+            ->will($this->throwException(new DatabaseException('Not good')));
 
         $table->updateAll(['username' => 'mark'], []);
     }
@@ -1118,7 +1118,7 @@ class TableTest extends TestCase
      */
     public function testDeleteAllFailure()
     {
-        $this->expectException(\Cake\Database\Exception::class);
+        $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
@@ -1133,7 +1133,7 @@ class TableTest extends TestCase
 
         $query->expects($this->once())
             ->method('execute')
-            ->will($this->throwException(new Exception('Not good')));
+            ->will($this->throwException(new DatabaseException('Not good')));
 
         $table->deleteAll(['id >' => 4]);
     }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Core\Exception\Exception as CakeException;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -148,7 +148,7 @@ class TestFixtureTest extends TestCase
      */
     public function testInitNoImportNoFieldsException()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`: the table does not exist.');
         $fixture = new LettersFixture();
         $fixture->init();

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7850,7 +7850,7 @@ class FormHelperTest extends TestCase
      */
     public function testHtml5ControlException()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->Form->email();
     }
 

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -208,7 +208,7 @@ class StringTemplateTest extends TestCase
      */
     public function testLoadErrorNoFile()
     {
-        $this->expectException(\Cake\Core\Exception\Exception::class);
+        $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Could not load configuration file');
         $this->template->load('no_such_file');
     }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1584,7 +1584,7 @@ class ViewTest extends TestCase
             $this->View->start('first');
             $this->View->start('first');
             $this->fail('No exception');
-        } catch (\Cake\Core\Exception\Exception $e) {
+        } catch (\Cake\Core\Exception\CakeException $e) {
             ob_end_clean();
             $this->assertTrue(true);
         }

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Table;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 
@@ -50,7 +50,7 @@ class AuthUsersTable extends Table
     public function findUsername(Query $query, array $options)
     {
         if (empty($options['username'])) {
-            throw new Exception(__('Username not defined'));
+            throw new CakeException(__('Username not defined'));
         }
 
         $query = $this->find()


### PR DESCRIPTION
Add package name to the base exception for all packages. This aligns all packages and reduces the need to alias the exception names in code to avoid collisions with the name `Exception.

We can leave the alias for Core exception through 5 if needed, but it helps our internal code and new code.

Moved `DatabaseException` into Exception namespace to match other packages.
