### PR TITLE
Allowing apps to change asset URL building

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\View\Helper;
 
+use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Routing\Asset;
 use Cake\Routing\Router;
 use Cake\View\Helper;
@@ -25,6 +27,43 @@ use Cake\View\Helper;
  */
 class UrlHelper extends Helper
 {
+    /**
+     * Default config for this class
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'assetUrlClassName' => Asset::class,
+    ];
+
+    /**
+     * Asset URL engine class name
+     *
+     * @var string
+     * @psalm-var class-string<\Cake\Routing\Asset>
+     */
+    protected $_assetUrlClassName;
+
+    /**
+     * Check proper configuration
+     *
+     * @param array $config The configuration settings provided to this helper.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+        $engineClassConfig = $this->getConfig('assetUrlClassName');
+
+        /** @psalm-var class-string<\Cake\Routing\Asset>|null $engineClass */
+        $engineClass = App::className($engineClassConfig, 'Routing');
+        if ($engineClass === null) {
+            throw new CakeException(sprintf('Class for %s could not be found', $engineClassConfig));
+        }
+
+        $this->_assetUrlClassName = $engineClass;
+    }
+
     /**
      * Returns a URL based on provided parameters.
      *
@@ -99,7 +138,7 @@ class UrlHelper extends Helper
     {
         $options += ['theme' => $this->_View->getTheme()];
 
-        return h(Asset::imageUrl($path, $options));
+        return h($this->_assetUrlClassName::imageUrl($path, $options));
     }
 
     /**
@@ -124,7 +163,7 @@ class UrlHelper extends Helper
     {
         $options += ['theme' => $this->_View->getTheme()];
 
-        return h(Asset::cssUrl($path, $options));
+        return h($this->_assetUrlClassName::cssUrl($path, $options));
     }
 
     /**
@@ -149,7 +188,7 @@ class UrlHelper extends Helper
     {
         $options += ['theme' => $this->_View->getTheme()];
 
-        return h(Asset::scriptUrl($path, $options));
+        return h($this->_assetUrlClassName::scriptUrl($path, $options));
     }
 
     /**
@@ -178,7 +217,7 @@ class UrlHelper extends Helper
     {
         $options += ['theme' => $this->_View->getTheme()];
 
-        return h(Asset::url($path, $options));
+        return h($this->_assetUrlClassName::url($path, $options));
     }
 
     /**
@@ -192,7 +231,7 @@ class UrlHelper extends Helper
      */
     public function assetTimestamp(string $path, $timestamp = null): string
     {
-        return h(Asset::assetTimestamp($path, $timestamp));
+        return h($this->_assetUrlClassName::assetTimestamp($path, $timestamp));
     }
 
     /**
@@ -205,7 +244,7 @@ class UrlHelper extends Helper
     {
         $options = ['theme' => $this->_View->getTheme()];
 
-        return h(Asset::webroot($file, $options));
+        return h($this->_assetUrlClassName::webroot($file, $options));
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
@@ -24,6 +25,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\UrlHelper;
 use Cake\View\View;
+use TestApp\Routing\Asset;
 
 /**
  * UrlHelperTest class
@@ -588,5 +590,39 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->css('TestTheme.app.css');
         $expected = $cdnPrefix . 'app.css';
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test if an app Asset class is being loaded
+     *
+     * @return void
+     */
+    public function testAppAssetPresent()
+    {
+        $Url = new UrlHelper($this->View, ['assetUrlClassName' => Asset::class]);
+        $Url->webroot = '';
+
+        $result = $Url->assetUrl('cake.generic.css', ['pathPrefix' => '/']);
+        $this->assertSame('/cake.generic.css?appHash', $result);
+
+        $result = $Url->css('cake.generic', ['pathPrefix' => '/']);
+        $this->assertSame('/cake.generic.css?appHash', $result);
+
+        $result = $Url->script('cake.generic', ['pathPrefix' => '/']);
+        $this->assertSame('/cake.generic.js?appHash', $result);
+
+        $result = $Url->image('cake.generic.png', ['pathPrefix' => '/']);
+        $this->assertSame('/cake.generic.png?appHash', $result);
+    }
+
+    /**
+     * Test if UrlHelper fails to load with wrong asset URL class name
+     *
+     * @return void
+     */
+    public function testAppAssetPresentWrong()
+    {
+        $this->expectException(CakeException::class);
+        new UrlHelper($this->View, ['assetUrlClassName' => 'InexistentClass']);
     }
 }

--- a/tests/test_app/TestApp/Routing/Asset.php
+++ b/tests/test_app/TestApp/Routing/Asset.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Routing;
+
+use Cake\Routing\Asset as CakeAsset;
+
+class Asset extends CakeAsset
+{
+    public static function url(string $path, array $options = []): string
+    {
+        return parent::url($path, $options) . '?appHash';
+    }
+}


### PR DESCRIPTION
It will allow the apps to implement/extend their own version of asset URL builder.

The app will be able to manipulate the asset generated URL. Some applications:
* Customize the versioning, changing from the core supported timestamp to something else (ie, md5 hash)
* Allow to change the asset filename based on file generated by asset builder, such as webpack
* Define different CDN hostname based on some option

Closes #15108

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
