### PR TITLE
4.x - Fix file cache engine trying to clear root on realpath failure.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -251,12 +251,18 @@ class FileEngine extends CacheEngine
             RecursiveIteratorIterator::SELF_FIRST
         );
         $cleared = [];
-        foreach ($contents as $path) {
-            if ($path->isFile()) {
+        /** @var \SplFileInfo $fileInfo */
+        foreach ($contents as $fileInfo) {
+            if ($fileInfo->isFile()) {
                 continue;
             }
 
-            $path = $path->getRealPath() . DIRECTORY_SEPARATOR;
+            $realPath = $fileInfo->getRealPath();
+            if (!$realPath) {
+                continue;
+            }
+
+            $path = $realPath . DIRECTORY_SEPARATOR;
             if (!in_array($path, $cleared, true)) {
                 $this->_clearDirectory($path);
                 $cleared[] = $path;


### PR DESCRIPTION
When `getRealPath()` fails and returns `false`, the path will finally
contain only the appended directory separator, thus pointing to the root
directory.

I've stumbled over this via a **[question on StackOverflow](https://stackoverflow.com/questions/66352205/how-to-debug-cakephp-3-5-cache-basedir-issue)**, where clearing the cache "randomly" tries to clear the root directory (`/`). This might not actually be the source of the problem that the OP is experiencing, but I would still like to see this possible problem patched.

I can try to add a test for this if you like, it would require a little refactoring for obtaining the iterator and some creative mocking I guess.
