### PR TITLE
Allow exception renderer to fallback to error400

### DIFF
--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -45,6 +45,7 @@ use RuntimeException;
 use TestApp\Controller\Admin\ErrorController;
 use TestApp\Error\Exception\MissingWidgetThing;
 use TestApp\Error\Exception\MissingWidgetThingException;
+use TestApp\Error\Exception\NonHttpMissingException;
 use TestApp\Error\MyCustomExceptionRenderer;
 
 class ExceptionRendererTest extends TestCase
@@ -143,6 +144,20 @@ class ExceptionRendererTest extends TestCase
             'Admin' . DIRECTORY_SEPARATOR . 'Error',
             $controller->viewBuilder()->getTemplatePath()
         );
+    }
+
+    public function testFallbackTemplatePath()
+    {
+        $request = (new ServerRequest())
+            ->withParam('controller', 'Foo')
+            ->withParam('action', 'bar');
+        $exception = new NonHttpMissingException();
+        $renderer = new MyCustomExceptionRenderer($exception, $request);
+
+        $renderer->render();
+        $controller = $renderer->__debugInfo()['controller'];
+        $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
+        $this->assertSame('Error', $controller->viewBuilder()->getTemplatePath());
     }
 
     /**

--- a/tests/test_app/TestApp/Error/Exception/NonHttpMissingException.php
+++ b/tests/test_app/TestApp/Error/Exception/NonHttpMissingException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Error\Exception;
+
+use Exception;
+
+/**
+ * Exception that should generate a method name for custom exception rendering template
+ * but the template `non_http_missing` does not exist.
+ */
+class NonHttpMissingException extends Exception
+{
+}

--- a/tests/test_app/TestApp/Error/MyCustomExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/MyCustomExceptionRenderer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace TestApp\Error;
 
 use Cake\Error\ExceptionRenderer;
+use TestApp\Error\Exception\NonHttpMissingException;
+use Throwable;
 
 class MyCustomExceptionRenderer extends ExceptionRenderer
 {
@@ -24,5 +26,17 @@ class MyCustomExceptionRenderer extends ExceptionRenderer
     public function missingWidgetThing()
     {
         return 'widget thing is missing';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getHttpCode(Throwable $exception): int
+    {
+        if ($exception instanceof NonHttpMissingException) {
+            return 404;
+        }
+
+        return parent::getHttpCode($exception);
     }
 }


### PR DESCRIPTION
When `debug` is true, `ExceptionRenderer` will try to render a custom error template based on the exception name. However, when rendering using TwigView, these custom templates don't exist which throws a `MissingTemplateException`. This causes the generic `error500` to render.

Since custom template engines won't re-implement all of the internal error templates, this allows falling back to the appropriate generic template based on the http exception.

When debug is enabled, users will see the appropriate `error400` page for missing routes.
