### PR TITLE
Throw exception on invalid SMTP client

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -231,6 +231,9 @@ class SmtpTransport extends AbstractTransport
 
         $host = 'localhost';
         if (isset($config['client'])) {
+            if (empty($config['client'])) {
+                throw new SocketException('Cannot use an empty client name.');
+            }
             $host = $config['client'];
         } else {
             /** @var string $httpHost */

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -452,23 +452,22 @@ class SmtpTransportTest extends TestCase
     }
 
     /**
-     * testEmptyConfigArray method
+     * Tests using empty client name
      *
      * @return void
      */
-    public function testEmptyConfigArray()
+    public function testEmptyClientName()
     {
-        $this->SmtpTransport->setConfig([
-            'client' => 'myhost.com',
-            'port' => 666,
-        ]);
-        $expected = $this->SmtpTransport->getConfig();
+        $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->any())
+           ->method('read')
+           ->will($this->onConsecutiveCalls("220 Welcome message\r\n", "250 Accepted\r\n"));
 
-        $this->assertSame(666, $expected['port']);
+        $this->SmtpTransport->setConfig(['client' => '']);
 
-        $this->SmtpTransport->setConfig([]);
-        $result = $this->SmtpTransport->getConfig();
-        $this->assertEquals($expected, $result);
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessage('Cannot use an empty client name');
+        $this->SmtpTransport->connect();
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/15277

An empty string usually indicates a configuration error so we should throw instead of defaulting to alert the developer.

The config test wasn't useful so replaced it.
