### PR TITLE
Update exception message for groupBy() and indexBy() missing path

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -269,10 +269,11 @@ trait CollectionTrait
         foreach ($this->optimizeUnwrap() as $value) {
             $pathValue = $callback($value);
             if ($pathValue === null) {
-                throw new InvalidArgumentException(
-                    'Cannot use a nonexistent path or null value. ' .
-                    'Use a callback to provide default values if necessary.'
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot group by `%s` because does not exist or contains a null value. ' .
+                    'Use a callback to provide a default value for paths that are optional.',
+                    $path
+                ));
             }
             $group[$pathValue][] = $value;
         }
@@ -290,10 +291,11 @@ trait CollectionTrait
         foreach ($this->optimizeUnwrap() as $value) {
             $pathValue = $callback($value);
             if ($pathValue === null) {
-                throw new InvalidArgumentException(
-                    'Cannot use a nonexistent path or null value. ' .
-                    'Use a callback to provide default values if necessary.'
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot index by `%s` because does not exist or contains a null value. ' .
+                    'Use a callback to provide a default value for paths that are optional.',
+                    $path
+                ));
             }
             $group[$pathValue] = $value;
         }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -731,7 +731,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $this->expectExceptionMessage('Cannot group by `missing` because does not exist or contains a null value.');
         $collection->groupBy('missing');
     }
 
@@ -829,7 +829,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $this->expectExceptionMessage('Cannot index by `missing` because does not exist or contains a null value');
         $collection->indexBy('missing');
     }
 


### PR DESCRIPTION
This is hopefully makes the issue more obvious to the user and less difficult to read.
