### PR TITLE
4.next - Add joins when `onlyTranslated` or `filterByCurrentLocale` is enabled.

### DIFF
--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -135,7 +135,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
         $fieldsAdded = $this->addFieldsToQuery($query, $config);
         $orderByTranslatedField = $this->iterateClause($query, 'order', $config);
-        $filteredByTranslatedField = $this->traverseClause($query, 'where', $config);
+        $filteredByTranslatedField =
+            $this->traverseClause($query, 'where', $config) ||
+            $config['onlyTranslated'] ||
+            ($options['filterByCurrentLocale'] ?? null);
 
         if (!$fieldsAdded && !$orderByTranslatedField && !$filteredByTranslatedField) {
             return;

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -340,6 +340,40 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     }
 
     /**
+     * Join when translations are necessary
+     *
+     * @return void
+     */
+    public function testNecessaryJoinsConfig()
+    {
+        $table = $this->getTableLocator()->get('Articles');
+
+        $table->addBehavior('Translate', [
+            'onlyTranslated' => true,
+        ]);
+        $table->setLocale('eng');
+
+        $query = $table->find()->select(['id'])->disableAutoFields();
+        $this->assertStringContainsString(
+            'articles_translations',
+            $query->sql(),
+            'Enabling `onlyTranslated` should join the translations table'
+        );
+
+        $table
+            ->removeBehavior('Translate')
+            ->addBehavior('Translate');
+        $table->setLocale('eng');
+
+        $query = $table->find('all', ['filterByCurrentLocale' => true])->select(['id'])->disableAutoFields();
+        $this->assertStringContainsString(
+            'articles_translations',
+            $query->sql(),
+            'Enabling `filterByCurrentLocale` should join the translations table'
+        );
+    }
+
+    /**
      * testTraversingWhereClauseWithNonStringField
      *
      * @return void


### PR DESCRIPTION
These options indicate the possible intent of applying filtering solely
based on translations existing, hence the join should always apply when
they are enabled.
