### PR TITLE
Throw exception on invalid path for groupBy and indexBy

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -267,7 +267,14 @@ trait CollectionTrait
         $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
-            $group[$callback($value)][] = $value;
+            $pathValue = $callback($value);
+            if ($pathValue === null) {
+                throw new InvalidArgumentException(
+                    'Cannot use a nonexistent path or null value. ' .
+                    'Use a callback to provide default values if necessary.'
+                );
+            }
+            $group[$pathValue][] = $value;
         }
 
         return $this->newCollection($group);
@@ -281,7 +288,14 @@ trait CollectionTrait
         $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
-            $group[$callback($value)] = $value;
+            $pathValue = $callback($value);
+            if ($pathValue === null) {
+                throw new InvalidArgumentException(
+                    'Cannot use a nonexistent path or null value. ' .
+                    'Use a callback to provide default values if necessary.'
+                );
+            }
+            $group[$pathValue] = $value;
         }
 
         return $this->newCollection($group);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -21,6 +21,7 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use NoRewindIterator;
 use stdClass;
 use TestApp\Collection\CountableIterator;
@@ -710,6 +711,25 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Tests passing an invalid path to groupBy.
+     *
+     * @return void
+     */
+    public function testGroupByInvalidPath()
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz'],
+        ];
+        $collection = new Collection($items);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $collection->groupBy('missing');
+    }
+
+    /**
      * Provider for some indexBy tests
      *
      * @return array
@@ -786,6 +806,25 @@ class CollectionTest extends TestCase
             11 => ['id' => 2, 'name' => 'bar', 'thing' => ['parent_id' => 11]],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
+    /**
+     * Tests passing an invalid path to indexBy.
+     *
+     * @return void
+     */
+    public function testIndexByInvalidPath()
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz'],
+        ];
+        $collection = new Collection($items);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $collection->indexBy('missing');
     }
 
     /**


### PR DESCRIPTION
When an invalid path is passed to `groupBy` and `indexBy`, php silently converts the `null` value returned by `_propertyExtractor` to an empty string.

This causes all mistakes to be ignored and data-loss in the case of `indexBy`.

Users can provide defaults by passing a callback, but the default implementation should throw an error since missing paths are typically not intentional. Unfortunately, there is no distinction between a null value that exists and an invalid path. Users expecting to group or index by `null` probably want to define valid default behavior anyway.