### PR TITLE
Fix BufferedIterator not yielding full results

### DIFF
--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -159,6 +159,10 @@ class BufferedIterator extends Collection implements Countable, Serializable
     {
         $this->_index++;
 
+        // Don't move inner iterator if we have more buffer
+        if ($this->_buffer->offsetExists($this->_index)) {
+            return;
+        }
         if (!$this->_finished) {
             parent::next();
         }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -553,7 +553,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection($items);
         $callback = function ($e) {
-            return $e['a']['b']['c'] * - 1;
+            return $e['a']['b']['c'] * -1;
         };
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max($callback));
     }
@@ -568,7 +568,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection($items);
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max(function ($e) {
-            return $e['a']['b']['c'] * - 1;
+            return $e['a']['b']['c'] * -1;
         }));
     }
 
@@ -1233,6 +1233,25 @@ class CollectionTest extends TestCase
         $buffered = (new Collection($items))->buffered();
         $this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $buffered->toArray());
         $this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $buffered->toArray());
+    }
+
+    public function testBufferedIterator()
+    {
+        $data = [
+            ['myField' => '1'],
+            ['myField' => '2'],
+            ['myField' => '3'],
+        ];
+        $buffered = (new \Cake\Collection\Collection($data))->buffered();
+        // Check going forwards
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '1']));
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '2']));
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '3']));
+
+        // And backwards.
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '3']));
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '2']));
+        $this->assertNotEmpty($buffered->firstMatch(['myField' => '1']));
     }
 
     /**

--- a/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
@@ -31,7 +31,7 @@ class BufferedIteratorTest extends TestCase
      *
      * @return void
      */
-    public function testBuffer()
+    public function testBufferItems()
     {
         $items = new ArrayObject([
             'a' => 1,
@@ -68,5 +68,26 @@ class BufferedIteratorTest extends TestCase
         $this->assertCount(3, $iterator);
         $buffered = $iterator->toArray();
         $this->assertSame((array)$items, $buffered);
+    }
+
+    /**
+     * Tests that partial iteration can be reset.
+     *
+     * @return void
+     */
+    public function testBufferPartial()
+    {
+        $items = new ArrayObject([1, 2, 3]);
+        $iterator = new BufferedIterator($items);
+        foreach ($iterator as $key => $value) {
+            if ($key == 1) {
+                break;
+            }
+        }
+        $result = [];
+        foreach ($iterator as $value) {
+            $result[] = $value;
+        }
+        $this->assertEquals([1, 2, 3], $result);
     }
 }


### PR DESCRIPTION
When a Collection\BufferedIterator is partially iterated, rewound and then iterated again it would not yield complete data as the inner iterator would be advanced while buffered data was being yielded.

Fixes #15341

