### PR TITLE
Add a method to get nodes from Debugger

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -627,6 +627,23 @@ class Debugger
     }
 
     /**
+     * Convert the variable to the internal node tree.
+     *
+     * The node tree can be manipulated and serialized more easily
+     * than many object graphs can.
+     *
+     * @param mixed $var Variable to convert.
+     * @param int $maxDepth The depth to generate nodes to. Defaults to 3.
+     * @return NodeInterface The root node of the tree.
+     */
+    public static function exportNodes($var, int $maxDepth = 3): NodeInterface
+    {
+        $context = new DebugContext($maxDepth);
+
+        return static::export($var, $context);
+    }
+
+    /**
      * Protected export function used to keep track of indentation and recursion.
      *
      * @param mixed $var The variable to dump.

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -634,7 +634,7 @@ class Debugger
      *
      * @param mixed $var Variable to convert.
      * @param int $maxDepth The depth to generate nodes to. Defaults to 3.
-     * @return NodeInterface The root node of the tree.
+     * @return \Cake\Error\Debug\NodeInterface The root node of the tree.
      */
     public static function exportNodes($var, int $maxDepth = 3): NodeInterface
     {

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -636,7 +636,7 @@ class Debugger
      * @param int $maxDepth The depth to generate nodes to. Defaults to 3.
      * @return \Cake\Error\Debug\NodeInterface The root node of the tree.
      */
-    public static function exportNodes($var, int $maxDepth = 3): NodeInterface
+    public static function exportVarAsNodes($var, int $maxDepth = 3): NodeInterface
     {
         return static::export($var, new DebugContext($maxDepth));
     }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -638,9 +638,7 @@ class Debugger
      */
     public static function exportNodes($var, int $maxDepth = 3): NodeInterface
     {
-        $context = new DebugContext($maxDepth);
-
-        return static::export($var, $context);
+        return static::export($var, new DebugContext($maxDepth));
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -505,11 +505,11 @@ TEXT;
     }
 
     /**
-     * Text exportNodes()
+     * Text exportVarAsNodes()
      *
      * @return void
      */
-    public function testExportNodes()
+    public function testExportVarAsNodes()
     {
         $data = [
             1 => 'Index one',
@@ -531,7 +531,7 @@ TEXT;
                 'value',
             ],
         ];
-        $result = Debugger::exportNodes($data, 1);
+        $result = Debugger::exportVarAsNodes($data, 1);
 
         $item = $result->getChildren()[0];
         $nestedItem = $item->getValue()->getChildren()[0];

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -519,7 +519,7 @@ TEXT;
         $this->assertInstanceOf(NodeInterface::class, $result);
         $this->assertCount(2, $result->getChildren());
 
-        /** @var \Cake\Error\Debug\ArrayItemNode */
+        /** @var \Cake\Error\Debug\ArrayItemNode $item */
         $item = $result->getChildren()[0];
         $key = new ScalarNode('int', 1);
         $this->assertEquals($key, $item->getKey());

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -18,6 +18,9 @@ namespace Cake\Test\TestCase\Error;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Error\Debug\NodeInterface;
+use Cake\Error\Debug\ScalarNode;
+use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
 use Cake\Log\Log;
@@ -499,6 +502,41 @@ object(SplFixedArray) id:0 {
 }
 TEXT;
         $this->assertTextEquals($expected, $result);
+    }
+
+    /**
+     * Text exportNodes()
+     *
+     * @return void
+     */
+    public function testExportNodes()
+    {
+        $data = [
+            1 => 'Index one',
+            5 => 'Index five',
+        ];
+        $result = Debugger::exportNodes($data);
+        $this->assertInstanceOf(NodeInterface::class, $result);
+        $this->assertCount(2, $result->getChildren());
+
+        /** @var \Cake\Error\Debug\ArrayItemNode */
+        $item = $result->getChildren()[0];
+        $key = new ScalarNode('int', 1);
+        $this->assertEquals($key, $item->getKey());
+        $value = new ScalarNode('string', 'Index one');
+        $this->assertEquals($value, $item->getValue());
+
+        $data = [
+            'key' => [
+                'value',
+            ],
+        ];
+        $result = Debugger::exportNodes($data, 1);
+
+        $item = $result->getChildren()[0];
+        $nestedItem = $item->getValue()->getChildren()[0];
+        $expected = new SpecialNode('[maximum depth reached]');
+        $this->assertEquals($expected, $nestedItem->getValue());
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -515,7 +515,7 @@ TEXT;
             1 => 'Index one',
             5 => 'Index five',
         ];
-        $result = Debugger::exportNodes($data);
+        $result = Debugger::exportVarAsNodes($data);
         $this->assertInstanceOf(NodeInterface::class, $result);
         $this->assertCount(2, $result->getChildren());
 


### PR DESCRIPTION
I don't see this method being used frequently, but I'm planning on using it DebugKit to resolve cakephp/debug_kit#777. This should also help simplify the Variable panel code as we can remove the various code paths that try to handle the unserializable classes. Instead of storing the actual variable data, the panel could store the debug nodes.
