### PR TITLE
Improve flash message capturing

### DIFF
--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -764,7 +764,24 @@ class IntegrationTestTraitTest extends TestCase
         $this->get('/posts/flashNoRender');
         $this->assertRedirect();
 
-        $this->assertSession('An error message', 'Flash.flash.0.message');
+        $this->assertFlashElement('flash/error');
+        $this->assertFlashMessage('An error message');
+    }
+
+    /**
+     * Test flash assertions stored with enableRememberFlashMessages() even if
+     * the controller clears flash data in `beforeRender`
+     *
+     * @return void
+     */
+    public function testFlashAssertionsRemoveInBeforeRender()
+    {
+        $this->enableRetainFlashMessages();
+        $this->get('/posts/index/with_flash/?clear=true');
+        $this->assertResponseOk();
+
+        $this->assertFlashElement('flash/error');
+        $this->assertFlashMessage('An error message');
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -47,6 +47,13 @@ class PostsController extends AppController
         $this->FormProtection->setConfig('unlockedFields', ['some_unlocked_field']);
     }
 
+    public function beforeRender(EventInterface $event)
+    {
+        if ($this->request->getQuery('clear')) {
+            $this->set('flash', $this->request->getSession()->consume('Flash'));
+        }
+    }
+
     /**
      * Index method.
      *


### PR DESCRIPTION
Some view implementations (like inertiajs) manipulate flash messages and make them into view variables during the `View::render()` method. This breaks flash assertions as the messages are deleted.

By capturing the messages with a early priority listener in the `Controller.beforeRender` event we can capture flash messages more reliably. The trade off being that we will not capture any changes made to flash messages during the controller `beforeRender` or during view initialization.