### PR TITLE
Add better exception output

### DIFF
--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -75,9 +75,13 @@ class OrderByExpression extends QueryExpression
                 !in_array(strtoupper($val), ['ASC', 'DESC'], true)
             ) {
                 throw new RuntimeException(
-                    'Passing extra expressions by associative array is not ' .
-                    'allowed to avoid potential SQL injection. ' .
-                    'Use QueryExpression or numeric array instead.'
+                    sprintf(
+                        'Passing extra expressions by associative array (`\'%s\' => \'%s\'`) ' .
+                        'is not allowed to avoid potential SQL injection. ' .
+                        'Use QueryExpression or numeric array instead.',
+                        $key,
+                        $val
+                    )
                 );
             }
         }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -750,7 +750,7 @@ class QueryExpression implements ExpressionInterface, Countable
             [$expression, $operator] = $parts;
             $operator = strtolower(trim($operator));
         }
-        $type = $this->getTypeMap() ->type($expression);
+        $type = $this->getTypeMap()->type($expression);
 
         $typeMultiple = (is_string($type) && strpos($type, '[]') !== false);
         if (in_array($operator, ['in', 'not in']) || $typeMultiple) {
@@ -792,7 +792,9 @@ class QueryExpression implements ExpressionInterface, Countable
         }
 
         if ($value === null && $this->_conjunction !== ',') {
-            throw new InvalidArgumentException('Expression is missing operator (IS, IS NOT) with `null` value.');
+            throw new InvalidArgumentException(
+                sprintf('Expression `%s` is missing operator (IS, IS NOT) with `null` value.', $expression)
+            );
         }
 
         return new ComparisonExpression($expression, $value, $type, $operator);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1864,8 +1864,8 @@ class QueryTest extends TestCase
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage(
-            'Passing extra expressions by associative array is not ' .
-            'allowed to avoid potential SQL injection. ' .
+            'Passing extra expressions by associative array (`\'id\' => \'desc -- Comment\'`) ' .
+            'is not allowed to avoid potential SQL injection. ' .
             'Use QueryExpression or numeric array instead.'
         );
 
@@ -4208,7 +4208,7 @@ class QueryTest extends TestCase
     public function testIsNullInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expression is missing operator (IS, IS NOT) with `null` value.');
+        $this->expectExceptionMessage('Expression `name` is missing operator (IS, IS NOT) with `null` value.');
 
         $this->loadFixtures('Authors');
         (new Query($this->connection))


### PR DESCRIPTION
The default exceptions are not too helpful if you have a larger condition array, as it could be any one of them:

> InvalidArgumentException: Expression is missing operator (IS, IS NOT) with `null` value.

This fixes it to e.g.

> InvalidArgumentException: Expression `Posts.user_id` is missing operator (IS, IS NOT) with `null` value.