### PR TITLE
Drop tables if isManaged is not defined

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -496,7 +496,7 @@ class FixtureManager
             function (ConnectionInterface $db, FixtureInterface $fixture, array $tableCache) {
                 $connection = $db->configName();
                 if ($this->isFixtureSetup($connection, $fixture)) {
-                    if (method_exists($fixture, 'isManaged') && $fixture->isManaged()) {
+                    if (!method_exists($fixture, 'isManaged') || $fixture->isManaged()) {
                         $fixture->drop($db);
                     } else {
                         $fixture->truncate($db);


### PR DESCRIPTION
This synchronizes the logic with `load()`. We assume the schema should be managed if not extending TestFixture.
