### PR TITLE
Fix at matcher pt1

### DIFF
--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Collection\Iterator;
 
 use Cake\Collection\Iterator\FilterIterator;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * FilterIterator test
@@ -33,15 +32,12 @@ class FilterIteratorTest extends TestCase
     public function testFilter()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = function ($key, $value, $itemArg) use ($items) {
+        $callable = function ($value, $key, $itemArg) use ($items) {
             $this->assertSame($items, $itemArg);
-            if ($key === 1 || $key === 3) {
-                return false;
-            }
-            if ($key === 2) {
-                return true;
-            }
-            throw new RuntimeException('Unexpected value');
+            $this->assertContains($value, $items);
+            $this->assertContains($key, [0, 1, 2]);
+
+            return $value === 2;
         };
 
         $filter = new FilterIterator($items, $callable);

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Collection\Iterator;
 
 use Cake\Collection\Iterator\ReplaceIterator;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * ReplaceIterator Test
@@ -33,18 +32,12 @@ class ReplaceIteratorTest extends TestCase
     public function testReplace()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = function ($key, $value, $itemsArg) use ($items) {
+        $callable = function ($value, $key, $itemsArg) use ($items) {
             $this->assertSame($items, $itemsArg);
-            if ($key === 1) {
-                return 1;
-            }
-            if ($key === 2) {
-                return 4;
-            }
-            if ($key === 3) {
-                return 9;
-            }
-            throw new RuntimeException('Unexpected value');
+            $this->assertContains($value, $items);
+            $this->assertContains($key, [0, 1, 2]);
+
+            return $value > 1 ? $value * $value : $value;
         };
 
         $map = new ReplaceIterator($items, $callable);

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -133,9 +133,9 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testBuildNoArgs()
     {
-        $this->cache->expects($this->once())
+        $this->cache->expects($this->atLeastOnce())
             ->method('set')
-            ->with('test_articles')
+            ->withConsecutive(['test_articles'])
             ->will($this->returnValue(true));
 
         $this->exec('schema_cache build --connection test');
@@ -211,9 +211,9 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testClearNoArgs()
     {
-        $this->cache->expects($this->once())
+        $this->cache->expects($this->atLeastOnce())
             ->method('delete')
-            ->with('test_articles')
+            ->withConsecutive(['test_articles'])
             ->will($this->returnValue(true));
 
         $this->exec('schema_cache clear --connection test');

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -133,7 +133,7 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testBuildNoArgs()
     {
-        $this->cache->expects($this->at(0))
+        $this->cache->expects($this->once())
             ->method('set')
             ->with('test_articles')
             ->will($this->returnValue(true));
@@ -211,7 +211,7 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testClearNoArgs()
     {
-        $this->cache->expects($this->at(0))
+        $this->cache->expects($this->once())
             ->method('delete')
             ->with('test_articles')
             ->will($this->returnValue(true));

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @since         1.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;
@@ -508,19 +510,16 @@ class ControllerTest extends TestCase
         $controller = new Controller(null, null, null, $eventManager);
 
         $eventManager
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('dispatch')
-            ->with($this->callback(function (EventInterface $event) {
-                return $event->getName() === 'Controller.initialize';
-            }))
-            ->will($this->returnValue(new Event('stub')));
-
-        $eventManager
-            ->expects($this->at(1))
-            ->method('dispatch')
-            ->with($this->callback(function (EventInterface $event) {
-                return $event->getName() === 'Controller.startup';
-            }))
+            ->withConsecutive(
+                [$this->callback(function (EventInterface $event) {
+                    return $event->getName() === 'Controller.initialize';
+                })],
+                [$this->callback(function (EventInterface $event) {
+                    return $event->getName() === 'Controller.startup';
+                })]
+            )
             ->will($this->returnValue(new Event('stub')));
 
         $controller->startupProcess();
@@ -787,7 +786,7 @@ class ControllerTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage(
             'Controller actions can only return ResponseInterface instance or null. '
-            . 'Got string instead.'
+                . 'Got string instead.'
         );
 
         $url = new ServerRequest([

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         1.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -102,8 +102,9 @@ class LoggingStatementTest extends TestCase
         $inner->method('execute')->will($this->returnValue(true));
 
         $date = new \DateTime('2013-01-01');
-        $inner->expects($this->at(0))->method('bindValue')->with('a', 1);
-        $inner->expects($this->at(1))->method('bindValue')->with('b', $date);
+        $inner->expects($this->atLeast(2))
+              ->method('bindValue')
+              ->withConsecutive(['a', 1], ['b', $date]);
 
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -32,7 +32,7 @@ class ConsoleLogTest extends TestCase
         $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
         $message = ' Error: oh noes</error>';
-        $output->expects($this->at(0))
+        $output->expects($this->once())
             ->method('write')
             ->with($this->stringContains($message));
 
@@ -67,7 +67,7 @@ class ConsoleLogTest extends TestCase
     {
         $output = $this->getMockBuilder(ConsoleOutput::class)->getMock();
 
-        $output->expects($this->at(0))
+        $output->expects($this->once())
             ->method('setOutputAs')
             ->with(ConsoleOutput::RAW);
 

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @since         2.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\Log\Engine;
 
 use Cake\Log\Engine\SyslogLog;
@@ -83,7 +85,7 @@ class SyslogLogTest extends TestCase
             ->method('_write')
             ->withConsecutive(
                 [LOG_DEBUG, 'debug: Foo'],
-                [LOG_DEBUG, 'debug: Bar'],
+                [LOG_DEBUG, 'debug: Bar']
             );
         $log->log('debug', "Foo\nBar");
     }

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -79,9 +79,12 @@ class SyslogLogTest extends TestCase
         $log = $this->getMockBuilder(SyslogLog::class)
             ->onlyMethods(['_open', '_write'])
             ->getMock();
-        $log->expects($this->at(1))->method('_write')->with(LOG_DEBUG, 'debug: Foo');
-        $log->expects($this->at(2))->method('_write')->with(LOG_DEBUG, 'debug: Bar');
-        $log->expects($this->exactly(2))->method('_write');
+        $log->expects($this->exactly(2))
+            ->method('_write')
+            ->withConsecutive(
+                [LOG_DEBUG, 'debug: Foo'],
+                [LOG_DEBUG, 'debug: Bar'],
+            );
         $log->log('debug', "Foo\nBar");
     }
 

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         2.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\Log\Engine;
 
 use Cake\Log\Engine\SyslogLog;

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -41,7 +41,7 @@ class LogTraitTest extends TestCase
             ->method('log')
             ->withConsecutive(
                 ['error', 'Testing'],
-                ['debug', 'message'],
+                ['debug', 'message']
             );
 
         Log::setConfig('trait_test', ['engine' => $mock]);

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -37,13 +37,12 @@ class LogTraitTest extends TestCase
     public function testLog()
     {
         $mock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
-        $mock->expects($this->at(0))
+        $mock->expects($this->exactly(2))
             ->method('log')
-            ->with('error', 'Testing');
-
-        $mock->expects($this->at(1))
-            ->method('log')
-            ->with('debug', 'message');
+            ->withConsecutive(
+                ['error', 'Testing'],
+                ['debug', 'message'],
+            );
 
         Log::setConfig('trait_test', ['engine' => $mock]);
         $subject = $this->getObjectForTrait('Cake\Log\LogTrait');

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -14,6 +15,7 @@ declare(strict_types=1);
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\ORM\Entity;
@@ -250,13 +252,14 @@ class EntityTest extends TestCase
             ->onlyMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
-        $entity->expects($this->at(0))
+        $entity->expects($this->exactly(2))
             ->method('set')
-            ->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false]);
-
-        $entity->expects($this->at(1))
-            ->method('set')
-            ->with(['foo' => 'bar'], ['setter' => false, 'guard' => false]);
+            ->withConsecutive(
+                [
+                    ['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false],
+                ],
+                [['foo' => 'bar'], ['setter' => false, 'guard' => false]]
+            );
 
         $entity->__construct(['a' => 'b', 'c' => 'd']);
         $entity->__construct(['foo' => 'bar'], ['useSetters' => false]);
@@ -583,7 +586,7 @@ class EntityTest extends TestCase
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['unset'])
             ->getMock();
-        $entity->expects($this->at(0))
+        $entity->expects($this->once())
             ->method('unset')
             ->with('foo');
         unset($entity->foo);
@@ -629,15 +632,13 @@ class EntityTest extends TestCase
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['get'])
             ->getMock();
-        $entity->expects($this->at(0))
+        $entity->expects($this->exactly(2))
             ->method('get')
-            ->with('foo')
-            ->will($this->returnValue('worked'));
-
-        $entity->expects($this->at(1))
-            ->method('get')
-            ->with('bar')
-            ->will($this->returnValue('worked too'));
+            ->withConsecutive(['foo'], ['bar'])
+            ->will($this->onConsecutiveCalls(
+                $this->returnValue('worked'),
+                $this->returnValue('worked too')
+            ));
 
         $this->assertSame('worked', $entity['foo']);
         $this->assertSame('worked too', $entity['bar']);
@@ -655,15 +656,13 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->setAccess('*', true);
 
-        $entity->expects($this->at(0))
+        $entity->expects($this->exactly(2))
             ->method('set')
-            ->with('foo', 1)
-            ->will($this->returnSelf());
-
-        $entity->expects($this->at(1))
-            ->method('set')
-            ->with('bar', 2)
-            ->will($this->returnSelf());
+            ->withConsecutive(['foo', 1], ['bar', 2])
+            ->will($this->onConsecutiveCalls(
+                $this->returnSelf(),
+                $this->returnSelf()
+            ));
 
         $entity['foo'] = 1;
         $entity['bar'] = 2;
@@ -680,7 +679,7 @@ class EntityTest extends TestCase
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['unset'])
             ->getMock();
-        $entity->expects($this->at(0))
+        $entity->expects($this->once())
             ->method('unset')
             ->with('foo');
         unset($entity['foo']);
@@ -784,7 +783,7 @@ class EntityTest extends TestCase
             'title' => 'Foo',
             'author_id' => 3,
         ]);
-        $expected = ['author_id' => 3, 'title' => 'Foo', ];
+        $expected = ['author_id' => 3, 'title' => 'Foo',];
         $this->assertEquals($expected, $entity->extract(['author_id', 'title']));
 
         $expected = ['id' => 1];

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\ORM\Entity;


### PR DESCRIPTION
I figured we should start the long process to update our usage of `at()` with undeprecated APIs. This is the first of many pull requests that will be needed to update all 300+ usages of `at()`.