### PR TITLE
Use PHP env variable in ServerCommand

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -126,8 +126,10 @@ class ServerCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->startup($args, $io);
+        $phpBinary = env('PHP', 'php');
         $command = sprintf(
-            'php -S %s:%d -t %s',
+            '%s -S %s:%d -t %s',
+            $phpBinary,
             $this->_host,
             $this->_port,
             escapeshellarg($this->_documentRoot)

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -126,7 +126,7 @@ class ServerCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->startup($args, $io);
-        $phpBinary = env('PHP', 'php');
+        $phpBinary = (string)env('PHP', 'php');
         $command = sprintf(
             '%s -S %s:%d -t %s',
             $phpBinary,


### PR DESCRIPTION
Use the PHP environment variable when starting up the PHP server.

Fixes #15116