### PR TITLE
Bulk Inserts for ORM/Query

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1300,6 +1300,38 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
+     * Insert multiple rows of data in one call make use of bulk inserts.
+     *
+     * @param  array  $columns The columns to insert as ['columnName', 'columnName']
+     * @param  array  $values The values to insert as [['columnName' => 'value'], ... ] or ['value', ...]
+     * @param  array  $types A map between columns & their datatypes.
+     * @return $this
+     */
+    public function insertAll(array $columns, array $values, array $types = [])
+    {
+        $query = $this->insert($columns, $types);
+        foreach ($values as $value) {
+            $preparedValue = [];
+            foreach ($value as $columnName => $val) {
+                if (is_numeric($columnName)) {
+                    if (isset($columns[$columnName]) && !empty($columns[$columnName])) {
+                        $columnName = $columns[$columnName];
+                    } else {
+                        throw new InvalidArgumentException(
+                            'No column found at index ' . $columnName . ' in passed $columns'
+                        );
+                    }
+                }
+                $preparedValue[$columnName] = $val;
+            }
+
+            $query->values($preparedValue);
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns a new Query that has automatic field aliasing disabled.
      *
      * @param \Cake\ORM\Table $table The table this query is starting on

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1842,6 +1842,94 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test insertAll method inserts more than one record
+     *
+     * @return void
+     */
+    public function testInsertAll()
+    {
+        $table = $this->getTableLocator()->get('articles');
+
+        $result = $table->query()
+            ->insertAll(
+                ['title'],
+                [
+                    ['title' => 'same ol same'],
+                    ['title' => 'other same ol'],
+                    ['title' => 'more of the same'],
+                ]
+            )
+            ->execute();
+
+        $result->closeCursor();
+
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $this->assertEquals(3, $result->rowCount());
+    }
+
+    /**
+     * Test insert method with no column name strings in the values array
+     *
+     * @return void
+     */
+    public function testInsertAllWithNoColumnNames()
+    {
+        $table = $this->getTableLocator()->get('articles');
+        $result = $table->query()
+            ->insertAll(
+                ['title'],
+                [
+                    ['same ol same'],
+                    ['other same ol'],
+                    ['more of the same'],
+                ]
+            )
+            ->execute();
+
+        $result->closeCursor();
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $this->assertEquals(3, $result->rowCount());
+    }
+
+    /**
+     * Inspect sql to insure bulk insert is being performed
+     */
+    public function testInsertAllWithSingleBulkInsertQuery()
+    {
+        $table = $this->getTableLocator()->get('articles');
+        $query = $table->query()
+            ->insertAll(
+                ['title'],
+                [
+                    ['same ol same'],
+                    ['other same ol'],
+                    ['more of the same'],
+                ]
+            );
+        $this->assertRegExpSql('^INSERT INTO .+ VALUES (\(.+\),? ?){3}', $query->sql());
+    }
+
+    /**
+     * Test insertAll method will throw an exception if columns don't match
+     *
+     * @return void
+     */
+    public function testInsertAllWithIncorrectColumnMapThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $table = $this->getTableLocator()->get('articles');
+
+        $table->query()
+            ->insertAll(
+                ['title'],
+                [
+                    [1 => 'same ol same'],
+                ]
+            )
+            ->execute();
+    }
+
+    /**
      * Test delete method.
      *
      * @return void


### PR DESCRIPTION
The following pull request address issue #15111 

As discussed in the issue I implemented the recommended interface insertAll($columns, $values). I added as a third optional parameter $types. I also added the ability to pass as values an array of column => values or just an array of values.  If only an array of values is passed, if a column indice isn't found, execution ends.

Tests include regular expression examination of the query to ensure a single bulk insert is being made.  As suggested in the issue I didn't move updateAll or deleteAll to ORM/Query. 

Now that I'm looking at it, I'm wondering if running a raw query without the usual ORM behaviors (validation, callbacks, ect) isn't a miss direction?
