### PR TITLE
Retain flash also for redirect

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -536,7 +536,8 @@ trait IntegrationTestTrait
         }
         $this->_controller = $controller;
         $events = $controller->getEventManager();
-        $events->on('Controller.beforeRedirect', function () use ($controller): void {
+        $events->on('Controller.beforeRedirect', function ($event): void {
+            $controller = $event->getSubject();
             if ($this->_retainFlashMessages) {
                 $this->_flashMessages = $controller->getRequest()->getSession()->read('Flash');
             }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -536,6 +536,11 @@ trait IntegrationTestTrait
         }
         $this->_controller = $controller;
         $events = $controller->getEventManager();
+        $events->on('Controller.beforeRedirect', function () use ($controller): void {
+            if ($this->_retainFlashMessages) {
+                $this->_flashMessages = $controller->getRequest()->getSession()->read('Flash');
+            }
+        });
         $events->on('View.beforeRender', function ($event, $viewFile) use ($controller): void {
             if (!$this->_viewName) {
                 $this->_viewName = $viewFile;


### PR DESCRIPTION
This worked in 3.x
```php
$this->post(['controller' => 'ReleaseGroups', 'action' => 'initAutoRelease', $id]);

$this->assertResponseCode(302);

$flashMessages = $this->_requestSession->read('Flash.flash');
$expected = [
    'flash/success',
];
$this->assertSame($expected, Hash::extract($flashMessages, '{n}.element'));
```

Then we upgraded the app this week to 4.1+.

In 4.x I then saw this test failing and added
```php
$this->enableRetainFlashMessages();
```
at the top

Still not finding the retained messages.

I then found out why, the redirect is not covered going from 3.x to 4.x
So here the bugfix for this regression.

I still feel like the session should still contain those after the redirect (inside the test method). So not sure why the session is dropped this quickly.
