### PR TITLE
Fix RouteBuilder::plugin() not forwarding namePrefix option

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -868,8 +868,14 @@ class RouteBuilder
      * Routes connected in the scoped collection will have the correct path segment
      * prepended, and have a matching plugin routing key set.
      *
+     * ### Options
+     *
+     * - `path` The path prefix to use. Defaults to `Inflector::dasherize($name)`.
+     * - `_namePrefix` Set a prefix used for named routes. The prefix is prepended to the
+     *   name of any route created in a scope callback.
+     *
      * @param string $name The plugin name to build routes for
-     * @param array|callable $options Either the options to use, or a callback
+     * @param array|callable $options Either the options to use, or a callback to build routes.
      * @param callable|null $callback The callback to invoke that builds the plugin routes
      *   Only required when $options is defined.
      * @return $this
@@ -881,8 +887,9 @@ class RouteBuilder
             $options = [];
         }
 
-        $params = ['plugin' => $name] + $this->_params;
         $path = $options['path'] ?? '/' . Inflector::dasherize($name);
+        unset($options['path']);
+        $params = ['plugin' => $name] + $options + $this->_params;
         $this->scope($path, $params, $callback);
 
         return $this;
@@ -894,6 +901,11 @@ class RouteBuilder
      * Scopes created with this method will inherit the properties of the scope they are
      * added to. This means that both the current path and parameters will be appended
      * to the supplied parameters.
+     *
+     * ### Special Keys in $params
+     *
+     * - `_namePrefix` Set a prefix used for named routes. The prefix is prepended to the
+     *   name of any route created in a scope callback.
      *
      * @param string $path The path to create a scope for.
      * @param array|callable $params Either the parameters to add to routes, or a callback.

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -889,8 +889,8 @@ class RouteBuilder
 
         $path = $options['path'] ?? '/' . Inflector::dasherize($name);
         unset($options['path']);
-        $params = ['plugin' => $name] + $options + $this->_params;
-        $this->scope($path, $params, $callback);
+        $options = ['plugin' => $name] + $options;
+        $this->scope($path, $options, $callback);
 
         return $this;
     }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -531,7 +531,7 @@ class RouteBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testNestedPlugin()
+    public function testPlugin()
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $res = $routes->plugin('Contacts', function (RouteBuilder $r) {
@@ -553,12 +553,31 @@ class RouteBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testNestedPluginPathOption()
+    public function testPluginPathOption()
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->plugin('Contacts', ['path' => '/people'], function (RouteBuilder $r) {
             $this->assertSame('/b/people', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
+        });
+    }
+
+    /**
+     * Test creating sub-scopes with plugin() + namePrefix option
+     *
+     * @return void
+     */
+    public function testPluginNamePrefix()
+    {
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->plugin('Contacts', ['_namePrefix' => 'contacts.'], function (RouteBuilder $r) {
+            $this->assertEquals('contacts.', $r->namePrefix());
+        });
+
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->namePrefix('default.');
+        $routes->plugin('Blog', ['_namePrefix' => 'blog.'], function (RouteBuilder $r) {
+            $this->assertEquals('default.blog.', $r->namePrefix(), 'Should combine nameprefix');
         });
     }
 


### PR DESCRIPTION
I also improved the API docs for plugin() and scope() to be clearer on the supported options.

Fixes #15394