### PR TITLE
3.x - Fix SQL Server missing parentheses on paging subquery in order clause.

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -120,6 +120,9 @@ trait SqlserverDialectTrait
                         $select[$orderBy] instanceof ExpressionInterface
                     ) {
                         $key = $select[$orderBy]->sql(new ValueBinder());
+                        if ($select[$orderBy] instanceof Query) {
+                            $key = "($key)";
+                        }
                     }
                     $order->add([$key => $direction]);
 


### PR DESCRIPTION
Backport of #15164