### PR TITLE
Allow class alias for helper config.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -299,7 +299,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
             }
             [, $name] = pluginSplit($objectName);
             if (isset($config['class'])) {
-                $normal[$name] = $config;
+                $normal[$name] = $config + ['config' => []];
             } else {
                 $normal[$name] = ['class' => $objectName, 'config' => $config];
             }

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -357,6 +357,7 @@ class HelperRegistryTest extends TestCase
     public function testArrayIsNormalized()
     {
         $config = [
+            'SomeHelper',
             'SomeHelper' => [
                 'value' => 1,
                 'value2' => 2,
@@ -403,6 +404,9 @@ class HelperRegistryTest extends TestCase
                 'value' => 1,
                 'value2' => 2,
             ],
+            'SomeAliasesHelper' => [
+                'class' => 'Plugin.SomeHelper',
+            ],
         ];
 
         $result1 = $this->Helpers->normalizeArray($config);
@@ -421,6 +425,10 @@ class HelperRegistryTest extends TestCase
                     'value' => 1,
                     'value2' => 2,
                 ],
+            ],
+            'SomeAliasesHelper' => [
+                'class' => 'Plugin.SomeHelper',
+                'config' => [],
             ],
         ];
         $this->assertEquals($expected, $result2);


### PR DESCRIPTION
I think https://github.com/cakephp/cakephp/pull/11708 tried to solve an issue, but also created another one in the process

When you set up helpers as
```
Foo => [class => PluginName.Bar]
```
You don't necessarily think about the config array, but it now is required to exist, or you get

> Undefined index: config

This resolves this merging issue.

We could also target master here, but since is only a small issue I added in top of my previous PR for 4.next.