### PR TITLE
4.next - Make association queries inherit the results casting mode.

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -178,6 +178,11 @@ class SelectLoader
             ->where($options['conditions'])
             ->eagerLoaded(true)
             ->enableHydration($options['query']->isHydrationEnabled());
+        if ($options['query']->isResultsCastingEnabled()) {
+            $fetchQuery->enableResultsCasting();
+        } else {
+            $fetchQuery->disableResultsCasting();
+        }
 
         if ($useSubquery) {
             $filter = $this->_buildSubquery($options['query']);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -4285,50 +4285,36 @@ class QueryTest extends TestCase
             ->belongsTo('Articles')
             ->setStrategy(BelongsTo::STRATEGY_SELECT);
 
-        $disabled = true;
-        $enabled = true;
-
         $articles
             ->find()
-            ->contain('Comments', function (Query $query) use (&$disabled) {
-                $disabled =
-                    $disabled &&
-                    !$query->isHydrationEnabled() &&
-                    !$query->isResultsCastingEnabled();
+            ->contain('Comments', function (Query $query) {
+                $this->assertFalse($query->isHydrationEnabled());
+                $this->assertFalse($query->isResultsCastingEnabled());
 
                 return $query;
             })
-            ->contain('Comments.Articles', function (Query $query) use (&$disabled) {
-                $disabled =
-                    $disabled &&
-                    !$query->isHydrationEnabled() &&
-                    !$query->isResultsCastingEnabled();
+            ->contain('Comments.Articles', function (Query $query) {
+                $this->assertFalse($query->isHydrationEnabled());
+                $this->assertFalse($query->isResultsCastingEnabled());
 
                 return $query;
             })
-            ->contain('Comments.Articles.Tags', function (Query $query) use (&$disabled) {
-                $disabled =
-                    $disabled &&
-                    !$query->isHydrationEnabled() &&
-                    !$query->isResultsCastingEnabled();
+            ->contain('Comments.Articles.Tags', function (Query $query) {
+                $this->assertFalse($query->isHydrationEnabled());
+                $this->assertFalse($query->isResultsCastingEnabled());
 
                 return $query
                     ->enableHydration()
                     ->enableResultsCasting();
             })
-            ->contain('Comments.Articles.Tags.Articles', function (Query $query) use (&$enabled) {
-                $enabled =
-                    $enabled &&
-                    $query->isHydrationEnabled() &&
-                    $query->isResultsCastingEnabled();
+            ->contain('Comments.Articles.Tags.Articles', function (Query $query) {
+                $this->assertTrue($query->isHydrationEnabled());
+                $this->assertTrue($query->isResultsCastingEnabled());
 
                 return $query;
             })
             ->disableHydration()
             ->disableResultsCasting()
             ->firstOrFail();
-
-        $this->assertTrue($disabled);
-        $this->assertTrue($enabled);
     }
 }


### PR DESCRIPTION
This brings the behavior in line with hydration, which is already being inherited accordingly.

Unfortunately it's the first time now that I ran into this, would have been good if it would've been included in #14863 for 4.2. You could call it a feature, you could call it a bug fix, it certainly is a change in behavior that could break things, even if it would probably be rather rare.

People who disabled results casting in combination with associations would have probably noticed it, and worked around it by manually disabling casting for the association query builders, just like I did now, leaving only few people who have the need to disable casting only partially, but still.