### PR TITLE
4.2 fix fixtures

### DIFF
--- a/tests/Fixture/BinaryUuidItemsBinaryUuidTagsFixture.php
+++ b/tests/Fixture/BinaryUuidItemsBinaryUuidTagsFixture.php
@@ -17,9 +17,9 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * BinaryUuiditemsBinaryUuidtagsFixture
+ * BinaryUuidItemsBinaryUuidTagsFixture
  */
-class BinaryUuiditemsBinaryUuidtagsFixture extends TestFixture
+class BinaryUuidItemsBinaryUuidTagsFixture extends TestFixture
 {
     /**
      * fields property
@@ -28,13 +28,13 @@ class BinaryUuiditemsBinaryUuidtagsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'binary_uuiditem_id' => ['type' => 'binaryuuid', 'null' => false],
-        'binary_uuidtag_id' => ['type' => 'binaryuuid', 'null' => false],
+        'binary_uuid_item_id' => ['type' => 'binaryuuid', 'null' => false],
+        'binary_uuid_tag_id' => ['type' => 'binaryuuid', 'null' => false],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'unique_item_tag' => [
                 'type' => 'unique',
-                'columns' => ['binary_uuiditem_id', 'binary_uuidtag_id'],
+                'columns' => ['binary_uuid_item_id', 'binary_uuid_tag_id'],
             ],
         ],
     ];

--- a/tests/Fixture/BinaryUuidTagsFixture.php
+++ b/tests/Fixture/BinaryUuidTagsFixture.php
@@ -17,9 +17,9 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * BinaryUuidtagsFixture
+ * BinaryUuidTagsFixture
  */
-class BinaryUuidtagsFixture extends TestFixture
+class BinaryUuidTagsFixture extends TestFixture
 {
     /**
      * fields property

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -48,7 +48,7 @@ class BelongsToManyTest extends TestCase
         'core.SpecialTags',
         'core.ArticlesTags',
         'core.Tags',
-        'core.BinaryUuiditems',
+        'core.BinaryUuidItems',
         'core.BinaryUuidtags',
         'core.BinaryUuiditemsBinaryUuidtags',
     ];
@@ -1018,7 +1018,7 @@ class BelongsToManyTest extends TestCase
             ConnectionManager::get('test')->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
             'This test is failing in SQLServer and needs to be revisited.'
         );
-        $items = $this->getTableLocator()->get('BinaryUuiditems');
+        $items = $this->getTableLocator()->get('BinaryUuidItems');
         $tags = $this->getTableLocator()->get('BinaryUuidtags');
 
         $items->belongsToMany('BinaryUuidtags', [
@@ -1026,7 +1026,7 @@ class BelongsToManyTest extends TestCase
             'targetTable' => $tags,
         ]);
         $itemName = 'Item 1';
-        $item = $items->find()->where(['BinaryUuiditems.name' => $itemName])->firstOrFail();
+        $item = $items->find()->where(['BinaryUuidItems.name' => $itemName])->firstOrFail();
 
         // 1=existing, 2=new tag
         $item->binary_uuidtags = [

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -49,8 +49,8 @@ class BelongsToManyTest extends TestCase
         'core.ArticlesTags',
         'core.Tags',
         'core.BinaryUuidItems',
-        'core.BinaryUuidtags',
-        'core.BinaryUuiditemsBinaryUuidtags',
+        'core.BinaryUuidTags',
+        'core.BinaryUuidItemsBinaryUuidTags',
     ];
 
     /**
@@ -1019,9 +1019,9 @@ class BelongsToManyTest extends TestCase
             'This test is failing in SQLServer and needs to be revisited.'
         );
         $items = $this->getTableLocator()->get('BinaryUuidItems');
-        $tags = $this->getTableLocator()->get('BinaryUuidtags');
+        $tags = $this->getTableLocator()->get('BinaryUuidTags');
 
-        $items->belongsToMany('BinaryUuidtags', [
+        $items->belongsToMany('BinaryUuidTags', [
             'sourceTable' => $items,
             'targetTable' => $tags,
         ]);
@@ -1029,21 +1029,21 @@ class BelongsToManyTest extends TestCase
         $item = $items->find()->where(['BinaryUuidItems.name' => $itemName])->firstOrFail();
 
         // 1=existing, 2=new tag
-        $item->binary_uuidtags = [
+        $item->binary_uuid_tags = [
             new Entity(['id' => '481fc6d0-b920-43e0-a40d-111111111111'], ['markNew' => false]),
             new Entity(['name' => 'net new']),
         ];
         $item->name = 'Updated';
         $items->saveOrFail($item);
 
-        $refresh = $items->find()->where(['id' => $item->id])->contain('BinaryUuidtags')->firstOrFail();
-        $this->assertCount(2, $refresh->binary_uuidtags, 'Two tags should exist');
+        $refresh = $items->find()->where(['id' => $item->id])->contain('BinaryUuidTags')->firstOrFail();
+        $this->assertCount(2, $refresh->binary_uuid_tags, 'Two tags should exist');
 
-        $refresh->binary_uuidtags = [$refresh->binary_uuidtags[0]];
+        $refresh->binary_uuid_tags = [$refresh->binary_uuid_tags[0]];
         $items->save($refresh);
 
-        $refresh = $items->get($item->id, ['contain' => 'BinaryUuidtags']);
-        $this->assertCount(1, $refresh->binary_uuidtags, 'One tag should remain');
+        $refresh = $items->get($item->id, ['contain' => 'BinaryUuidTags']);
+        $this->assertCount(1, $refresh->binary_uuid_tags, 'One tag should remain');
     }
 
     /**


### PR DESCRIPTION
Completes https://github.com/cakephp/cakephp/pull/15229
Fixes PSR-4 autoloadable class names as well as also fixing up the remaining fixture case issues.

Makes tests more readable.
The issue will only be for very few (plugin) repos and only the tests here.
So given that this seems a reasonable fix up for early 4.2 now still.