### PR TITLE
Update exception message for groupBy() and indexBy() missing path

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -270,8 +270,8 @@ trait CollectionTrait
             $pathValue = $callback($value);
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
-                    'Cannot use a nonexistent path or null value. ' .
-                    'Use a callback to provide default values if necessary.'
+                    'Cannot group by path that does not exist or contains a null value. ' .
+                    'Use a callback to return a default value for that path.'
                 );
             }
             $group[$pathValue][] = $value;
@@ -291,8 +291,8 @@ trait CollectionTrait
             $pathValue = $callback($value);
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
-                    'Cannot use a nonexistent path or null value. ' .
-                    'Use a callback to provide default values if necessary.'
+                    'Cannot index by path that does not exist or contains a null value. ' .
+                    'Use a callback to return a default value for that path.'
                 );
             }
             $group[$pathValue] = $value;

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -731,7 +731,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $this->expectExceptionMessage('Cannot group by path that does not exist or contains a null value.');
         $collection->groupBy('missing');
     }
 
@@ -829,8 +829,29 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use a nonexistent path or null value.');
+        $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
         $collection->indexBy('missing');
+    }
+
+    /**
+     * Tests passing an invalid path to indexBy.
+     *
+     * @return void
+     */
+    public function testIndexByInvalidPathCallback()
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz'],
+        ];
+        $collection = new Collection($items);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
+        $collection->indexBy(function ($e) {
+            return null;
+        });
     }
 
     /**


### PR DESCRIPTION
This also adds a missing test for callbacks that return null values.
