### PR TITLE
Escape pre tag in markdown block

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -135,7 +135,7 @@ if (!function_exists('pr')) {
      * print_r() convenience function.
      *
      * In terminals this will act similar to using print_r() directly, when not run on cli
-     * print_r() will also wrap <pre> tags around the output of given variable. Similar to debug().
+     * print_r() will also wrap `<pre>` tags around the output of given variable. Similar to debug().
      *
      * This function returns the same variable that was passed.
      *


### PR DESCRIPTION
Fixes api docs
