### PR TITLE
Fix incorrect type checks in ErrorHandlerMiddleware

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -71,7 +71,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     /**
      * Error handler instance.
      *
-     * @var \Cake\Error\ErrorHandler|null
+     * @var \Cake\Error\BaseErrorHandler|null
      */
     protected $errorHandler;
 
@@ -101,7 +101,8 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
 
         if (!$errorHandler instanceof BaseErrorHandler) {
             throw new InvalidArgumentException(sprintf(
-                '$errorHandler argument must be an array of configuration or a subclass of BaseErrorHandler. Got `%s` instead.',
+                '$errorHandler argument must be an array of configuration or ' .
+                'a subclass of BaseErrorHandler. Got `%s` instead.',
                 getTypeName($errorHandler)
             ));
         }

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -181,9 +181,9 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     /**
      * Get a error handler instance
      *
-     * @return \Cake\Error\ErrorHandler The error handler.
+     * @return \Cake\Error\BaseErrorHandler The error handler.
      */
-    protected function getErrorHandler(): ErrorHandler
+    protected function getErrorHandler(): BaseErrorHandler
     {
         if ($this->errorHandler === null) {
             /** @var class-string<\Cake\Error\ErrorHandler> $className */

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -18,6 +18,7 @@ namespace Cake\Error\Middleware;
 
 use Cake\Core\App;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Error\BaseErrorHandler;
 use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRenderer;
 use Cake\Http\Exception\RedirectException;
@@ -98,9 +99,9 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
             return;
         }
 
-        if (!$errorHandler instanceof ErrorHandler) {
+        if (!$errorHandler instanceof BaseErrorHandler) {
             throw new InvalidArgumentException(sprintf(
-                '$errorHandler argument must be a config array or ErrorHandler instance. Got `%s` instead.',
+                '$errorHandler argument must be an array of configuration or a subclass of BaseErrorHandler. Got `%s` instead.',
                 getTypeName($errorHandler)
             ));
         }

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -78,7 +78,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
     public function testConstructorInvalid()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$errorHandler argument must be a config array or ErrorHandler');
+        $this->expectExceptionMessage('$errorHandler argument must be a configuration array');
+        $this->expectExceptionMessage('or a subclass of BaseErrorHandler');
         new ErrorHandlerMiddleware('nope');
     }
 


### PR DESCRIPTION
Check for the base class instead of the implementation.

Fixes #15254