### PR TITLE
4.x - Fix binding conflicts with SQL Server when ordering on fields with expressions

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -30,7 +30,6 @@ use Cake\Database\Schema\SqlserverSchemaDialect;
 use Cake\Database\SqlserverCompiler;
 use Cake\Database\Statement\SqlserverStatement;
 use Cake\Database\StatementInterface;
-use Cake\Database\ValueBinder;
 use InvalidArgumentException;
 use PDO;
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Driver;
 use Cake\Database\Driver;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderByExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Expression\UnaryExpression;
 use Cake\Database\ExpressionInterface;
@@ -356,12 +357,10 @@ class Sqlserver extends Driver
                         isset($select[$orderBy]) &&
                         $select[$orderBy] instanceof ExpressionInterface
                     ) {
-                        $key = $select[$orderBy]->sql(new ValueBinder());
-                        if ($select[$orderBy] instanceof Query) {
-                            $key = "($key)";
-                        }
+                        $order->add(new OrderClauseExpression($select[$orderBy], $direction));
+                    } else {
+                        $order->add([$key => $direction]);
                     }
-                    $order->add([$key => $direction]);
 
                     // Leave original order clause unchanged.
                     return $orderBy;

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use Closure;
 
@@ -53,7 +54,9 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     {
         /** @var string|\Cake\Database\ExpressionInterface $field */
         $field = $this->_field;
-        if ($field instanceof ExpressionInterface) {
+        if ($field instanceof Query) {
+            $field = sprintf('(%s)', $field->sql($generator));
+        } elseif ($field instanceof ExpressionInterface) {
             $field = $field->sql($generator);
         }
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -389,6 +389,50 @@ class SqlserverTest extends TestCase
             ') _cake_paging_ ' .
             'WHERE _cake_paging_._cake_page_rownum_ > 10';
         $this->assertSame($expected, $query->sql());
+
+        $subqueryA = new Query($connection);
+        $subqueryA
+            ->select('count(*)')
+            ->from(['a' => 'articles'])
+            ->where([
+                'a.id = articles.id',
+                'a.published' => 'Y',
+            ]);
+
+        $subqueryB = new Query($connection);
+        $subqueryB
+            ->select('count(*)')
+            ->from(['b' => 'articles'])
+            ->where([
+                'b.id = articles.id',
+                'b.published' => 'N',
+                '1 = :customBinding',
+            ])
+            ->bind(':customBinding', 1, 'integer');
+
+        $query = new Query($connection);
+        $query
+            ->select([
+                'id',
+                'computedA' => $subqueryA,
+                'computedB' => $subqueryB,
+            ])
+            ->from('articles')
+            ->order([
+                'computedA' => 'ASC',
+            ])
+            ->offset(10);
+
+        $this->assertEquals(
+            'SELECT * FROM (' .
+                'SELECT id, ' .
+                '(SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c0)) AS computedA, ' .
+                '(SELECT count(*) FROM articles b WHERE (b.id = articles.id AND b.published = :c1 AND 1 = :customBinding)) AS computedB, ' .
+                '(ROW_NUMBER() OVER (ORDER BY (SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c2)) ASC)) AS _cake_page_rownum_ FROM articles' .
+            ') _cake_paging_ ' .
+            'WHERE _cake_paging_._cake_page_rownum_ > 10',
+            $query->sql()
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -406,9 +406,7 @@ class SqlserverTest extends TestCase
             ->where([
                 'b.id = articles.id',
                 'b.published' => 'N',
-                '1 = :customBinding',
-            ])
-            ->bind(':customBinding', 1, 'integer');
+            ]);
 
         $query = new Query($connection);
         $query
@@ -427,7 +425,7 @@ class SqlserverTest extends TestCase
             'SELECT * FROM (' .
                 'SELECT id, ' .
                 '(SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c0)) AS computedA, ' .
-                '(SELECT count(*) FROM articles b WHERE (b.id = articles.id AND b.published = :c1 AND 1 = :customBinding)) AS computedB, ' .
+                '(SELECT count(*) FROM articles b WHERE (b.id = articles.id AND b.published = :c1)) AS computedB, ' .
                 '(ROW_NUMBER() OVER (ORDER BY (SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c2)) ASC)) AS _cake_page_rownum_ FROM articles' .
             ') _cake_paging_ ' .
             'WHERE _cake_paging_._cake_page_rownum_ > 10',

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -421,7 +421,7 @@ class SqlserverTest extends TestCase
             ])
             ->offset(10);
 
-        $this->assertEquals(
+        $this->assertSame(
             'SELECT * FROM (' .
                 'SELECT id, ' .
                 '(SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c0)) AS computedA, ' .

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -5015,7 +5015,10 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('articles')
             ->orderDesc($subquery)
-            ->orderAsc('id');
+            ->orderAsc('id')
+            ->setSelectTypeMap(new TypeMap([
+                'id' => 'integer',
+            ]));
 
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> ORDER BY \(' .
@@ -5030,13 +5033,13 @@ class QueryTest extends TestCase
         $this->assertEquals(
             [
                 [
-                    'id' => '3',
+                    'id' => 3,
                 ],
                 [
-                    'id' => '1',
+                    'id' => 1,
                 ],
                 [
-                    'id' => '2',
+                    'id' => 2,
                 ],
             ],
             $query->execute()->fetchAll('assoc')
@@ -5088,7 +5091,12 @@ class QueryTest extends TestCase
             ])
             ->from('articles')
             ->orderDesc($subqueryB)
-            ->orderAsc('id');
+            ->orderAsc('id')
+            ->setSelectTypeMap(new TypeMap([
+                'id' => 'integer',
+                'computedA' => 'integer',
+                'computedB' => 'integer',
+            ]));
 
         $this->assertQuotedQuery(
             'SELECT <id>, ' .
@@ -5102,28 +5110,28 @@ class QueryTest extends TestCase
             !$this->autoQuote
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 [
-                    'id' => '3',
-                    'computedA' => '0',
-                    'computedB' => '1',
+                    'id' => 3,
+                    'computedA' => 0,
+                    'computedB' => 1,
                 ],
                 [
-                    'id' => '1',
-                    'computedA' => '1',
-                    'computedB' => '0',
+                    'id' => 1,
+                    'computedA' => 1,
+                    'computedB' => 0,
                 ],
                 [
-                    'id' => '2',
-                    'computedA' => '1',
-                    'computedB' => '0',
+                    'id' => 2,
+                    'computedA' => 1,
+                    'computedB' => 0,
                 ],
             ],
             $query->execute()->fetchAll('assoc')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 ':c0' => [
                     'value' => 'Y',

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -5083,9 +5083,7 @@ class QueryTest extends TestCase
             ])
             ->from('articles')
             ->orderDesc($subqueryB)
-            ->orderAsc('id')
-            ->limit(10)
-            ->offset(0);
+            ->orderAsc('id');
 
         $this->assertQuotedQuery(
             'SELECT <id>, ' .
@@ -5094,8 +5092,7 @@ class QueryTest extends TestCase
             'FROM <articles> ' .
             'ORDER BY \(' .
                 'SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c2 AND 1 = :customBinding\)' .
-            '\) DESC, <id> ASC ' .
-            'LIMIT 10 OFFSET 0',
+            '\) DESC, <id> ASC',
             $query->sql(),
             !$this->autoQuote
         );

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -5078,9 +5078,7 @@ class QueryTest extends TestCase
             ->where([
                 'b.id = articles.id',
                 'b.published' => 'N',
-                '1 = :customBinding',
-            ])
-            ->bind(':customBinding', 1, 'integer');
+            ]);
 
         $query
             ->select([
@@ -5095,10 +5093,10 @@ class QueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id>, ' .
                 '\(SELECT count\(\*\) FROM <articles> <a> WHERE \(a\.id = articles\.id AND <a>\.<published> = :c0\)\) AS <computedA>, ' .
-                '\(SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c1 AND 1 = :customBinding\)\) AS <computedB> ' .
+                '\(SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c1\)\) AS <computedB> ' .
             'FROM <articles> ' .
             'ORDER BY \(' .
-                'SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c2 AND 1 = :customBinding\)' .
+                'SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c2\)' .
             '\) DESC, <id> ASC',
             $query->sql(),
             !$this->autoQuote
@@ -5137,11 +5135,6 @@ class QueryTest extends TestCase
                     'type' => null,
                     'placeholder' => 'c1',
                 ],
-                ':customBinding' => [
-                    'value' => 1,
-                    'type' => 'integer',
-                    'placeholder' => 'customBinding',
-                ],
                 ':c2' => [
                     'value' => 'N',
                     'type' => null,
@@ -5149,17 +5142,6 @@ class QueryTest extends TestCase
                 ],
             ],
             $query->getValueBinder()->bindings()
-        );
-
-        $this->assertEquals(
-            [
-                ':customBinding' => [
-                    'value' => 1,
-                    'type' => 'integer',
-                    'placeholder' => 'customBinding',
-                ],
-            ],
-            $subqueryB->getValueBinder()->bindings()
         );
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -5003,7 +5003,7 @@ class QueryTest extends TestCase
             ->from(['a' => 'articles'])
             ->where([
                 'a.id = articles.id',
-                'a.published' => 'N'
+                'a.published' => 'N',
             ]);
 
         $query
@@ -5023,14 +5023,14 @@ class QueryTest extends TestCase
         $this->assertEquals(
             [
                 [
-                    'id' => '3'
+                    'id' => '3',
                 ],
                 [
-                    'id' => '1'
+                    'id' => '1',
                 ],
                 [
-                    'id' => '2'
-                ]
+                    'id' => '2',
+                ],
             ],
             $query->execute()->fetchAll('assoc')
         );
@@ -5061,7 +5061,7 @@ class QueryTest extends TestCase
             ->from(['a' => 'articles'])
             ->where([
                 'a.id = articles.id',
-                'a.published' => 'Y'
+                'a.published' => 'Y',
             ]);
 
         $subqueryB = new Query($connection);
@@ -5071,7 +5071,7 @@ class QueryTest extends TestCase
             ->where([
                 'b.id = articles.id',
                 'b.published' => 'N',
-                '1 = :customBinding'
+                '1 = :customBinding',
             ])
             ->bind(':customBinding', 1, 'integer');
 
@@ -5116,7 +5116,7 @@ class QueryTest extends TestCase
                     'id' => '2',
                     'computedA' => '1',
                     'computedB' => '0',
-                ]
+                ],
             ],
             $query->execute()->fetchAll('assoc')
         );


### PR DESCRIPTION
So after [**fixing the parentheses problem**](https://github.com/cakephp/cakephp/pull/15164), additional problems became apparent, that is when the expression has bindings they can clash with bindings on the original query (or other subqueries), as the value binder's counter is being reset to `0` when the queries are being compiled, so the manually compiled subquery for the order clause might cause `:c0` to be created, and then a binding on the original query could create another `:c0`. This could cause the wrong values being assigned in the order clause, or possibly an SQL error.

I'm not 100% sure whether/how to fix this. Manually using the original query's value binder will make no difference, as it is being reset when the query is compiled, so it would result in the very same problem. The only thing that came to my mind so far is using order clause expressions (and fixing the missing parentheses in there), so that the subquery expression becomes part of the main query's expression tree. That way the subquery will use the main query's value binder after it has been reset, resulting in the values being bound multiple times with different placeholders instead.

The tests are, well, let's say there's room for improvment, but for now it should just illustrate the problem. I've added an additional integration test (that kinda replicates what the SQL Server driver would do) to see what generally happens in such a situation, and while it seems to work, I'm unsure about possible hidden side effects.

It seems that custom bindings would never work in these expressions, it would cause multiple identically named placedholders to end up in the SQL, and (at least current) SQL Server seems to either require the placeholder names to be unique, or to exactly match the count of bound values.