### PR TITLE
Simplify disabling of association target fields

### DIFF
--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -158,7 +158,7 @@ class HasOneTest extends TestCase
         $association = new HasOne('Profiles', $config);
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['join', 'select'])
+            ->onlyMethods(['join'])
             ->disableOriginalConstructor()
             ->getMock();
         $field1 = new IdentifierExpression('Profiles.user_id');
@@ -173,8 +173,7 @@ class HasOneTest extends TestCase
                 'table' => 'profiles',
             ],
         ]);
-        $query->expects($this->never())->method('select');
-        $association->attachTo($query, ['includeFields' => false]);
+        $association->attachTo($query);
     }
 
     /**


### PR DESCRIPTION
`Query::*joinWith()` functions call `setMatching()` with `fields => false` to disable including all the target table fields.

This moves the configuration up to `attachTo()` and simplifies the appending of fields.
