### PR TITLE
Add FlashMessage utility class.

### DIFF
--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -60,7 +60,8 @@ class FlashMessage
     }
 
     /**
-     * Used to set a session variable that can be used to output messages in the view.
+     * Store flash messages that can be output in the view.
+     *
      * If you make consecutive calls to this method, the messages will stack
      * (if they are set with the same flash key)
      *

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -36,6 +36,7 @@ class FlashMessage
     protected $_defaultConfig = [
         'key' => 'flash',
         'element' => 'default',
+        'plugin' => null,
         'params' => [],
         'clear' => false,
         'duplicate' => true,
@@ -67,7 +68,9 @@ class FlashMessage
      * ### Options:
      *
      * - `key` The key to set under the session's Flash key.
-     * - `element` The element used to render the flash message.
+     * - `element` The element used to render the flash message. You can use
+     *     `'SomePlugin.name'` style value for flash elements from a plugin.
+     * - `plugin` Plugin name to use element from.
      * - `params` An array of variables to be made available to the element.
      * - `clear` A bool stating if the current stack should be cleared to start a new one.
      * - `escape` Set to false to allow templates to print out HTML content.
@@ -86,6 +89,9 @@ class FlashMessage
         }
 
         [$plugin, $element] = pluginSplit($options['element']);
+        if ($options['plugin']) {
+            $plugin = $options['plugin'];
+        }
 
         if ($plugin) {
             $options['element'] = $plugin . '.flash/' . $element;

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -157,12 +157,7 @@ class FlashMessage
      */
     public function consume(string $key): ?array
     {
-        $messages = $this->session->read("Flash.{$key}");
-        if ($messages !== null) {
-            $this->session->delete("Flash.{$key}");
-        }
-
-        return $messages;
+        return $this->session->consume("Flash.{$key}");
     }
 
     /**

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -172,7 +172,6 @@ class FlashMessage
     public function success(string $message, array $options = []): void
     {
         $options['element'] = 'success';
-
         $this->set($message, $options);
     }
 
@@ -189,7 +188,38 @@ class FlashMessage
     public function error(string $message, array $options = []): void
     {
         $options['element'] = 'error';
+        $this->set($message, $options);
+    }
 
+    /**
+     * Set a warning message.
+     *
+     * The `'element'` option will be set to  `'warning'`.
+     *
+     * @param string $message Message to flash.
+     * @param array $options An array of options.
+     * @return void
+     * @see FlashMessage::set() For list of valid options
+     */
+    public function warning(string $message, array $options = []): void
+    {
+        $options['element'] = 'warning';
+        $this->set($message, $options);
+    }
+
+    /**
+     * Set an info message.
+     *
+     * The `'element'` option will be set to  `'info'`.
+     *
+     * @param string $message Message to flash.
+     * @param array $options An array of options.
+     * @return void
+     * @see FlashMessage::set() For list of valid options
+     */
+    public function info(string $message, array $options = []): void
+    {
+        $options['element'] = 'info';
         $this->set($message, $options);
     }
 }

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Utility\Hash;
 use Throwable;
 
 /**
@@ -82,7 +81,7 @@ class FlashMessage
      */
     public function set($message, array $options = []): void
     {
-        $options = Hash::merge((array)$this->getConfig(), $options);
+        $options += (array)$this->getConfig();
 
         if (isset($options['escape']) && !isset($options['params']['escape'])) {
             $options['params']['escape'] = $options['escape'];

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -1,0 +1,195 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Utility\Hash;
+use Throwable;
+
+/**
+ * The FlashMessage class provides a way for you to write a flash variable
+ * to the session, to be rendered in a view with the FlashHelper.
+ */
+class FlashMessage
+{
+    use InstanceConfigTrait;
+
+    /**
+     * Default configuration
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'key' => 'flash',
+        'element' => 'default',
+        'params' => [],
+        'clear' => false,
+        'duplicate' => true,
+    ];
+
+    /**
+     * @var \Cake\Http\Session
+     */
+    protected $session;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Http\Session $session Session instance.
+     * @param array $config Config array.
+     * @see FlashMessage::set() For list of valid config keys.
+     */
+    public function __construct(Session $session, array $config = [])
+    {
+        $this->session = $session;
+        $this->setConfig($config);
+    }
+
+    /**
+     * Used to set a session variable that can be used to output messages in the view.
+     * If you make consecutive calls to this method, the messages will stack
+     * (if they are set with the same flash key)
+     *
+     * ### Options:
+     *
+     * - `key` The key to set under the session's Flash key.
+     * - `element` The element used to render the flash message.
+     * - `params` An array of variables to be made available to the element.
+     * - `clear` A bool stating if the current stack should be cleared to start a new one.
+     * - `escape` Set to false to allow templates to print out HTML content.
+     *
+     * @param string $message Message to be flashed.
+     * @param array $options An array of options
+     * @return void
+     * @see FlashMessage::$_defaultConfig For default values for the options.
+     */
+    public function set($message, array $options = []): void
+    {
+        $options = Hash::merge((array)$this->getConfig(), $options);
+
+        if (isset($options['escape']) && !isset($options['params']['escape'])) {
+            $options['params']['escape'] = $options['escape'];
+        }
+
+        [$plugin, $element] = pluginSplit($options['element']);
+
+        if ($plugin) {
+            $options['element'] = $plugin . '.flash/' . $element;
+        } else {
+            $options['element'] = 'flash/' . $element;
+        }
+
+        $messages = [];
+        if (!$options['clear']) {
+            $messages = (array)$this->session->read('Flash.' . $options['key']);
+        }
+
+        if (!$options['duplicate']) {
+            foreach ($messages as $existingMessage) {
+                if ($existingMessage['message'] === $message) {
+                    return;
+                }
+            }
+        }
+
+        $messages[] = [
+            'message' => $message,
+            'key' => $options['key'],
+            'element' => $options['element'],
+            'params' => $options['params'],
+        ];
+
+        $this->session->write('Flash.' . $options['key'], $messages);
+    }
+
+    /**
+     * Set an exception's message as flash message.
+     *
+     * The following options will be set by default if unset:
+     * ```
+     * 'element' => 'error',
+     * `params' => ['code' => $exception->getCode()]
+     * ```
+     *
+     * @param \Throwable $exception Exception instance.
+     * @param array $options An array of options.
+     * @return void
+     * @see FlashMessage::set() For list of valid options
+     */
+    public function setExceptionMessage(Throwable $exception, array $options = []): void
+    {
+        if (!isset($options['element'])) {
+            $options['element'] = 'error';
+        }
+        if (!isset($options['params']['code'])) {
+            $options['params']['code'] = $exception->getCode();
+        }
+
+        $message = $exception->getMessage();
+        $this->set($message, $options);
+    }
+
+    /**
+     * Get the messages for given key and remove from session.
+     *
+     * @param string $key The key for get messages for.
+     * @return array|null
+     */
+    public function consume(string $key): ?array
+    {
+        $messages = $this->session->read("Flash.{$key}");
+        if ($messages !== null) {
+            $this->session->delete("Flash.{$key}");
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Set a success message.
+     *
+     * The `'element'` option will be set to  `'success'`.
+     *
+     * @param string $message Message to flash.
+     * @param array $options An array of options.
+     * @return void
+     * @see FlashMessage::set() For list of valid options
+     */
+    public function success(string $message, array $options = []): void
+    {
+        $options['element'] = 'success';
+
+        $this->set($message, $options);
+    }
+
+    /**
+     * Set an success message.
+     *
+     * The `'element'` option will be set to  `'error'`.
+     *
+     * @param string $message Message to flash.
+     * @param array $options An array of options.
+     * @return void
+     * @see FlashMessage::set() For list of valid options
+     */
+    public function error(string $message, array $options = []): void
+    {
+        $options['element'] = 'error';
+
+        $this->set($message, $options);
+    }
+}

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -161,6 +161,13 @@ class ServerRequest implements ServerRequestInterface
     protected $session;
 
     /**
+     * Instance of a FlashMessage object relative to this request
+     *
+     * @var \Cake\Http\FlashMessage
+     */
+    protected $flash;
+
+    /**
      * Store the additional attributes attached to the request.
      *
      * @var array
@@ -172,7 +179,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @var array
      */
-    protected $emulatedAttributes = ['session', 'webroot', 'base', 'params', 'here'];
+    protected $emulatedAttributes = ['session', 'flash', 'webroot', 'base', 'params', 'here'];
 
     /**
      * Array of Psr\Http\Message\UploadedFileInterface objects.
@@ -288,6 +295,7 @@ class ServerRequest implements ServerRequestInterface
         $this->query = $config['query'];
         $this->params = $config['params'];
         $this->session = $config['session'];
+        $this->flash = new FlashMessage($this->session);
     }
 
     /**
@@ -339,6 +347,16 @@ class ServerRequest implements ServerRequestInterface
     public function getSession(): Session
     {
         return $this->session;
+    }
+
+    /**
+     * Returns the instance of the FlashMessage object for this request
+     *
+     * @return \Cake\Http\FlashMessage
+     */
+    public function getFlash(): FlashMessage
+    {
+        return $this->flash;
     }
 
     /**

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventManager;
+use Cake\Http\FlashMessage;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
@@ -164,7 +165,9 @@ class MiddlewareDispatcher
             $spec['cookies'],
             $spec['files']
         );
-        $request = $request->withAttribute('session', $spec['session']);
+        $request = $request
+            ->withAttribute('session', $spec['session'])
+            ->withAttribute('flash', new FlashMessage($spec['session']));
 
         return $request;
     }

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\View\Helper;
 
 use Cake\View\Helper;
-use UnexpectedValueException;
 
 /**
  * FlashHelper class to render flash messages.
@@ -67,27 +66,16 @@ class FlashHelper extends Helper
      *    Supports the 'params', and 'element' keys that are used in the helper.
      * @return string|null Rendered flash message or null if flash key does not exist
      *   in session.
-     * @throws \UnexpectedValueException If value for flash settings key is not an array.
      */
     public function render(string $key = 'flash', array $options = []): ?string
     {
-        $session = $this->_View->getRequest()->getSession();
-
-        if (!$session->check("Flash.$key")) {
+        $messages = $this->_View->getRequest()->getFlash()->consume($key);
+        if ($messages === null) {
             return null;
         }
 
-        $flash = $session->read("Flash.$key");
-        if (!is_array($flash)) {
-            throw new UnexpectedValueException(sprintf(
-                'Value for flash setting key "%s" must be an array.',
-                $key
-            ));
-        }
-        $session->delete("Flash.$key");
-
         $out = '';
-        foreach ($flash as $message) {
+        foreach ($messages as $message) {
             $message = $options + $message;
             $out .= $this->_View->element($message['element'], $message);
         }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -210,7 +210,7 @@ class FlashComponentTest extends TestCase
             [
                 'message' => 'This is a test message',
                 'key' => 'flash',
-                'element' => 'flash/default',
+                'element' => 'flash/error',
                 'params' => ['code' => 404],
             ],
         ];

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -229,21 +229,34 @@ class FlashMessageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testSuccess(): void
+    /**
+     * @dataProvider convenienceMethods
+     */
+    public function testConvenienceMethods(string $type): void
     {
         $this->assertNull($this->Session->read('Flash.flash'));
 
-        $this->Flash->success('It worked');
+        $this->Flash->{$type}('It worked');
         $expected = [
             [
                 'message' => 'It worked',
                 'key' => 'flash',
-                'element' => 'flash/success',
+                'element' => 'flash/' . $type,
                 'params' => [],
             ],
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
+    }
+
+    public function convenienceMethods(): array
+    {
+        return [
+            ['success'],
+            ['error'],
+            ['warning'],
+            ['info'],
+        ];
     }
 
     public function testSuccessWithClear(): void

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -104,6 +104,27 @@ class FlashMessageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testDefaultParamsOverriding()
+    {
+        $this->Flash = new FlashMessage(
+            $this->Session,
+            ['params' => ['foo' => 'bar']]
+        );
+
+        $this->Flash->set(
+            'This is a test message',
+            ['params' => ['username' => 'ADmad']]
+        );
+        $expected[] = [
+            'message' => 'This is a test message',
+            'key' => 'flash',
+            'element' => 'flash/default',
+            'params' => ['username' => 'ADmad'],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
     public function testDuplicateIgnored(): void
     {
         $this->assertNull($this->Session->read('Flash.flash'));

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -1,0 +1,291 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\FlashMessage;
+use Cake\Http\Session;
+use Cake\TestSuite\TestCase;
+use Exception;
+
+/**
+ * FlashMessageTest class
+ */
+class FlashMessageTest extends TestCase
+{
+    /**
+     * @var \Cake\Http\FlashMessage
+     */
+    protected $Flash;
+
+    /**
+     * @var \Cake\Http\Session
+     */
+    protected $Session;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        static::setAppNamespace();
+        $this->Session = new Session();
+        $this->Flash = new FlashMessage($this->Session);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->Session->destroy();
+    }
+
+    public function testSet(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message');
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'flash/default',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set(
+            'This is a test message',
+            ['element' => 'test', 'params' => ['foo' => 'bar']]
+        );
+        $expected[] = [
+            'message' => 'This is a test message',
+            'key' => 'flash',
+            'element' => 'flash/test',
+            'params' => ['foo' => 'bar'],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set('This is a test message', ['element' => 'MyPlugin.alert']);
+        $expected[] = [
+            'message' => 'This is a test message',
+            'key' => 'flash',
+            'element' => 'MyPlugin.flash/alert',
+            'params' => [],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set('This is a test message', ['key' => 'foobar']);
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'foobar',
+                'element' => 'flash/default',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.foobar');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testDuplicateIgnored(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->setConfig('duplicate', false);
+        $this->Flash->set('This test message should appear once only');
+        $this->Flash->set('This test message should appear once only');
+        $result = $this->Session->read('Flash.flash');
+        $this->assertCount(1, $result);
+    }
+
+    public function testSetEscape(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set(
+            'This is a <b>test</b> message',
+            ['escape' => false, 'params' => ['foo' => 'bar']]
+        );
+        $expected = [
+            [
+                'message' => 'This is a <b>test</b> message',
+                'key' => 'flash',
+                'element' => 'flash/default',
+                'params' => ['foo' => 'bar', 'escape' => false],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set(
+            'This is a test message',
+            ['key' => 'escaped', 'escape' => false, 'params' => ['foo' => 'bar', 'escape' => true]]
+        );
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'escaped',
+                'element' => 'flash/default',
+                'params' => ['foo' => 'bar', 'escape' => true],
+            ],
+        ];
+        $result = $this->Session->read('Flash.escaped');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testSetWithClear(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message');
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'flash/default',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set('This is another test message', ['clear' => true]);
+        $expected = [
+            [
+                'message' => 'This is another test message',
+                'key' => 'flash',
+                'element' => 'flash/default',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testSetExceptionMessage(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->setExceptionMessage(new Exception('This is a test message', 404));
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'flash/error',
+                'params' => ['code' => 404],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->setExceptionMessage(
+            new Exception('This is a test message'),
+            ['element' => 'default', 'clear' => true]
+        );
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'flash/default',
+                'params' => ['code' => null],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testSetWithConstructorConfiguration(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $flash = new FlashMessage($this->Session, ['element' => 'test']);
+        $flash->set('This is a test message');
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'flash/test',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testSuccess(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->success('It worked');
+        $expected = [
+            [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'flash/success',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testSuccessWithClear(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+        $this->Flash->success('It worked');
+        $expected = [
+            [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'flash/success',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+        $this->Flash->success('It worked too', ['clear' => true]);
+        $expected = [
+            [
+                'message' => 'It worked too',
+                'key' => 'flash',
+                'element' => 'flash/success',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testError(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->error('It did not work', ['element' => 'error_thing']);
+
+        $expected[] = [
+            'message' => 'It did not work',
+            'key' => 'flash',
+            'element' => 'flash/error',
+            'params' => [],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result, 'Element is ignored in convenience method call.');
+    }
+}

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -179,6 +179,38 @@ class FlashMessageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testSetWithPlugin(): void
+    {
+        $this->Flash->set('This is a test message', ['plugin' => 'FooBar']);
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'FooBar.flash/default',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        // Value of 'plugin' will override the plugin name used in 'element'
+        $this->Flash->set('This is a test message', [
+            'key' => 'msg',
+            'element' => 'Plugin.success',
+            'plugin' => 'FooBar',
+        ]);
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'msg',
+                'element' => 'FooBar.flash/success',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.msg');
+        $this->assertEquals($expected, $result);
+    }
+
     public function testSetExceptionMessage(): void
     {
         $this->assertNull($this->Session->read('Flash.flash'));

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Exception\MethodNotAllowedException;
+use Cake\Http\FlashMessage;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
@@ -99,8 +100,14 @@ class ServerRequestTest extends TestCase
         $this->assertFalse($request->is('json'));
     }
 
+    public function testConstructor()
+    {
+        $request = new ServerRequest();
+        $this->assertInstanceOf(FlashMessage::class, $request->getAttribute('flash'));
+    }
+
     /**
-     * Test construction
+     * Test construction with query data
      *
      * @return void
      */
@@ -1854,6 +1861,12 @@ XML;
 
         $request = new ServerRequest();
         $this->assertEquals($session, $request->getSession());
+    }
+
+    public function testGetFlash()
+    {
+        $request = new ServerRequest();
+        $this->assertInstanceOf(FlashMessage::class, $request->getFlash());
     }
 
     /**

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -142,16 +142,6 @@ class FlashHelperTest extends TestCase
     }
 
     /**
-     * testFlashThrowsException
-     */
-    public function testFlashThrowsException()
-    {
-        $this->expectException(\UnexpectedValueException::class);
-        $this->View->getRequest()->getSession()->write('Flash.foo', 'bar');
-        $this->Flash->render('foo');
-    }
-
-    /**
      * test setting the element from the attrs.
      *
      * @return void


### PR DESCRIPTION
I found the need to be able to set flash message from middlewares before redirection. While that could be done by directly setting the `Flash.flash` session key with required array format, having to rely on an internal implementation detail isn't pretty. Also I noticed that the `FlashComponent`s code and public API could be improved.

So here's `FlashMessage` class to solve the above issues. I can finish up the work, add tests and retro fit the `FlashComponent` to use `FlashMessage` internally if the idea is approved. 