### PR TITLE
Rename $callback to $path for methods that take a column/path

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -251,13 +251,13 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * echo $max->name;
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for sorting
+     * @param callable|string $path The column name to use for sorting or callback that returns the value.
      * @param int $sort The sort type, one of SORT_STRING
      * SORT_NUMERIC or SORT_NATURAL
      * @see \Cake\Collection\CollectionInterface::sortBy()
      * @return mixed The value of the top element in the collection
      */
-    public function max($callback, int $sort = \SORT_NUMERIC);
+    public function max($path, int $sort = \SORT_NUMERIC);
 
     /**
      * Returns the bottom element in this collection after being sorted by a property.
@@ -277,13 +277,13 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * echo $min->name;
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for sorting
+     * @param callable|string $path The column name to use for sorting or callback that returns the value.
      * @param int $sort The sort type, one of SORT_STRING
      * SORT_NUMERIC or SORT_NATURAL
      * @see \Cake\Collection\CollectionInterface::sortBy()
      * @return mixed The value of the bottom element in the collection
      */
-    public function min($callback, int $sort = \SORT_NUMERIC);
+    public function min($path, int $sort = \SORT_NUMERIC);
 
     /**
      * Returns the average of all the values extracted with $path
@@ -372,13 +372,13 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * }
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for sorting
+     * @param callable|string $path The column name to use for sorting or callback that returns the value.
      * @param int $order The sort order, either SORT_DESC or SORT_ASC
      * @param int $sort The sort type, one of SORT_STRING
      * SORT_NUMERIC or SORT_NATURAL
      * @return self
      */
-    public function sortBy($callback, int $order = SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface;
+    public function sortBy($path, int $order = SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface;
 
     /**
      * Splits a collection into sets, grouped by the result of running each value
@@ -417,11 +417,11 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ];
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for grouping
+     * @param callable|string $path The column name to use for grouping or callback that returns the value.
      * or a function returning the grouping key out of the provided element
      * @return self
      */
-    public function groupBy($callback): CollectionInterface;
+    public function groupBy($path): CollectionInterface;
 
     /**
      * Given a list and a callback function that returns a key for each element
@@ -456,11 +456,11 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ];
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for indexing
+     * @param callable|string $path The column name to use for indexing or callback that returns the value.
      * or a function returning the indexing key out of the provided element
      * @return self
      */
-    public function indexBy($callback): CollectionInterface;
+    public function indexBy($path): CollectionInterface;
 
     /**
      * Sorts a list into groups and returns a count for the number of elements
@@ -494,11 +494,11 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ];
      * ```
      *
-     * @param callable|string $callback the callback or column name to use for indexing
+     * @param callable|string $path The column name to use for indexing or callback that returns the value.
      * or a function returning the indexing key out of the provided element
      * @return self
      */
-    public function countBy($callback): CollectionInterface;
+    public function countBy($path): CollectionInterface;
 
     /**
      * Returns the total sum of all the values extracted with $matcher

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -189,17 +189,17 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function max($callback, int $sort = \SORT_NUMERIC)
+    public function max($path, int $sort = \SORT_NUMERIC)
     {
-        return (new SortIterator($this->unwrap(), $callback, \SORT_DESC, $sort))->first();
+        return (new SortIterator($this->unwrap(), $path, \SORT_DESC, $sort))->first();
     }
 
     /**
      * @inheritDoc
      */
-    public function min($callback, int $sort = \SORT_NUMERIC)
+    public function min($path, int $sort = \SORT_NUMERIC)
     {
-        return (new SortIterator($this->unwrap(), $callback, \SORT_ASC, $sort))->first();
+        return (new SortIterator($this->unwrap(), $path, \SORT_ASC, $sort))->first();
     }
 
     /**
@@ -254,17 +254,17 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function sortBy($callback, int $order = \SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface
+    public function sortBy($path, int $order = \SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface
     {
-        return new SortIterator($this->unwrap(), $callback, $order, $sort);
+        return new SortIterator($this->unwrap(), $path, $order, $sort);
     }
 
     /**
      * @inheritDoc
      */
-    public function groupBy($callback): CollectionInterface
+    public function groupBy($path): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($callback);
+        $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
             $group[$callback($value)][] = $value;
@@ -276,9 +276,9 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function indexBy($callback): CollectionInterface
+    public function indexBy($path): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($callback);
+        $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
             $group[$callback($value)] = $value;
@@ -290,9 +290,9 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function countBy($callback): CollectionInterface
+    public function countBy($path): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($callback);
+        $callback = $this->_propertyExtractor($path);
 
         $mapper = function ($value, $key, $mr) use ($callback): void {
             /** @var \Cake\Collection\Iterator\MapReduce $mr */

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -29,27 +29,27 @@ trait ExtractTrait
      * Returns a callable that can be used to extract a property or column from
      * an array or object based on a dot separated path.
      *
-     * @param string|callable $callback A dot separated path of column to follow
+     * @param string|callable $path A dot separated path of column to follow
      * so that the final one can be returned or a callable that will take care
      * of doing that.
      * @return callable
      */
-    protected function _propertyExtractor($callback): callable
+    protected function _propertyExtractor($path): callable
     {
-        if (!is_string($callback)) {
-            return $callback;
+        if (!is_string($path)) {
+            return $path;
         }
 
-        $path = explode('.', $callback);
+        $parts = explode('.', $path);
 
-        if (strpos($callback, '{*}') !== false) {
-            return function ($element) use ($path) {
-                return $this->_extract($element, $path);
+        if (strpos($path, '{*}') !== false) {
+            return function ($element) use ($parts) {
+                return $this->_extract($element, $parts);
             };
         }
 
-        return function ($element) use ($path) {
-            return $this->_simpleExtract($element, $path);
+        return function ($element) use ($parts) {
+            return $this->_simpleExtract($element, $parts);
         };
     }
 
@@ -59,15 +59,15 @@ trait ExtractTrait
      * It will return arrays for elements in represented with `{*}`
      *
      * @param array|\ArrayAccess $data Data.
-     * @param string[] $path Path to extract from.
+     * @param string[] $parts Path to extract from.
      * @return mixed
      */
-    protected function _extract($data, array $path)
+    protected function _extract($data, array $parts)
     {
         $value = null;
         $collectionTransform = false;
 
-        foreach ($path as $i => $column) {
+        foreach ($parts as $i => $column) {
             if ($column === '{*}') {
                 $collectionTransform = true;
                 continue;
@@ -84,7 +84,7 @@ trait ExtractTrait
             }
 
             if ($collectionTransform) {
-                $rest = implode('.', array_slice($path, $i));
+                $rest = implode('.', array_slice($parts, $i));
 
                 return (new Collection($data))->extract($rest);
             }
@@ -105,13 +105,13 @@ trait ExtractTrait
      * by iterating over the column names contained in $path
      *
      * @param array|\ArrayAccess $data Data.
-     * @param string[] $path Path to extract from.
+     * @param string[] $parts Path to extract from.
      * @return mixed
      */
-    protected function _simpleExtract($data, array $path)
+    protected function _simpleExtract($data, array $parts)
     {
         $value = null;
-        foreach ($path as $column) {
+        foreach ($parts as $column) {
             if (!isset($data[$column])) {
                 return null;
             }


### PR DESCRIPTION
I think my first pass of cleaning up collection parameter names was a little too generic. These should primarily be "paths" to the user even though a callback can represent a path. Other function are using $path and it makes sense in the documentation.

Updated any parameter that takes both `string` and `callable`.