### PR TITLE
Allow passing options for helpers.

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -305,12 +305,19 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Adds a helper to use.
      *
      * @param string $helper Helper to use.
+     * @param array $options Options.
      * @return $this
      * @since 4.1.0
      */
-    public function addHelper(string $helper)
+    public function addHelper(string $helper, array $options = [])
     {
-        return $this->setHelpers([$helper]);
+        if ($options) {
+            $array = [$helper => $options];
+        } else {
+            $array = [$helper];
+        }
+
+        return $this->setHelpers($array);
     }
 
     /**

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -448,4 +448,17 @@ class ViewBuilderTest extends TestCase
         ];
         $this->assertSame($expected, $helpers);
     }
+
+    /**
+     * @return void
+     */
+    public function testAddHelperOptions()
+    {
+        $builder = new ViewBuilder();
+        $builder->addHelper('Form')
+            ->addHelper('Text', ['foo' => 'bar']);
+
+        $helpers = $builder->getHelpers();
+        $this->assertSame(['foo' => 'bar'], $helpers['Text']);
+    }
 }


### PR DESCRIPTION
Looks like we forgot the ability to set helper options.

In general, I am not so sure about the handling of keys (assoc vs int) and options for helpers, components, etc.
If they get merged, this can have some side effects, when they exist twice, once as key, and once as value.

We might want to consolidate this to always use assoc array (with always array of options as value, either empty or set).