### PR TITLE
Fix issue #15372

### DIFF
--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -226,10 +226,10 @@ class Folder {
 		}
 
 		if ($dirs) {
-			$dirs = call_user_func_array('array_merge', $dirs);
+			$dirs = call_user_func_array('array_merge',  array_values($dirs));
 		}
 		if ($files) {
-			$files = call_user_func_array('array_merge', $files);
+			$files = call_user_func_array('array_merge',  array_values($files));
 		}
 		return array($dirs, $files);
 	}


### PR DESCRIPTION
Fix issue #15372

array_merge() expects to be passed one or more arrays to be merged. As the $arrays parameter is variadic, PHP 8.0 named parameters is not supported.
So I just replace named parameters to numeric using array_values
