### PR TITLE
Remove the "relative-paths" option.

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -60,13 +60,6 @@ class I18nExtractCommand extends Command
     protected $_merge = false;
 
     /**
-     * Use relative paths in the pot files rather than full path
-     *
-     * @var bool
-     */
-    protected $_relativePaths = false;
-
-    /**
      * Current file being processed
      *
      * @var string
@@ -267,7 +260,6 @@ class I18nExtractCommand extends Command
         }
 
         $this->_markerError = (bool)$args->getOption('marker-error');
-        $this->_relativePaths = (bool)$args->getOption('relative-paths');
 
         if (empty($this->_files)) {
             $this->_searchFiles();
@@ -368,10 +360,6 @@ class I18nExtractCommand extends Command
             'help' => 'Merge all domain strings into a single default.po file.',
             'default' => 'no',
             'choices' => ['yes', 'no'],
-        ])->addOption('relative-paths', [
-            'help' => 'Use application relative paths in the .pot file.',
-            'boolean' => true,
-            'default' => false,
         ])->addOption('output', [
             'help' => 'Full path to output directory.',
         ])->addOption('files', [
@@ -510,9 +498,7 @@ class I18nExtractCommand extends Command
                         'file' => $this->_file,
                         'line' => $line,
                     ];
-                    if ($this->_relativePaths) {
-                        $details['file'] = '.' . str_replace(ROOT, '', $details['file']);
-                    }
+                    $details['file'] = '.' . str_replace(ROOT, '', $details['file']);
                     if ($plural !== null) {
                         $details['msgid_plural'] = $plural;
                     }
@@ -562,7 +548,7 @@ class I18nExtractCommand extends Command
                         $occurrences = implode("\n#: ", $occurrences);
 
                         $header = '#: '
-                            . str_replace(DIRECTORY_SEPARATOR, '/', str_replace($paths, '', $occurrences))
+                            . str_replace(DIRECTORY_SEPARATOR, '/', $occurrences)
                             . "\n";
                     }
 

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -84,38 +84,39 @@ class I18nExtractCommandTest extends TestCase
 
         $this->assertFileDoesNotExist($this->path . DS . 'cake.pot');
 
-        // extract.ctp
-        $pattern = '/\#: [\/\\\\]extract\.php:\d+\n';
-        $pattern .= '\#: [\/\\\\]extract\.php:\d+\n';
-        $pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
+        // The additional "./tests/test_app" is just due to the wonky folder structure of the test app.
+        // In a regular app the path would start with "./templates".
+        $pattern = '@\#: \./tests/test_app/templates/Pages/extract\.php:\d+\n';
+        $pattern .= '\#: \./tests/test_app/templates/Pages/extract\.php:\d+\n';
+        $pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."@';
         $this->assertMatchesRegularExpression($pattern, $result);
 
         $pattern = '/msgid "You have %d new message."\nmsgstr ""/';
         $this->assertDoesNotMatchRegularExpression($pattern, $result, 'No duplicate msgid');
 
-        $pattern = '/\#: [\/\\\\]extract\.php:\d+\n';
-        $pattern .= 'msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."/';
+        $pattern = '@\#: \./tests/test_app/templates/Pages/extract\.php:\d+\n';
+        $pattern .= 'msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."@';
         $this->assertMatchesRegularExpression($pattern, $result);
 
-        $pattern = '/\#: [\/\\\\]extract\.php:\d+\nmsgid "';
+        $pattern = '@\#: \./tests/test_app/templates/Pages/extract\.php:\d+\nmsgid "';
         $pattern .= 'Hot features!';
         $pattern .= '\\\n - No Configuration: Set-up the database and let the magic begin';
         $pattern .= '\\\n - Extremely Simple: Just look at the name...It\'s Cake';
         $pattern .= '\\\n - Active, Friendly Community: Join us #cakephp on IRC. We\'d love to help you get started';
-        $pattern .= '"\nmsgstr ""/';
+        $pattern .= '"\nmsgstr ""@';
         $this->assertMatchesRegularExpression($pattern, $result);
 
         $this->assertStringContainsString('msgid "double \\"quoted\\""', $result, 'Strings with quotes not handled correctly');
         $this->assertStringContainsString("msgid \"single 'quoted'\"", $result, 'Strings with quotes not handled correctly');
 
-        $pattern = '/\#: [\/\\\\]extract\.php:\d+\n';
+        $pattern = '@\#: \./tests/test_app/templates/Pages/extract\.php:\d+\n';
         $pattern .= 'msgctxt "mail"\n';
-        $pattern .= 'msgid "letter"/';
+        $pattern .= 'msgid "letter"@';
         $this->assertMatchesRegularExpression($pattern, $result);
 
-        $pattern = '/\#: [\/\\\\]extract\.php:\d+\n';
+        $pattern = '@\#: \./tests/test_app/templates/Pages/extract\.php:\d+\n';
         $pattern .= 'msgctxt "alphabet"\n';
-        $pattern .= 'msgid "letter"/';
+        $pattern .= 'msgid "letter"@';
         $this->assertMatchesRegularExpression($pattern, $result);
 
         // extract.php - reading the domain.pot
@@ -389,7 +390,6 @@ class I18nExtractCommandTest extends TestCase
     {
         $this->exec(
             'i18n extract ' .
-            '--relative-paths ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates ' .
             '--output=' . $this->path . DS


### PR DESCRIPTION
Paths in pot file comments are now always relative to the app root. Refs #15432.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
