### PR TITLE
4.x - Fix add non matched routing parameters to query

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -725,6 +725,12 @@ class Route
                 unset($url[$key]);
                 continue;
             }
+
+            // keys that don't exist are interpreted as query parameters
+            if (!isset($defaults[$key]) && ($value !== null && $value !== false && $value !== '')) {
+                $query[$key] = $value;
+                unset($url[$key]);
+            }
         }
 
         // if not a greedy route, no extra params are allowed.


### PR DESCRIPTION
This is a:

* [x] bugfix
* [ ] enhancement
* [ ] feature-discussion (RFC)

* CakePHP Version: 4.0.0 and up
* Platform and Target: windows, php74

### What you did
config/routes.php:
```
$routes->scope('/', function (RouteBuilder $builder) {
	$builder->fallbacks();
});
```

in Controller:
```
class UsersController extends AppController
{
	public function index()
	{
		echo Router::url(['test' => '123']);
		exit;
	}
}

```
### What happened
prints: /users

### What you expected to happen
prints: /users?test=123

Since cakephp 4, not matched routing parameters are not added to query.

But as documented in the [official documentation](https://book.cakephp.org/4/en/development/routing.html#using-router-url) this should be the case:
"Router will also convert any parameters with unknown keys in a routing array to querystring parameters"

In cakephp 3 this worked as expected but not in cake 4, I have adapted the missing code from the cake 3 branch.