### PR TITLE
DATE_RFC7231

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -809,7 +809,7 @@ class Response implements ResponseInterface
     public function withDisabledCache()
     {
         return $this->withHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT')
-            ->withHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT')
+            ->withHeader('Last-Modified', gmdate(DATE_RFC7231))
             ->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
     }
 
@@ -831,7 +831,7 @@ class Response implements ResponseInterface
             }
         }
 
-        return $this->withHeader('Date', gmdate('D, j M Y G:i:s ', time()) . 'GMT')
+        return $this->withHeader('Date', gmdate(DATE_RFC7231, time()))
             ->withModified($since)
             ->withExpires($time)
             ->withSharable(true)
@@ -959,7 +959,7 @@ class Response implements ResponseInterface
     {
         $date = $this->_getUTCDate($time);
 
-        return $this->withHeader('Expires', $date->format('D, j M Y H:i:s') . ' GMT');
+        return $this->withHeader('Expires', $date->format(DATE_RFC7231));
     }
 
     /**
@@ -982,7 +982,7 @@ class Response implements ResponseInterface
     {
         $date = $this->_getUTCDate($time);
 
-        return $this->withHeader('Last-Modified', $date->format('D, j M Y H:i:s') . ' GMT');
+        return $this->withHeader('Last-Modified', $date->format(DATE_RFC7231));
     }
 
     /**

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -158,8 +158,8 @@ class AssetMiddleware implements MiddlewareInterface
         return $response
             ->withHeader('Content-Type', $contentType)
             ->withHeader('Cache-Control', 'public,max-age=' . $maxAge)
-            ->withHeader('Date', gmdate('D, j M Y G:i:s \G\M\T', time()))
-            ->withHeader('Last-Modified', gmdate('D, j M Y G:i:s \G\M\T', $modified))
-            ->withHeader('Expires', gmdate('D, j M Y G:i:s \G\M\T', $expire));
+            ->withHeader('Date', gmdate(DATE_RFC7231, time()))
+            ->withHeader('Last-Modified', gmdate(DATE_RFC7231, $modified))
+            ->withHeader('Expires', gmdate(DATE_RFC7231, $expire));
     }
 }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -301,7 +301,7 @@ class ResponseTest extends TestCase
         $response = new Response();
         $expected = [
             'Expires' => ['Mon, 26 Jul 1997 05:00:00 GMT'],
-            'Last-Modified' => [gmdate('D, d M Y H:i:s') . ' GMT'],
+            'Last-Modified' => [gmdate(DATE_RFC7231)],
             'Cache-Control' => ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0'],
             'Content-Type' => ['text/html; charset=UTF-8'],
         ];
@@ -325,9 +325,9 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Date'));
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
-        $this->assertSame(gmdate('D, j M Y G:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
-        $this->assertSame(gmdate('D, j M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Last-Modified'));
-        $this->assertSame(gmdate('D, j M Y H:i:s', $time) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame(gmdate(DATE_RFC7231, $since), $new->getHeaderLine('Date'));
+        $this->assertSame(gmdate(DATE_RFC7231, $since), $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate(DATE_RFC7231, $time), $new->getHeaderLine('Expires'));
         $this->assertSame('public, max-age=0', $new->getHeaderLine('Cache-Control'));
     }
 
@@ -474,7 +474,6 @@ class ResponseTest extends TestCase
      */
     public function testWithExpires()
     {
-        $format = 'D, j M Y H:i:s';
         $response = new Response();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
 
@@ -482,15 +481,15 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Expires'));
 
         $now->setTimeZone(new \DateTimeZone('UTC'));
-        $this->assertSame($now->format($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame($now->format(DATE_RFC7231), $new->getHeaderLine('Expires'));
 
         $now = time();
         $new = $response->withExpires($now);
-        $this->assertSame(gmdate($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame(gmdate(DATE_RFC7231), $new->getHeaderLine('Expires'));
 
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $new = $response->withExpires('+1 day');
-        $this->assertSame($time->format($format) . ' GMT', $new->getHeaderLine('Expires'));
+        $this->assertSame($time->format(DATE_RFC7231), $new->getHeaderLine('Expires'));
     }
 
     /**
@@ -500,26 +499,25 @@ class ResponseTest extends TestCase
      */
     public function testWithModified()
     {
-        $format = 'D, j M Y H:i:s';
         $response = new Response();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
         $new = $response->withModified($now);
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
         $now->setTimeZone(new \DateTimeZone('UTC'));
-        $this->assertSame($now->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame($now->format(DATE_RFC7231), $new->getHeaderLine('Last-Modified'));
 
         $now = time();
         $new = $response->withModified($now);
-        $this->assertSame(gmdate($format, $now) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate(DATE_RFC7231, $now), $new->getHeaderLine('Last-Modified'));
 
         $now = new \DateTimeImmutable();
         $new = $response->withModified($now);
-        $this->assertSame(gmdate($format, $now->getTimestamp()) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame(gmdate(DATE_RFC7231, $now->getTimestamp()), $new->getHeaderLine('Last-Modified'));
 
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $new = $response->withModified('+1 day');
-        $this->assertSame($time->format($format) . ' GMT', $new->getHeaderLine('Last-Modified'));
+        $this->assertSame($time->format(DATE_RFC7231), $new->getHeaderLine('Last-Modified'));
     }
 
     /**

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -58,7 +58,7 @@ class AssetMiddlewareTest extends TestCase
         $modified = filemtime(TEST_APP . 'Plugin/TestPlugin/webroot/root.js');
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/test_plugin/root.js',
-            'HTTP_IF_MODIFIED_SINCE' => date('D, j M Y G:i:s \G\M\T', $modified),
+            'HTTP_IF_MODIFIED_SINCE' => date(DATE_RFC7231, $modified),
         ]);
         $handler = new TestRequestHandler();
         $middleware = new AssetMiddleware();
@@ -157,7 +157,7 @@ class AssetMiddlewareTest extends TestCase
             $res->getHeaderLine('Content-Type')
         );
         $this->assertSame(
-            gmdate('D, j M Y G:i:s ', $time) . 'GMT',
+            gmdate(DATE_RFC7231, $time),
             $res->getHeaderLine('Date')
         );
         $this->assertSame(
@@ -165,11 +165,11 @@ class AssetMiddlewareTest extends TestCase
             $res->getHeaderLine('Cache-Control')
         );
         $this->assertSame(
-            gmdate('D, j M Y G:i:s ', $modified) . 'GMT',
+            gmdate(DATE_RFC7231, $modified),
             $res->getHeaderLine('Last-Modified')
         );
         $this->assertSame(
-            gmdate('D, j M Y G:i:s ', $expires) . 'GMT',
+            gmdate(DATE_RFC7231, $expires),
             $res->getHeaderLine('Expires')
         );
     }


### PR DESCRIPTION
`D, j M Y G:i:s` generates invalid format. `j` and `G` don't add leading zeros as required by the [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.1) datetime format.

This fix needs to be backported to 3.x too, but constant `DATE_RFC7231` doesn't exist in older PHP versions so there `D, d M Y H:i:s` will have to be used.