### PR TITLE
change Method Visibility to public

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -188,7 +188,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @param array $input The results of a CommandScanner operation.
      * @return string[] A flat map of command names => class names.
      */
-    protected function resolveNames(array $input): array
+    public function resolveNames(array $input): array
     {
         $out = [];
         foreach ($input as $info) {

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -108,7 +108,7 @@ class CommandScanner
      * @param string[] $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
      */
-    protected function scanDir(string $path, string $namespace, string $prefix, array $hide): array
+    public function scanDir(string $path, string $namespace, string $prefix, array $hide): array
     {
         if (!is_dir($path)) {
             return [];


### PR DESCRIPTION
when using a CakePHP Console Library into a simple another project, for Automatically discover shell commands, we need public access for this methods: CommandScanner::scanDir() & CommandCollection::resolveNames().

```
<?php
namespace Tools;

use Cake\Console\CommandScanner;
use Cake\Console\CommandCollection;
use Cake\Core\ConsoleApplicationInterface;

class App implements ConsoleApplicationInterface
{
    public function bootstrap(): void
    {
    }

    public function console(CommandCollection $commands): CommandCollection
    {

        $scanner = new CommandScanner();
        $lists = $scanner->scanDir(__DIR__ . DS . 'Command' . DS, 'Tools\Command\\', '', []);
        $lists = $commands->resolveNames($lists);
        $commands->addMany($lists);

        return $commands;
    }
}

```