### PR TITLE
Alter wrong doc-block

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1478,11 +1478,11 @@ class Validation
     }
 
     /**
-     * Validates the image width.
+     * Validates the image height.
      *
      * @param mixed $file The uploaded file data from PHP.
      * @param string $operator Comparison operator.
-     * @param int $height Min or max width.
+     * @param int $height Min or max height.
      * @return bool
      */
     public static function imageHeight($file, string $operator, int $height): bool


### PR DESCRIPTION
In the doc-block of the "imageHeight"-function the headline and the parameter where declared as "width" instead of "height".
