### PR TITLE
4.next - Fix logging via debugger applies Console/HTML formatting.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -348,7 +348,10 @@ class Debugger
         $source = static::trace(['start' => 1]);
         $source .= "\n";
 
-        Log::write($level, "\n" . $source . static::exportVar($var, $maxDepth));
+        Log::write(
+            $level,
+            "\n" . $source . static::exportVarAsPlainText($var, $maxDepth)
+        );
     }
 
     /**
@@ -624,6 +627,20 @@ class Debugger
         $node = static::export($var, $context);
 
         return static::getInstance()->getExportFormatter()->dump($node);
+    }
+
+    /**
+     * Converts a variable to a plain text string.
+     *
+     * @param mixed $var Variable to convert.
+     * @param int $maxDepth The depth to output to. Defaults to 3.
+     * @return string Variable as a string
+     */
+    public static function exportVarAsPlainText($var, int $maxDepth = 3): string
+    {
+        return (new TextFormatter())->dump(
+            static::export($var, new DebugContext($maxDepth))
+        );
     }
 
     /**


### PR DESCRIPTION
With the introduction of Console/HTML formatting, logging started applying the formatting too, which I would assume to be pretty much unintended, and usually not what users would expect.

I would like to suggest introducing a new method, as the `Debugger::exportVar()` behavior changed too. Certainly the plain text formatting could be done directly in `Debugger::log()` instead, however I'm kinda missing a public shorthand method that would export as plain text, as at least for me the use case 99% of the times using `Debugger::exportVar()`, was custom logging. `Debugger::exportVarAsNodes()` is nice, giving us the option to use any formatter on the fly, but a shorthand for this specific case might be considered reasonable.