### PR TITLE
Remove Duplicate Virtual Fields in DboSource

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2681,6 +2681,7 @@ class DboSource extends DataSource {
 				$fields = array_diff($fields, array($field));
 			}
 			$fields = array_values($fields);
+			$virtual = array_unique($virtual);
 		}
 		if (!$quote) {
 			if (!empty($virtual)) {


### PR DESCRIPTION
I noticed the `fields` method in DboSource.php duplicates the virtualFields when the `$quote` argument is set to *false*. This simply fixes that issue by removing duplicate keys from the `$virtual` array before the virtual fields are constructed below.