### PR TITLE
Error handling is logging silenced (@) errors in PHP8. Issue #15336

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -148,7 +148,7 @@ abstract class BaseErrorHandler
         ?int $line = null,
         ?array $context = null
     ): bool {
-        if (error_reporting() === 0) {
+        if (!(error_reporting() & $code)) {
             return false;
         }
         $this->_handled = true;


### PR DESCRIPTION
As requested by Mark Story, I have created a pull request for the issue:
Error handling is logging silenced (@) errors in PHP8. Issue #15336