### PR TITLE
Update memcached clear test

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,7 +28,6 @@ parameters:
         - '#Binary operation "\+" between array|false and array results in an error#'
         - '#Call to an undefined method DateTimeInterface::setTimezone\(\)#'
         - '#Access to undefined constant NumberFormatter::CURRENCY_ACCOUNTING#'
-        - '#Class APCuIterator referenced with incorrect case: APCUIterator#'
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -453,13 +453,19 @@ class MemcachedEngine extends CacheEngine
             return false;
         }
 
+        $cleared = true;
         foreach ($keys as $key) {
             if (strpos($key, $this->_config['prefix']) === 0) {
-                $this->_Memcached->delete($key);
+                if (!$this->_Memcached->delete($key)) {
+                    $result = $this->_Memcached->getResultCode();
+                    if ($result !== Memcached::RES_NOTFOUND && $result !== Memcached::RES_SUCCESS) {
+                        $cleared = false;
+                    }
+                }
             }
         }
 
-        return true;
+        return $cleared;
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -798,16 +798,14 @@ class MemcachedEngineTest extends TestCase
         ]);
 
         Cache::write('some_value', 'cache1', 'memcached');
-        $result = Cache::clear(true, 'memcached');
-        $this->assertTrue($result);
-        $this->assertEquals('cache1', Cache::read('some_value', 'memcached'));
+        $this->assertSame('cache1', Cache::read('some_value', 'memcached'));
 
         Cache::write('some_value', 'cache2', 'memcached2');
-        $result = Cache::clear(false, 'memcached');
-        $this->assertTrue($result);
+        $this->assertTrue(Cache::clear(false, 'memcached'));
         $this->assertFalse(Cache::read('some_value', 'memcached'));
         $this->assertEquals('cache2', Cache::read('some_value', 'memcached2'));
 
+        Cache::clear(false, 'memcached');
         Cache::clear(false, 'memcached2');
     }
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -801,6 +801,7 @@ class MemcachedEngineTest extends TestCase
         $this->assertSame('cache1', Cache::read('some_value', 'memcached'));
 
         Cache::write('some_value', 'cache2', 'memcached2');
+        sleep(1); // try to allow time for getAllKeys() to include everything for clear()
         $this->assertTrue(Cache::clear(false, 'memcached'));
         $this->assertFalse(Cache::read('some_value', 'memcached'));
         $this->assertEquals('cache2', Cache::read('some_value', 'memcached2'));

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -104,7 +104,6 @@ class IcuFormatterTest extends TestCase
     public function testBadMessageFormatPHP7()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Constructor failed');
         $this->skipIf(version_compare(PHP_VERSION, '7', '<'));
 
         $formatter = new IcuFormatter();


### PR DESCRIPTION
Return false if any of the key deletions failed. I cleaned up this test while trying to figure out GA failures with clear().

Moving to separate PR to easier review/merging.