### PR TITLE
Handle missing translations when saving. Fixes #15272

### DIFF
--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -111,7 +111,7 @@ trait TranslateStrategyTrait
         foreach ($translations as $locale => $translation) {
             $fields = $translation->extract($this->_config['fields'], false);
             foreach ($fields as $field => $value) {
-                if (strlen($value) === 0) {
+                if ($value === null || strlen($value) === 0) {
                     $translation->unset($field);
                 }
             }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -952,6 +952,36 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     }
 
     /**
+     * Tests adding new translation to a record with a missing translation
+     *
+     * @return void
+     */
+    public function testAllowEmptyFalseWithNull()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'description'], 'allowEmptyTranslations' => false]);
+
+        $article = $table->find()->first();
+        $this->assertSame(1, $article->get('id'));
+
+        $article = $table->patchEntity($article, [
+            '_translations' => [
+                'fra' => [
+                    'title' => 'Title',
+                ],
+            ],
+        ]);
+
+        $table->save($article);
+
+        // Remove the Behavior to unset the content != '' condition
+        $table->removeBehavior('Translate');
+
+        $fra = $table->ArticlesTranslations->find()->where(['locale' => 'fra'])->first();
+        $this->assertNotEmpty($fra);
+    }
+
+    /**
      * Tests adding new translation to a record
      *
      * @return void

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -978,6 +978,36 @@ class TranslateBehaviorTest extends TestCase
      *
      * @return void
      */
+    public function testAllowEmptyFalseWithNull()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'description'], 'allowEmptyTranslations' => false]);
+
+        $article = $table->find()->first();
+        $this->assertSame(1, $article->get('id'));
+
+        $article = $table->patchEntity($article, [
+            '_translations' => [
+                'fra' => [
+                    'title' => 'Title',
+                ],
+            ],
+        ]);
+
+        $table->save($article);
+
+        // Remove the Behavior to unset the content != '' condition
+        $table->removeBehavior('Translate');
+
+        $fra = $table->I18n->find()->where(['locale' => 'fra'])->first();
+        $this->assertNotEmpty($fra);
+    }
+
+    /**
+     * Tests adding new translation to a record
+     *
+     * @return void
+     */
     public function testMixedAllowEmptyFalse()
     {
         $table = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -974,7 +974,7 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
-     * Tests adding new translation to a record
+     * Tests adding new translation to a record with a missing translation
      *
      * @return void
      */


### PR DESCRIPTION
This fixes #15272. Commit c24dd3a changed the functionality of the `allowEmptyTranslations` configuration for TranslateBehavior which causes a type error.
