### PR TITLE
Use source Table connection when creating association target Table

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -391,7 +391,7 @@ abstract class Association
             $config = [];
             $exists = $tableLocator->exists($registryAlias);
             if (!$exists) {
-                $config = ['className' => $this->_className];
+                $config = ['className' => $this->_className, 'connection' => $this->getSource()->getConnection()];
             }
             $this->_targetTable = $tableLocator->get($registryAlias, $config);
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -93,7 +93,6 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertSame('CustomI18n', $i18n->getName());
         $this->assertInstanceOf(CustomI18nTable::class, $i18n->getTarget());
-        $this->assertSame('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
         $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTable());
     }
 


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/15448
Fixes https://github.com/cakephp/bake/issues/742

There doesn't seem to be a test specific to creating a target Table instance from `getTarget()`.
