### PR TITLE
Add cronjob for master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    - cron: "0 0 * * *"
+      branches:
+        - master
 
 jobs:
   testsuite:


### PR DESCRIPTION
I used to have this in travis for all repos
Now I migrate those to GA

the same we should do for all core relevant topics and plugins, as we have dependencies and this alerts us early about those breaking BC and failing our CI (before anyone does a commit and finds out).

https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events