### PR TITLE
4.x - Fix SQL Server missing parentheses on paging subquery in order clause.

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -357,6 +357,9 @@ class Sqlserver extends Driver
                         $select[$orderBy] instanceof ExpressionInterface
                     ) {
                         $key = $select[$orderBy]->sql(new ValueBinder());
+                        if ($select[$orderBy] instanceof Query) {
+                            $key = "($key)";
+                        }
                     }
                     $order->add([$key => $direction]);
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -368,6 +368,27 @@ class SqlserverTest extends TestCase
             'FROM articles WHERE title = :c0) _cake_paging_ ' .
             'WHERE (_cake_paging_._cake_page_rownum_ > 50 AND _cake_paging_._cake_page_rownum_ <= 60)';
         $this->assertSame($expected, $query->sql());
+
+        $query = new Query($connection);
+        $subquery = new Query($connection);
+        $subquery->select(1);
+        $query
+            ->select([
+                'id',
+                'computed' => $subquery,
+            ])
+            ->from('articles')
+            ->order([
+                'computed' => 'ASC',
+            ])
+            ->offset(10);
+        $expected =
+            'SELECT * FROM (' .
+                'SELECT id, (SELECT 1) AS computed, ' .
+                '(ROW_NUMBER() OVER (ORDER BY (SELECT 1) ASC)) AS _cake_page_rownum_ FROM articles' .
+            ') _cake_paging_ ' .
+            'WHERE _cake_paging_._cake_page_rownum_ > 10';
+        $this->assertSame($expected, $query->sql());
     }
 
     /**


### PR DESCRIPTION
The paging subquery workaround for older SQL Server versions is treating all expressions equally, but subqueries need to be wrapped in parentheses.