### PR TITLE
Allow fallback table for translation table aliases.

### DIFF
--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -117,9 +117,10 @@ class EavStrategy implements TranslateStrategyInterface
                     'className' => $table,
                     'alias' => $name,
                     'table' => $this->translationTable->getTable(),
+                    'allowFallbackClass' => true,
                 ]);
             } else {
-                $fieldTable = $tableLocator->get($name, ['allowFallbackClass' => true]);
+                $fieldTable = $tableLocator->get($name);
             }
 
             $conditions = [


### PR DESCRIPTION
Earlier use of fallback class wasn't properly enabled for table alias
used for hasOne association with translation table.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
