### PR TITLE
Remove invalid options from attachTo

### DIFF
--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -609,11 +609,10 @@ class QueryRegressionTest extends TestCase
         ]);
 
         $result = $table->find()->contain(['Articles.Tags'])->toArray();
-        $this->skipIf(count($result) === 0, 'No results, this test sometimes acts up on PHP 5.6');
 
         $this->assertEquals(
             ['tag1', 'tag3'],
-            collection($result[2]->articles[0]->tags)->extract('name')->toArray()
+            collection($result[2]->articles[0]->tags)->sortBy('name')->extract('name')->toArray()
         );
     }
 


### PR DESCRIPTION
This avoids putting invalid keys into `$options` and cleans up the docblock. Looks like a couple old commits partly removed some lines.

I added checks for `type` option when running query and association tests. Nothing was passing this invalid option in that I could find.