### PR TITLE
Automatically set CSP nonces.

### DIFF
--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -56,7 +56,7 @@ class CspMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Serve assets if the path matches one.
+     * Add nonces to the request and apply the CSP header to the response.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
@@ -64,6 +64,10 @@ class CspMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $request = $request
+            ->withAttribute('cspScriptNonce', $this->csp->nonce('script-src'))
+            ->withAttribute('cspStyleNonce', $this->csp->nonce('style-src'));
+
         $response = $handler->handle($request);
 
         // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -483,7 +483,7 @@ class HtmlHelper extends Helper
         $defaults = [
             'block' => null,
             'once' => true,
-            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce')
+            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
         ];
         $options += $defaults;
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -376,7 +376,12 @@ class HtmlHelper extends Helper
      */
     public function css($path, array $options = []): ?string
     {
-        $options += ['once' => true, 'block' => null, 'rel' => 'stylesheet'];
+        $options += [
+            'once' => true,
+            'block' => null,
+            'rel' => 'stylesheet',
+            'nonce' => $this->_View->getRequest()->getAttribute('cspStyleNonce'),
+        ];
 
         if (is_array($path)) {
             $out = '';
@@ -402,10 +407,6 @@ class HtmlHelper extends Helper
         }
         unset($options['once']);
         $this->_includedAssets[__METHOD__][$path] = true;
-        $nonce = $this->_View->getRequest()->getAttribute('cspStyleNonce');
-        if (!isset($options['nonce']) && $nonce) {
-            $options['nonce'] = $nonce;
-        }
 
         $templater = $this->templater();
         if ($options['rel'] === 'import') {
@@ -479,7 +480,11 @@ class HtmlHelper extends Helper
      */
     public function script($url, array $options = []): ?string
     {
-        $defaults = ['block' => null, 'once' => true];
+        $defaults = [
+            'block' => null,
+            'once' => true,
+            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce')
+        ];
         $options += $defaults;
 
         if (is_array($url)) {
@@ -502,11 +507,6 @@ class HtmlHelper extends Helper
             return null;
         }
         $this->_includedAssets[__METHOD__][$url] = true;
-
-        $nonce = $this->_View->getRequest()->getAttribute('cspScriptNonce');
-        if (!isset($options['nonce']) && $nonce) {
-            $options['nonce'] = $nonce;
-        }
 
         $out = $this->formatTemplate('javascriptlink', [
             'url' => $url,

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -363,6 +363,10 @@ class HtmlHelper extends Helper
      * - `rel` Defaults to 'stylesheet'. If equal to 'import' the stylesheet will be imported.
      * - `fullBase` If true the URL will get a full address for the css file.
      *
+     * All other options will be treated as HTML attributes. If the request contains a
+     * `cspStyleNonce` attribute, that value will be applied as the `nonce` attribute on the
+     * generated HTML.
+     *
      * @param string|string[] $path The name of a CSS style sheet or an array containing names of
      *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
      *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
@@ -398,8 +402,12 @@ class HtmlHelper extends Helper
         }
         unset($options['once']);
         $this->_includedAssets[__METHOD__][$path] = true;
-        $templater = $this->templater();
+        $nonce = $this->_View->getRequest()->getAttribute('cspStyleNonce');
+        if (!isset($options['nonce']) && $nonce) {
+            $options['nonce'] = $nonce;
+        }
 
+        $templater = $this->templater();
         if ($options['rel'] === 'import') {
             $out = $templater->format('style', [
                 'attrs' => $templater->formatAttributes($options, ['rel', 'block']),
@@ -459,6 +467,10 @@ class HtmlHelper extends Helper
      * - `plugin` False value will prevent parsing path as a plugin
      * - `fullBase` If true the url will get a full address for the script file.
      *
+     * All other options will be added as attributes to the generated script tag.
+     * If the current request has a `cspScriptNonce` attribute, that value will
+     * be inserted as a `nonce` attribute on the script tag.
+     *
      * @param string|string[] $url String or array of javascript files to include
      * @param array $options Array of options, and html attributes see above.
      * @return string|null String of `<script />` tags or null if block is specified in options
@@ -490,6 +502,11 @@ class HtmlHelper extends Helper
             return null;
         }
         $this->_includedAssets[__METHOD__][$url] = true;
+
+        $nonce = $this->_View->getRequest()->getAttribute('cspScriptNonce');
+        if (!isset($options['nonce']) && $nonce) {
+            $options['nonce'] = $nonce;
+        }
 
         $out = $this->formatTemplate('javascriptlink', [
             'url' => $url,
@@ -524,6 +541,10 @@ class HtmlHelper extends Helper
     public function scriptBlock(string $script, array $options = []): ?string
     {
         $options += ['block' => null];
+        $nonce = $this->_View->getRequest()->getAttribute('cspScriptNonce');
+        if (!isset($options['nonce']) && $nonce) {
+            $options['nonce'] = $nonce;
+        }
 
         $out = $this->formatTemplate('javascriptblock', [
             'attrs' => $this->templater()->formatAttributes($options, ['block']),

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -540,11 +540,7 @@ class HtmlHelper extends Helper
      */
     public function scriptBlock(string $script, array $options = []): ?string
     {
-        $options += ['block' => null];
-        $nonce = $this->_View->getRequest()->getAttribute('cspScriptNonce');
-        if (!isset($options['nonce']) && $nonce) {
-            $options['nonce'] = $nonce;
-        }
+        $options += ['block' => null, 'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce')];
 
         $out = $this->formatTemplate('javascriptblock', [
             'attrs' => $this->templater()->formatAttributes($options, ['block']),

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -92,7 +92,7 @@ class CspMiddlewareTest extends TestCase
                 'self' => true,
                 'unsafe-inline' => false,
                 'unsafe-eval' => false,
-            ]
+            ],
         ]);
 
         $handler = new TestRequestHandler(function ($request) {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -686,6 +686,24 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+     /**
+      * Test that css() includes CSP nonces if available.
+      *
+      * @return void
+      */
+     public function testCssWithCspNonce()
+     {
+        $nonce = 'r@nd0mV4lue';
+        $request = $this->View->getRequest()->withAttribute('cspStyleNonce', $nonce);
+        $this->View->setRequest($request);
+
+        $result = $this->Html->css('app');
+        $expected = [
+            'link' => ['rel' => 'stylesheet', 'href' => 'css/app.css', 'nonce' => $nonce],
+        ];
+        $this->assertHtml($expected, $result);
+     }
+
     /**
      * Test css() with once option.
      *
@@ -1037,6 +1055,26 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
+     * Test that content-security-policy nonces are applied if the request attribute
+     * is present.
+     *
+     * @return void
+     */
+    public function testScriptCspNonce()
+    {
+        $nonce = 'r@ndomV4lue';
+        $request = $this->View->getRequest()
+            ->withAttribute('cspScriptNonce', $nonce);
+        $this->View->setRequest($request);
+
+        $result = $this->Html->script('app.js', ['defer' => true, 'encoding' => 'utf-8']);
+        $expected = [
+            'script' => ['src' => 'js/app.js', 'defer' => 'defer', 'encoding' => 'utf-8', 'nonce' => $nonce],
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test that plugin scripts added with uses() are only ever included once.
      * test script tag generation with plugin syntax
      *
@@ -1226,6 +1264,27 @@ class HtmlHelperTest extends TestCase
             'script' => ['encoding' => 'utf-8'],
             'window.foo = 2;',
             '/script',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Ensure that scriptBlock() uses CSP nonces.
+     *
+     * @return void
+     */
+    public function testScriptBlockCspNonce()
+    {
+        $nonce = 'r@ndomV4lue';
+        $request = $this->View->getRequest()
+            ->withAttribute('cspScriptNonce', $nonce);
+        $this->View->setRequest($request);
+
+        $result = $this->Html->scriptBlock('window.foo = 2;');
+        $expected = [
+            'script' => ['nonce' => $nonce],
+            'window.foo = 2;',
+            '/script'
         ];
         $this->assertHtml($expected, $result);
     }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -686,23 +686,23 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-     /**
-      * Test that css() includes CSP nonces if available.
-      *
-      * @return void
-      */
-     public function testCssWithCspNonce()
-     {
+    /**
+     * Test that css() includes CSP nonces if available.
+     *
+     * @return void
+     */
+    public function testCssWithCspNonce()
+    {
         $nonce = 'r@nd0mV4lue';
         $request = $this->View->getRequest()->withAttribute('cspStyleNonce', $nonce);
         $this->View->setRequest($request);
 
         $result = $this->Html->css('app');
         $expected = [
-            'link' => ['rel' => 'stylesheet', 'href' => 'css/app.css', 'nonce' => $nonce],
+           'link' => ['rel' => 'stylesheet', 'href' => 'css/app.css', 'nonce' => $nonce],
         ];
         $this->assertHtml($expected, $result);
-     }
+    }
 
     /**
      * Test css() with once option.
@@ -1284,7 +1284,7 @@ class HtmlHelperTest extends TestCase
         $expected = [
             'script' => ['nonce' => $nonce],
             'window.foo = 2;',
-            '/script'
+            '/script',
         ];
         $this->assertHtml($expected, $result);
     }


### PR DESCRIPTION
When using the CSP middleware we can automatically set nonces for script and style sources. HtmlHelper can use then use these request attributes to generate HTML attributes. Having nonces automated eases the adoption of more strict content-security-policies

Fixes #15301
