### PR TITLE
Add salted tokens to SessionCsrfProtectionMiddleware

### DIFF
--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -167,13 +167,14 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
             // XOR the token and salt together so that we can reverse it later.
             $salted .= chr(ord($token[$i]) ^ ord($salt[$i]));
         }
+
         return $salted . $salt;
     }
 
     /**
      * Remove the salt from a CSRF token.
      *
-     * If the token is not TOKEN_VALUE_LENGTH * 2 it is an old 
+     * If the token is not TOKEN_VALUE_LENGTH * 2 it is an old
      * unsalted value that is supported for backwards compatibility.
      *
      * @param string $token The token that could be salty.
@@ -192,6 +193,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
             // Reverse the the XOR to desalt.
             $unsalted .= chr(ord($salted[$i]) ^ ord($salt[$i]));
         }
+
         return $unsalted;
     }
 

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -94,10 +94,11 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $token = $updatedRequest->getSession()->read('csrfToken');
         $this->assertNotEmpty($token, 'Should set a token.');
-        $this->assertMatchesRegularExpression('/^[a-f0-9]+$/', $token, 'Should look like a hash.');
+        $this->assertMatchesRegularExpression('/^[A-Z0-9+\/]+=*$/i', $token, 'Should look like base64 data.');
         $requestAttr = $updatedRequest->getAttribute('csrfToken');
         $this->assertNotEquals($token, $requestAttr);
         $this->assertEquals(strlen($token) * 2, strlen($requestAttr));
+        $this->assertMatchesRegularExpression('/^[A-Z0-9\/+]+=*$/i', $requestAttr);
     }
 
     /**
@@ -360,7 +361,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $this->assertEmpty($session->read('csrfToken'));
         $token = $session->read('csrf');
         $this->assertNotEmpty($token, 'Should set a token.');
-        $this->assertMatchesRegularExpression('/^[a-f0-9]+$/', $token, 'Should look like a hash.');
+        $this->assertMatchesRegularExpression('/^[A-Z0-9\/+]+=*$/i', $token, 'Should look like base64 data.');
     }
 
     /**

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -80,7 +80,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
             'webroot' => '/dir/',
         ]);
 
-        /** @var $updatedRequest \Cake\Http\ServerRequest|null */
+        /** @var \Cake\Http\ServerRequest|null $updatedRequest */
         $updatedRequest = null;
         $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
@@ -174,7 +174,6 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $response = $middleware->process($request, $this->_getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
-
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -80,6 +80,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
             'webroot' => '/dir/',
         ]);
 
+        /** @var $updatedRequest \Cake\Http\ServerRequest|null */
         $updatedRequest = null;
         $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
@@ -91,9 +92,12 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertInstanceOf(Response::class, $response);
-        $token = $request->getSession()->read('csrfToken');
+        $token = $updatedRequest->getSession()->read('csrfToken');
         $this->assertNotEmpty($token, 'Should set a token.');
         $this->assertMatchesRegularExpression('/^[a-f0-9]+$/', $token, 'Should look like a hash.');
+        $requestAttr = $updatedRequest->getAttribute('csrfToken');
+        $this->assertNotEquals($token, $requestAttr);
+        $this->assertEquals(strlen($token) * 2, strlen($requestAttr));
     }
 
     /**
@@ -121,10 +125,12 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
     /**
      * Test that the X-CSRF-Token works with the various http methods.
      *
+     * Ensure unsalted tokens work.
+     *
      * @dataProvider httpMethodProvider
      * @return void
      */
-    public function testValidTokenInHeader($method)
+    public function testValidTokenInHeaderBackwardsCompat($method)
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -142,6 +148,33 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $response = $middleware->process($request, $this->_getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
+
+    /**
+     * Test that the X-CSRF-Token works with the various http methods.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testValidTokenInHeader($method)
+    {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
+        $salted = $middleware->saltToken($token);
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => $salted,
+            ],
+            'post' => ['a' => 'b'],
+        ]);
+        $request->getSession()->write('csrfToken', $token);
+        $response = new Response();
+
+        // No exception means the test is valid
+        $response = $middleware->process($request, $this->_getRequestHandler());
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
@@ -175,10 +208,12 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
     /**
      * Test that request data works with the various http methods.
      *
+     * Ensure unsalted tokens are still accepted.
+     *
      * @dataProvider httpMethodProvider
      * @return void
      */
-    public function testValidTokenInRequestData($method)
+    public function testValidTokenInRequestDataBackwardsCompat($method)
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -204,18 +239,52 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
     /**
      * Test that request data works with the various http methods.
      *
+     * Ensure salted tokens are accepted.
+     *
+     * @dataProvider httpMethodProvider
+     * @return void
+     */
+    public function testValidTokenInRequestData($method)
+    {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
+        $salted = $middleware->saltToken($token);
+
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
+            'post' => ['_csrfToken' => $salted],
+        ]);
+        $request->getSession()->write('csrfToken', $token);
+
+        $handler = new TestRequestHandler(function ($request) {
+            $this->assertNull($request->getData('_csrfToken'));
+
+            return new Response();
+        });
+
+        // No exception means everything is OK
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * Test that request data works with the various http methods.
+     *
      * @dataProvider httpMethodProvider
      * @return void
      */
     public function testInvalidTokenRequestData($method)
     {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
         $request = new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => $method,
             ],
             'post' => ['_csrfToken' => 'nope'],
         ]);
-        $request->getSession()->write('csrfToken', 'testing123');
+        $request->getSession()->write('csrfToken', $token);
 
         $middleware = new SessionCsrfProtectionMiddleware();
 
@@ -349,5 +418,21 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
         $response = $middleware->process($request, $handler);
         $this->assertInstanceOf(Response::class, $response);
+    }
+
+    /**
+     * Ensure salting is not consistent
+     *
+     * @return void
+     */
+    public function testSaltToken()
+    {
+        $middleware = new SessionCsrfProtectionMiddleware();
+        $token = $middleware->createToken();
+        $results = [];
+        for ($i = 0; $i < 10; $i++) {
+            $results[] = $middleware->saltToken($token);
+        }
+        $this->assertCount(10, array_unique($results));
     }
 }


### PR DESCRIPTION
Our current tokens are consistent across the entire session. This can allow CSRF tokens to be exfiltrated via a BREACH vulnerability. Salting the token will ensure that it is always different can thus cannot be reliabily extracted via BREACH.

I have this targeting master the session CSRF is new in 4.2 and I think the adoption rate will be very low right now. Furthermore, there are tests ensuring that unsalted tokens are still accepted. If this pull request is good, I'll also add salting to the stateless CSRF tokens.