### PR TITLE
Align FrozenDate API docs with chronos

### DIFF
--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -122,7 +122,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
-     * timezone will always be UTC. Normalizing the timezone allows for
+     * timezone will always be the server local time. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTime|\DateTimeImmutable|null $time Fixed or relative time

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -124,7 +124,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
-     * timezone will always be UTC. Normalizing the timezone allows for
+     * timezone will always be the server local time. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param string|int|\DateTime|\DateTimeImmutable|null $time Fixed or relative time


### PR DESCRIPTION
Align the documentation with what is in Chronos. Chronos was changed in https://github.com/cakephp/chronos/pull/227 (a820c1b1a523df341468d536ca7a2900ccaabc05) to fix problems with timezones that are far away from UTC.

Fixes #15418