### PR TITLE
Fix asset symlink and Filesystem::deleteDir() on windows

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,22 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Strict comparison using \\=\\=\\= between '/' and '\\\\\\\\' will always evaluate to false\\.$#"
+			path: src/Command/PluginAssetsTrait.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between \\*NEVER\\* and '\\\\\\\\' will always evaluate to false\\.$#"
+			path: src/Filesystem/Filesystem.php
+
+		-
+			message: "#^Result of && is always false.$#"
+			path: src/Filesystem/Filesystem.php
+
+		-
+			message: "#^Right side of \\|\\| is always false\\.$#"
+			path: src/Filesystem/Filesystem.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/Auth/DigestAuthenticate.php

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -180,7 +180,8 @@ trait PluginAssetsTrait
 
         if (is_link($dest)) {
             // phpcs:ignore
-            if (@unlink($dest)) {
+            $success = DS === '\\' ? @rmdir($dest) : @unlink($dest);
+            if ($success) {
                 $this->io->out('Unlinked ' . $dest);
 
                 return true;

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -204,7 +204,8 @@ class Filesystem
 
         $result = true;
         foreach ($iterator as $fileInfo) {
-            if ($fileInfo->getType() === self::TYPE_DIR) {
+            $isWindowsLink = DS === '\\' && $fileInfo->getType() === 'link';
+            if ($fileInfo->getType() === self::TYPE_DIR || $isWindowsLink) {
                 // phpcs:ignore
                 $result = $result && @rmdir($fileInfo->getPathname());
                 continue;

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -88,39 +88,28 @@ class PluginAssetsCommandsTest extends TestCase
 
         $path = $this->wwwRoot . 'test_plugin';
         $this->assertFileExists($path . DS . 'root.js');
-        if (DS === '\\') {
-            $this->assertDirectoryExists($path);
-        } else {
-            $this->assertTrue(is_link($path));
-        }
+        $this->assertTrue(is_link($path));
 
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
-        // If "company" directory exists beforehand "test_plugin_three" would
-        // be a link. But if the directory is created by the shell itself
-        // symlinking fails and the assets folder is copied as fallback.
-        $this->assertDirectoryExists($path);
         $this->assertFileExists($path . DS . 'css' . DS . 'company.css');
+        $this->assertTrue(is_link($path));
     }
 
     /**
-     * testSymlinkWhenVendorDirectoryExits
-     *
      * @return void
      */
-    public function testSymlinkWhenVendorDirectoryExits()
+    public function testSymlinkWhenVendorDirectoryExists()
     {
         $this->loadPlugins(['Company/TestPluginThree']);
 
         mkdir($this->wwwRoot . 'company');
 
         $this->exec('plugin assets symlink');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
-        if (DS === '\\') {
-            $this->assertDirectoryExists($path);
-        } else {
-            $this->assertTrue(is_link($path));
-        }
         $this->assertFileExists($path . DS . 'css' . DS . 'company.css');
+        $this->assertTrue(is_link($path));
     }
 
     /**
@@ -180,7 +169,6 @@ class PluginAssetsCommandsTest extends TestCase
         $path = $this->wwwRoot . 'test_plugin';
         $link = new \SplFileInfo($path);
         $this->assertFileExists($path . DS . 'root.js');
-        unlink($path);
 
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
         $this->assertDirectoryDoesNotExist($path);
@@ -243,12 +231,6 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testRemoveSymlink()
     {
-        if (DS === '\\') {
-            $this->markTestSkipped(
-                "Can't test symlink removal on windows."
-            );
-        }
-
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
         mkdir($this->wwwRoot . 'company');
@@ -265,8 +247,6 @@ class PluginAssetsCommandsTest extends TestCase
         $this->assertFalse(is_link($this->wwwRoot . 'test_plugin'));
         $this->assertFalse(is_link($path));
         $this->assertDirectoryExists($this->wwwRoot . 'company', 'Ensure namespace folder isn\'t removed');
-
-        rmdir($this->wwwRoot . 'company');
     }
 
     /**
@@ -289,8 +269,6 @@ class PluginAssetsCommandsTest extends TestCase
         $this->assertDirectoryDoesNotExist($this->wwwRoot . 'test_plugin');
         $this->assertDirectoryDoesNotExist($this->wwwRoot . 'company' . DS . 'test_plugin_three');
         $this->assertDirectoryExists($this->wwwRoot . 'company', 'Ensure namespace folder isn\'t removed');
-
-        rmdir($this->wwwRoot . 'company');
     }
 
     /**
@@ -309,20 +287,10 @@ class PluginAssetsCommandsTest extends TestCase
 
         sleep(1);
         $this->exec('plugin assets symlink TestPlugin --overwrite');
-        if (DS === '\\') {
-            $this->assertDirectoryExists($path);
-        } else {
-            $this->assertTrue(is_link($path));
-        }
+        $this->assertTrue(is_link($path));
 
         $newfilectime = filectime($path);
         $this->assertTrue($newfilectime !== $filectime);
-
-        if (DS === '\\') {
-            $this->fs->deleteDir($path);
-        } else {
-            unlink($path);
-        }
 
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
         mkdir($path, 0777, true);

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -51,11 +51,6 @@ class PluginAssetsCommandsTest extends TestCase
     {
         parent::setUp();
 
-        $this->skipIf(
-            DS === '\\',
-            'Skip AssetsTask tests on windows to prevent side effects for UrlHelper tests on AppVeyor.'
-        );
-
         $this->wwwRoot = TMP . 'assets_task_webroot' . DS;
         Configure::write('App.wwwRoot', $this->wwwRoot);
 

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -50,11 +50,6 @@ class ConsoleInputTest extends TestCase
     public function testDataAvailable()
     {
         $this->skipIf(
-            DS === '\\',
-            'Skip ConsoleInput tests on Windows as they fail on AppVeyor.'
-        );
-
-        $this->skipIf(
             (bool)env('GITHUB_ACTIONS'),
             'Skip test for ConsoleInput::dataAvailable() on Github VM as stream_select() incorrectly return 1 even though no data is available on STDIN.'
         );

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -109,4 +109,26 @@ class FilesystemTest extends TestCase
 
         $this->assertTrue($return);
     }
+
+    /**
+     * Tests deleteDir() on directory that contains symlinks
+     *
+     * @return void
+     */
+    public function testDeleteDirWithLinks()
+    {
+        $path = TMP . 'fs_links_test';
+        // phpcs:ignore
+        @mkdir($path);
+        $target = $path . DS . 'target';
+        // phpcs:ignore
+        @mkdir($target);
+
+        $link = $path . DS . 'link';
+        // phpcs:ignore
+        @symlink($target, $link);
+
+        $this->assertTrue($this->fs->deleteDir($path));
+        $this->assertFalse(file_exists($link));
+    }
 }


### PR DESCRIPTION
Let's see if these run correctly with github actions.
