### PR TITLE
Fix errors reported by psalm.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
             "@phpstan",
             "@psalm"
         ],
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.56 psalm/phar:~4.2.0 && mv composer.backup composer.json"
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.58 psalm/phar:~4.3.0 && mv composer.backup composer.json"
     },
     "config": {
         "sort-packages": true,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: src/Command/I18nExtractCommand.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Console/CommandRunner.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Console/ConsoleOptionParser.php
@@ -171,7 +166,7 @@ parameters:
 			path: src/Core/ObjectRegistry.php
 
 		-
-			message: "#^Array \\(array\\<string, TObject\\>\\) does not accept object\\.$#"
+			message: "#^Array \\(array\\<TObject\\>\\) does not accept object\\.$#"
 			count: 1
 			path: src/Core/ObjectRegistry.php
 
@@ -236,17 +231,17 @@ parameters:
 			path: src/Database/Log/LoggingStatement.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Datasource/QueryCacher.php
-
-		-
 			message: "#^Property Cake\\\\ORM\\\\Query\\:\\:\\$_repository \\(Cake\\\\ORM\\\\Table\\) does not accept Cake\\\\Datasource\\\\RepositoryInterface\\.$#"
 			count: 1
 			path: src/ORM/Query.php
 
 		-
 			message: "#^Method Cake\\\\ORM\\\\Query\\:\\:find\\(\\) should return static\\(Cake\\\\ORM\\\\Query\\) but returns Cake\\\\ORM\\\\Query\\.$#"
+			count: 1
+			path: src/ORM/Query.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/ORM/Query.php
 
@@ -279,6 +274,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$request of static method Cake\\\\Routing\\\\Router\\:\\:setRequest\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
 			count: 1
 			path: src/Http/BaseApplication.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Client.php
 
 		-
 			message: "#^Constructor of class Cake\\\\Http\\\\Client\\\\Auth\\\\Digest has an unused parameter \\$options\\.$#"
@@ -540,8 +540,3 @@ parameters:
 			count: 1
 			path: src/Mailer/Renderer.php
 
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			paths:
-				- src/ORM\Query.php
-				- src/Http/Client.php

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -342,7 +342,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
         if ($this->_groupPrefix) {
             $prefix = md5(implode('_', $this->groups()));
         }
-        $key = preg_replace('/[\s]+/', '_', (string)$key);
+        $key = preg_replace('/[\s]+/', '_', $key);
 
         return $this->_config['prefix'] . $prefix . $key;
     }

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -198,7 +198,7 @@ class FileEngine extends CacheEngine
         $data = trim($data);
 
         if ($data !== '' && !empty($this->_config['serialize'])) {
-            $data = unserialize((string)$data);
+            $data = unserialize($data);
         }
 
         return $data;

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -134,6 +134,7 @@ class MemcachedEngine extends CacheEngine
             $this->_config['servers'] = [$this->_config['servers']];
         }
 
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
         if (isset($this->_Memcached)) {
             return true;
         }
@@ -329,7 +330,7 @@ class MemcachedEngine extends CacheEngine
         }
         $duration = $this->duration($ttl);
 
-        return (bool)$this->_Memcached->setMulti($cacheData, $duration);
+        return $this->_Memcached->setMulti($cacheData, $duration);
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -186,7 +186,7 @@ class RedisEngine extends CacheEngine
         $duration = $this->_config['duration'];
         $key = $this->_key($key);
 
-        $value = (int)$this->_Redis->incrBy($key, $offset);
+        $value = $this->_Redis->incrBy($key, $offset);
         if ($duration > 0) {
             $this->_Redis->expire($key, $duration);
         }
@@ -206,7 +206,7 @@ class RedisEngine extends CacheEngine
         $duration = $this->_config['duration'];
         $key = $this->_key($key);
 
-        $value = (int)$this->_Redis->decrBy($key, $offset);
+        $value = $this->_Redis->decrBy($key, $offset);
         if ($duration > 0) {
             $this->_Redis->expire($key, $duration);
         }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -207,7 +207,7 @@ class I18nExtractCommand extends Command
                 ['y', 'n'],
                 'n'
             );
-            $this->_extractCore = strtolower((string)$response) === 'y';
+            $this->_extractCore = strtolower($response) === 'y';
         }
 
         if ($args->hasOption('exclude-plugins') && $this->_isExtractingApp()) {
@@ -263,7 +263,7 @@ class I18nExtractCommand extends Command
                 ['y', 'n'],
                 'n'
             );
-            $this->_merge = strtolower((string)$response) === 'y';
+            $this->_merge = strtolower($response) === 'y';
         }
 
         $this->_markerError = (bool)$args->getOption('marker-error');

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -353,9 +353,7 @@ class CommandRunner implements EventDispatcherInterface
 
             return $shell->runCommand($argv, true);
         } catch (StopException $e) {
-            $code = $e->getCode();
-
-            return $code === null ? $code : (int)$code;
+            return $e->getCode();
         }
     }
 

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -144,7 +144,7 @@ class ConsoleInputOption
      */
     public function short(): string
     {
-        return (string)$this->_short;
+        return $this->_short;
     }
 
     /**

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -198,7 +198,7 @@ class ConsoleIo
     public function out($message = '', int $newlines = 1, int $level = self::NORMAL): ?int
     {
         if ($level <= $this->_level) {
-            $this->_lastWritten = (int)$this->_out->write($message, $newlines);
+            $this->_lastWritten = $this->_out->write($message, $newlines);
 
             return $this->_lastWritten;
         }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -373,7 +373,7 @@ class ConsoleOptionParser
      */
     public function enableSubcommandSort(bool $value = true)
     {
-        $this->_subcommandSort = (bool)$value;
+        $this->_subcommandSort = $value;
 
         return $this;
     }
@@ -793,7 +793,7 @@ class ConsoleOptionParser
         throw new MissingOptionException(
             $message,
             $subcommand,
-            array_keys((array)$this->subcommands())
+            array_keys($this->subcommands())
         );
     }
 
@@ -805,7 +805,7 @@ class ConsoleOptionParser
      */
     public function setRootName(string $name)
     {
-        $this->rootName = (string)$name;
+        $this->rootName = $name;
 
         return $this;
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -287,7 +287,7 @@ class Shell
         if ($this->tasks === true || empty($this->tasks) || empty($this->Tasks)) {
             return true;
         }
-        $this->_taskMap = $this->Tasks->normalizeArray((array)$this->tasks);
+        $this->_taskMap = $this->Tasks->normalizeArray($this->tasks);
         $this->taskNames = array_merge($this->taskNames, array_keys($this->_taskMap));
 
         $this->_validateTasks();

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -60,7 +60,7 @@ class ShellDispatcher
     public function __construct(array $args = [], bool $bootstrap = true)
     {
         set_time_limit(0);
-        $this->args = (array)$args;
+        $this->args = $args;
 
         $this->addShortPluginAliases();
 
@@ -181,7 +181,7 @@ class ShellDispatcher
         } catch (StopException $e) {
             $code = $e->getCode();
 
-            return (int)$code;
+            return $code;
         }
         if ($result === null || $result === true) {
             /** @psalm-suppress DeprecatedClass */

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -539,7 +539,7 @@ class SecurityComponent extends Component
         $messages = [];
         foreach ($dataFields as $key => $value) {
             if (is_int($key)) {
-                $foundKey = array_search($value, (array)$expectedFields, true);
+                $foundKey = array_search($value, $expectedFields, true);
                 if ($foundKey === false) {
                     $messages[] = sprintf($intKeyMessage, $value);
                 } else {
@@ -570,7 +570,7 @@ class SecurityComponent extends Component
         }
 
         $expectedFieldNames = [];
-        foreach ((array)$expectedFields as $key => $expectedField) {
+        foreach ($expectedFields as $key => $expectedField) {
             if (is_int($key)) {
                 $expectedFieldNames[] = $expectedField;
             } else {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -47,7 +47,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * Map of loaded objects.
      *
      * @var object[]
-     * @psalm-var array<string, TObject>
+     * @psalm-var array<array-key, TObject>
      */
     protected $_loaded = [];
 
@@ -103,8 +103,10 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
             }
         }
 
-        // phpcs:ignore SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName
-        /** @psalm-var TObject $instance */
+        /**
+         * @psalm-var TObject $instance
+         * @psalm-suppress PossiblyNullArgument
+         **/
         $instance = $this->_create($className, $name, $config);
         $this->_loaded[$name] = $instance;
 

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -155,6 +155,7 @@ trait StaticConfigTrait
         if (!isset(static::$_config[$config])) {
             return false;
         }
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
         if (isset(static::$_registry)) {
             static::$_registry->unload($config);
         }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -373,10 +373,10 @@ class Sqlserver extends Driver
             ->from(['_cake_paging_' => $query]);
 
         if ($offset) {
-            $outer->where(["$field > " . (int)$offset]);
+            $outer->where(["$field > " . $offset]);
         }
         if ($limit) {
-            $value = (int)$offset + (int)$limit;
+            $value = (int)$offset + $limit;
             $outer->where(["$field <= $value"]);
         }
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -350,7 +350,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * "field NOT IN (value1, value2)".
      *
      * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
-     * @param array|\Cake\Database\ExpressionInterface $values the value to be bound to $field for comparison
+     * @param string|array|\Cake\Database\ExpressionInterface $values the value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -134,7 +134,7 @@ class IdentifierQuoter
     protected function _basicQuoter(array $part): array
     {
         $result = [];
-        foreach ((array)$part as $alias => $value) {
+        foreach ($part as $alias => $value) {
             $value = !is_string($value) ? $value : $this->_driver->quoteIdentifier($value);
             $alias = is_numeric($alias) ? $alias : $this->_driver->quoteIdentifier($alias);
             $result[$alias] = $value;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -867,7 +867,10 @@ class Query implements ExpressionInterface, IteratorAggregate
             $table = current($table);
         }
 
-        /** @psalm-suppress InvalidReturnStatement */
+        /**
+         * @psalm-suppress InvalidArrayOffset
+         * @psalm-suppress InvalidReturnStatement
+         */
         return [
             $alias => [
                 'table' => $table,
@@ -1490,9 +1493,6 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function limit($num)
     {
         $this->_dirty();
-        if ($num !== null && !is_object($num)) {
-            $num = (int)$num;
-        }
         $this->_parts['limit'] = $num;
 
         return $this;
@@ -1519,9 +1519,6 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function offset($num)
     {
         $this->_dirty();
-        if ($num !== null && !is_object($num)) {
-            $num = (int)$num;
-        }
         $this->_parts['offset'] = $num;
 
         return $this;

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -451,7 +451,7 @@ class MysqlSchemaDialect extends SchemaDialect
             $out .= ' NOT NULL';
         }
         $addAutoIncrement = (
-            (array)$schema->getPrimaryKey() === [$name] &&
+            $schema->getPrimaryKey() === [$name] &&
             !$schema->hasAutoincrement() &&
             !isset($data['autoIncrement'])
         );

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -363,7 +363,7 @@ class SqliteSchemaDialect extends SchemaDialect
             isset($data['unsigned']) &&
             $data['unsigned'] === true
         ) {
-            if ($data['type'] !== TableSchema::TYPE_INTEGER || (array)$schema->getPrimaryKey() !== [$name]) {
+            if ($data['type'] !== TableSchema::TYPE_INTEGER || $schema->getPrimaryKey() !== [$name]) {
                 $out .= ' UNSIGNED';
             }
         }
@@ -410,7 +410,7 @@ class SqliteSchemaDialect extends SchemaDialect
         if (
             in_array($data['type'], $integerTypes, true) &&
             isset($data['length']) &&
-            (array)$schema->getPrimaryKey() !== [$name]
+            $schema->getPrimaryKey() !== [$name]
         ) {
             $out .= '(' . (int)$data['length'] . ')';
         }
@@ -430,7 +430,7 @@ class SqliteSchemaDialect extends SchemaDialect
             $out .= ' NOT NULL';
         }
 
-        if ($data['type'] === TableSchema::TYPE_INTEGER && (array)$schema->getPrimaryKey() === [$name]) {
+        if ($data['type'] === TableSchema::TYPE_INTEGER && $schema->getPrimaryKey() === [$name]) {
             $out .= ' PRIMARY KEY AUTOINCREMENT';
         }
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -710,7 +710,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function setTemporary(bool $temporary)
     {
-        $this->_temporary = (bool)$temporary;
+        $this->_temporary = $temporary;
 
         return $this;
     }

--- a/src/Database/Statement/BufferResultsTrait.php
+++ b/src/Database/Statement/BufferResultsTrait.php
@@ -38,7 +38,7 @@ trait BufferResultsTrait
      */
     public function bufferResults(bool $buffer)
     {
-        $this->_bufferResults = (bool)$buffer;
+        $this->_bufferResults = $buffer;
 
         return $this;
     }

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1152,15 +1152,15 @@ trait EntityTrait
     {
         if ($field === '*') {
             $this->_accessible = array_map(function ($p) use ($set) {
-                return (bool)$set;
+                return $set;
             }, $this->_accessible);
-            $this->_accessible['*'] = (bool)$set;
+            $this->_accessible['*'] = $set;
 
             return $this;
         }
 
         foreach ((array)$field as $prop) {
-            $this->_accessible[$prop] = (bool)$set;
+            $this->_accessible[$prop] = $set;
         }
 
         return $this;

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -96,7 +96,7 @@ class QueryCacher
         $key = $this->_resolveKey($query);
         $storage = $this->_resolveCacher();
 
-        return (bool)$storage->set($key, $results);
+        return $storage->set($key, $results);
     }
 
     /**

--- a/src/Error/ConsoleErrorHandler.php
+++ b/src/Error/ConsoleErrorHandler.php
@@ -66,7 +66,7 @@ class ConsoleErrorHandler extends BaseErrorHandler
 
         $exitCode = Command::CODE_ERROR;
         if ($exception instanceof ConsoleException) {
-            $exitCode = (int)$exception->getCode();
+            $exitCode = $exception->getCode();
         }
         $this->_stop($exitCode);
     }

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -142,7 +142,7 @@ class ConsoleFormatter implements FormatterInterface
             return $this->exportObject($var, $indent + 1);
         }
         if ($var instanceof SpecialNode) {
-            return $this->style('special', (string)$var->getValue());
+            return $this->style('special', $var->getValue());
         }
         throw new RuntimeException('Unknown node received ' . get_class($var));
     }

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -147,7 +147,7 @@ class HtmlFormatter implements FormatterInterface
             return $this->exportObject($var, $indent + 1);
         }
         if ($var instanceof SpecialNode) {
-            return $this->style('special', (string)$var->getValue());
+            return $this->style('special', $var->getValue());
         }
         throw new RuntimeException('Unknown node received ' . get_class($var));
     }

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -89,7 +89,7 @@ TEXT;
             return $this->exportObject($var, $indent + 1);
         }
         if ($var instanceof SpecialNode) {
-            return (string)$var->getValue();
+            return $var->getValue();
         }
         throw new RuntimeException('Unknown node received ' . get_class($var));
     }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -694,7 +694,7 @@ class Debugger
 
         $remaining = $context->remainingDepth();
         if ($remaining >= 0) {
-            $outputMask = (array)static::outputMask();
+            $outputMask = static::outputMask();
             foreach ($var as $key => $val) {
                 if (array_key_exists($key, $outputMask)) {
                     $node = new ScalarNode('string', $outputMask[$key]);
@@ -750,12 +750,13 @@ class Debugger
                 }
             }
 
-            $outputMask = (array)static::outputMask();
+            $outputMask = static::outputMask();
             $objectVars = get_object_vars($var);
             foreach ($objectVars as $key => $value) {
                 if (array_key_exists($key, $outputMask)) {
                     $value = $outputMask[$key];
                 }
+                /** @psalm-suppress RedundantCast */
                 $node->addProperty(
                     new PropertyNode((string)$key, 'public', static::export($value, $context->withAddedDepth()))
                 );

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -374,7 +374,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
     protected function getHttpCode(Throwable $exception): int
     {
         if ($exception instanceof HttpException) {
-            return (int)$exception->getCode();
+            return $exception->getCode();
         }
 
         return $this->exceptionHttpCodes[get_class($exception)] ?? 500;

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -172,6 +172,7 @@ class Event implements EventInterface
             return $this->_data[$key] ?? null;
         }
 
+        /** @psalm-suppress RedundantCastGivenDocblockType */
         return (array)$this->_data;
     }
 

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -130,7 +130,7 @@ class EventManager implements EventManagerInterface
      */
     protected function _attachSubscriber(EventListenerInterface $subscriber): void
     {
-        foreach ((array)$subscriber->implementedEvents() as $eventKey => $function) {
+        foreach ($subscriber->implementedEvents() as $eventKey => $function) {
             $options = [];
             $method = $function;
             if (is_array($function) && isset($function['callable'])) {
@@ -234,7 +234,7 @@ class EventManager implements EventManagerInterface
      */
     protected function _detachSubscriber(EventListenerInterface $subscriber, ?string $eventKey = null): void
     {
-        $events = (array)$subscriber->implementedEvents();
+        $events = $subscriber->implementedEvents();
         if (!empty($eventKey) && empty($events[$eventKey])) {
             return;
         }
@@ -406,7 +406,7 @@ class EventManager implements EventManagerInterface
      */
     public function trackEvents(bool $enabled)
     {
-        $this->_trackEvents = (bool)$enabled;
+        $this->_trackEvents = $enabled;
 
         return $this;
     }

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -533,7 +533,7 @@ class FormProtector
         $messages = [];
         foreach ($dataFields as $key => $value) {
             if (is_int($key)) {
-                $foundKey = array_search($value, (array)$expectedFields, true);
+                $foundKey = array_search($value, $expectedFields, true);
                 if ($foundKey === false) {
                     $messages[] = sprintf($intKeyMessage, $value);
                 } else {
@@ -564,7 +564,7 @@ class FormProtector
         }
 
         $expectedFieldNames = [];
-        foreach ((array)$expectedFields as $key => $expectedField) {
+        foreach ($expectedFields as $key => $expectedField) {
             if (is_int($key)) {
                 $expectedFieldNames[] = $expectedField;
             } else {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -247,7 +247,7 @@ class Response extends Message implements ResponseInterface
      */
     public function getStatusCode(): int
     {
-        return (int)$this->code;
+        return $this->code;
     }
 
     /**

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -192,7 +192,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      */
     public function setXssProtection(string $mode = self::XSS_BLOCK)
     {
-        $mode = (string)$mode;
+        $mode = $mode;
 
         if ($mode === self::XSS_BLOCK) {
             $mode = self::XSS_ENABLED_BLOCK;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1209,7 +1209,7 @@ class Response implements ResponseInterface
      */
     public function checkNotModified(ServerRequest $request): bool
     {
-        $etags = preg_split('/\s*,\s*/', (string)$request->getHeaderLine('If-None-Match'), 0, PREG_SPLIT_NO_EMPTY);
+        $etags = preg_split('/\s*,\s*/', $request->getHeaderLine('If-None-Match'), 0, PREG_SPLIT_NO_EMPTY);
         $responseTag = $this->getHeaderLine('Etag');
         $etagMatches = null;
         if ($responseTag) {
@@ -1243,7 +1243,7 @@ class Response implements ResponseInterface
     {
         $this->stream->rewind();
 
-        return (string)$this->stream->getContents();
+        return $this->stream->getContents();
     }
 
     /**

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -509,6 +509,7 @@ class Session
             $data = Hash::insert($data, $key, $val);
         }
 
+        /** @psalm-suppress NullReference */
         $this->_overwrite($_SESSION, $data);
     }
 

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -104,7 +104,7 @@ class CacheSession implements SessionHandlerInterface
             return false;
         }
 
-        return (bool)Cache::write($id, $data, $this->_options['config']);
+        return Cache::write($id, $data, $this->_options['config']);
     }
 
     /**

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -721,7 +721,7 @@ class Message implements JsonSerializable, Serializable
             if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
                 return;
             }
-        } elseif (preg_match($this->emailPattern, (string)$email)) {
+        } elseif (preg_match($this->emailPattern, $email)) {
             return;
         }
 

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -68,7 +68,7 @@ class Renderer
         $view = $this->createView();
 
         [$templatePlugin] = pluginSplit($view->getTemplate());
-        [$layoutPlugin] = pluginSplit((string)$view->getLayout());
+        [$layoutPlugin] = pluginSplit($view->getLayout());
         if ($templatePlugin) {
             $view->setPlugin($templatePlugin);
         } elseif ($layoutPlugin) {

--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -35,7 +35,7 @@ class DebugTransport extends AbstractTransport
         $headers = $message->getHeadersString(
             ['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject']
         );
-        $message = implode("\r\n", (array)$message->getBody());
+        $message = implode("\r\n", $message->getBody());
 
         return ['headers' => $headers, 'message' => $message];
     }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -267,7 +267,7 @@ class SelectLoader
             throw new InvalidArgumentException(
                 sprintf(
                     'You are required to select the "%s" field(s)',
-                    implode(', ', (array)$key)
+                    implode(', ', $key)
                 )
             );
         }

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -311,7 +311,7 @@ class AssociationCollection implements IteratorAggregate
             return true;
         }
         if (!empty($nested)) {
-            $options = (array)$nested + $options;
+            $options = $nested + $options;
         }
 
         return (bool)$association->saveAssociated($entity, $options);

--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -47,6 +47,7 @@ trait AssociationsNormalizerTrait
 
             $path = explode('.', $table);
             $table = array_pop($path);
+            /** @var string $first */
             $first = array_shift($path);
             $pointer += [$first => []];
             $pointer = &$pointer[$first];

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -217,7 +217,7 @@ class EagerLoadable
      */
     public function setCanBeJoined(bool $possible)
     {
-        $this->_canBeJoined = (bool)$possible;
+        $this->_canBeJoined = $possible;
 
         return $this;
     }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -308,7 +308,7 @@ class EagerLoader
         $contain = [];
         foreach ($this->_containments as $alias => $options) {
             if (!empty($options['instance'])) {
-                $contain = (array)$this->_containments;
+                $contain = $this->_containments;
                 break;
             }
             $contain[$alias] = $this->_normalizeContain(
@@ -336,7 +336,7 @@ class EagerLoader
     {
         $result = $original;
 
-        foreach ((array)$associations as $table => $options) {
+        foreach ($associations as $table => $options) {
             $pointer = &$result;
             if (is_int($table)) {
                 $table = $options;
@@ -388,6 +388,7 @@ class EagerLoader
             }
 
             if (!is_array($options)) {
+                /** @psalm-suppress InvalidArrayOffset */
                 $options = [$options => []];
             }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -314,7 +314,7 @@ class Marshaller
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
         $type = $assoc->type();
         if (in_array($type, $types, true)) {
-            return $marshaller->one($value, (array)$options);
+            return $marshaller->one($value, $options);
         }
         if ($type === Association::ONE_TO_MANY || $type === Association::MANY_TO_MANY) {
             $hasIds = array_key_exists('_ids', $value);
@@ -328,10 +328,10 @@ class Marshaller
             }
         }
         if ($type === Association::MANY_TO_MANY) {
-            return $marshaller->_belongsToMany($assoc, $value, (array)$options);
+            return $marshaller->_belongsToMany($assoc, $value, $options);
         }
 
-        return $marshaller->many($value, (array)$options);
+        return $marshaller->many($value, $options);
     }
 
     /**
@@ -748,11 +748,11 @@ class Marshaller
         $type = $assoc->type();
         if (in_array($type, $types, true)) {
             /** @psalm-suppress PossiblyInvalidArgument */
-            return $marshaller->merge($original, $value, (array)$options);
+            return $marshaller->merge($original, $value, $options);
         }
         if ($type === Association::MANY_TO_MANY) {
             /** @psalm-suppress PossiblyInvalidArgument */
-            return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
+            return $marshaller->_mergeBelongsToMany($original, $assoc, $value, $options);
         }
 
         if ($type === Association::ONE_TO_MANY) {
@@ -767,7 +767,7 @@ class Marshaller
         }
 
         /** @psalm-suppress PossiblyInvalidArgument */
-        return $marshaller->mergeMany($original, $value, (array)$options);
+        return $marshaller->mergeMany($original, $value, $options);
     }
 
     /**

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -141,7 +141,7 @@ class SaveOptionsBuilder extends ArrayObject
      */
     public function guard(bool $guard)
     {
-        $this->_options['guard'] = (bool)$guard;
+        $this->_options['guard'] = $guard;
 
         return $this;
     }
@@ -168,7 +168,7 @@ class SaveOptionsBuilder extends ArrayObject
      */
     public function checkExisting(bool $checkExisting)
     {
-        $this->_options['checkExisting'] = (bool)$checkExisting;
+        $this->_options['checkExisting'] = $checkExisting;
 
         return $this;
     }
@@ -181,7 +181,7 @@ class SaveOptionsBuilder extends ArrayObject
      */
     public function checkRules(bool $checkRules)
     {
-        $this->_options['checkRules'] = (bool)$checkRules;
+        $this->_options['checkRules'] = $checkRules;
 
         return $this;
     }
@@ -194,7 +194,7 @@ class SaveOptionsBuilder extends ArrayObject
      */
     public function atomic(bool $atomic)
     {
-        $this->_options['atomic'] = (bool)$atomic;
+        $this->_options['atomic'] = $atomic;
 
         return $this;
     }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -420,7 +420,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($this->_alias === null) {
             $alias = namespaceSplit(static::class);
             $alias = substr(end($alias), 0, -5) ?: $this->_table;
-            $this->_alias = (string)$alias;
+            $this->_alias = $alias;
         }
 
         return $this->_alias;
@@ -650,7 +650,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getPrimaryKey()
     {
         if ($this->_primaryKey === null) {
-            $key = (array)$this->getSchema()->getPrimaryKey();
+            $key = $this->getSchema()->getPrimaryKey();
             if (count($key) === 1) {
                 $key = $key[0];
             }
@@ -2091,7 +2091,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _newId(array $primary)
     {
-        if (!$primary || count((array)$primary) > 1) {
+        if (!$primary || count($primary) > 1) {
             return null;
         }
         /** @var string $typeName */
@@ -2451,7 +2451,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         $query = $this->query();
-        $conditions = (array)$entity->extract($primaryKey);
+        $conditions = $entity->extract($primaryKey);
         $statement = $query->delete()
             ->where($conditions)
             ->execute();

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -153,12 +153,12 @@ class RoutingMiddleware implements MiddlewareInterface
         } catch (RedirectException $e) {
             return new RedirectResponse(
                 $e->getMessage(),
-                (int)$e->getCode()
+                $e->getCode()
             );
         } catch (DeprecatedRedirectException $e) {
             return new RedirectResponse(
                 $e->getMessage(),
-                (int)$e->getCode()
+                $e->getCode()
             );
         }
         $matching = Router::getRouteCollection()->getMiddleware($middleware);

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -428,7 +428,7 @@ class Route
             return null;
         }
 
-        return $this->parse($uri->getPath(), (string)$request->getMethod());
+        return $this->parse($uri->getPath(), $request->getMethod());
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -631,7 +631,7 @@ abstract class TestCase extends BaseTestCase
     {
         $regex = [];
         $normalized = [];
-        foreach ((array)$expected as $key => $val) {
+        foreach ($expected as $key => $val) {
             if (!is_numeric($key)) {
                 $normalized[] = [$key => $val];
             } else {
@@ -645,6 +645,7 @@ abstract class TestCase extends BaseTestCase
             }
             $i++;
             if (is_string($tags) && $tags[0] === '<') {
+                /** @psalm-suppress InvalidArrayOffset */
                 $tags = [substr($tags, 1) => []];
             } elseif (is_string($tags)) {
                 $tagsTrimmed = preg_replace('/\s+/m', '', $tags);

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -1111,10 +1111,10 @@ class Hash
     public static function diff(array $data, array $compare): array
     {
         if (empty($data)) {
-            return (array)$compare;
+            return $compare;
         }
         if (empty($compare)) {
-            return (array)$data;
+            return $data;
         }
         $intersection = array_intersect_key($data, $compare);
         while (($key = key($intersection)) !== null) {
@@ -1241,7 +1241,7 @@ class Hash
             $parentId = static::get($result, $parentKeys);
 
             if (isset($idMap[$id][$options['children']])) {
-                $idMap[$id] = array_merge($result, (array)$idMap[$id]);
+                $idMap[$id] = array_merge($result, $idMap[$id]);
             } else {
                 $idMap[$id] = array_merge($result, [$options['children'] => []]);
             }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -89,7 +89,7 @@ class ValidationRule
      */
     public function isLast(): bool
     {
-        return (bool)$this->_last;
+        return $this->_last;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1237,9 +1237,12 @@ class FormHelper extends Helper
             return 'select';
         }
 
+        $type = 'text';
         $internalType = $context->type($fieldName);
         $map = $this->_config['typeMap'];
-        $type = $map[$internalType] ?? 'text';
+        if ($internalType !== null && isset($map[$internalType])) {
+            $type = $map[$internalType];
+        }
         $fieldName = array_slice(explode('.', $fieldName), -1)[0];
 
         switch (true) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -121,7 +121,7 @@ class View implements EventDispatcherInterface
      *
      * @var string
      */
-    protected $templatePath;
+    protected $templatePath = '';
 
     /**
      * The name of the template file to render. The name specified
@@ -808,7 +808,7 @@ class View implements EventDispatcherInterface
 
         $title = $this->Blocks->get('title');
         if ($title === '') {
-            $title = Inflector::humanize(str_replace(DIRECTORY_SEPARATOR, '/', (string)$this->templatePath));
+            $title = Inflector::humanize(str_replace(DIRECTORY_SEPARATOR, '/', $this->templatePath));
             $this->Blocks->set('title', $title);
         }
 

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -67,6 +67,7 @@ trait ViewVarsTrait
             }
         }
 
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
         return $builder->build(
             [],
             $this->request ?? null,

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -235,7 +235,7 @@ class MultiCheckboxWidget extends BasicWidget
      * Helper method for deciding what options are selected.
      *
      * @param string $key The key to test.
-     * @param array|string|null $selected The selected values.
+     * @param string[]|string|int|false|null $selected The selected values.
      * @return bool
      */
     protected function _isSelected(string $key, $selected): bool

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -306,7 +306,7 @@ class SelectBoxWidget extends BasicWidget
      * Helper method for deciding what options are selected.
      *
      * @param string $key The key to test.
-     * @param  string[]|string|false|null $selected The selected values.
+     * @param string[]|string|int|false|null $selected The selected values.
      * @return bool
      */
     protected function _isSelected(string $key, $selected): bool

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -143,6 +143,7 @@ class XmlView extends SerializedView
                 $data &&
                 (!is_array($data) || Hash::numeric(array_keys($data)))
             ) {
+                /** @psalm-suppress InvalidArrayOffset */
                 $data = [$rootNode => [$serialize => $data]];
             }
         }

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -420,7 +420,7 @@ class ShellTest extends TestCase
         $this->assertTrue($this->Shell->loadTasks());
         $this->assertInstanceOf('Cake\Shell\Task\TestAppleTask', $this->Shell->TestApple);
 
-        $this->Shell->tasks = 'TestBanana';
+        $this->Shell->tasks = ['TestBanana'];
         $this->assertTrue($this->Shell->loadTasks());
         $this->assertInstanceOf('Cake\Shell\Task\TestAppleTask', $this->Shell->TestApple);
         $this->assertInstanceOf('Cake\Shell\Task\TestBananaTask', $this->Shell->TestBanana);

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -336,7 +336,7 @@ object(Cake\View\View) id:0 {
     (int) 0 => 'Html',
     (int) 1 => 'Form'
   ]
-  [protected] templatePath => null
+  [protected] templatePath => ''
   [protected] template => null
   [protected] layout => 'default'
   [protected] layoutPath => ''


### PR DESCRIPTION
The new pslam release allowed cleaning up numerous type casting made redundant by addition of argument types in 4.x.