### PR TITLE
Add TestFixture::isManaged()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
         php-version: ${{ env.PHP_VERSION }}
         extensions: ${{ env.EXTENSIONS }}
         ini-values: apc.enable_cli = 1, extension = php_fileinfo.dll
+        tools: composer:v1
         coverage: none
 
     - name: Setup SQLServer

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -18,6 +18,8 @@ namespace Cake\Datasource;
 
 /**
  * Defines the interface that testing fixtures use.
+ *
+ * @method bool isManaged() Returns whether the fixture should be created/destroyed.
  */
 interface FixtureInterface
 {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -274,7 +274,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             return false;
         }
 
-        if (empty($this->import) && empty($this->fields)) {
+        if (!$this->isManaged()) {
             return true;
         }
 
@@ -309,8 +309,8 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             return false;
         }
 
-        if (empty($this->import) && empty($this->fields)) {
-            return $this->truncate($connection);
+        if (!$this->isManaged()) {
+            return true;
         }
 
         try {
@@ -437,6 +437,18 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
         }
 
         return true;
+    }
+
+    /**
+     * Returns whether the fixture should be created/destroyed.
+     *
+     * Fixtures that are't managed will be truncated instead of created.
+     *
+     * @return bool
+     */
+    public function isManaged(): bool
+    {
+        return !empty($this->import) || !empty($this->fields);
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -75,6 +75,7 @@ class TestFixtureTest extends TestCase
         $Fixture->table = null;
         $Fixture->init();
         $this->assertSame('articles', $Fixture->table);
+        $this->assertTrue($Fixture->isManaged());
 
         $schema = $Fixture->getTableSchema();
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $schema);
@@ -104,6 +105,7 @@ class TestFixtureTest extends TestCase
             'connection' => 'test',
         ];
         $fixture->init();
+        $this->assertTrue($fixture->isManaged());
 
         $expected = [
             'id',
@@ -129,6 +131,7 @@ class TestFixtureTest extends TestCase
             'connection' => 'test',
         ];
         $fixture->init();
+        $this->assertTrue($fixture->isManaged());
 
         $expected = [
             'id',
@@ -176,6 +179,7 @@ class TestFixtureTest extends TestCase
         $fixture = new LettersFixture();
         $fixture->init();
         $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
+        $this->assertFalse($fixture->isManaged());
 
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()


### PR DESCRIPTION
This allows porting more of FixtureManager cleanup. 

This adds a way to flag a fixture as unmanaged where the fixture instance should not be create/destroyed, only truncated. Previously, we had to hack the drop()/create() methods to work around being called when they shouldn't be.
