### PR TITLE
Clean up testFindSingleLocaleHasMany

### DIFF
--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -602,17 +602,12 @@ class TranslateBehaviorTest extends TestCase
     public function testFindSingleLocaleHasMany()
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->hasMany('Comments');
         $comments = $table->hasMany('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
-        $table->setLocale('eng');
         $comments->setLocale('eng');
 
-        $results = $table->find()->contain(['Comments' => function ($q) {
-            return $q->select(['id', 'comment', 'article_id']);
-        }]);
+        $results = $table->find()->contain(['Comments'])->order(['id']);
 
         $list = new Collection($results->first()->comments);
         $expected = [

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -40,11 +40,15 @@ class TranslateBehaviorTest extends TestCase
     protected $fixtures = [
         'core.Articles',
         'core.ArticlesTags',
+        'core.ArticlesTranslations',
         'core.Authors',
         'core.Sections',
         'core.SpecialTags',
+        'core.SpecialTagsTranslations',
         'core.Tags',
+        'core.TagsTranslations',
         'core.Comments',
+        'core.CommentsTranslations',
         'core.Translates',
     ];
 


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/15464

Only the Comments table needs translation configured. The 'Comments' association should only be added once.

~I don't see any issue that would cause the query to return 0 results, but the association shouldn't be added twice.~

The translation fixtures were not loaded for TranslateBehaviorTest. I can only guess some combination of TranslateBehaviorShadowTableTest running first caused it to pass tests.
