### PR TITLE
Use passed-in class name when clearing initializing list

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -208,13 +208,8 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      */
     public function get(string $alias, array $options = []): Table
     {
-        /** @var \Cake\ORM\Table $table */
-        $table = parent::get($alias, $options);
-
-        $className = get_class($table);
-        unset($this->initializing[$className]);
-
-        return $table;
+        /** @var \Cake\ORM\Table */
+        return parent::get($alias, $options);
     }
 
     /**
@@ -282,6 +277,9 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         if ($options['className'] === $this->fallbackClassName) {
             $this->_fallbacked[$alias] = $instance;
         }
+
+        // clear initializing flag after construction complete
+        unset($this->initializing[$options['className']]);
 
         return $instance;
     }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -449,7 +449,7 @@ class TableLocatorTest extends TestCase
     }
 
     /**
-     * Tests calling get() after table initialization
+     * Tests calling get() after table initialization doesn't trigger recursion check.
      *
      * @return void
      */
@@ -457,6 +457,12 @@ class TableLocatorTest extends TestCase
     {
         $locator = new TableLocator(['Model/Table']);
         $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles'));
+        $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles'));
+
+        // Test FQCN
+        $locator = new TableLocator(['Model/Table']);
+        $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles', ['className' => '\TestApp\Model\Table\ArticlesTable']));
+        $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles', ['className' => '\TestApp\Model\Table\ArticlesTable']));
         $this->assertInstanceOf(ArticlesTable::class, $locator->get('Articles'));
     }
 


### PR DESCRIPTION
This fixes an edge case where the user looks up a table using a fully qualified class name. `get_class()` only returns a qualified name without the leading `\`.

This means a scenarios exists where infinite recursion is not detected due to a FQCN get() and then a QCN get while initializing.

Seems rare enough to keep the code simple.