### PR TITLE
Fix(FixtureManager): Add back FK checks disabling for fixtures loading

### DIFF
--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -59,9 +59,9 @@ class Sqlite extends Driver
     /**
      * Stores the initial state of foreign key support in sqlite db
      *
-     * @var bool
+     * @var bool|null
      */
-    protected $_isFKEnabled = false;
+    protected $_isFKEnabled = null;
 
     /**
      * The schema dialect class for this driver
@@ -146,11 +146,6 @@ class Sqlite extends Driver
             }
         }
 
-        // Fetch the current state of FK support
-        $statement = $this->getConnection()->query('PRAGMA foreign_keys');
-        $statement->execute();
-        $this->_isFKEnabled = (bool)$statement->fetch()['foreign_keys'];
-
         return true;
     }
 
@@ -193,6 +188,13 @@ class Sqlite extends Driver
      */
     public function disableForeignKeySQL(): string
     {
+        // Fetch the current state of FK support
+        if ($this->_isFKEnabled === null) {
+            $statement = $this->getConnection()->query('PRAGMA foreign_keys');
+            $statement->execute();
+            $this->_isFKEnabled = (bool)$statement->fetch()['foreign_keys'];
+        }
+
         return 'PRAGMA foreign_keys = OFF';
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -149,7 +149,7 @@ class Sqlite extends Driver
         // Fetch the current state of FK support
         $statement = $this->getConnection()->query('PRAGMA foreign_keys');
         $statement->execute();
-        $this->_isFKEnabled = (bool) $statement->fetch()['foreign_keys'];
+        $this->_isFKEnabled = (bool)$statement->fetch()['foreign_keys'];
 
         return true;
     }

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -206,6 +206,7 @@ class Sqlite extends Driver
         if ($this->_isFKEnabled === null) {
             $this->_isFKEnabled = $this->isForeignKeyEnabled();
         }
+        
         return 'PRAGMA foreign_keys = OFF';
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -206,7 +206,7 @@ class Sqlite extends Driver
         if ($this->_isFKEnabled === null) {
             $this->_isFKEnabled = $this->isForeignKeyEnabled();
         }
-        
+
         return 'PRAGMA foreign_keys = OFF';
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -183,6 +183,15 @@ class Sqlite extends Driver
         return $result;
     }
 
+    public function isForeignKeyEnabled(): bool
+    {
+        $statement = $this->getConnection()->query('PRAGMA foreign_keys');
+        $statement->execute();
+        $status = $statement->fetch()['foreign_keys'];
+
+        return (bool)$status;
+    }
+
     /**
      * @inheritDoc
      */
@@ -190,11 +199,8 @@ class Sqlite extends Driver
     {
         // Fetch the current state of FK support
         if ($this->_isFKEnabled === null) {
-            $statement = $this->getConnection()->query('PRAGMA foreign_keys');
-            $statement->execute();
-            $this->_isFKEnabled = (bool)$statement->fetch()['foreign_keys'];
+            $this->_isFKEnabled = $this->isForeignKeyEnabled();
         }
-
         return 'PRAGMA foreign_keys = OFF';
     }
 
@@ -203,7 +209,7 @@ class Sqlite extends Driver
      */
     public function enableForeignKeySQL(): string
     {
-        return 'PRAGMA foreign_keys = ' . ($this->_isFKEnabled ? 'ON' : 'OFF');
+        return 'PRAGMA foreign_keys = ' . ($this->_isFKEnabled === false ? 'OFF' : 'ON');
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -57,6 +57,13 @@ class Sqlite extends Driver
     ];
 
     /**
+     * Stores the initial state of foreign key support in sqlite db
+     *
+     * @var bool
+     */
+    protected $_isFKEnabled = false;
+
+    /**
      * The schema dialect class for this driver
      *
      * @var \Cake\Database\Schema\SqliteSchemaDialect|null
@@ -139,6 +146,11 @@ class Sqlite extends Driver
             }
         }
 
+        // Fetch the current state of FK support
+        $statement = $this->getConnection()->query('PRAGMA foreign_keys');
+        $statement->execute();
+        $this->_isFKEnabled = (bool) $statement->fetch()['foreign_keys'];
+
         return true;
     }
 
@@ -189,7 +201,7 @@ class Sqlite extends Driver
      */
     public function enableForeignKeySQL(): string
     {
-        return 'PRAGMA foreign_keys = ON';
+        return 'PRAGMA foreign_keys = ' . ($this->_isFKEnabled ? 'ON' : 'OFF');
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -183,6 +183,11 @@ class Sqlite extends Driver
         return $result;
     }
 
+    /**
+     * Query SQLite DB for current status of foreign keys support
+     *
+     * @return  bool      True if foreign key support is currently enabled
+     */
     public function isForeignKeyEnabled(): bool
     {
         $statement = $this->getConnection()->query('PRAGMA foreign_keys');

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -389,9 +389,11 @@ class FixtureManager
                     });
                 });
             } else {
-                foreach ($fixtures as $fixture) {
-                    $callback($db, $fixture, $tableCache);
-                }
+                $db->disableConstraints(function (ConnectionInterface $db) use ($fixtures, $callback, $tableCache) {
+                    foreach ($fixtures as $fixture) {
+                        $callback($db, $fixture, $tableCache);
+                    }
+                });
             }
 
             if ($logQueries) {

--- a/tests/TestCase/Database/Driver/SqliteFKTest.php
+++ b/tests/TestCase/Database/Driver/SqliteFKTest.php
@@ -32,6 +32,9 @@ class SqliteFKTest extends TestCase
     {
         parent::setUp();
 
+        $config = ConnectionManager::getConfig('test');
+        $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
+
         ConnectionManager::setConfig('sqliteFKtest', ['url' => 'sqlite:///:memory:']);
         $connection = ConnectionManager::get('sqliteFKtest');
         $connection->connect();

--- a/tests/TestCase/Database/Driver/SqliteFKTest.php
+++ b/tests/TestCase/Database/Driver/SqliteFKTest.php
@@ -58,7 +58,7 @@ class SqliteFKTest extends TestCase
             $current ?
             'PRAGMA foreign_keys = ON' :
             'PRAGMA foreign_keys = OFF',
-          $driver->enableForeignKeySQL()
+            $driver->enableForeignKeySQL()
         );
     }
 

--- a/tests/TestCase/Database/Driver/SqliteFKTest.php
+++ b/tests/TestCase/Database/Driver/SqliteFKTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Driver;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests Sqlite driver
+ */
+class SqliteFKTest extends TestCase
+{
+    protected $_currentState;
+
+    public $driver;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ConnectionManager::setConfig('sqliteFKtest', ['url' => 'sqlite:///:memory:']);
+        $connection = ConnectionManager::get('sqliteFKtest');
+        $connection->connect();
+        $this->driver = $connection->getDriver();
+        $this->_currentState = $this->driver->isForeignKeyEnabled();
+    }
+
+    public function tearDown(): void
+    {
+        // Restore current state
+        $this->driver->getConnection()->exec('PRAGMA foreign_keys = ' . ($this->_currentState ? 'ON' : 'OFF'));
+        $this->driver = null;
+        ConnectionManager::drop('sqliteFKtest');
+
+        parent::tearDown();
+    }
+
+    public function testInitialFKCheckAsDefault()
+    {
+        $driver = $this->driver;
+        $current = $driver->isForeignKeyEnabled();
+        $this->assertEquals('PRAGMA foreign_keys = OFF', $driver->disableForeignKeySQL());
+        $this->assertEquals(
+            $current ?
+            'PRAGMA foreign_keys = ON' :
+            'PRAGMA foreign_keys = OFF',
+          $driver->enableForeignKeySQL()
+        );
+    }
+
+    public function testInitialFKCheckAsON()
+    {
+        $driver = $this->driver;
+        $current = $driver->isForeignKeyEnabled();
+        $driver->getConnection()->exec('PRAGMA foreign_keys = ON');
+
+        $this->assertTrue($driver->isForeignKeyEnabled());
+        $this->assertEquals('PRAGMA foreign_keys = OFF', $driver->disableForeignKeySQL());
+        $this->assertEquals('PRAGMA foreign_keys = ON', $driver->enableForeignKeySQL());
+    }
+
+    public function testInitialFKCheckAsOFF()
+    {
+        $driver = $this->driver;
+        $current = $driver->isForeignKeyEnabled();
+        $driver->getConnection()->exec('PRAGMA foreign_keys = OFF');
+
+        $this->assertFalse($driver->isForeignKeyEnabled());
+        $this->assertEquals('PRAGMA foreign_keys = OFF', $driver->disableForeignKeySQL());
+        $this->assertEquals('PRAGMA foreign_keys = OFF', $driver->enableForeignKeySQL());
+    }
+}


### PR DESCRIPTION
The last rework of FixtureManager introduces a breaking change as described here : #15234 

As stated in #4461, FK checks have been disabled for fixtures operations to ease tests writing. It has been maintained for data insertion but not for FK constraints creation. Therefore, one must load all referenced tables even if their data is not used in the test.

This PR proposes to restore previous behavior.