### PR TITLE
Improve setup warnings for Security.salt

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -1058,12 +1058,12 @@ class Debugger
      */
     public static function checkSecurityKeys(): void
     {
-        if (Security::getSalt() === '__SALT__') {
-            trigger_error(sprintf(
-                'Please change the value of %s in %s to a salt value specific to your application.',
-                '\'Security.salt\'',
-                'ROOT/config/app.php'
-            ), E_USER_NOTICE);
+        $salt = Security::getSalt();
+        if ($salt === '__SALT__' || strlen($salt) < 32) {
+            trigger_error(
+                "Please change the value of `Security.salt` in `ROOT/config/app.php` to a random value of at least 32 characters.",
+                E_USER_NOTICE
+            );
         }
     }
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -1061,7 +1061,8 @@ class Debugger
         $salt = Security::getSalt();
         if ($salt === '__SALT__' || strlen($salt) < 32) {
             trigger_error(
-                "Please change the value of `Security.salt` in `ROOT/config/app.php` to a random value of at least 32 characters.",
+                'Please change the value of `Security.salt` in `ROOT/config/app.php` ' .
+                'to a random value of at least 32 characters.',
                 E_USER_NOTICE
             );
         }

--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -19,8 +19,8 @@ namespace Cake\Test\TestCase\Auth;
 use Cake\Auth\DefaultPasswordHasher;
 use Cake\Auth\FallbackPasswordHasher;
 use Cake\Auth\WeakPasswordHasher;
-use Cake\Utility\Security;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
 
 /**
  * Test case for FallbackPasswordHasher

--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Auth;
 use Cake\Auth\DefaultPasswordHasher;
 use Cake\Auth\FallbackPasswordHasher;
 use Cake\Auth\WeakPasswordHasher;
+use Cake\Utility\Security;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -26,6 +27,12 @@ use Cake\TestSuite\TestCase;
  */
 class FallbackPasswordHasherTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mia1390as13dla8kjasdlwerpoiASf');
+    }
+
     /**
      * Tests that only the first hasher is user for hashing a password
      *

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -34,7 +34,7 @@ class WeakPasswordHasherTest extends TestCase
     {
         parent::setUp();
 
-        Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+        Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mia1390as13dla8kjasdlwerpoiASf');
     }
 
     /**


### PR DESCRIPTION
Improve the wording of the warning and also check for length. While the installer hook already chooses a good value, this could help folks who don't use that flow.