### PR TITLE
#15308 Introduces a SchemaManager to create a sql file based test sch…

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,13 @@
             <!-- Excludes are required in order to let DatabaseSuite decorate the tests -->
             <exclude>tests/TestCase/Database/</exclude>
             <exclude>tests/TestCase/ORM/</exclude>
+            <exclude>tests/TestCase/TestSuite/Schema/</exclude>
         </testsuite>
         <testsuite name="database">
             <file>tests/TestCase/DatabaseSuite.php</file>
+        </testsuite>
+        <testsuite name="test-schema">
+            <directory>tests/TestCase/TestSuite/Schema</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,13 +11,9 @@
             <!-- Excludes are required in order to let DatabaseSuite decorate the tests -->
             <exclude>tests/TestCase/Database/</exclude>
             <exclude>tests/TestCase/ORM/</exclude>
-            <exclude>tests/TestCase/TestSuite/Schema/</exclude>
         </testsuite>
         <testsuite name="database">
             <file>tests/TestCase/DatabaseSuite.php</file>
-        </testsuite>
-        <testsuite name="test-schema">
-            <directory>tests/TestCase/TestSuite/Schema</directory>
         </testsuite>
     </testsuites>
 

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -33,20 +33,13 @@ class SchemaCleaner
     protected $io;
 
     /**
-     * @var bool
-     */
-    protected $isDroppingEnabled = true;
-
-    /**
      * SchemaCleaner constructor.
      *
      * @param \Cake\Console\ConsoleIo|null $io Outputs if provided.
-     * @param bool $enableDropping Enable dropping (useful for testing purposes)
      */
-    public function __construct(?ConsoleIo $io = null, ?bool $enableDropping = true)
+    public function __construct(?ConsoleIo $io = null)
     {
         $this->io = $io;
-        $this->isDroppingEnabled = $enableDropping;
     }
 
     /**
@@ -59,9 +52,7 @@ class SchemaCleaner
      */
     public function dropTables(string $connectionName, $tables = null): void
     {
-        if ($this->isDroppingEnabled === true) {
-            $this->handle($connectionName, 'dropTableSql', 'dropping', $tables);
-        }
+        $this->handle($connectionName, 'dropTableSql', 'dropping', $tables);
     }
 
     /**

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -54,8 +54,8 @@ class SchemaCleaner
     /**
      * Truncate all tables of the provided connection.
      *
-     * @param \Cake\Console\ConsoleIo|null $io Console IO to output the processes.
      * @param string $connectionName Name of the connection.
+     * @param \Cake\Console\ConsoleIo|null $io Console IO to output the processes.
      * @return void
      * @throws \Exception if the truncation failed.
      */
@@ -117,9 +117,7 @@ class SchemaCleaner
     }
 
     /**
-     *
      * @param string $msg Message to display.
-     *
      * @param \Cake\Console\ConsoleIo|null $io Console IO.
      * @return void
      */

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -49,7 +49,7 @@ class SchemaCleaner
      * @return void
      * @throws \Exception if the dropping failed.
      */
-    public function drop(string $connectionName)
+    public function dropTables(string $connectionName)
     {
         $this->info('Dropping all tables for connection ' . $connectionName);
 

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Schema;
+
+use Cake\Console\ConsoleIo;
+use Cake\Database\Schema\BaseSchema;
+use Cake\Database\Schema\CollectionInterface;
+use Cake\Datasource\ConnectionInterface;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestConnectionManager;
+
+/**
+ * This class will help dropping all tables of a given connection
+ * and truncate the non phinx migrations tables.
+ */
+class SchemaCleaner
+{
+    /**
+     * Drop all tables of the provided connection.
+     *
+     * @param string $connectionName Name of the connection.
+     * @param \Cake\Console\ConsoleIo|null $io Console IO to output the processes.
+     * @return void
+     * @throws \Exception if the dropping failed.
+     */
+    public static function drop(string $connectionName, ?ConsoleIo $io = null)
+    {
+        self::info($io, __d('cake', 'Dropping all tables for connection ' . $connectionName));
+
+        $schema = static::getSchema($connectionName);
+        $dialect = static::getDialect($connectionName);
+
+        $stmts = [];
+        foreach ($schema->listTables() as $table) {
+            $table = $schema->describe($table);
+            $stmts = array_merge($stmts, $dialect->dropTableSql($table));
+        }
+
+        static::executeStatements(ConnectionManager::get($connectionName), $stmts);
+    }
+
+    /**
+     * Truncate all tables of the provided connection.
+     *
+     * @param string $connectionName Name of the connection.
+     * @param \Cake\Console\ConsoleIo|null $io Console IO to output the processes.
+     * @return void
+     * @throws \Exception if the truncation failed.
+     */
+    public static function truncate(string $connectionName, ?ConsoleIo $io = null)
+    {
+        static::info($io, __d('cake', 'Truncating all tables for connection ' . $connectionName));
+
+        $stmts = [];
+        $schema = static::getSchema($connectionName);
+        $dialect = static::getDialect($connectionName);
+        $tables = $schema->listTables();
+        $tables = TestConnectionManager::unsetMigrationTables($tables);
+        foreach ($tables as $table) {
+            $table = $schema->describe($table);
+            $stmts = array_merge($stmts, $dialect->truncateTableSql($table));
+        }
+
+        static::executeStatements(ConnectionManager::get($connectionName), $stmts);
+    }
+
+    /**
+     * @param  \Cake\Datasource\ConnectionInterface $connection Connection.
+     * @param  array               $commands Sql commands to run
+     * @return void
+     * @throws \Exception
+     */
+    private static function executeStatements(ConnectionInterface $connection, array $commands): void
+    {
+        $connection->disableConstraints(function ($connection) use ($commands) {
+            $connection->transactional(function (ConnectionInterface $connection) use ($commands) {
+                foreach ($commands as $sql) {
+                    $connection->execute($sql);
+                }
+            });
+        });
+    }
+
+    /**
+     * @param \Cake\Console\ConsoleIo|null $io Console IO.
+     * @param string         $msg Message to display.
+     * @return void
+     */
+    private static function info($io, string $msg): void
+    {
+        if ($io instanceof ConsoleIo) {
+            $io->info($msg);
+        }
+    }
+
+    /**
+     * @param  string $connectionName name of the connection.
+     * @return \Cake\Database\Schema\CollectionInterface
+     */
+    private static function getSchema(string $connectionName): CollectionInterface
+    {
+        return ConnectionManager::get($connectionName)->getSchemaCollection();
+    }
+
+    /**
+     * @param  string $connectionName Name of the connection.
+     * @return \Cake\Database\Schema\BaseSchema
+     */
+    private static function getDialect(string $connectionName): BaseSchema
+    {
+        return ConnectionManager::get($connectionName)->getDriver()->schemaDialect();
+    }
+}

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -35,13 +35,13 @@ class SchemaCleaner
     /**
      * @var bool
      */
-    protected $isDroppingEnabled;
+    protected $isDroppingEnabled = true;
 
     /**
      * SchemaCleaner constructor.
      *
      * @param \Cake\Console\ConsoleIo|null $io Outputs if provided.
-     * @param bool|null $enableDropping Enable dropping (useful for testing purposes)
+     * @param bool $enableDropping Enable dropping (useful for testing purposes)
      */
     public function __construct(?ConsoleIo $io = null, ?bool $enableDropping = true)
     {

--- a/src/TestSuite/Schema/SchemaManager.php
+++ b/src/TestSuite/Schema/SchemaManager.php
@@ -59,21 +59,19 @@ class SchemaManager
 
         foreach ($files as $file) {
             if (!file_exists($file)) {
-                throw new \RuntimeException('The file {0} was not found.', $file);
+                throw new \RuntimeException('The file ' . $file . ' could not found.');
             }
 
             $sql = file_get_contents($file);
             if ($sql === false) {
-                throw new \RuntimeException('The file {0} could not be read.', $file);
+                throw new \RuntimeException('The file ' . $file . ' could not read.');
             }
 
             ConnectionManager::get($connectionName)->execute($sql);
 
-            $migrator->io->success(__d(
-                'cake',
-                'Dump of schema in file {0} for connection {1} successful.',
-                [$file, $connectionName]
-            ));
+            $migrator->io->success(
+                'Dump of schema in file ' . $file . ' for connection ' . $connectionName . ' successful.'
+            );
         }
 
         SchemaCleaner::truncate($connectionName, $migrator->io);

--- a/src/TestSuite/Schema/SchemaManager.php
+++ b/src/TestSuite/Schema/SchemaManager.php
@@ -59,12 +59,12 @@ class SchemaManager
 
         foreach ($files as $file) {
             if (!file_exists($file)) {
-                throw new \RuntimeException(__('cake', 'The file {0} was not found.', $file));
+                throw new \RuntimeException('The file {0} was not found.', $file);
             }
 
             $sql = file_get_contents($file);
             if ($sql === false) {
-                throw new \RuntimeException(__('cake', 'The file {0} could not be read.', $file));
+                throw new \RuntimeException('The file {0} could not be read.', $file);
             }
 
             ConnectionManager::get($connectionName)->execute($sql);

--- a/src/TestSuite/Schema/SchemaManager.php
+++ b/src/TestSuite/Schema/SchemaManager.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Schema;
+
+use Cake\Console\ConsoleIo;
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * This class will create the schema of the test DB
+ */
+class SchemaManager
+{
+    /**
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * SchemaManager constructor.
+     *
+     * @param bool|null $verbose Output CLI messages.
+     */
+    final public function __construct(?bool $verbose = false)
+    {
+        $this->io = new ConsoleIo();
+        $this->io->level($verbose ? ConsoleIo::NORMAL : ConsoleIo::QUIET);
+    }
+
+    /**
+     * Import the schema from a file, or an array of files.
+     *
+     * @param string $connectionName Connection
+     * @param string|string[] $file File to dump
+     * @param bool|null $verbose Set to true to display messages
+     * @return void
+     * @throws \Exception if the truncation failed
+     * @throws \RuntimeException if the file could not be processed
+     */
+    public static function create(string $connectionName, $file, ?bool $verbose = false)
+    {
+        $files = (array)$file;
+
+        $migrator = new static($verbose);
+
+        SchemaCleaner::drop($connectionName, $migrator->io);
+
+        foreach ($files as $file) {
+            if (!file_exists($file)) {
+                throw new \RuntimeException(__('cake', 'The file {0} was not found.', $file));
+            }
+
+            $sql = file_get_contents($file);
+            if ($sql === false) {
+                throw new \RuntimeException(__('cake', 'The file {0} could not be read.', $file));
+            }
+
+            ConnectionManager::get($connectionName)->execute($sql);
+
+            $migrator->io->success(__d(
+                'cake',
+                'Dump of schema in file {0} for connection {1} successful.',
+                [$file, $connectionName]
+            ));
+        }
+
+        SchemaCleaner::truncate($connectionName, $migrator->io);
+    }
+}

--- a/src/TestSuite/Schema/SchemaManager.php
+++ b/src/TestSuite/Schema/SchemaManager.php
@@ -56,7 +56,7 @@ class SchemaManager
         $migrator = new static($verbose);
         $schemaCleaner = new SchemaCleaner($migrator->io);
 
-        $schemaCleaner->drop($connectionName);
+        $schemaCleaner->dropTables($connectionName);
 
         foreach ($files as $file) {
             if (!file_exists($file)) {

--- a/src/TestSuite/Schema/SchemaManager.php
+++ b/src/TestSuite/Schema/SchemaManager.php
@@ -54,8 +54,9 @@ class SchemaManager
         $files = (array)$file;
 
         $migrator = new static($verbose);
+        $schemaCleaner = new SchemaCleaner($migrator->io);
 
-        SchemaCleaner::drop($connectionName, $migrator->io);
+        $schemaCleaner->drop($connectionName);
 
         foreach ($files as $file) {
             if (!file_exists($file)) {
@@ -74,6 +75,6 @@ class SchemaManager
             );
         }
 
-        SchemaCleaner::truncate($connectionName, $migrator->io);
+        $schemaCleaner->truncate($connectionName);
     }
 }

--- a/src/TestSuite/TestConnectionManager.php
+++ b/src/TestSuite/TestConnectionManager.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * This class provides utility for the management of the test connections.
+ */
+final class TestConnectionManager
+{
+    /**
+     * @var bool
+     */
+    public static $aliasConnectionIsLoaded = false;
+
+    /**
+     * @return void
+     */
+    public static function aliasConnections()
+    {
+        if (!self::$aliasConnectionIsLoaded) {
+            (new self())->_aliasConnections();
+            self::$aliasConnectionIsLoaded = true;
+        }
+    }
+
+    /**
+     * Unset the phinx migration tables from an array of tables.
+     *
+     * @param  string[] $tables Array of strings with table names.
+     * @return array
+     */
+    public static function unsetMigrationTables(array $tables): array
+    {
+        $endsWithPhinxlog = function (string $string) {
+            $needle = 'phinxlog';
+
+            return substr($string, -strlen($needle)) === $needle;
+        };
+
+        foreach ($tables as $i => $table) {
+            if ($endsWithPhinxlog($table)) {
+                unset($tables[$i]);
+            }
+        }
+
+        return array_values($tables);
+    }
+
+    /**
+     * Add aliases for all non test prefixed connections.
+     *
+     * This allows models to use the test connections without
+     * a pile of configuration work.
+     *
+     * @return void
+     */
+    protected function _aliasConnections()
+    {
+        $connections = ConnectionManager::configured();
+        ConnectionManager::alias('test', 'default');
+        $map = [];
+        foreach ($connections as $connection) {
+            if ($connection === 'test' || $connection === 'default') {
+                continue;
+            }
+            if (isset($map[$connection])) {
+                continue;
+            }
+            if (strpos($connection, 'test_') === 0) {
+                $map[$connection] = substr($connection, 5);
+            } else {
+                $map['test_' . $connection] = $connection;
+            }
+        }
+        foreach ($map as $testConnection => $normal) {
+            ConnectionManager::alias($testConnection, $normal);
+        }
+    }
+}

--- a/src/TestSuite/TestConnectionManager.php
+++ b/src/TestSuite/TestConnectionManager.php
@@ -39,29 +39,6 @@ final class TestConnectionManager
     }
 
     /**
-     * Unset the phinx migration tables from an array of tables.
-     *
-     * @param  string[] $tables Array of strings with table names.
-     * @return array
-     */
-    public static function unsetMigrationTables(array $tables): array
-    {
-        $endsWithPhinxlog = function (string $string) {
-            $needle = 'phinxlog';
-
-            return substr($string, -strlen($needle)) === $needle;
-        };
-
-        foreach ($tables as $i => $table) {
-            if ($endsWithPhinxlog($table)) {
-                unset($tables[$i]);
-            }
-        }
-
-        return array_values($tables);
-    }
-
-    /**
      * Add aliases for all non test prefixed connections.
      *
      * This allows models to use the test connections without

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -55,7 +55,7 @@ class SchemaCleanerTest extends TestCase
         $this->assertSame(['test_table'], $tables, 'The schema should not be empty.');
 
         // Drop the schema
-        (new SchemaCleaner())->drop('test');
+        (new SchemaCleaner())->dropTables('test');
 
         // Schema is empty
         $tables = $connection->execute($sql, $params)->count();
@@ -83,7 +83,7 @@ class SchemaCleanerTest extends TestCase
     private function createSchemas()
     {
         $schemaCleaner = new SchemaCleaner();
-        $schemaCleaner->drop('test');
+        $schemaCleaner->dropTables('test');
 
         $connection = ConnectionManager::get('test');
 

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -58,7 +58,7 @@ class SchemaCleanerTest extends TestCase
         (new SchemaCleaner())->drop('test');
 
         // Schema is empty
-        $tables = $connection->execute($stmt[0], $stmt[1])->count();
+        $tables = $connection->execute($sql, $params)->count();
         $this->assertSame(0, $tables, 'The schema should be empty.');
     }
 

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -49,7 +49,7 @@ class SchemaCleanerTest extends TestCase
         $this->createSchemas();
 
         $stmt = $dialect->listTablesSql($connection->config());
-        $tables = $connection->execute($stmt[0])->fetch();
+        $tables = $connection->execute($stmt[0], $stmt[1])->fetch();
 
         // Assert that the schema is not empty
         $this->assertSame(['test_table'], $tables, 'The schema should not be empty.');
@@ -58,7 +58,7 @@ class SchemaCleanerTest extends TestCase
         (new SchemaCleaner())->drop('test');
 
         // Schema is empty
-        $tables = $connection->execute($stmt[0])->count();
+        $tables = $connection->execute($stmt[0], $stmt[1])->count();
         $this->assertSame(0, $tables, 'The schema should be empty.');
     }
 

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -48,8 +48,8 @@ class SchemaCleanerTest extends TestCase
 
         $this->createSchemas();
 
-        $stmt = $dialect->listTablesSql($connection->config());
-        $tables = $connection->execute($stmt[0], $stmt[1])->fetch();
+        [$sql, $params] = $dialect->listTablesSql($connection->config());
+        $tables = $connection->execute($sql, $params)->fetch();
 
         // Assert that the schema is not empty
         $this->assertSame(['test_table'], $tables, 'The schema should not be empty.');

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite\Schema;
+
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Schema\SchemaCleaner;
+use Cake\TestSuite\TestCase;
+
+class SchemaCleanerTest extends TestCase
+{
+    public function testForeignKeyConstruction()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $this->createSchemas();
+        $this->assertSame(
+            1,
+            $connection->newQuery()->select('id')->from('test_table')->execute()->count()
+        );
+        $this->assertSame(
+            1,
+            $connection->newQuery()->select('id')->from('test_table2')->execute()->count()
+        );
+
+        $this->expectException(\PDOException::class);
+        $connection->delete('test_table');
+    }
+
+    public function testDropSchema()
+    {
+        $connection = ConnectionManager::get('test');
+        /** @var SchemaDialect $dialect */
+        $dialect = $connection->getDriver()->schemaDialect();
+
+        $this->createSchemas();
+
+        $stmt = $dialect->listTablesSql($connection->config());
+        $tables = $connection->execute($stmt[0])->fetch();
+
+        // Assert that the schema is not empty
+        $this->assertSame(['test_table'], $tables, 'The schema should not be empty.');
+
+        // Drop the schema
+        SchemaCleaner::drop('test');
+
+        // Schema is empty
+        $tables = $connection->execute($stmt[0])->count();
+        $this->assertSame(0, $tables, 'The schema should be empty.');
+    }
+
+    public function testTruncateSchema()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $this->createSchemas();
+
+        SchemaCleaner::truncate('test');
+
+        $this->assertSame(
+            0,
+            $connection->newQuery()->select('id')->from('test_table')->execute()->count()
+        );
+        $this->assertSame(
+            0,
+            $connection->newQuery()->select('id')->from('test_table2')->execute()->count()
+        );
+    }
+
+    private function createSchemas()
+    {
+        SchemaCleaner::drop('test');
+
+        $connection = ConnectionManager::get('test');
+
+        $schema = new TableSchema('test_table');
+        $schema
+            ->addColumn('id', 'integer')
+            ->addColumn('name', 'string')
+            ->addConstraint('primary', [
+                'type' => TableSchema::CONSTRAINT_PRIMARY,
+                'columns' => ['id'],
+            ]);
+
+        $queries = $schema->createSql($connection);
+        foreach ($queries as $sql) {
+            $connection->execute($sql);
+        }
+
+        $schema = new TableSchema('test_table2');
+        $schema
+            ->addColumn('id', 'integer')
+            ->addColumn('name', 'string')
+            ->addColumn('fk_id', 'integer')
+            ->addConstraint('primary', [
+                'type' => TableSchema::CONSTRAINT_PRIMARY,
+                'columns' => ['id'],
+            ])
+            ->addConstraint('foreign_key', [
+                'columns' => ['fk_id'],
+                'type' => TableSchema::CONSTRAINT_FOREIGN,
+                'references' => ['test_table', 'id', ],
+            ]);
+
+        $queries = $schema->createSql($connection);
+
+        foreach ($queries as $sql) {
+            $connection->execute($sql);
+        }
+
+        $connection->insert('test_table', ['name' => 'foo']);
+
+        $id = $connection->newQuery()->select('id')->from('test_table')->limit(1)->execute()->fetch()[0];
+        $connection->insert('test_table2', ['name' => 'foo', 'fk_id' => $id]);
+
+        $connection->execute($connection->getDriver()->enableForeignKeySQL());
+    }
+}

--- a/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaCleanerTest.php
@@ -55,7 +55,7 @@ class SchemaCleanerTest extends TestCase
         $this->assertSame(['test_table'], $tables, 'The schema should not be empty.');
 
         // Drop the schema
-        SchemaCleaner::drop('test');
+        (new SchemaCleaner())->drop('test');
 
         // Schema is empty
         $tables = $connection->execute($stmt[0])->count();
@@ -68,7 +68,7 @@ class SchemaCleanerTest extends TestCase
 
         $this->createSchemas();
 
-        SchemaCleaner::truncate('test');
+        (new SchemaCleaner())->truncate('test');
 
         $this->assertSame(
             0,
@@ -82,7 +82,8 @@ class SchemaCleanerTest extends TestCase
 
     private function createSchemas()
     {
-        SchemaCleaner::drop('test');
+        $schemaCleaner = new SchemaCleaner();
+        $schemaCleaner->drop('test');
 
         $connection = ConnectionManager::get('test');
 

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -94,6 +94,6 @@ class SchemaManagerTest extends TestCase
 
         $stmt = $dialect->listTablesSql($connection->config());
 
-        return $connection->execute($stmt[0])->fetchAll(StatementInterface::FETCH_TYPE_NUM);
+        return $connection->execute($stmt[0], $stmt[1])->fetchAll(StatementInterface::FETCH_TYPE_NUM);
     }
 }

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite\Schema;
+
+use Cake\Database\Schema\TableSchema;
+use Cake\Database\StatementInterface;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Schema\SchemaCleaner;
+use Cake\TestSuite\Schema\SchemaManager;
+use Cake\TestSuite\TestCase;
+
+class SchemaManagerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        SchemaCleaner::drop('test');
+    }
+
+    public function testCreateFromOneFile()
+    {
+        $tableName = 'test_table';
+        $file = $this->createSchemaFile($tableName);
+
+        SchemaManager::create('test', $file);
+
+        $this->assertSame([[$tableName]], $this->listTables());
+    }
+
+    public function testCreateFromMultipleFiles()
+    {
+        $tableName1 = 'test_table';
+        $tableName2 = 'test_table_2';
+        $tableName3 = 'test_table_3';
+        $file1 = $this->createSchemaFile($tableName1);
+        $file2 = $this->createSchemaFile($tableName2);
+        $file3 = $this->createSchemaFile($tableName3);
+
+        SchemaManager::create('test', [$file1, $file2, $file3]);
+
+        $this->assertSame([[$tableName1], [$tableName2], [$tableName3],], array_values($this->listTables()));
+    }
+
+    public function testCreateFromNonExistentFile()
+    {
+        $this->expectException(\RuntimeException::class);
+        SchemaManager::create('test', 'foo');
+    }
+
+    public function testCreateFromCorruptedFile()
+    {
+        $query = 'This is no valid SQL';
+        $tmpFile = tempnam(sys_get_temp_dir(), 'SchemaManagerTest');
+        file_put_contents($tmpFile, $query);
+
+        $this->expectException(\RuntimeException::class);
+        SchemaManager::create('test', $tmpFile);
+    }
+
+    private function createSchemaFile(string $tableName): string
+    {
+        $connection = ConnectionManager::get('test');
+
+        $schema = new TableSchema($tableName);
+        $schema
+            ->addColumn('id', 'integer')
+            ->addColumn('name', 'string');
+
+        $query = $schema->createSql($connection)[0];
+        $tmpFile = tempnam(sys_get_temp_dir(), 'SchemaManagerTest');
+        file_put_contents($tmpFile, $query);
+
+        return $tmpFile;
+    }
+
+    private function listTables(): array
+    {
+        $connection = ConnectionManager::get('test');
+        /** @var SchemaDialect $dialect */
+        $dialect = $connection->getDriver()->schemaDialect();
+
+        $stmt = $dialect->listTablesSql($connection->config());
+
+        return $connection->execute($stmt[0])->fetchAll(StatementInterface::FETCH_TYPE_NUM);
+    }
+}

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -27,7 +27,7 @@ class SchemaManagerTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        (new SchemaCleaner())->drop('test');
+        (new SchemaCleaner())->dropTables('test');
     }
 
     public function testCreateFromOneFile()

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -27,7 +27,7 @@ class SchemaManagerTest extends TestCase
     {
         $connection = ConnectionManager::get('test');
 
-        $tableName = 'test_table';
+        $tableName = 'test_table_' . rand();
         (new SchemaCleaner())->dropTables('test', [$tableName]);
 
         $file = $this->createSchemaFile($tableName);
@@ -47,18 +47,23 @@ class SchemaManagerTest extends TestCase
     public function testCreateFromMultipleFiles()
     {
         $connection = ConnectionManager::get('test');
+        $tables = [
+            'test_table_' . rand(),
+            'test_table_' . rand(),
+            'test_table_' . rand(),
+        ];
 
-        (new SchemaCleaner())->dropTables('test', $this->getTestTables());
+        (new SchemaCleaner())->dropTables('test', $tables);
 
         $files = [];
-        foreach ($this->getTestTables() as $table) {
+        foreach ($tables as $table) {
             $files[] = $this->createSchemaFile($table);
         }
 
         SchemaManager::create('test', $files, false, false);
 
         // Assert that all test tables were created
-        foreach ($this->getTestTables() as $table) {
+        foreach ($tables as $table) {
             $this->assertSame(
                 0,
                 $connection->newQuery()->select('id')->from($table)->execute()->count()
@@ -66,7 +71,7 @@ class SchemaManagerTest extends TestCase
         }
 
         // Cleanup
-        (new SchemaCleaner())->dropTables('test', $this->getTestTables());
+        (new SchemaCleaner())->dropTables('test', $tables);
     }
 
     public function testCreateFromNonExistentFile()
@@ -83,15 +88,6 @@ class SchemaManagerTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         SchemaManager::create('test', $tmpFile, false, false);
-    }
-
-    private function getTestTables(): array
-    {
-        return [
-            'test_table',
-            'test_table_2',
-            'test_table_3',
-        ];
     }
 
     private function createSchemaFile(string $tableName): string

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -27,7 +27,7 @@ class SchemaManagerTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        SchemaCleaner::drop('test');
+        (new SchemaCleaner())->drop('test');
     }
 
     public function testCreateFromOneFile()

--- a/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Schema/SchemaManagerTest.php
@@ -92,8 +92,8 @@ class SchemaManagerTest extends TestCase
         /** @var SchemaDialect $dialect */
         $dialect = $connection->getDriver()->schemaDialect();
 
-        $stmt = $dialect->listTablesSql($connection->config());
+        [$sql, $params] = $dialect->listTablesSql($connection->config());
 
-        return $connection->execute($stmt[0], $stmt[1])->fetchAll(StatementInterface::FETCH_TYPE_NUM);
+        return $connection->execute($sql, $params)->fetchAll(StatementInterface::FETCH_TYPE_NUM);
     }
 }

--- a/tests/TestCase/TestSuite/TestConnectionManagerTest.php
+++ b/tests/TestCase/TestSuite/TestConnectionManagerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\Exception\MissingDatasourceConfigException;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestConnectionManager;
 
@@ -23,23 +24,23 @@ class TestConnectionManagerTest extends TestCase
 {
     public function testAliasConnections()
     {
-        ConnectionManager::drop('dummy');
-        ConnectionManager::drop('test_dummy');
-        $testConfig = ConnectionManager::get('test')->config();
+        ConnectionManager::dropAlias('default');
 
-        ConnectionManager::setConfig('dummy', array_merge($testConfig,  ['some_key' => 'foo',]));
-        ConnectionManager::setConfig('test_dummy', array_merge($testConfig,  ['some_key' => 'bar',]));
-
-        $someKeyValueBeforeAliasing = ConnectionManager::get('dummy')->config()['some_key'];
-        $this->assertSame('foo', $someKeyValueBeforeAliasing);
+        try {
+            $exceptionThrown = false;
+            ConnectionManager::get('default');
+        } catch (MissingDatasourceConfigException $e) {
+            $exceptionThrown = true;
+        } finally {
+            $this->assertTrue($exceptionThrown);
+        }
 
         TestConnectionManager::$aliasConnectionIsLoaded = false;
         TestConnectionManager::aliasConnections();
 
-        $someKeyValueAfterAliasing = ConnectionManager::get('dummy')->config()['database'];
-        $this->assertSame('bar', $someKeyValueAfterAliasing);
-
-        ConnectionManager::drop('dummy');
-        ConnectionManager::drop('test_dummy');
+        $this->assertSame(
+            ConnectionManager::get('test'),
+            ConnectionManager::get('default')
+        );
     }
 }

--- a/tests/TestCase/TestSuite/TestConnectionManagerTest.php
+++ b/tests/TestCase/TestSuite/TestConnectionManagerTest.php
@@ -25,18 +25,19 @@ class TestConnectionManagerTest extends TestCase
     {
         ConnectionManager::drop('dummy');
         ConnectionManager::drop('test_dummy');
+        $testConfig = ConnectionManager::get('test')->config();
 
-        ConnectionManager::setConfig('dummy', ['url' => 'sqlite:///:foo:',]);
-        ConnectionManager::setConfig('test_dummy', ['url' => 'sqlite:///:bar:',]);
+        ConnectionManager::setConfig('dummy', array_merge($testConfig,  ['some_key' => 'foo',]));
+        ConnectionManager::setConfig('test_dummy', array_merge($testConfig,  ['some_key' => 'bar',]));
 
-        $testDB = ConnectionManager::get('dummy')->config()['database'];
-        $this->assertSame(':foo:', $testDB);
+        $someKeyValueBeforeAliasing = ConnectionManager::get('dummy')->config()['some_key'];
+        $this->assertSame('foo', $someKeyValueBeforeAliasing);
 
         TestConnectionManager::$aliasConnectionIsLoaded = false;
         TestConnectionManager::aliasConnections();
 
-        $testDB = ConnectionManager::get('dummy')->config()['database'];
-        $this->assertSame(':bar:', $testDB);
+        $someKeyValueAfterAliasing = ConnectionManager::get('dummy')->config()['database'];
+        $this->assertSame('bar', $someKeyValueAfterAliasing);
 
         ConnectionManager::drop('dummy');
         ConnectionManager::drop('test_dummy');

--- a/tests/TestCase/TestSuite/TestConnectionManagerTest.php
+++ b/tests/TestCase/TestSuite/TestConnectionManagerTest.php
@@ -21,16 +21,6 @@ use Cake\TestSuite\TestConnectionManager;
 
 class TestConnectionManagerTest extends TestCase
 {
-    /**
-     * Note that phinxlog tables are suffixed by _phinxlog.
-     */
-    public function testUnsetMigrationTables()
-    {
-        $input = ['foo', 'phinxlog', 'phinxlog_bar', 'some_table', 'some_plugin_phinxlog'];
-        $output = TestConnectionManager::unsetMigrationTables($input);
-        $this->assertSame(['foo', 'phinxlog_bar', 'some_table',], $output);
-    }
-
     public function testAliasConnections()
     {
         ConnectionManager::drop('dummy');

--- a/tests/TestCase/TestSuite/TestConnectionManagerTest.php
+++ b/tests/TestCase/TestSuite/TestConnectionManagerTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use Cake\TestSuite\TestConnectionManager;
+
+class TestConnectionManagerTest extends TestCase
+{
+    /**
+     * Note that phinxlog tables are suffixed by _phinxlog.
+     */
+    public function testUnsetMigrationTables()
+    {
+        $input = ['foo', 'phinxlog', 'phinxlog_bar', 'some_table', 'some_plugin_phinxlog'];
+        $output = TestConnectionManager::unsetMigrationTables($input);
+        $this->assertSame(['foo', 'phinxlog_bar', 'some_table',], $output);
+    }
+
+    public function testAliasConnections()
+    {
+        ConnectionManager::drop('dummy');
+        ConnectionManager::drop('test_dummy');
+
+        ConnectionManager::setConfig('dummy', ['url' => 'sqlite:///:foo:',]);
+        ConnectionManager::setConfig('test_dummy', ['url' => 'sqlite:///:bar:',]);
+
+        $testDB = ConnectionManager::get('dummy')->config()['database'];
+        $this->assertSame(':foo:', $testDB);
+
+        TestConnectionManager::$aliasConnectionIsLoaded = false;
+        TestConnectionManager::aliasConnections();
+
+        $testDB = ConnectionManager::get('dummy')->config()['database'];
+        $this->assertSame(':bar:', $testDB);
+
+        ConnectionManager::drop('dummy');
+        ConnectionManager::drop('test_dummy');
+    }
+}


### PR DESCRIPTION
This commit introduces a test schema management strategy based on SQL files.

The developer is entitled, e.g. in `tests/bootstrap.php`, to provide one file or an array of files, containing the SQl commands to be run prior to the test suite to start.

The whole schema gets dropped, recreated and the table are truncated prior to the test suite to run.

This strategy will find a corresponding, more efficient, approach in the Migrations plugin.
