### PR TITLE
Detect infinite recursion when initializing Table

### DIFF
--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use RuntimeException;
 use TestApp\Infrastructure\Table\AddressesTable;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\MyUsersTable;
@@ -431,6 +432,32 @@ class TableLocatorTest extends TestCase
         $this->assertFalse($this->_locator->exists('TestPluginComments'), 'Class name should not exist');
         $this->assertFalse($this->_locator->exists('TestPlugin.TestPluginComments'), 'Full class alias should not exist');
         $this->assertTrue($this->_locator->exists('Comments'), 'Class name should exist');
+    }
+
+    /**
+     * Tests calling get() on a table that's being initialized.
+     *
+     * @return void
+     */
+    public function testGetInfiniteRecursion()
+    {
+        $locator = new TableLocator(['Model/Table']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Infinite recursion.');
+        $locator->get('Recursion', ['locator' => $locator]);
+    }
+
+    /**
+     * Tests calling get() after table initialization
+     *
+     * @return void
+     */
+    public function testGetAfterGet()
+    {
+        $locator = new TableLocator(['Model/Table']);
+        $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles'));
+        $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles'));
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/RecursionTable.php
+++ b/tests/test_app/TestApp/Model/Table/RecursionTable.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.2.5
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Table with recursive reference
+ */
+class RecursionTable extends Table
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(array $config): void
+    {
+        $config['locator']->get('Recursion');
+    }
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/15351

Users can make the same calls in  `initialize()` since it's the same Table instance.

An exception throw in Table constructor will cause the initializing flag to remain set, but it seems the code is unable to use that Table class anyway.