### PR TITLE
4.next - Add test case methods for mocking services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",
-        "league/container": "^3.0",
+        "league/container": "^3.2",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -164,6 +164,11 @@
       <code>Shell</code>
     </DeprecatedClass>
   </file>
+  <file src="src/TestSuite/ContainerStubTrait.php">
+    <DeprecatedClass occurrences="2">
+      <code>$this</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/TestSuite/Constraint/EventFired.php">
     <InternalClass occurrences="1"/>
   </file>

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -52,4 +52,12 @@ interface ContainerInterface extends PsrInterface
      * @return $this
      */
     public function addServiceProvider($provider);
+
+    /**
+     * Modify an existing definition
+     *
+     * @param string $id The class name or name of the service being modified.
+     * @return \League\Container\Definition\DefinitionInterface
+     */
+    public function extend(string $id): DefinitionInterface;
 }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -269,6 +269,11 @@ abstract class BaseApplication implements
             $plugin->services($container);
         }
 
+        $event = $this->dispatchEvent('Application.buildContainer', ['container' => $container]);
+        if ($event->getResult() instanceof ContainerInterface) {
+            return $event->getResult();
+        }
+
         return $container;
     }
 

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -282,6 +282,7 @@ trait ConsoleIntegrationTestTrait
         if ($this->_useCommandRunner) {
             /** @var \Cake\Core\ConsoleApplicationInterface $app */
             $app = $this->createApp();
+
             return new CommandRunner($app);
         }
 

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -280,7 +280,7 @@ trait ConsoleIntegrationTestTrait
     protected function makeRunner()
     {
         if ($this->_useCommandRunner) {
-            /** @var \Cake\Core\ConsoleApplicationInterface */
+            /** @var \Cake\Core\ConsoleApplicationInterface $app */
             $app = $this->createApp();
             return new CommandRunner($app);
         }

--- a/src/TestSuite/ContainerStubTrait.php
+++ b/src/TestSuite/ContainerStubTrait.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         4.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Core\Configure;
+use Cake\Core\ContainerInterface;
+use Cake\Event\EventInterface;
+use Closure;
+use LogicException;
+
+/**
+ * A set of methods used for defining container services
+ * in test cases.
+ *
+ * This trait leverages the `Application.buildContainer` event
+ * to inject the mocked services into the container that the
+ * application uses.
+ */
+trait ContainerStubTrait
+{
+    /**
+     * The customized application class name.
+     *
+     * @psalm-var class-string<\Cake\Core\HttpApplicationInterface>|class-string<\Cake\Core\ConsoleApplicationInterface>|null
+     * @var string|null
+     */
+    protected $_appClass;
+
+    /**
+     * The customized application constructor arguments.
+     *
+     * @var array|null
+     */
+    protected $_appArgs;
+
+    /**
+     * The collection of container services.
+     *
+     * @var array
+     */
+    private $containerServices = [];
+
+    /**
+     * Configure the application class to use in integration tests.
+     *
+     * @param string $class The application class name.
+     * @param array|null $constructorArgs The constructor arguments for your application class.
+     * @return void
+     * @psalm-param class-string<\Cake\Core\HttpApplicationInterface>|class-string<\Cake\Core\ConsoleApplicationInterface> $class
+     */
+    public function configApplication(string $class, ?array $constructorArgs): void
+    {
+        $this->_appClass = $class;
+        $this->_appArgs = $constructorArgs;
+    }
+
+    /**
+     * Create an application instance.
+     *
+     * Uses the configuration set in `configApplication()`.
+     *
+     * @return \Cake\Core\HttpApplicationInterface|\Cake\Core\ConsoleApplicationInterface
+     */
+    protected function createApp()
+    {
+        if ($this->_appClass) {
+            $appClass = $this->_appClass;
+        } else {
+            /** @psalm-var class-string<\Cake\Http\BaseApplication> */
+            $appClass = Configure::read('App.namespace') . '\Application';
+        }
+        if (!class_exists($appClass)) {
+            throw new LogicException("Cannot load `{$appClass}` for use in integration testing.");
+        }
+        $appArgs = $this->_appArgs ?: [CONFIG];
+
+        $app = new $appClass(...$appArgs);
+        if (!empty($this->containerServices) && method_exists($app, 'getEventManager')) {
+            $app->getEventManager()->on('Application.buildContainer', [$this, 'modifyContainer']);
+        }
+        return $app;
+    }
+
+    /**
+     * Add a mocked service to the container.
+     *
+     * When the container is created the provided classname
+     * will be mapped to the factory function. The factory
+     * function will be used to create mocked services.
+     *
+     * @param string $class The class or interface you want to define.
+     * @param \Closure $factory The factory function for mocked services.
+     * @return $this
+     */
+    public function mockService(string $class, Closure $factory)
+    {
+        $this->containerServices[$class] = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Remove a mocked service to the container.
+     *
+     * @param string $class The class or interface you want to remove.
+     * @return $this
+     */
+    public function removeMockService(string $class)
+    {
+        unset($this->containerServices[$class]);
+
+        return $this;
+    }
+
+    /**
+     * Wrap the application's container with one containing mocks.
+     *
+     * If any mocked services are defined, the application's container
+     * will be replaced with one containing mocks. The original
+     * container will be set as a delegate to the mock container.
+     *
+     * @param \Cake\Event\EventInterface $event The event
+     * @param \Cake\Core\ContainerInterface $container The container to wrap.
+     * @return null|\Cake\Core\ContainerInterface
+     */
+    public function modifyContainer(EventInterface $event, ContainerInterface $container): ?ContainerInterface
+    {
+        if (empty($this->containerServices)) {
+            return null;
+        }
+        foreach ($this->containerServices as $key => $factory) {
+            if ($container->has($key)) {
+                $container->extend($key)->setConcrete($factory);
+            } else {
+                $container->add($key, $factory);
+            }
+        }
+
+        return $container;
+    }
+
+    /**
+     * Clears any mocks that were defined and cleans
+     * up application class configuration.
+     *
+     * @after
+     * @return void
+     */
+    public function cleanupContainer(): void
+    {
+        $this->_appArgs = null;
+        $this->_appClass = null;
+        $this->containerServices = [];
+    }
+}

--- a/src/TestSuite/ContainerStubTrait.php
+++ b/src/TestSuite/ContainerStubTrait.php
@@ -91,6 +91,7 @@ trait ContainerStubTrait
         if (!empty($this->containerServices) && method_exists($app, 'getEventManager')) {
             $app->getEventManager()->on('Application.buildContainer', [$this, 'modifyContainer']);
         }
+
         return $app;
     }
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Error\ExceptionRenderer;
 use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
 use Cake\Form\FormProtector;
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\Session;
@@ -75,21 +76,7 @@ use Throwable;
 trait IntegrationTestTrait
 {
     use CookieCryptTrait;
-
-    /**
-     * The customized application class name.
-     *
-     * @var string|null
-     * @psalm-var class-string<\Cake\Core\HttpApplicationInterface>|null
-     */
-    protected $_appClass;
-
-    /**
-     * The customized application constructor arguments.
-     *
-     * @var array|null
-     */
-    protected $_appArgs;
+    use ContainerStubTrait;
 
     /**
      * The data used to build the next request.
@@ -215,25 +202,9 @@ trait IntegrationTestTrait
         $this->_viewName = null;
         $this->_layoutName = null;
         $this->_requestSession = null;
-        $this->_appClass = null;
-        $this->_appArgs = null;
         $this->_securityToken = false;
         $this->_csrfToken = false;
         $this->_retainFlashMessages = false;
-    }
-
-    /**
-     * Configure the application class to use in integration tests.
-     *
-     * @param string $class The application class name.
-     * @param array|null $constructorArgs The constructor arguments for your application class.
-     * @return void
-     * @psalm-param class-string<\Cake\Core\HttpApplicationInterface> $class
-     */
-    public function configApplication(string $class, ?array $constructorArgs): void
-    {
-        $this->_appClass = $class;
-        $this->_appArgs = $constructorArgs;
     }
 
     /**
@@ -518,7 +489,11 @@ trait IntegrationTestTrait
      */
     protected function _makeDispatcher(): MiddlewareDispatcher
     {
-        return new MiddlewareDispatcher($this, $this->_appClass, $this->_appArgs);
+        EventManager::instance()->on('Controller.initialize', [$this, 'controllerSpy']);
+        /** @var \Cake\Core\HttpApplicationInterface */
+        $app = $this->createApp();
+
+        return new MiddlewareDispatcher($app);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -490,7 +490,7 @@ trait IntegrationTestTrait
     protected function _makeDispatcher(): MiddlewareDispatcher
     {
         EventManager::instance()->on('Controller.initialize', [$this, 'controllerSpy']);
-        /** @var \Cake\Core\HttpApplicationInterface */
+        /** @var \Cake\Core\HttpApplicationInterface $app */
         $app = $this->createApp();
 
         return new MiddlewareDispatcher($app);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -454,7 +454,7 @@ class CommandRunnerTest extends TestCase
 
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString('Dependency Command', $messages);
-        $this->assertStringContainsString('constructor inject: stdClass', $messages);
+        $this->assertStringContainsString('constructor inject: {"key":"value"}', $messages);
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -247,7 +247,7 @@ class BaseApplicationTest extends TestCase
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $called = false;
-        $app->getEventManager()->on('Application.buildContainer', function ($event, $container)  use (&$called) {
+        $app->getEventManager()->on('Application.buildContainer', function ($event, $container) use (&$called) {
             $this->assertInstanceOf(BaseApplication::class, $event->getSubject());
             $this->assertInstanceOf(ContainerInterface::class, $container);
             $called = true;

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Http;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
+use Cake\Core\Container;
 use Cake\Core\ContainerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
@@ -240,5 +241,35 @@ class BaseApplicationTest extends TestCase
 
         $this->assertInstanceOf(ContainerInterface::class, $container);
         $this->assertSame($container, $app->getContainer(), 'Should return a reference');
+    }
+
+    public function testBuildContainerEvent()
+    {
+        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $called = false;
+        $app->getEventManager()->on('Application.buildContainer', function ($event, $container)  use (&$called) {
+            $this->assertInstanceOf(BaseApplication::class, $event->getSubject());
+            $this->assertInstanceOf(ContainerInterface::class, $container);
+            $called = true;
+        });
+
+        $container = $app->getContainer();
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+        $this->assertTrue($called, 'Listener should be called');
+    }
+
+    public function testBuildContainerEventReplaceContainer()
+    {
+        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app->getEventManager()->on('Application.buildContainer', function () {
+            $new = new Container();
+            $new->add('testing', 'yes');
+
+            return $new;
+        });
+
+        $container = $app->getContainer();
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+        $this->assertTrue($container->has('testing'));
     }
 }

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -15,11 +15,12 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Console\Shell;
+use Cake\Command\Command;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\Stub\MissingConsoleInputException;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
+use stdClass;
 
 class ConsoleIntegrationTestTraitTest extends TestCase
 {
@@ -47,7 +48,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->useCommandRunner();
         $this->exec('');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Current Paths');
         $this->assertExitSuccess();
     }
@@ -62,7 +63,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->exec('sample');
 
         $this->assertOutputContains('SampleShell');
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
     }
 
     /**
@@ -73,7 +74,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     public function testExecShellWithStopException()
     {
         $this->exec('integration abort_shell');
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertExitError();
         $this->assertErrorContains('Shell aborted');
     }
@@ -101,7 +102,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->useCommandRunner();
         $this->exec('routes');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
     }
 
     /**
@@ -116,7 +117,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->assertErrorEmpty();
         $this->assertOutputContains('arg: arg');
         $this->assertOutputContains('opt: some string');
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
     }
 
     /**
@@ -131,7 +132,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->assertOutputEmpty();
         $this->assertErrorContains('Missing required argument');
         $this->assertErrorContains('`arg` argument is required');
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
     }
 
     /**
@@ -144,7 +145,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->exec('integration bridge', ['javascript']);
 
         $this->assertErrorContains('No!');
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
     }
 
     /**
@@ -169,7 +170,19 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->exec('integration bridge', ['cake', 'blue']);
 
         $this->assertOutputContains('You may pass');
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
+
+    public function testExecWithMockServiceDependencies()
+    {
+        $this->mockService(stdClass::class, function () {
+            return json_decode('{"console-mock":true}');
+        });
+        $this->useCommandRunner();
+        $this->exec('dependency');
+
+        $this->assertOutputContains('constructor inject: {"console-mock":true}');
+        $this->assertExitCode(Command::CODE_SUCCESS);
     }
 
     /**
@@ -248,7 +261,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     public function assertionFailureMessagesProvider()
     {
         return [
-            'assertExitCode' => ['assertExitCode', 'Failed asserting that 1 matches exit code 0', 'routes', Shell::CODE_ERROR],
+            'assertExitCode' => ['assertExitCode', 'Failed asserting that 1 matches exit code 0', 'routes', Command::CODE_ERROR],
             'assertOutputEmpty' => ['assertOutputEmpty', 'Failed asserting that output is empty', 'routes'],
             'assertOutputContains' => ['assertOutputContains', 'Failed asserting that \'missing\' is in output', 'routes', 'missing'],
             'assertOutputNotContains' => ['assertOutputNotContains', 'Failed asserting that \'controller\' is not in output', 'routes', 'controller'],

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -34,6 +34,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Laminas\Diactoros\UploadedFile;
 use PHPUnit\Framework\AssertionFailedError;
+use stdClass;
 
 /**
  * Self test of the IntegrationTestTrait
@@ -1739,16 +1740,58 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHandleWithContainerDependencies()
     {
-        $this->get('/dependencies/');
+        $this->get('/dependencies/requiredDep');
+        $this->assertResponseOk();
         $this->assertResponseContains('"key":"value"', 'Contains the data from the stdClass container object.');
     }
 
-    public function testHandleWithMockedDependencies()
+    /**
+     * Test that mockService() injects into controllers.
+     *
+     * @return void
+     */
+    public function testHandleWithMockServices()
     {
         $this->mockService(stdClass::class, function () {
             return json_decode('{"mock":true}');
         });
-        $this->get('/dependencies/');
+        $this->get('/dependencies/requiredDep');
+        $this->assertResponseOk();
         $this->assertResponseContains('"mock":true', 'Contains the data from the stdClass mock container.');
+    }
+
+    /**
+     * Test that mockService() injects into controllers.
+     *
+     * @return void
+     */
+    public function testHandleWithMockServicesOverwrite()
+    {
+        $this->mockService(stdClass::class, function () {
+            return json_decode('{"first":true}');
+        });
+        $this->mockService(stdClass::class, function () {
+            return json_decode('{"second":true}');
+        });
+        $this->get('/dependencies/requiredDep');
+        $this->assertResponseOk();
+        $this->assertResponseContains('"second":true', 'Contains the data from the stdClass mock container.');
+    }
+
+    /**
+     * Test that removeMock() unsets mocks
+     *
+     * @return void
+     */
+    public function testHandleWithMockServicesUnset()
+    {
+        $this->mockService(stdClass::class, function () {
+            return json_decode('{"first":true}');
+        });
+        $this->removeMockService(stdClass::class);
+
+        $this->get('/dependencies/requiredDep');
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('"first":true');
     }
 }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1742,4 +1742,13 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/dependencies/');
         $this->assertResponseContains('"key":"value"', 'Contains the data from the stdClass container object.');
     }
+
+    public function testHandleWithMockedDependencies()
+    {
+        $this->mockService(stdClass::class, function () {
+            return json_decode('{"mock":true}');
+        });
+        $this->get('/dependencies/');
+        $this->assertResponseContains('"mock":true', 'Contains the data from the stdClass mock container.');
+    }
 }

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -26,6 +26,7 @@ use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\RouteBuilder;
 use stdClass;
 use TestApp\Command\AbortCommand;
+use TestApp\Command\DependencyCommand;
 
 class Application extends BaseApplication
 {
@@ -101,5 +102,7 @@ class Application extends BaseApplication
     public function services(ContainerInterface $container): void
     {
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
+        $container->add(DependencyCommand::class)
+            ->addArgument(stdClass::class);
     }
 }

--- a/tests/test_app/TestApp/Command/DependencyCommand.php
+++ b/tests/test_app/TestApp/Command/DependencyCommand.php
@@ -21,7 +21,7 @@ class DependencyCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $io->out('Dependency Command');
-        $io->out('constructor inject: ' . get_class($this->inject));
+        $io->out('constructor inject: ' . json_encode($this->inject));
 
         return static::CODE_SUCCESS;
     }


### PR DESCRIPTION
Implements the changes described in #15184

I wasn't able to use container delegates because if the top-level dependency isn't in the mocked container, it is forwarded to the delegate, where all dependencies are resolved. This resulted in the mocked dependencies never being used. Instead overwriting/adding mocked services is simpler and works.

I've also refactored the configApplication() and application creation code as we had duplicates and I felt those methods fit well with the new trait. I'm not sold on the new trait name and welcome suggestions for a better name.