### PR TITLE
4.2 fallback table class

### DIFF
--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -44,7 +44,7 @@ abstract class AbstractLocator implements LocatorInterface
     public function get(string $alias, array $options = [])
     {
         $storeOptions = $options;
-        unset($storeOptions['useFallbackClass']);
+        unset($storeOptions['allowFallbackClass']);
 
         if (isset($this->instances[$alias])) {
             if (!empty($storeOptions) && $this->options[$alias] !== $storeOptions) {

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -43,8 +43,11 @@ abstract class AbstractLocator implements LocatorInterface
      */
     public function get(string $alias, array $options = [])
     {
+        $storeOptions = $options;
+        unset($storeOptions['useFallbackClass']);
+
         if (isset($this->instances[$alias])) {
-            if (!empty($options) && $this->options[$alias] !== $options) {
+            if (!empty($storeOptions) && $this->options[$alias] !== $storeOptions) {
                 throw new RuntimeException(sprintf(
                     'You cannot configure "%s", it already exists in the registry.',
                     $alias
@@ -54,7 +57,7 @@ abstract class AbstractLocator implements LocatorInterface
             return $this->instances[$alias];
         }
 
-        $this->options[$alias] = $options;
+        $this->options[$alias] = $storeOptions;
 
         return $this->instances[$alias] = $this->createInstance($alias, $options);
     }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -270,7 +270,7 @@ class BelongsToMany extends Association
 
             $config = [];
             if (!$tableLocator->exists($tableAlias)) {
-                $config = ['table' => $tableName];
+                $config = ['table' => $tableName, 'useFallbackClass' => true];
 
                 // Propagate the connection if we'll get an auto-model
                 if (!App::className($tableAlias, 'Model/Table', 'Table')) {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -270,7 +270,7 @@ class BelongsToMany extends Association
 
             $config = [];
             if (!$tableLocator->exists($tableAlias)) {
-                $config = ['table' => $tableName, 'useFallbackClass' => true];
+                $config = ['table' => $tableName, 'allowFallbackClass' => true];
 
                 // Propagate the connection if we'll get an auto-model
                 if (!App::className($tableAlias, 'Model/Table', 'Table')) {

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -82,7 +82,7 @@ class EavStrategy implements TranslateStrategyInterface
         $this->table = $table;
         $this->translationTable = $this->getTableLocator()->get(
             $this->_config['translationTable'],
-            ['useFallbackClass' => true]
+            ['allowFallbackClass' => true]
         );
 
         $this->setupAssociations();
@@ -119,7 +119,7 @@ class EavStrategy implements TranslateStrategyInterface
                     'table' => $this->translationTable->getTable(),
                 ]);
             } else {
-                $fieldTable = $tableLocator->get($name, ['useFallbackClass' => true]);
+                $fieldTable = $tableLocator->get($name, ['allowFallbackClass' => true]);
             }
 
             $conditions = [

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -80,7 +80,10 @@ class EavStrategy implements TranslateStrategyInterface
 
         $this->setConfig($config);
         $this->table = $table;
-        $this->translationTable = $this->getTableLocator()->get($this->_config['translationTable']);
+        $this->translationTable = $this->getTableLocator()->get(
+            $this->_config['translationTable'],
+            ['useFallbackClass' => true]
+        );
 
         $this->setupAssociations();
     }
@@ -116,7 +119,7 @@ class EavStrategy implements TranslateStrategyInterface
                     'table' => $this->translationTable->getTable(),
                 ]);
             } else {
-                $fieldTable = $tableLocator->get($name);
+                $fieldTable = $tableLocator->get($name, ['useFallbackClass' => true]);
             }
 
             $conditions = [

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -84,7 +84,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $this->table = $table;
         $this->translationTable = $this->getTableLocator()->get(
             $this->_config['translationTable'],
-            ['useFallbackClass' => true]
+            ['allowFallbackClass' => true]
         );
 
         $this->setupAssociations();

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -82,7 +82,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
         $this->setConfig($config);
         $this->table = $table;
-        $this->translationTable = $this->getTableLocator()->get($this->_config['translationTable']);
+        $this->translationTable = $this->getTableLocator()->get(
+            $this->_config['translationTable'],
+            ['useFallbackClass' => true]
+        );
 
         $this->setupAssociations();
     }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -73,7 +73,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      *
      * @var bool
      */
-    protected $useFallbackClass = true;
+    protected $allowFallbackClass = true;
 
     /**
      * Constructor.
@@ -100,12 +100,12 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * Controls whether a fallback class should be used to create a table
      * instance if a concrete class for alias used in `get()` could not be found.
      *
-     * @param bool $enable Flag to enable or disable fallback
+     * @param bool $allow Flag to enable or disable fallback
      * @return $this
      */
-    public function useFallbackClass(bool $enable)
+    public function allowFallbackClass(bool $allow)
     {
-        $this->useFallbackClass = $enable;
+        $this->allowFallbackClass = $allow;
 
         return $this;
     }
@@ -223,11 +223,11 @@ class TableLocator extends AbstractLocator implements LocatorInterface
             $options += $this->_config[$alias];
         }
 
-        $useFallbackClass = $options['allowFallbackClass'] ?? $this->useFallbackClass;
+        $allowFallbackClass = $options['allowFallbackClass'] ?? $this->allowFallbackClass;
         $className = $this->_getClassName($alias, $options);
         if ($className) {
             $options['className'] = $className;
-        } elseif ($useFallbackClass) {
+        } elseif ($allowFallbackClass) {
             if (empty($options['className'])) {
                 $options['className'] = $alias;
             }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -98,11 +98,13 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * Set if fallback class should be used.
      *
      * @param bool $enable Flag to enable or disable fallback
-     * @return void
+     * @return $this
      */
-    public function useFallbackClass(bool $enable): void
+    public function useFallbackClass(bool $enable)
     {
         $this->useFallbackClass = $enable;
+
+        return $this;
     }
 
     /**

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -97,6 +97,9 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * Set if fallback class should be used.
      *
+     * Controls whether a fallback class should be used to create a table
+     * instance if a concrete class for alias used in `get()` could not be found.
+     *
      * @param bool $enable Flag to enable or disable fallback
      * @return $this
      */
@@ -109,6 +112,10 @@ class TableLocator extends AbstractLocator implements LocatorInterface
 
     /**
      * Set fallback class name.
+     *
+     * The class that should be used to create a table instance if a concrete
+     * class for alias used in `get()` could not be found. Defaults to
+     * `Cake\ORM\Table`.
      *
      * @param string $className Fallback class name
      * @return $this

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -63,7 +63,8 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * Fallback class to use
      *
-     * @var \Cake\ORM\Table;
+     * @var string
+     * @psalm-var class-string<\Cake\ORM\Table>
      */
     protected $fallbackClassName = Table::class;
 

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -108,6 +108,20 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     }
 
     /**
+     * Set fallback class name.
+     *
+     * @param string $className Fallback class name
+     * @return $this
+     * @psalm-param class-string<\Cake\ORM\Table> $className
+     */
+    public function setFallbackClassName($className)
+    {
+        $this->fallbackClassName = $className;
+
+        return $this;
+    }
+
+    /**
      * @inheritDoc
      */
     public function setConfig($alias, $options = null)

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -223,7 +223,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
             $options += $this->_config[$alias];
         }
 
-        $useFallbackClass = $options['useFallbackClass'] ?? $this->useFallbackClass;
+        $useFallbackClass = $options['allowFallbackClass'] ?? $this->useFallbackClass;
         $className = $this->_getClassName($alias, $options);
         if ($className) {
             $options['className'] = $className;

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -60,6 +60,13 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     protected $_fallbacked = [];
 
     /**
+     * Fallback class to use
+     *
+     * @var \Cake\ORM\Table;
+     */
+    protected $fallbackClassName = Table::class;
+
+    /**
      * Constructor.
      *
      * @param array|null $locations Locations where tables should be looked for.
@@ -184,7 +191,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
                 [, $table] = pluginSplit($options['className']);
                 $options['table'] = Inflector::underscore($table);
             }
-            $options['className'] = Table::class;
+            $options['className'] = $this->fallbackClassName;
         }
 
         if (empty($options['connection'])) {
@@ -205,7 +212,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         $options['registryAlias'] = $alias;
         $instance = $this->_create($options);
 
-        if ($options['className'] === Table::class) {
+        if ($options['className'] === $this->fallbackClassName) {
             $this->_fallbacked[$alias] = $instance;
         }
 

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -94,6 +94,17 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     }
 
     /**
+     * Set if fallback class should be used.
+     *
+     * @param bool $enable Flag to enable or disable fallback
+     * @return void
+     */
+    public function useFallbackClass(bool $enable): void
+    {
+        $this->useFallbackClass = $enable;
+    }
+
+    /**
      * @inheritDoc
      */
     public function setConfig($alias, $options = null)

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1235,9 +1235,7 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
         ]);
-        $tableLocator = new TableLocator();
-        $tableLocator->useFallbackClass(false);
-        $assoc->setTableLocator($tableLocator);
+        $assoc->setTableLocator((new TableLocator())->useFallbackClass(false));
         $junction = $assoc->junction();
         $this->assertInstanceOf(Table::class, $junction);
     }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -25,6 +25,8 @@ use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
+use Cake\ORM\Exception\MissingTableClassException;
+use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -1219,6 +1221,47 @@ class BelongsToManyTest extends TestCase
         $inverseRelation = $this->tag->getAssociation('Articles');
         $this->assertSame('Tag', $inverseRelation->getForeignKey());
         $this->assertSame('Art', $inverseRelation->getTargetForeignKey());
+    }
+
+    /**
+     * Test that fallback class is used for join table even when fallback
+     * class usage is turned off for table locator.
+     *
+     * @return void
+     */
+    public function testFallbackClassForJunction()
+    {
+        $assoc = new BelongsToMany('Test', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag,
+        ]);
+        $tableLocator = new TableLocator();
+        $tableLocator->useFallbackClass(false);
+        $assoc->setTableLocator($tableLocator);
+        $junction = $assoc->junction();
+        $this->assertInstanceOf(Table::class, $junction);
+    }
+
+    /**
+     * Test that fallback class is used for join table even when fallback
+     * class usage is turned off for table locator.
+     *
+     * @return void
+     */
+    public function testNoFallbackClassForThrough()
+    {
+        $this->expectException(MissingTableClassException::class);
+        $this->expectExceptionMessage('Table class for alias `ArticlesTags` could not be found.');
+
+        $assoc = new BelongsToMany('Test', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag,
+            'through' => 'ArticlesTags',
+        ]);
+        $tableLocator = new TableLocator();
+        $tableLocator->useFallbackClass(false);
+        $assoc->setTableLocator($tableLocator);
+        $assoc->junction();
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1235,7 +1235,7 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
         ]);
-        $assoc->setTableLocator((new TableLocator())->useFallbackClass(false));
+        $assoc->setTableLocator((new TableLocator())->allowFallbackClass(false));
         $junction = $assoc->junction();
         $this->assertInstanceOf(Table::class, $junction);
     }
@@ -1257,7 +1257,7 @@ class BelongsToManyTest extends TestCase
             'through' => 'ArticlesTags',
         ]);
         $tableLocator = new TableLocator();
-        $tableLocator->useFallbackClass(false);
+        $tableLocator->allowFallbackClass(false);
         $assoc->setTableLocator($tableLocator);
         $assoc->junction();
     }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -720,4 +720,12 @@ class TableLocatorTest extends TestCase
         $table = $locator->get('Addresses');
         $this->assertInstanceOf(AddressesTable::class, $table);
     }
+
+    public function testSetFallbackClassName()
+    {
+        $this->_locator->setFallbackClassName(ArticlesTable::class);
+
+        $table = $this->_locator->get('FooBar');
+        $this->assertInstanceOf(ArticlesTable::class, $table);
+    }
 }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Locator;
 
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -232,6 +233,22 @@ class TableLocatorTest extends TestCase
         $this->assertInstanceOf(Table::class, $result);
         $this->assertSame('stuff', $result->getTable(), 'The table should be derived from the alias');
         $this->assertSame('Stuff', $result->getAlias());
+    }
+
+    public function testExceptionForAliasWhenFallbackTurnedOff()
+    {
+        $this->expectException(MissingTableClassException::class);
+        $this->expectExceptionMessage('Table class for alias `Droids` could not be found.');
+
+        $this->_locator->get('Droids', ['useFallbackClass' => false]);
+    }
+
+    public function testExceptionForFQCNWhenFallbackTurnedOff()
+    {
+        $this->expectException(MissingTableClassException::class);
+        $this->expectExceptionMessage('Table class `App\Model\DroidsTable` could not be found.');
+
+        $this->_locator->get('App\Model\DroidsTable', ['useFallbackClass' => false]);
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -240,7 +240,7 @@ class TableLocatorTest extends TestCase
         $this->expectException(MissingTableClassException::class);
         $this->expectExceptionMessage('Table class for alias `Droids` could not be found.');
 
-        $this->_locator->get('Droids', ['useFallbackClass' => false]);
+        $this->_locator->get('Droids', ['allowFallbackClass' => false]);
     }
 
     public function testExceptionForFQCNWhenFallbackTurnedOff()
@@ -248,7 +248,7 @@ class TableLocatorTest extends TestCase
         $this->expectException(MissingTableClassException::class);
         $this->expectExceptionMessage('Table class `App\Model\DroidsTable` could not be found.');
 
-        $this->_locator->get('App\Model\DroidsTable', ['useFallbackClass' => false]);
+        $this->_locator->get('App\Model\DroidsTable', ['allowFallbackClass' => false]);
     }
 
     /**


### PR DESCRIPTION
The Cake ORM's "auto table" feature which allows accessing db tables without having to create concrete classes for them is a boon and a curse :slightly_smiling_face:.

It can often lead to a lot of hair pulling, especially for new users, if one makes a typo in a table name/alias or forgets to use prefix for plugin tables and keep wondering why their table class is not loaded. We added a list of auto generated models to debug kit's SQL Log tab but it hasn't helped much as a lot of new users are not aware of it.

So this PR adds the ability to turn off the fallback to `Cake\ORM\Table` class in the `TableLocator`, when a concrete class does not exist for a table. On can now add the following in `Application::bootstrap()` for example to turn off the fallback/"auto model" feature.

```php
FactoryLocator::add('Table', (new TableLocator())->useFallbackClass(false));
```

To maintain some balance and not require having to create concrete classes for every database table, there are some cases where use of fallback class is still always enabled:
1. Join/junction table for belongsToMany association. Unless you specify `through` option you still won't need to create concrete class for join table.
2. Tables used by `TranslateBehavior` to store translated values (for both `EavStrategy` and `ShadowTableStrategy`). 