### PR TITLE
Fix datetime format in response headers.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1370,7 +1370,7 @@ class Response implements ResponseInterface
             }
         }
 
-        $this->_setHeader('Date', gmdate('D, j M Y G:i:s ', time()) . 'GMT');
+        $this->_setHeader('Date', gmdate('D, d M Y H:i:s ', time()) . 'GMT');
 
         $this->modified($since);
         $this->expires($time);
@@ -1395,7 +1395,7 @@ class Response implements ResponseInterface
             }
         }
 
-        return $this->withHeader('Date', gmdate('D, j M Y G:i:s ', time()) . 'GMT')
+        return $this->withHeader('Date', gmdate('D, d M Y H:i:s ', time()) . 'GMT')
             ->withModified($since)
             ->withExpires($time)
             ->withSharable(true)

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -174,9 +174,9 @@ class AssetMiddleware
         return $response->withBody($stream)
             ->withHeader('Content-Type', $contentType)
             ->withHeader('Cache-Control', 'public,max-age=' . $maxAge)
-            ->withHeader('Date', gmdate('D, j M Y G:i:s \G\M\T', time()))
-            ->withHeader('Last-Modified', gmdate('D, j M Y G:i:s \G\M\T', $modified))
-            ->withHeader('Expires', gmdate('D, j M Y G:i:s \G\M\T', $expire));
+            ->withHeader('Date', gmdate('D, d M Y H:i:s \G\M\T', time()))
+            ->withHeader('Last-Modified', gmdate('D, d M Y H:i:s \G\M\T', $modified))
+            ->withHeader('Expires', gmdate('D, d M Y H:i:s \G\M\T', $expire));
     }
 
     /**

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -722,7 +722,7 @@ class ResponseTest extends TestCase
             $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
             $response->expires('+1 day');
             $expected = [
-                'Date' => gmdate('D, j M Y G:i:s ', $since) . 'GMT',
+                'Date' => gmdate('D, d M Y H:i:s ', $since) . 'GMT',
                 'Last-Modified' => gmdate('D, j M Y H:i:s ', $since) . 'GMT',
                 'Expires' => $time->format('D, j M Y H:i:s') . ' GMT',
                 'Cache-Control' => 'public, max-age=' . ($time->format('U') - time()),
@@ -735,7 +735,7 @@ class ResponseTest extends TestCase
             $since = time();
             $time = '+5 day';
             $expected = [
-                'Date' => gmdate('D, j M Y G:i:s ', $since) . 'GMT',
+                'Date' => gmdate('D, d M Y H:i:s ', $since) . 'GMT',
                 'Last-Modified' => gmdate('D, j M Y H:i:s ', $since) . 'GMT',
                 'Expires' => gmdate('D, j M Y H:i:s', strtotime($time)) . ' GMT',
                 'Cache-Control' => 'public, max-age=' . (strtotime($time) - time()),
@@ -748,7 +748,7 @@ class ResponseTest extends TestCase
             $since = time();
             $time = time();
             $expected = [
-                'Date' => gmdate('D, j M Y G:i:s ', $since) . 'GMT',
+                'Date' => gmdate('D, d M Y H:i:s ', $since) . 'GMT',
                 'Last-Modified' => gmdate('D, j M Y H:i:s ', $since) . 'GMT',
                 'Expires' => gmdate('D, j M Y H:i:s', $time) . ' GMT',
                 'Cache-Control' => 'public, max-age=0',
@@ -773,7 +773,7 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->hasHeader('Date'));
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
-        $this->assertEquals(gmdate('D, j M Y G:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
+        $this->assertEquals(gmdate('D, d M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Date'));
         $this->assertEquals(gmdate('D, j M Y H:i:s ', $since) . 'GMT', $new->getHeaderLine('Last-Modified'));
         $this->assertEquals(gmdate('D, j M Y H:i:s', $time) . ' GMT', $new->getHeaderLine('Expires'));
         $this->assertEquals('public, max-age=0', $new->getHeaderLine('Cache-Control'));

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -57,7 +57,7 @@ class AssetMiddlewareTest extends TestCase
         $modified = filemtime(TEST_APP . 'Plugin/TestPlugin/webroot/root.js');
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/test_plugin/root.js',
-            'HTTP_IF_MODIFIED_SINCE' => date('D, j M Y G:i:s \G\M\T', $modified),
+            'HTTP_IF_MODIFIED_SINCE' => date('D, d M Y H:i:s \G\M\T', $modified),
         ]);
         $response = new Response();
         $next = function ($req, $res) {
@@ -168,7 +168,7 @@ class AssetMiddlewareTest extends TestCase
             $res->getHeaderLine('Content-Type')
         );
         $this->assertEquals(
-            gmdate('D, j M Y G:i:s ', $time) . 'GMT',
+            gmdate('D, d M Y H:i:s ', $time) . 'GMT',
             $res->getHeaderLine('Date')
         );
         $this->assertEquals(
@@ -176,11 +176,11 @@ class AssetMiddlewareTest extends TestCase
             $res->getHeaderLine('Cache-Control')
         );
         $this->assertEquals(
-            gmdate('D, j M Y G:i:s ', $modified) . 'GMT',
+            gmdate('D, d M Y H:i:s ', $modified) . 'GMT',
             $res->getHeaderLine('Last-Modified')
         );
         $this->assertEquals(
-            gmdate('D, j M Y G:i:s ', $expires) . 'GMT',
+            gmdate('D, d M Y H:i:s ', $expires) . 'GMT',
             $res->getHeaderLine('Expires')
         );
     }


### PR DESCRIPTION
The numeric values need to be in 2 digit format while "j" and "G" don't add leading zero for single digits.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
