### PR TITLE
Handle exceptions args with php >= 7.4

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -80,6 +80,10 @@ class ErrorHandlerMiddleware
 
         $config = $config ?: Configure::read('Error');
         $this->setConfig($config);
+
+        if (PHP_VERSION_ID >= 70400 && Configure::read('debug')) {
+            ini_set('zend.exception_ignore_args', 0);
+        }
     }
 
     /**

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Error\Middleware;
 
+use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -335,5 +336,28 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $response = $middleware($request, $response, $next);
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('An Internal Server Error Occurred', '' . $response->getBody());
+    }
+
+    /**
+     * Test exception args are not ignored in php7.4 with debug enabled.
+     *
+     * @return void
+     */
+    public function testExceptionArgs()
+    {
+        $this->skipIf(PHP_VERSION_ID < 70400);
+
+        // Force exception_ignore_args to true for test
+        ini_set('zend.exception_ignore_args', 1);
+
+        // Debug disabled
+        Configure::write('debug', false);
+        new ErrorHandlerMiddleware();
+        $this->assertSame('1', ini_get('zend.exception_ignore_args'));
+
+        // Debug enabled
+        Configure::write('debug', true);
+        new ErrorHandlerMiddleware();
+        $this->assertSame('0', ini_get('zend.exception_ignore_args'));
     }
 }


### PR DESCRIPTION
php7.4 ignore exception args.
This patch restore it.