### PR TITLE
`ServerRequest::is()`: `$args` is mixed

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -477,7 +477,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string|string[] $type The type of request you want to check. If an array
      *   this method will return true if the request matches any type.
-     * @param string ...$args List of arguments
+     * @param mixed ...$args List of arguments
      * @return bool Whether or not the request is the type you are checking.
      */
     public function is($type, ...$args): bool

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -883,6 +883,24 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
+        ServerRequest::addDetector('withParams', function ($request, array $params) {
+            foreach ($params as $name => $value) {
+                if ($request->getParam($name) != $value) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        $request = $request->withParam('controller', 'Pages')->withParam('action', 'index');
+        $request->clearDetectorCache();
+        $this->assertTrue($request->isWithParams(['controller' => 'Pages', 'action' => 'index']));
+
+        $request = $request->withParam('controller', 'Posts');
+        $request->clearDetectorCache();
+        $this->assertFalse($request->isWithParams(['controller' => 'Pages', 'action' => 'index']));
+
         ServerRequest::addDetector('callme', function ($request) {
             return $request->getAttribute('return');
         });


### PR DESCRIPTION
For the `ServerRequest::is()` method, now `$args` is described as a list of strings, but there is no reason why this should be so and why other types of value (array, integer, etc.) cannot be passed.