### PR TITLE
Allow new fixtures to use the data only loader

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,11 +457,6 @@ parameters:
 			path: src/TestSuite/Constraint/Response/StatusCodeBase.php
 
 		-
-			message: "#^Access to an undefined property PHPUnit\\\\Framework\\\\Test\\:\\:\\$fixtureManager\\.$#"
-			count: 1
-			path: src/TestSuite/Fixture/FixtureInjector.php
-
-		-
 			message: "#^Parameter \\#1 \\$connection of method Cake\\\\Database\\\\Schema\\\\SqlGeneratorInterface\\:\\:createSql\\(\\) expects Cake\\\\Database\\\\Connection, Cake\\\\Datasource\\\\ConnectionInterface given\\.$#"
 			count: 1
 			path: src/TestSuite/Fixture/TestFixture.php

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -125,7 +125,7 @@ class FixtureDataManager extends FixtureLoader
     /**
      * @inheritDoc
      */
-    public function loadSingle(string $name, ?ConnectionInterface $connection = null): void
+    public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {
         if (!isset($this->nameMap[$name])) {
             throw new UnexpectedValueException(sprintf('Referenced fixture class %s not found', $name));

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -35,7 +35,7 @@ use UnexpectedValueException;
  * This class implements a common interface with the Cake\TestSuite\FixtureManager so that
  * test cases only need to interact with a single interface.
  */
-class FixtureDataManager
+class FixtureDataManager extends FixtureLoader
 {
     /**
      * A mapping between the fixture name (including the prefix) and the object.
@@ -123,13 +123,7 @@ class FixtureDataManager
     }
 
     /**
-     * Loads the data for a single fixture.
-     *
-     * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
-     *  to get a Connection from the fixture.
-     * @return void
-     * @throws \UnexpectedValueException if $name is not a previously fixtures class
+     * @inheritDoc
      */
     public function loadSingle(string $name, ?ConnectionInterface $connection = null): void
     {
@@ -146,12 +140,7 @@ class FixtureDataManager
     }
 
     /**
-     * Creates records defined in a test case's fixtures.
-     *
-     * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
-     * @return void
-     * @throws \Cake\Core\Exception\CakeException When fixture records cannot be inserted.
-     * @throws \RuntimeException
+     * @inheritDoc
      */
     public function load(TestCase $test): void
     {
@@ -227,10 +216,7 @@ class FixtureDataManager
     }
 
     /**
-     * Inspects the test to to load fixture classes.
-     *
-     * @param \Cake\TestSuite\TestCase $test The test case to inspect.
-     * @return void
+     * @inheritDoc
      */
     public function fixturize(TestCase $test): void
     {
@@ -241,9 +227,7 @@ class FixtureDataManager
     }
 
     /**
-     * Get the fixtures fixtures.
-     *
-     * @return \Cake\Datasource\FixtureInterface[]
+     * @inheritDoc
      */
     public function loaded(): array
     {

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
+use Cake\TestSuite\Fix;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestListenerTrait;
 use PHPUnit\Framework\Test;
@@ -29,13 +30,6 @@ use PHPUnit\Framework\TestSuite;
 class FixtureInjector implements TestListener
 {
     use TestListenerTrait;
-
-    /**
-     * The instance of the fixture manager to use
-     *
-     * @var \Cake\TestSuite\Fixture\FixtureManager
-     */
-    protected $_fixtureManager;
 
     /**
      * Holds a reference to the container test suite
@@ -54,6 +48,7 @@ class FixtureInjector implements TestListener
         if (isset($_SERVER['argv'])) {
             $manager->setDebug(in_array('--debug', $_SERVER['argv'], true));
         }
+        FixtureLoader::setInstance($manager);
         $this->_fixtureManager = $manager;
         $this->_fixtureManager->shutDown();
     }
@@ -94,9 +89,6 @@ class FixtureInjector implements TestListener
      */
     public function startTest(Test $test): void
     {
-        // TODO replace this with reading from the singleton
-        /** @psalm-suppress NoInterfaceProperties */
-        $test->fixtureManager = $this->_fixtureManager;
         if ($test instanceof TestCase) {
             $this->_fixtureManager->fixturize($test);
             $this->_fixtureManager->load($test);

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
-use Cake\TestSuite\Fix;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestListenerTrait;
 use PHPUnit\Framework\Test;
@@ -30,6 +29,13 @@ use PHPUnit\Framework\TestSuite;
 class FixtureInjector implements TestListener
 {
     use TestListenerTrait;
+
+    /**
+     * The instance of the fixture manager to use
+     *
+     * @var \Cake\TestSuite\Fixture\FixtureManager
+     */
+    protected $_fixtureManager;
 
     /**
      * Holds a reference to the container test suite

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Datasource\ConnectionInterface;

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -46,7 +46,7 @@ abstract class FixtureLoader
      *
      * @return \Cake\TestSuite\Fixture\FixtureLoader|null
      */
-    public static function getInstance(): self
+    public static function getInstance(): ?self
     {
         return static::$instance;
     }

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Fixture;
+
+use Cake\Datasource\ConnectionInterface;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Abstract base class and singleton container for fixture
+ * managers.
+ */
+abstract class FixtureLoader
+{
+    /**
+     * @var \Cake\TestSuite\Fixture\FixtureLoader|null
+     */
+    private static $instance;
+
+    /**
+     * Set the shared instance
+     *
+     * @param \Cake\TestSuite\Fixture\FixtureLoader $instance The instance to set.
+     * @return void
+     */
+    public static function setInstance(FixtureLoader $instance): void
+    {
+        static::$instance = $instance;
+    }
+
+    /**
+     * Get the shared instance
+     *
+     * @return \Cake\TestSuite\Fixture\FixtureLoader|null
+     */
+    public static function getInstance(): self
+    {
+        return static::$instance;
+    }
+
+    /**
+     * Loads the data for a single fixture.
+     *
+     * @param string $name of the fixture
+     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
+     *  to get a Connection from the fixture.
+     * @return void
+     * @throws \UnexpectedValueException if $name is not a previously fixtures class
+     */
+    abstract public function loadSingle(string $name, ?ConnectionInterface $connection = null): void;
+
+    /**
+     * Creates records defined in a test case's fixtures.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
+     * @return void
+     * @throws \Cake\Core\Exception\CakeException When fixture records cannot be inserted.
+     * @throws \RuntimeException
+     */
+    abstract public function load(TestCase $test): void;
+
+    /**
+     * Inspects the test to to load fixture classes.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test case to inspect.
+     * @return void
+     */
+    abstract public function fixturize(TestCase $test): void;
+
+    /**
+     * Get the fixtures fixtures.
+     *
+     * @return \Cake\Datasource\FixtureInterface[]
+     */
+    abstract public function loaded(): array;
+}

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Datasource\ConnectionInterface;
@@ -57,10 +59,16 @@ abstract class FixtureLoader
      * @param string $name of the fixture
      * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
      *  to get a Connection from the fixture.
+     * @param bool $dropTables Whether or not tables should be dropped. Not all implementations
+     *   support this parameter.
      * @return void
      * @throws \UnexpectedValueException if $name is not a previously fixtures class
      */
-    abstract public function loadSingle(string $name, ?ConnectionInterface $connection = null): void;
+    abstract public function loadSingle(
+        string $name,
+        ?ConnectionInterface $connection = null,
+        bool $dropTables = true
+    ): void;
 
     /**
      * Creates records defined in a test case's fixtures.

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -32,7 +32,7 @@ use UnexpectedValueException;
 /**
  * A factory class to manage the life cycle of test fixtures
  */
-class FixtureManager
+class FixtureManager extends FixtureLoader
 {
     /**
      * Was this instance already initialized?
@@ -89,10 +89,7 @@ class FixtureManager
     }
 
     /**
-     * Inspects the test to look for unloaded fixtures and loads them
-     *
-     * @param \Cake\TestSuite\TestCase $test The test case to inspect.
-     * @return void
+     * @inheritDoc
      */
     public function fixturize(TestCase $test): void
     {
@@ -105,9 +102,7 @@ class FixtureManager
     }
 
     /**
-     * Get the loaded fixtures.
-     *
-     * @return \Cake\Datasource\FixtureInterface[]
+     * @inheritDoc
      */
     public function loaded(): array
     {
@@ -269,12 +264,7 @@ class FixtureManager
     }
 
     /**
-     * Creates the fixtures tables and inserts data on them.
-     *
-     * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
-     * @return void
-     * @throws \Cake\Core\Exception\CakeException When fixture records cannot be inserted.
-     * @throws \RuntimeException
+     * @inheritDoc
      */
     public function load(TestCase $test): void
     {
@@ -440,14 +430,7 @@ class FixtureManager
     }
 
     /**
-     * Creates a single fixture table and loads data into it.
-     *
-     * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
-     *  to get a Connection from the fixture.
-     * @param bool $dropTables Whether or not tables should be dropped and re-created.
-     * @return void
-     * @throws \UnexpectedValueException if $name is not a previously loaded class
+     * @inheritDoc
      */
     public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -430,14 +430,7 @@ class FixtureManager extends FixtureLoader
     }
 
     /**
-     * Loads the data for a single fixture.
-     *
-     * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
-     *  to get a Connection from the fixture.
-     * @param bool $dropTables Whether or not to drop tables.
-     * @return void
-     * @throws \UnexpectedValueException if $name is not a previously fixtures class
+     * @inheritDoc
      */
     public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -430,7 +430,14 @@ class FixtureManager extends FixtureLoader
     }
 
     /**
-     * @inheritDoc
+     * Loads the data for a single fixture.
+     *
+     * @param string $name of the fixture
+     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance or null
+     *  to get a Connection from the fixture.
+     * @param bool $dropTables Whether or not to drop tables.
+     * @return void
+     * @throws \UnexpectedValueException if $name is not a previously fixtures class
      */
     public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {

--- a/src/TestSuite/FixtureSchemaExtension.php
+++ b/src/TestSuite/FixtureSchemaExtension.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite;
 
+use Cake\TestSuite\Fixture\FixtureDataManager;
+use Cake\TestSuite\Fixture\FixtureLoader;
 use Cake\TestSuite\Fixture\TransactionStrategy;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeTestHook;
@@ -42,7 +44,7 @@ class FixtureSchemaExtension implements
         $enableLogging = in_array('--debug', $_SERVER['argv'] ?? [], true);
         $this->state = new $stateStrategy($enableLogging);
 
-        // TODO Create the singleton fixture manager that tests will use.
+        FixtureLoader::setInstance(new FixtureDataManager());
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -27,6 +27,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Routing\Router;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
+use Cake\TestSuite\Fixture\FixtureLoader;
 use Cake\Utility\Inflector;
 use LogicException;
 use PHPUnit\Framework\Constraint\DirectoryExists;
@@ -48,7 +49,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * The class responsible for managing the creation, loading and removing of fixtures
      *
-     * @var \Cake\TestSuite\Fixture\FixtureManager|null
+     * @var \Cake\TestSuite\Fixture\FixtureLoader|null
      */
     public $fixtureManager;
 
@@ -211,9 +212,7 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        // TODO add loading data only fixtures.
-
+        $this->fixtureManager = FixtureLoader::getInstance();
         if (!$this->_configure) {
             $this->_configure = Configure::read();
         }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -26,7 +26,6 @@ use Cake\ORM\Table;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Router;
 use Cake\Test\Fixture\FixturizedTestCase;
-use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
 use TestApp\Model\Table\SecondaryPostsTable;

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -109,44 +109,6 @@ class TestCaseTest extends TestCase
     }
 
     /**
-     * testLoadFixturesOnDemand
-     *
-     * @return void
-     */
-    public function testLoadFixturesOnDemand()
-    {
-        $test = new FixturizedTestCase('testFixtureLoadOnDemand');
-        $test->autoFixtures = false;
-        $manager = $this->getMockBuilder('Cake\TestSuite\Fixture\FixtureManager')->getMock();
-        $manager->fixturize($test);
-        $test->fixtureManager = $manager;
-        $manager->expects($this->once())->method('loadSingle');
-        $result = $test->run();
-
-        $this->assertSame(0, $result->errorCount());
-    }
-
-    /**
-     * tests loadFixtures loads all fixtures on the test
-     *
-     * @return void
-     */
-    public function testLoadAllFixtures()
-    {
-        $test = new FixturizedTestCase('testLoadAllFixtures');
-        $test->autoFixtures = false;
-        $manager = new FixtureManager();
-        $manager->fixturize($test);
-        $test->fixtureManager = $manager;
-
-        $result = $test->run();
-
-        $this->assertSame(0, $result->errorCount());
-        $this->assertCount(1, $result->passed());
-        $this->assertFalse($test->autoFixtures);
-    }
-
-    /**
      * testSkipIf
      *
      * @return void


### PR DESCRIPTION
Convert the active fixture loader to a singleton. This allows the
PHPUnit extension/listener to inject its own implementation. TestCases
now pull from this singleton as the extension cannot set properties, and
I'd like both fixture systems to have properties available with the same
sequencing.