### PR TITLE
Fix incorrect URL generation

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -256,7 +256,10 @@ class CakeRequest implements ArrayAccess {
 			if ($qPosition !== false && strpos($_SERVER['REQUEST_URI'], '://') > $qPosition) {
 				$uri = $_SERVER['REQUEST_URI'];
 			} else {
-				$uri = substr($_SERVER['REQUEST_URI'], strlen(Configure::read('App.fullBaseUrl')));
+				$baseUrl = Configure::read('App.fullBaseUrl');
+				if (substr($_SERVER['REQUEST_URI'], 0, strlen($baseUrl)) === $baseUrl) {
+					$uri = substr($_SERVER['REQUEST_URI'], strlen($baseUrl));
+				}
 			}
 		} elseif (isset($_SERVER['PHP_SELF']) && isset($_SERVER['SCRIPT_NAME'])) {
 			$uri = str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['PHP_SELF']);

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -220,7 +220,7 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest();
 		$this->assertEquals('other/path', $request->url);
 
-		$_SERVER['REQUEST_URI'] =  str_repeat('x', strlen($base) - 4) . '://?/other/path';
+		$_SERVER['REQUEST_URI'] = str_repeat('x', strlen($base) - 4) . '://?/other/path';
 		$request = new CakeRequest();
 		$this->assertEquals('', $request->url);
 	}

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -215,9 +215,14 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest();
 		$this->assertEquals('some/path', $request->url);
 
-		$_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/other/path?url=https://cakephp.org';
+		$base = Configure::read('App.fullBaseUrl');
+		$_SERVER['REQUEST_URI'] = $base . '/other/path?url=https://cakephp.org';
 		$request = new CakeRequest();
 		$this->assertEquals('other/path', $request->url);
+
+		$_SERVER['REQUEST_URI'] =  str_repeat('x', strlen($base) - 4) . '://?/other/path';
+		$request = new CakeRequest();
+		$this->assertEquals('', $request->url);
 	}
 
 /**


### PR DESCRIPTION
When a fullBaseURL is being used we should check for the exact base string being a prefix and not just the string length as it could be full of garbage.

Fixes #15163
