### PR TITLE
Allow integers to be passed to command table helper

### DIFF
--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -59,12 +59,12 @@ class TableHelper extends Helper
     /**
      * Get the width of a cell exclusive of style tags.
      *
-     * @param string|null $text The text to calculate a width for.
+     * @param string $text The text to calculate a width for.
      * @return int The width of the textual content in visible characters.
      */
-    protected function _cellWidth(?string $text): int
+    protected function _cellWidth(string $text): int
     {
-        if ($text === null) {
+        if (strlen($text) === 0) {
             return 0;
         }
 
@@ -116,7 +116,7 @@ class TableHelper extends Helper
             if (!empty($options['style'])) {
                 $column = $this->_addStyle($column, $options['style']);
             }
-            if ($column !== null && preg_match('#(.*)<text-right>.+</text-right>(.*)#', $column, $matches)) {
+            if (strlen($column) > 0 && preg_match('#(.*)<text-right>.+</text-right>(.*)#', $column, $matches)) {
                 if ($matches[1] !== '' || $matches[2] !== '') {
                     throw new UnexpectedValueException('You cannot include text before or after the text-right tag.');
                 }

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -46,6 +46,7 @@ class TableHelper extends Helper
         $widths = [];
         foreach ($rows as $line) {
             foreach (array_values($line) as $k => $v) {
+                $v = is_integer($v) ? (string)$v : $v;
                 $columnLength = $this->_cellWidth($v);
                 if ($columnLength >= ($widths[$k] ?? 0)) {
                     $widths[$k] = $columnLength;
@@ -111,6 +112,7 @@ class TableHelper extends Helper
 
         $out = '';
         foreach (array_values($row) as $i => $column) {
+            $column = is_integer($column) ? (string)$column : $column;
             $pad = $widths[$i] - $this->_cellWidth($column);
             if (!empty($options['style'])) {
                 $column = $this->_addStyle($column, $options['style']);

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -46,8 +46,7 @@ class TableHelper extends Helper
         $widths = [];
         foreach ($rows as $line) {
             foreach (array_values($line) as $k => $v) {
-                $v = is_integer($v) ? (string)$v : $v;
-                $columnLength = $this->_cellWidth($v);
+                $columnLength = $this->_cellWidth((string)$v);
                 if ($columnLength >= ($widths[$k] ?? 0)) {
                     $widths[$k] = $columnLength;
                 }
@@ -112,7 +111,7 @@ class TableHelper extends Helper
 
         $out = '';
         foreach (array_values($row) as $i => $column) {
-            $column = is_integer($column) ? (string)$column : $column;
+            $column = (string)$column;
             $pad = $widths[$i] - $this->_cellWidth($column);
             if (!empty($options['style'])) {
                 $column = $this->_addStyle($column, $options['style']);

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -451,4 +451,25 @@ class TableHelperTest extends TestCase
 
         $this->assertEquals($expected, $this->stub->messages());
     }
+
+    /**
+     * Table row column of type null should be cast to empty string
+     */
+    public function testRowValueNull()
+    {
+        $data = [
+            ['Item', 'Quantity'],
+            ['Cakes', null],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+-------+----------+',
+            '| <info>Item</info>  | <info>Quantity</info> |',
+            '+-------+----------+',
+            '| Cakes |          |',
+            '+-------+----------+',
+        ];
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
 }

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -430,4 +430,25 @@ class TableHelperTest extends TestCase
         ];
         $this->helper->output($data);
     }
+
+    /**
+     * Table row column of type integer should be cast to string
+     */
+    public function testRowValueInteger()
+    {
+        $data = [
+            ['Item', 'Quantity'],
+            ['Cakes', 2],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+-------+----------+',
+            '| <info>Item</info>  | <info>Quantity</info> |',
+            '+-------+----------+',
+            '| Cakes | 2        |',
+            '+-------+----------+',
+        ];
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
 }


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
## Command Table Helper - Integers
Passing integers to the Command/Shell table helper throws exceptions. With this PR they will now cast integers to string, allowing them to be output properly.

Closes #15327