### PR TITLE
Change @return type of Cake\Http\Session::read()

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -420,7 +420,7 @@ class Session
      * Returns given session variable, or all of them, if no parameters given.
      *
      * @param string|null $name The name of the session variable (or a path as sent to Hash.extract)
-     * @return string|array|null The value of the session variable, null if session not available,
+     * @return mixed|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
     public function read($name = null)


### PR DESCRIPTION
This was throwing a lot of "false" errors on IDEs since this method can actually return more than `string|array`

This is already fixed in 4.x