### PR TITLE
Dont operate on bool

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -260,7 +260,7 @@ class PaginatorHelper extends Helper
             $options = $this->params($model);
         }
 
-        if (isset($options['direction'])) {
+        if (!empty($options['direction'])) {
             $dir = strtolower($options['direction']);
         }
 


### PR DESCRIPTION
```php
if (isset($options['direction'])) {
    $dir = strtolower($options['direction']);
}
```
This throws type error

> strtolower() expects parameter 1 to be string, bool given

as the value is bool false here due to a non-existend sort value used, e.g.

    /sandbox/search-examples/table?sort=fooooooo&direction=desc

Stack Trace:
- /var/www/dereuromark/sandbox4/vendor/cakephp/cakephp/src/View/Helper/PaginatorHelper.php:264
- /var/www/dereuromark/sandbox4/vendor/cakephp/cakephp/src/View/Helper/PaginatorHelper.php:477
- /var/www/dereuromark/sandbox4/plugins/Sandbox/templates/SearchExamples/table.php:40
