### PR TITLE
Make Router::routes() return a sorted routes list.

### DIFF
--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -166,7 +166,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertNotEmpty(Router::routes());
-            $this->assertSame('/app/articles', Router::routes()[0]->template);
+            $this->assertSame('/app/articles', Router::routes()[4]->template);
 
             return new Response();
         });

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -575,7 +575,7 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertSame('/api/articles', $all[0]->template);
+        $this->assertSame('/api/articles', $all[4]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[0]->defaults)
@@ -596,12 +596,12 @@ class RouteBuilderTest extends TestCase
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
-        $this->assertSame('Articles', $all[0]->defaults['controller']);
-        $this->assertSame('/api/posts', $all[0]->template);
-        $this->assertSame('/api/posts/:id', $all[2]->template);
+        $this->assertSame('Articles', $all[8]->defaults['controller']);
+        $this->assertSame('/api/posts', $all[8]->template);
+        $this->assertSame('/api/posts/:id', $all[1]->template);
         $this->assertSame(
             '/api/posts/:article_id/comments',
-            $all[6]->template,
+            $all[4]->template,
             'parameter name should reflect resource name'
         );
     }
@@ -632,7 +632,7 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertSame('/api/articles', $all[0]->template);
+        $this->assertSame('/api/articles', $all[4]->template);
         foreach ($all as $route) {
             $this->assertSame('api/rest', $route->defaults['prefix']);
             $this->assertSame('Articles', $route->defaults['controller']);
@@ -652,7 +652,7 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertSame('/api/blog-posts', $all[0]->template);
+        $this->assertSame('/api/blog-posts', $all[4]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[0]->defaults)
@@ -679,9 +679,9 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(10, $all);
 
-        $this->assertSame('/api/network-objects', $all[0]->template);
+        $this->assertSame('/api/network-objects', $all[8]->template);
         $this->assertSame('/api/network-objects/:id', $all[2]->template);
-        $this->assertSame('/api/network-objects/:network_object_id/attributes', $all[5]->template);
+        $this->assertSame('/api/network-objects/:network_object_id/attributes', $all[4]->template);
     }
 
     /**
@@ -703,21 +703,21 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(7, $all);
 
-        $this->assertSame('/api/articles/delete_all', $all[5]->template, 'Path defaults to key name.');
+        $this->assertSame('/api/articles/delete_all', $all[1]->template, 'Path defaults to key name.');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[5]->defaults)
         );
         $this->assertSame('Articles', $all[5]->defaults['controller']);
-        $this->assertSame('deleteAll', $all[5]->defaults['action']);
+        $this->assertSame('deleteAll', $all[1]->defaults['action']);
 
-        $this->assertSame('/api/articles/updateAll', $all[6]->template, 'Explicit path option');
+        $this->assertSame('/api/articles/updateAll', $all[0]->template, 'Explicit path option');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
             array_keys($all[6]->defaults)
         );
         $this->assertSame('Articles', $all[6]->defaults['controller']);
-        $this->assertSame('updateAll', $all[6]->defaults['action']);
+        $this->assertSame('updateAll', $all[0]->defaults['action']);
     }
 
     /**
@@ -839,13 +839,13 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[0]->template);
-        $this->assertSame('index', $result[0]->defaults['action']);
-        $this->assertSame('GET', $result[0]->defaults['_method']);
+        $this->assertSame('/articles', $result[1]->template);
+        $this->assertSame('index', $result[1]->defaults['action']);
+        $this->assertSame('GET', $result[1]->defaults['_method']);
 
-        $this->assertSame('/articles/:id', $result[1]->template);
-        $this->assertSame('delete', $result[1]->defaults['action']);
-        $this->assertSame('DELETE', $result[1]->defaults['_method']);
+        $this->assertSame('/articles/:id', $result[0]->template);
+        $this->assertSame('delete', $result[0]->defaults['action']);
+        $this->assertSame('DELETE', $result[0]->defaults['_method']);
     }
 
     /**
@@ -863,11 +863,11 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[0]->template);
-        $this->assertSame('showList', $result[0]->defaults['action']);
+        $this->assertSame('/articles', $result[1]->template);
+        $this->assertSame('showList', $result[1]->defaults['action']);
 
-        $this->assertSame('/articles/:id', $result[1]->template);
-        $this->assertSame('delete', $result[1]->defaults['action']);
+        $this->assertSame('/articles/:id', $result[0]->template);
+        $this->assertSame('delete', $result[0]->defaults['action']);
     }
 
     /**
@@ -883,7 +883,7 @@ class RouteBuilderTest extends TestCase
             $this->assertEquals(['prefix' => 'api'], $routes->params());
 
             $routes->resources('Comments');
-            $route = $this->collection->routes()[6];
+            $route = $this->collection->routes()[3];
             $this->assertSame('/api/articles/:article_id/comments', $route->template);
         });
     }


### PR DESCRIPTION
Users wouldn't be aware that the connected routes are sorted based on paths first when parsing request URL. Having the `RoutesCommand` show the routes list in the order that they will be matched would better help debugging routing issues.

I can update the tests once there is a consensus for the change. A few tests pluck the routes using specific index from the list returned by `Router::routes()` so those indexes will need to be updated.

This change was suggested by @ndm2 on Slack :slightly_smiling_face:.

> It might be helpful if the routes command would output the routes in the same order as they are being matched, seeing routes working even though the shown order suggested that it wouldn't work, was quite confusing.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
