### PR TITLE
Deprecate Text::insert() support for ? placeholders

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -203,6 +203,11 @@ class Text
         }
 
         if (strpos($str, '?') !== false && is_numeric(key($data))) {
+            deprecationWarning(
+                'Using Text::insert() with `?` placeholders is deprecated. ' .
+                'Use sprintf() with `%s` placeholders instead.'
+            );
+
             $offset = 0;
             while (($pos = strpos($str, '?', $offset)) !== false) {
                 $val = array_shift($data);

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -186,13 +186,15 @@ class TextTest extends TestCase
         $result = Text::insert($string, ['src' => 'foo', 'extra' => 'bar'], ['clean' => 'html']);
         $this->assertSame($expected, $result);
 
-        $result = Text::insert('this is a ? string', ['test']);
-        $expected = 'this is a test string';
-        $this->assertSame($expected, $result);
+        $this->deprecated(function () {
+            $result = Text::insert('this is a ? string', ['test']);
+            $expected = 'this is a test string';
+            $this->assertSame($expected, $result);
 
-        $result = Text::insert('this is a ? string with a ? ? ?', ['long', 'few?', 'params', 'you know']);
-        $expected = 'this is a long string with a few? params you know';
-        $this->assertSame($expected, $result);
+            $result = Text::insert('this is a ? string with a ? ? ?', ['long', 'few?', 'params', 'you know']);
+            $expected = 'this is a long string with a few? params you know';
+            $this->assertSame($expected, $result);
+        });
 
         $result = Text::insert('update saved_urls set url = :url where id = :id', ['url' => 'http://www.testurl.com/param1:url/param2:id', 'id' => 1]);
         $expected = 'update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1';
@@ -218,9 +220,11 @@ class TextTest extends TestCase
         $expected = 'We are passing.';
         $this->assertSame($expected, $result);
 
-        $result = Text::insert('?-pended result', ['Pre']);
-        $expected = 'Pre-pended result';
-        $this->assertSame($expected, $result);
+        $this->deprecated(function () {
+            $result = Text::insert('?-pended result', ['Pre']);
+            $expected = 'Pre-pended result';
+            $this->assertSame($expected, $result);
+        });
 
         $string = 'switching :timeout / :timeout_count';
         $expected = 'switching 5 / 10';


### PR DESCRIPTION
Text::insert() `?` placeholders aren't providing any value that sprintf() can't do better.

https://github.com/cakephp/cakephp/pull/14829#issuecomment-662782598