### PR TITLE
3.x - Fix Hash::mergeDiff() not handling scalar values.

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -1123,8 +1123,8 @@ class Hash
         foreach ($compare as $key => $value) {
             if (!array_key_exists($key, $data)) {
                 $data[$key] = $value;
-            } elseif (is_array($value)) {
-                $data[$key] = static::mergeDiff($data[$key], $compare[$key]);
+            } elseif (is_array($value) && is_array($data[$key])) {
+                $data[$key] = static::mergeDiff($data[$key], $value);
             }
         }
 

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -3230,6 +3230,20 @@ class HashTest extends TestCase
     }
 
     /**
+     * Test mergeDiff() with scalar elements.
+     *
+     * @return void
+     */
+    public function testMergeDiffWithScalarValue()
+    {
+        $result = Hash::mergeDiff(['a' => 'value'], ['a' => ['value']]);
+        $this->assertSame(['a' => 'value'], $result);
+
+        $result = Hash::mergeDiff(['a' => ['value']], ['a' => 'value']);
+        $this->assertSame(['a' => ['value']], $result);
+    }
+
+    /**
      * Tests Hash::expand
      *
      * @return void


### PR DESCRIPTION
Fixes #15190
