### PR TITLE
4.3 - Truncation strategy for new fixtures

### DIFF
--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Fixture;
+
+use Cake\Database\Connection;
+use Cake\Database\Schema\SqlGeneratorInterface;
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * Fixture state strategy that truncates tables before a test.
+ *
+ * This strategy is slower than the TransactionStrategy, but
+ * allows tests to reset state when applications require operations
+ * that cannot be executed in a transaction. An example
+ * of this is DDL operations in MySQL which auto-commit any open
+ * transactions.
+ *
+ * This mode also offers 'backwards compatible' behavior
+ * with the schema + data fixture system.
+ */
+class TruncationStrategy
+{
+    /**
+     * Constructor.
+     *
+     * @param bool $enableLogging Whether or not to enable query logging.
+     * @return void
+     */
+    public function __construct(bool $enableLogging = false)
+    {
+        $this->aliasConnections($enableLogging);
+    }
+
+    /**
+     * Alias non test connections to the test ones
+     * so that models reach the test database connections instead.
+     *
+     * @param bool $enableLogging Whether or not to enable query logging.
+     * @return void
+     */
+    protected function aliasConnections(bool $enableLogging): void
+    {
+        $connections = ConnectionManager::configured();
+        ConnectionManager::alias('test', 'default');
+        $map = [];
+        foreach ($connections as $connection) {
+            if ($connection === 'test' || $connection === 'default') {
+                continue;
+            }
+            if (isset($map[$connection])) {
+                continue;
+            }
+            if (strpos($connection, 'test_') === 0) {
+                $map[$connection] = substr($connection, 5);
+            } else {
+                $map['test_' . $connection] = $connection;
+            }
+        }
+        foreach ($map as $testConnection => $normal) {
+            ConnectionManager::alias($testConnection, $normal);
+            $connection = ConnectionManager::get($normal);
+            if ($connection instanceof Connection && $enableLogging) {
+                $connection->enableQueryLogging();
+            }
+        }
+    }
+
+    /**
+     * Before each test start a transaction.
+     *
+     * @return void
+     */
+    public function beforeTest(): void
+    {
+        $connections = ConnectionManager::configured();
+        foreach ($connections as $connection) {
+            if (strpos($connection, 'test') !== 0) {
+                continue;
+            }
+            $db = ConnectionManager::get($connection);
+            if (!($db instanceof Connection)) {
+                continue;
+            }
+
+            $db->disableConstraints(function (Connection $db): void {
+                $schema = $db->getSchemaCollection();
+                foreach ($schema->listTables() as $table) {
+                    $tableSchema = $schema->describe($table);
+                    if (!($tableSchema instanceof SqlGeneratorInterface)) {
+                        continue;
+                    }
+                    $sql = $tableSchema->truncateSql($db);
+                    foreach ($sql as $stmt) {
+                        $db->execute($stmt)->closeCursor();
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * No op.
+     *
+     * Implemented to satisfy the interface.
+     *
+     * @return void
+     */
+    public function afterTest(): void
+    {
+        // Do nothing
+    }
+}

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -45,11 +45,11 @@ class ShellTest extends TestCase
      */
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.ArticlesTags',
         'core.Attachments',
         'core.Comments',
         'core.Posts',
-        'core.Tags',
         'core.Users',
     ];
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -41,7 +41,7 @@ class PaginatorComponentTest extends TestCase
      */
     protected $fixtures = [
         'core.Posts', 'core.Articles', 'core.ArticlesTags',
-        'core.Tags', 'core.Authors', 'core.AuthorsTags'
+        'core.Tags', 'core.Authors', 'core.AuthorsTags',
     ];
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -41,7 +41,7 @@ class PaginatorComponentTest extends TestCase
      */
     protected $fixtures = [
         'core.Posts', 'core.Articles', 'core.ArticlesTags',
-        'core.Authors', 'core.AuthorsTags', 'core.Tags',
+        'core.Tags', 'core.Authors', 'core.AuthorsTags'
     ];
 
     /**

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -31,8 +31,8 @@ class TableSchemaTest extends TestCase
         'core.Articles',
         'core.Tags',
         'core.ArticlesTags',
-        'core.Orders',
         'core.Products',
+        'core.Orders',
     ];
 
     protected $_map;

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -29,8 +29,8 @@ class PaginatorTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'core.Posts', 'core.Articles', 'core.ArticlesTags',
-        'core.Authors', 'core.AuthorsTags', 'core.Tags',
+        'core.Posts', 'core.Articles', 'core.Tags', 'core.ArticlesTags',
+        'core.Authors', 'core.AuthorsTags',
     ];
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -45,9 +45,9 @@ class BelongsToManyTest extends TestCase
      */
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.SpecialTags',
         'core.ArticlesTags',
-        'core.Tags',
         'core.BinaryUuidItems',
         'core.BinaryUuidTags',
         'core.BinaryUuidItemsBinaryUuidTags',

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -44,10 +44,10 @@ class HasManyTest extends TestCase
     protected $fixtures = [
         'core.Comments',
         'core.Articles',
+        'core.Tags',
         'core.Authors',
         'core.Users',
         'core.ArticlesTags',
-        'core.Tags',
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -39,11 +39,11 @@ class TranslateBehaviorTest extends TestCase
      */
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.ArticlesTags',
         'core.Authors',
         'core.Sections',
         'core.SpecialTags',
-        'core.Tags',
         'core.Comments',
         'core.Translates',
     ];

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -36,10 +36,10 @@ class MarshallerTest extends TestCase
 {
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.ArticlesTags',
         'core.Comments',
         'core.SpecialTags',
-        'core.Tags',
         'core.Users',
     ];
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -50,13 +50,13 @@ class QueryTest extends TestCase
      */
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.ArticlesTags',
         'core.ArticlesTranslations',
         'core.Authors',
         'core.Comments',
         'core.Datatypes',
         'core.Posts',
-        'core.Tags',
     ];
 
     /**

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -38,10 +38,10 @@ class LinkConstraintTest extends TestCase
      */
     protected $fixtures = [
         'core.Articles',
+        'core.Tags',
         'core.ArticlesTags',
         'core.Attachments',
         'core.Comments',
-        'core.Tags',
     ];
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -37,7 +37,7 @@ class RulesCheckerIntegrationTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'core.Articles', 'core.ArticlesTags', 'core.Authors', 'core.Comments', 'core.Tags',
+        'core.Articles', 'core.Tags', 'core.ArticlesTags', 'core.Authors', 'core.Comments',
         'core.SpecialTags', 'core.Categories', 'core.SiteArticles', 'core.SiteAuthors',
         'core.Comments', 'core.UniqueAuthors',
     ];

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\ORM\TableRegistry;

--- a/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
  */
 class TruncationStrategyTest extends TestCase
 {
-    public $fixtures = ['core.Articles', 'core.ArticlesTags', 'core.Tags'];
+    public $fixtures = ['core.Articles', 'core.Tags', 'core.ArticlesTags'];
 
     /**
      * Test that beforeTest truncates tables from the previous test

--- a/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\Fixture\TruncationStrategy;
+use Cake\TestSuite\TestCase;
+
+/**
+ * TruncationStrategy test
+ */
+class TruncationStrategyTest extends TestCase
+{
+    public $fixtures = ['core.Articles', 'core.ArticlesTags', 'core.Tags'];
+
+    /**
+     * Test that beforeTest truncates tables from the previous test
+     *
+     * @return void
+     */
+    public function testBeforeTestSimple()
+    {
+        $articles = TableRegistry::get('Articles');
+        $articlesTags = TableRegistry::get('ArticlesTags');
+
+        $rowCount = $articles->find()->count();
+        $this->assertGreaterThan(0, $rowCount);
+        $rowCount = $articlesTags->find()->count();
+        $this->assertGreaterThan(0, $rowCount);
+
+        $strategy = new TruncationStrategy();
+        $strategy->beforeTest();
+
+        $rowCount = $articles->find()->count();
+        $this->assertEquals(0, $rowCount);
+        $rowCount = $articlesTags->find()->count();
+        $this->assertEquals(0, $rowCount);
+    }
+}

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -155,7 +155,7 @@ class FixtureManagerTest extends TestCase
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
             ->method('getFixtures')
-            ->willReturn(['core.Articles', 'core.ArticlesTags', 'core.Tags']);
+            ->willReturn(['core.Articles', 'core.Tags', 'core.ArticlesTags']);
         $this->manager->fixturize($test);
         $this->manager->load($test);
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -37,7 +37,7 @@ class EntityContextTest extends TestCase
      *
      * @var array
      */
-    protected $fixtures = ['core.Articles', 'core.Comments', 'core.ArticlesTags', 'core.Tags'];
+    protected $fixtures = ['core.Articles', 'core.Comments', 'core.Tags', 'core.ArticlesTags'];
 
     /**
      * setup method.


### PR DESCRIPTION
This adds another strategy for resetting state in the new fixtures system. This strategy will be 'slow' but will be useful when applications need to run operations that cannot be run within transactions like DDL statements in MySQL.

Part of #15308 

cc @pabloelcolombiano