### PR TITLE
Fix CSRF token backwards compatibility

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -236,12 +236,15 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     /**
      * Test if the token predates salted tokens.
      *
-     * These tokens are vulnerable to BREACH but will rotate over time.
+     * These tokens are hexadecimal values and equal
+     * to the token with checksum length. While they are vulnerable
+     * to BREACH they should rotate over time and support will be dropped
+     * in 5.x.
      *
      * @param string $token The token to test.
      * @return bool
      */
-    protected function isOldToken(string $token): bool
+    protected function isUnsaltedToken(string $token): bool
     {
         return preg_match('/^[a-f0-9]{' . static::TOKEN_WITH_CHECKSUM_LENGTH . '}$/', $token) === 1;
     }
@@ -270,7 +273,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function saltToken(string $token): string
     {
-        if ($this->isOldToken($token)) {
+        if ($this->isUnsaltedToken($token)) {
             return $token;
         }
         $decoded = base64_decode($token, true);
@@ -296,7 +299,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function unsaltToken(string $token): string
     {
-        if ($this->isOldToken($token)) {
+        if ($this->isUnsaltedToken($token)) {
             return $token;
         }
         $decoded = base64_decode($token, true);
@@ -325,7 +328,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     {
         // If we have a hexadecimal value we're in a compatibility mode from before
         // tokens were salted on each request.
-        if ($this->isOldToken($token)) {
+        if ($this->isUnsaltedToken($token)) {
             $decoded = $token;
         } else {
             $decoded = base64_decode($token, true);

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -244,7 +244,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param string $token The token to test.
      * @return bool
      */
-    protected function isUnsaltedToken(string $token): bool
+    protected function isHexadecimalToken(string $token): bool
     {
         return preg_match('/^[a-f0-9]{' . static::TOKEN_WITH_CHECKSUM_LENGTH . '}$/', $token) === 1;
     }
@@ -273,7 +273,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function saltToken(string $token): string
     {
-        if ($this->isUnsaltedToken($token)) {
+        if ($this->isHexadecimalToken($token)) {
             return $token;
         }
         $decoded = base64_decode($token, true);
@@ -299,7 +299,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function unsaltToken(string $token): string
     {
-        if ($this->isUnsaltedToken($token)) {
+        if ($this->isHexadecimalToken($token)) {
             return $token;
         }
         $decoded = base64_decode($token, true);
@@ -328,7 +328,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     {
         // If we have a hexadecimal value we're in a compatibility mode from before
         // tokens were salted on each request.
-        if ($this->isUnsaltedToken($token)) {
+        if ($this->isHexadecimalToken($token)) {
             $decoded = $token;
         } else {
             $decoded = base64_decode($token, true);

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -234,6 +234,19 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     }
 
     /**
+     * Test if the token predates salted tokens.
+     *
+     * These tokens are vulnerable to BREACH but will rotate over time.
+     *
+     * @param string $token The token to test.
+     * @return bool
+     */
+    protected function isOldToken(string $token): bool
+    {
+        return preg_match('/^[a-f0-9]{' . static::TOKEN_WITH_CHECKSUM_LENGTH . '}$/', $token) === 1;
+    }
+
+    /**
      * Create a new token to be used for CSRF protection
      *
      * @return string
@@ -257,7 +270,10 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function saltToken(string $token): string
     {
-        $decoded = base64_decode($token);
+        if ($this->isOldToken($token)) {
+            return $token;
+        }
+        $decoded = base64_decode($token, true);
         $length = strlen($decoded);
         $salt = Security::randomBytes($length);
         $salted = '';
@@ -280,6 +296,9 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function unsaltToken(string $token): string
     {
+        if ($this->isOldToken($token)) {
+            return $token;
+        }
         $decoded = base64_decode($token, true);
         if ($decoded === false || strlen($decoded) !== static::TOKEN_WITH_CHECKSUM_LENGTH * 2) {
             return $token;
@@ -304,13 +323,14 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     protected function _verifyToken(string $token): bool
     {
-        $decoded = base64_decode($token, true);
-        // If base64 fails we're in a compatibility mode from before
+        // If we have a hexadecimal value we're in a compatibility mode from before
         // tokens were salted on each request.
-        if ($decoded === false) {
+        if ($this->isOldToken($token)) {
             $decoded = $token;
+        } else {
+            $decoded = base64_decode($token, true);
         }
-        if (strlen($decoded) <= self::TOKEN_VALUE_LENGTH) {
+        if (strlen($decoded) <= static::TOKEN_VALUE_LENGTH) {
             return false;
         }
 

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -39,6 +39,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
     {
         // Create an old style token. These tokens are hexadecimal with an hmac.
         $random = Security::randomString(CsrfProtectionMiddleware::TOKEN_VALUE_LENGTH);
+
         return $random . hash_hmac('sha1', $random, Security::getSalt());
     }
 


### PR DESCRIPTION
I did more thorough testing with salted CSRF tokens and this change is required to provide backwards compatibility. Because the old tokens are hexadecimal, they also decode as base64 data. When an old token is found in the cookie we shouldn't base64 decode or apply salting, as the data becomes hard to manage in subsequent requests.
