### PR TITLE
Parameter check of function fileSize in Validation class accept array

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1335,7 +1335,7 @@ class Validation
                 return false;
             }
         }
-        
+
         return true;
     }
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1307,19 +1307,36 @@ class Validation
      */
     public static function fileSize($check, string $operator, $size): bool
     {
-        $file = static::getFilename($check);
-        if ($file === false) {
-            return false;
+        if (is_array($check)) {
+            foreach ($check as $fileInCheck) {
+                $file = static::getFilename($fileInCheck);
+                if ($file === false) {
+                    return false;
+                } else {
+                    $files[] = $file;
+                }
+            }
+        } else {
+            $file = static::getFilename($check);
+            if ($file === false) {
+                return false;
+            } else {
+                $files[] = $file;
+            }
         }
 
         if (is_string($size)) {
             $size = Text::parseFileSize($size);
         }
-        $filesize = filesize($file);
 
-        return static::comparison($filesize, $operator, $size);
+        foreach ($files as $file) {
+            $filesize = filesize($file);
+            if (!static::comparison($filesize, $operator, $size)) {
+                return false;
+            }
+        }
+        return true;
     }
-
     /**
      * Checking for upload errors
      *

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1335,6 +1335,7 @@ class Validation
                 return false;
             }
         }
+        
         return true;
     }
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1338,6 +1338,7 @@ class Validation
 
         return true;
     }
+
     /**
      * Checking for upload errors
      *


### PR DESCRIPTION
When I use fileSize function in Validation class, the $check param accept array type but the function doesn't work with array.
So I edit this function to accept array in $check param.