### PR TITLE
Remove unneeded request method override check.

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -136,11 +136,6 @@ class RoutingMiddleware implements MiddlewareInterface
             $params = (array)$request->getAttribute('params', []);
             $middleware = [];
             if (empty($params['controller'])) {
-                $parsedBody = $request->getParsedBody();
-                if (is_array($parsedBody) && isset($parsedBody['_method'])) {
-                    /** @var \Cake\Http\ServerRequest $request */
-                    $request = $request->withMethod($parsedBody['_method']);
-                }
                 $params = Router::parseRequest($request) + $params;
                 if (isset($params['_middleware'])) {
                     $middleware = $params['_middleware'];


### PR DESCRIPTION
`ServerRequestFactory` already checks for `_method` in parsed body and overrides
the request method https://github.com/cakephp/cakephp/blob/3af4af99365145325ed427687d7692a0e78c54e0/src/Http/ServerRequestFactory.php#L121-L122.

Having the method override check scattered across multiple locations could actually cause problems in future.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
