### PR TITLE
Make debugging easier for tests

### DIFF
--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -64,6 +64,6 @@ trait StringCompareTrait
         }
 
         $expected = file_get_contents($path);
-        $this->assertTextEquals($expected, $result);
+        $this->assertTextEquals($expected, $result, 'Content does not match file ' . $path);
     }
 }


### PR DESCRIPTION
Right now, trying to fix migration issues, it is hard to debug without the path to see the expected output.

> 1) Migrations\Test\TestCase\Command\BakeMigrationSnapshotCommandTest::testPluginBlog
Content does not match file /.../vendor/cakephp/migrations/tests/comparisons/Migration/test_plugin_blog.php
Failed asserting that two strings are equal.
