### PR TITLE
Log errors before rendering

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -139,8 +139,8 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         $renderer = $errorHandler->getRenderer($exception, $request);
 
         try {
-            $response = $renderer->render();
             $errorHandler->logException($exception, $request);
+            $response = $renderer->render();
         } catch (Throwable $internalException) {
             $errorHandler->logException($internalException, $request);
             $response = $this->handleInternalError();


### PR DESCRIPTION
Make sure we log errors before rendering in case an internal exception is thrown.