### PR TITLE
Remove invalid sqlserver connection flag

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -129,7 +129,6 @@ class Sqlserver extends Driver
         }
 
         $config['flags'] += [
-            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -147,7 +147,6 @@ class SqlserverTest extends TestCase
 
         $expected = $config;
         $expected['flags'] += [
-            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::SQLSRV_ATTR_ENCODING => 'a-language',
         ];
@@ -209,7 +208,6 @@ class SqlserverTest extends TestCase
 
         $expected = $config;
         $expected['flags'] = [
-            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::SQLSRV_ATTR_ENCODING => 'a-language',
         ];


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/15315

This causes a failure with pdo_sqlsrv 5.9 with php8 support. The flag is disabled by default so there's no need to set it for prepares anyway.