### PR TITLE
Allowing scalar and empty body for JSON requests

### DIFF
--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -178,11 +178,19 @@ class BodyParserMiddleware implements MiddlewareInterface
      * Decode JSON into an array.
      *
      * @param string $body The request body to decode
-     * @return mixed
+     * @return array|null
      */
     protected function decodeJson(string $body)
     {
-        return json_decode($body, true);
+        if ($body === '') {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return (array)$decoded;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
When the request is set as `application/json` and contains a valid body, such as empty body or non-array/object, the `BodyParserMiddleware` was throwing a `BadRequestException`.

This change will put the content in an indexed array to conform with the PSR interface. It will keep giving `BadRequestException` for invalid JSON content.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
