### PR TITLE
[2.x] php-8.0-compat: fix "Error: Unknown named parameter $subject"

### DIFF
--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -126,7 +126,7 @@ abstract class ObjectCollection {
 		}
 		$result = null;
 		foreach ($list as $name) {
-			$result = call_user_func_array(array($this->_loaded[$name], $callback), array_filter(compact('subject')) + $params);
+			$result = call_user_func_array(array($this->_loaded[$name], $callback), array_values(array_filter(compact('subject')) + $params));
 			if ($options['collectReturn'] === true) {
 				$collected[] = $result;
 			}


### PR DESCRIPTION
## Summary
PHP 8 added support for named parameters however will throw an error when
a named parameter, which does not exist, will be called/appears.

In this case the code uses `array_filter(compact('subject))` to conveniently
prepend `$subject` to the callback, if it's non-null.

It's then combined with `$params` but mixing a hash wih a sequential array
and then end result is `['subject' => …, ]` which then triggers this
TypeError in PHP 8.

The solution applies `array_values()` on above array as to remove the keys
and then the error disappears.

With this change, our internal test suite (2k tests) is green on both PHP8
and PHP7.4, aka this change is expecte to be backwards compatible.