### PR TITLE
Fixed setting of errors for translated records in the primary entity.

### DIFF
--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -178,7 +178,7 @@ trait TranslateStrategyTrait
 
                 // Set errors into the root entity, so validation errors match the original form data position.
                 if ($errors) {
-                    $entity->setErrors($errors);
+                    $entity->setErrors(['_translations' => $errors]);
                 }
 
                 return $translations;

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1847,7 +1847,7 @@ class TranslateBehaviorTest extends TestCase
                 '_empty' => 'This field cannot be left empty',
             ],
         ];
-        $this->assertEquals($expected, $entity->getError('es'));
+        $this->assertEquals($expected, $entity->getError('_translations.es'));
 
         $this->assertSame('English Title', $result['en']->title);
         $this->assertNull($result['es']->title);
@@ -1936,7 +1936,7 @@ class TranslateBehaviorTest extends TestCase
                 '_empty' => 'This field cannot be left empty',
             ],
         ];
-        $this->assertEquals($expected, $entity->getError('es'));
+        $this->assertEquals($expected, $entity->getError('_translations.es'));
     }
 
     /**


### PR DESCRIPTION
For .e.g. the error should be set for key '_translations.{lang}.{field}' not
'{lang}.{field}', for the error to be properly displayed in the form.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
