### PR TITLE
Accept hyphens in locale

### DIFF
--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -143,7 +143,7 @@ class PluralRules
         $locale = strtolower($locale);
 
         if (!isset(static::$_rulesMap[$locale])) {
-            $locale = explode('_', $locale)[0];
+            $locale = explode('_', str_replace('-', '_', $locale))[0];
         }
 
         if (!isset(static::$_rulesMap[$locale])) {


### PR DESCRIPTION
– IETF Language Tag: uses a hyphen
– ISO 15897: uses an underscore

More info in #15383
