### PR TITLE
Organizes output of `bin/cake routes` into columns.

### DIFF
--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -58,7 +58,7 @@ class RoutesCommand extends Command
                 $methods,
             ];
 
-            if ($args->getOption('verbose') !== null) {
+            if ($args->getOption('verbose') === true) {
                 ksort($route->defaults);
                 $item[] = json_encode($route->defaults);
             }
@@ -66,7 +66,7 @@ class RoutesCommand extends Command
             $output[] = $item;
         }
 
-        if ($args->getOption('sort') !== null) {
+        if ($args->getOption('sort') === true) {
             usort($output, function ($a, $b) {
                 return strcasecmp($a[0], $b[0]);
             });
@@ -93,6 +93,7 @@ class RoutesCommand extends Command
             ->addOption('sort', [
                 'help' => 'Sorts alphabetically by route name A-Z',
                 'short' => 's',
+                'boolean' => true,
             ]);
 
         return $parser;

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -36,7 +36,7 @@ class RoutesCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $header = ['Route name', 'URI template', 'Controller', 'Action', 'Plugin', 'Prefix', 'Method(s)'];
-        if ($args->getOption('verbose') !== null) {
+        if ($args->getOption('verbose')) {
             $header[] = 'Defaults';
         }
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -66,7 +66,7 @@ class RoutesCommand extends Command
             $output[] = $item;
         }
 
-        if ($args->getOption('sort') === true) {
+        if ($args->getOption('sort')) {
             usort($output, function ($a, $b) {
                 return strcasecmp($a[0], $b[0]);
             });

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -58,7 +58,7 @@ class RoutesCommand extends Command
                 $methods,
             ];
 
-            if ($args->getOption('verbose') === true) {
+            if ($args->getOption('verbose')) {
                 ksort($route->defaults);
                 $item[] = json_encode($route->defaults);
             }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -66,9 +66,11 @@ class RoutesCommand extends Command
             $output[] = $item;
         }
 
-        usort($output, function ($a, $b) {
-            return strcasecmp($a[0], $b[0]);
-        });
+        if ($args->getOption('sort') !== null) {
+            usort($output, function ($a, $b) {
+                return strcasecmp($a[0], $b[0]);
+            });
+        }
 
         array_unshift($output, $header);
 
@@ -91,6 +93,10 @@ class RoutesCommand extends Command
             ->addOption('verbose', [
                 'help' => 'Display verbose output',
                 'short' => 'v',
+            ])
+            ->addOption('sort', [
+                'help' => 'Sorts alphabetically by route name A-Z',
+                'short' => 's',
             ]);
 
         return $parser;

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -43,10 +43,7 @@ class RoutesCommand extends Command
         $output = [];
 
         foreach (Router::routes() as $route) {
-            $methods = '';
-            if (isset($route->defaults['_method']) && is_array($route->defaults['_method'])) {
-                $methods = implode(', ', $route->defaults['_method']);
-            }
+            $methods = $route->defaults['_method'] ?? '';
 
             $item = [
                 $route->options['_name'] ?? $route->getName(),
@@ -55,7 +52,7 @@ class RoutesCommand extends Command
                 $route->defaults['prefix'] ?? '',
                 $route->defaults['controller'] ?? '',
                 $route->defaults['action'] ?? '',
-                $methods,
+                is_string($methods) ? $methods : implode(', ', $route->defaults['_method']),
             ];
 
             if ($args->getOption('verbose')) {

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -90,10 +90,6 @@ class RoutesCommand extends Command
     {
         $parser
             ->setDescription('Get the list of routes connected in this application.')
-            ->addOption('verbose', [
-                'help' => 'Display verbose output',
-                'short' => 'v',
-            ])
             ->addOption('sort', [
                 'help' => 'Sorts alphabetically by route name A-Z',
                 'short' => 's',

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -35,7 +35,7 @@ class RoutesCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $header = ['Route name', 'URI template', 'Controller', 'Action', 'Plugin', 'Prefix', 'Method(s)'];
+        $header = ['Route name', 'URI template', 'Plugin', 'Prefix', 'Controller', 'Action', 'Method(s)'];
         if ($args->getOption('verbose')) {
             $header[] = 'Defaults';
         }
@@ -51,10 +51,10 @@ class RoutesCommand extends Command
             $item = [
                 $route->options['_name'] ?? $route->getName(),
                 $route->template,
-                $route->defaults['controller'] ?? '',
-                $route->defaults['action'] ?? '',
                 $route->defaults['plugin'] ?? '',
                 $route->defaults['prefix'] ?? '',
+                $route->defaults['controller'] ?? '',
+                $route->defaults['action'] ?? '',
                 $methods,
             ];
 

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -145,16 +145,6 @@ trait ConsoleIntegrationTestTrait
     }
 
     /**
-     * Get an array of messages from \Cake\TestSuite\Stub\ConsoleOutput::messages()
-     *
-     * @return array
-     */
-    public function getMessages(): array
-    {
-        return $this->_out->messages();
-    }
-
-    /**
      * Asserts shell exited with the expected code
      *
      * @param int $expected Expected exit code

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -145,6 +145,16 @@ trait ConsoleIntegrationTestTrait
     }
 
     /**
+     * Get an array of messages from \Cake\TestSuite\Stub\ConsoleOutput::messages()
+     *
+     * @return array
+     */
+    public function getMessages(): array
+    {
+        return $this->_out->messages();
+    }
+
+    /**
      * Asserts shell exited with the expected code
      *
      * @param int $expected Expected exit code

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -156,8 +156,7 @@ class RoutesCommandTest extends TestCase
 
         $this->exec('routes -s');
         $this->assertExitCode(Command::CODE_SUCCESS);
-        $messages = $this->getMessages();
-        $this->assertOutputContains('_aRoute', $messages[3]);
+        $this->assertOutputContains('_aRoute', $this->_out->messages()[3]);
     }
 
     /**

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -76,40 +76,40 @@ class RoutesCommandTest extends TestCase
         $this->assertOutputContainsRow([
             '<info>Route name</info>',
             '<info>URI template</info>',
-            '<info>Controller</info>',
-            '<info>Action</info>',
             '<info>Plugin</info>',
             '<info>Prefix</info>',
+            '<info>Controller</info>',
+            '<info>Action</info>',
             '<info>Method(s)</info>',
             '<info>Defaults</info>',
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',
             '/app/articles/:action/*',
+            '',
+            '',
             'Articles',
             'index',
-            '',
-            '',
             '',
             '{"action":"index","controller":"Articles","plugin":null}',
         ]);
         $this->assertOutputContainsRow([
             'bake._controller:_action',
             '/bake/:controller/:action',
-            '',
-            'index',
             'Bake',
             '',
+            '',
+            'index',
             '',
             '{"action":"index","plugin":"Bake"}',
         ]);
         $this->assertOutputContainsRow([
             'testName',
             '/app/tests/:action/*',
+            '',
+            '',
             'Tests',
             'index',
-            '',
-            '',
             '',
             '{"action":"index","controller":"Tests","plugin":null}',
         ]);

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Command;
 
 use Cake\Command\Command;
+use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -71,7 +72,54 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteList()
     {
-        $this->exec('routes -v -s');
+        $this->exec('routes');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContainsRow([
+            '<info>Route name</info>',
+            '<info>URI template</info>',
+            '<info>Plugin</info>',
+            '<info>Prefix</info>',
+            '<info>Controller</info>',
+            '<info>Action</info>',
+            '<info>Method(s)</info>',
+        ]);
+        $this->assertOutputContainsRow([
+            'articles:_action',
+            '/app/articles/:action/*',
+            '',
+            '',
+            'Articles',
+            'index',
+            '',
+        ]);
+        $this->assertOutputContainsRow([
+            'bake._controller:_action',
+            '/bake/:controller/:action',
+            'Bake',
+            '',
+            '',
+            'index',
+            '',
+        ]);
+        $this->assertOutputContainsRow([
+            'testName',
+            '/app/tests/:action/*',
+            '',
+            '',
+            'Tests',
+            'index',
+            '',
+        ]);
+    }
+
+    /**
+     * Test routes with --verbose option
+     *
+     * @return void
+     */
+    public function testRouteListVerbose()
+    {
+        $this->exec('routes -v');
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContainsRow([
             '<info>Route name</info>',
@@ -93,26 +141,23 @@ class RoutesCommandTest extends TestCase
             '',
             '{"action":"index","controller":"Articles","plugin":null}',
         ]);
-        $this->assertOutputContainsRow([
-            'bake._controller:_action',
-            '/bake/:controller/:action',
-            'Bake',
-            '',
-            '',
-            'index',
-            '',
-            '{"action":"index","plugin":"Bake"}',
-        ]);
-        $this->assertOutputContainsRow([
-            'testName',
-            '/app/tests/:action/*',
-            '',
-            '',
-            'Tests',
-            'index',
-            '',
-            '{"action":"index","controller":"Tests","plugin":null}',
-        ]);
+    }
+
+    /**
+     * Test routes with --sort option
+     *
+     * @return void
+     */
+    public function testRouteListSorted()
+    {
+        Router::connect(
+            new Route('/a/route/sorted', [], ['_name' => '_aRoute'])
+        );
+
+        $this->exec('routes -s');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $messages = $this->getMessages();
+        $this->assertOutputContains('_aRoute', $messages[3]);
     }
 
     /**

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -71,26 +71,46 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteList()
     {
-        $this->exec('routes');
+        $this->exec('routes -v');
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContainsRow([
             '<info>Route name</info>',
             '<info>URI template</info>',
-            '<info>Defaults</info>',
+            '<info>Controller</info>',
+            '<info>Action</info>',
+            '<info>Plugin</info>',
+            '<info>Prefix</info>',
+            '<info>Method(s)</info>',
+            '<info>Defaults</info>'
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',
             '/app/articles/:action/*',
+            'Articles',
+            'index',
+            '',
+            '',
+            '',
             '{"action":"index","controller":"Articles","plugin":null}',
         ]);
         $this->assertOutputContainsRow([
             'bake._controller:_action',
             '/bake/:controller/:action',
+            '',
+            'index',
+            'Bake',
+            '',
+            '',
             '{"action":"index","plugin":"Bake"}',
         ]);
         $this->assertOutputContainsRow([
             'testName',
             '/app/tests/:action/*',
+            'Tests',
+            'index',
+            '',
+            '',
+            '',
             '{"action":"index","controller":"Tests","plugin":null}',
         ]);
     }

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -81,7 +81,7 @@ class RoutesCommandTest extends TestCase
             '<info>Plugin</info>',
             '<info>Prefix</info>',
             '<info>Method(s)</info>',
-            '<info>Defaults</info>'
+            '<info>Defaults</info>',
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -71,7 +71,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteList()
     {
-        $this->exec('routes -v');
+        $this->exec('routes -v -s');
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContainsRow([
             '<info>Route name</info>',


### PR DESCRIPTION
The motivation behind this PR is cleaning up the output of `bin/cake routes` so data is easier to read for developers maintaining applications with a large number of routes. This change:

- Sorts alphabetically by route name (edit: optionally via `--sort`)
- Previous JSON display is maintained (edit: with the existing) `--verbose` switch
- Updates unit test

Sample output:

```
> bin/cake routes
+-------------------------------------+-------------------------------------------+-------------+-------------------+-------------+-----------+---------------+
| Route name                          | URI template                              | Controller  | Action            | Plugin      | Prefix    | Method(s)     |
+-------------------------------------+-------------------------------------------+-------------+-------------------+-------------+-----------+---------------+
| _controller:_action                 | /{controller}/{action}/*                  |             | index             |             |           |               |
| actors:edit                         | /actors/:id                               | Actors      | edit              |             |           | PUT, PATCH    |
| admin:setup._controller:_action     | /admin/setup/{controller}/{action}/*      |             | index             | Setup       | Admin     |               |
```

Adding the `--verbose` or `-v` switch simply appends a column called Defaults to the end of the rows.

I had considered adding some additional switches such as `--plugin` for limiting to a specific plugin and `--no-plugins` for hiding all plugins, but I think these use-cases can be accomplished with `grep`. This keeps the change relatively small and eliminates the need for additional unit tests.