### PR TITLE
Allow specifying timezone to use when marshaling DateTimeType.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -320,7 +320,8 @@ class DateTimeType extends BaseType implements BatchCastingInterface
     public function marshal($value): ?DateTimeInterface
     {
         if ($value instanceof DateTimeInterface) {
-            return $value;
+            /** @var \Datetime|\DateTimeImmutable $value */
+            return $value->setTimezone($this->defaultTimezone);
         }
 
         /** @var class-string<\DatetimeInterface> $class */
@@ -331,7 +332,10 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             }
 
             if (ctype_digit($value)) {
-                return new $class('@' . $value);
+                /** @var \Datetime|\DateTimeImmutable $dateTime */
+                $dateTime = new $class('@' . $value);
+
+                return $dateTime->setTimezone($this->defaultTimezone);
             }
 
             if (is_string($value)) {
@@ -342,11 +346,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
                 }
 
                 /** @var \Datetime|\DateTimeImmutable $dateTime */
-                if (
-                    $dateTime !== null &&
-                    $this->userTimezone &&
-                    $this->userTimezone->getName() !== $this->defaultTimezone->getName()
-                ) {
+                if ($dateTime !== null) {
                     $dateTime = $dateTime->setTimezone($this->defaultTimezone);
                 }
 
@@ -388,7 +388,10 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             $value['microsecond']
         );
 
-        return new $class($format, $value['timezone'] ?? $this->userTimezone);
+        /** @var \Datetime|\DateTimeImmutable $dateTime */
+        $dateTime = new $class($format, $value['timezone'] ?? $this->userTimezone);
+
+        return $dateTime->setTimezone($this->defaultTimezone);
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -320,6 +320,10 @@ class DateTimeType extends BaseType implements BatchCastingInterface
     public function marshal($value): ?DateTimeInterface
     {
         if ($value instanceof DateTimeInterface) {
+            if ($value instanceof DateTime) {
+                $value = clone $value;
+            }
+
             /** @var \Datetime|\DateTimeImmutable $value */
             return $value->setTimezone($this->defaultTimezone);
         }

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -319,7 +319,8 @@ class DateTimeTypeTest extends TestCase
 
         $result = $this->type->marshal($expected);
         $this->assertEquals('UTC', $result->getTimezone()->getName());
-        $this->assertEquals($expected, $result->addHours(2));
+        $this->assertEquals($expected->toDateTimeString(), $result->addHours(2)->toDateTimeString());
+        $this->assertEquals('Europe/Paris', $expected->getTimezone()->getName());
     }
 
     public function testMarshalWithUserTimezone()

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -308,6 +308,20 @@ class DateTimeTypeTest extends TestCase
         }
     }
 
+    /**
+     * Test that the marhsalled datetime instance always has the system's default timezone.
+     *
+     * @return void
+     */
+    public function testMarshalDateTimeInstance()
+    {
+        $expected = new Time('2020-05-01 23:28:00', 'Europe/Paris');
+
+        $result = $this->type->marshal($expected);
+        $this->assertEquals('UTC', $result->getTimezone()->getName());
+        $this->assertEquals($expected, $result->addHours(2));
+    }
+
     public function testMarshalWithUserTimezone()
     {
         $this->type->setUserTimezone('+0200');
@@ -316,13 +330,15 @@ class DateTimeTypeTest extends TestCase
         $expected = new Time($value);
 
         $result = $this->type->marshal($value);
+        $this->assertEquals('UTC', $result->getTimezone()->getName());
         $this->assertEquals($expected, $result->addHours(2));
 
-        $expected = new Time('2020-05-01 23:28:00', '+0200');
+        $expected = new Time('2020-05-01 21:28:00', 'UTC');
         $result = $this->type->marshal([
             'year' => 2020, 'month' => 5, 'day' => 1,
             'hour' => 23, 'minute' => 28, 'second' => 0,
         ]);
+        $this->assertEquals('UTC', $result->getTimezone()->getName());
         $this->assertEquals($expected, $result);
 
         $this->type->setUserTimezone(null);
@@ -362,6 +378,7 @@ class DateTimeTypeTest extends TestCase
 
         $this->type->setUserTimezone('+0200');
         $result = $this->type->marshal('10/13/2013 11:28pm');
+        $this->assertEquals('UTC', $result->getTimezone()->getName());
         $this->assertEquals($expected, $result->addHours(2));
         $this->type->setUserTimezone(null);
 

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -308,6 +308,26 @@ class DateTimeTypeTest extends TestCase
         }
     }
 
+    public function testMarshalWithUserTimezone()
+    {
+        $this->type->setUserTimezone('+0200');
+
+        $value = '2020-05-01 23:28:00';
+        $expected = new Time($value);
+
+        $result = $this->type->marshal($value);
+        $this->assertEquals($expected, $result->addHours(2));
+
+        $expected = new Time('2020-05-01 23:28:00', '+0200');
+        $result = $this->type->marshal([
+            'year' => 2020, 'month' => 5, 'day' => 1,
+            'hour' => 23, 'minute' => 28, 'second' => 0,
+        ]);
+        $this->assertEquals($expected, $result);
+
+        $this->type->setUserTimezone(null);
+    }
+
     /**
      * Test that useLocaleParser() can disable locale parsing.
      *
@@ -337,7 +357,13 @@ class DateTimeTypeTest extends TestCase
         $expected = new Time('13-10-2013 23:28:00');
         $result = $this->type->marshal('10/13/2013 11:28pm');
         $this->assertEquals($expected, $result);
+
         $this->assertNull($this->type->marshal('11/derp/2013 11:28pm'));
+
+        $this->type->setUserTimezone('+0200');
+        $result = $this->type->marshal('10/13/2013 11:28pm');
+        $this->assertEquals($expected, $result->addHours(2));
+        $this->type->setUserTimezone(null);
 
         $this->type->useLocaleParser(false);
     }


### PR DESCRIPTION
In apps using localized datetime, generally the values are converted to user's
timezone when used in datetime inputs of forms. When marshaling the submitted
values `DateTimeType` is unaware of the user's timezone and always marshals datetime
strings into `Time`/`FrozenTime` instances assuming they are in the system's timezone.

The new `DateTimeType::setLocalTimezone()` methods allows you to specify the
user's timezone to be used when marshaling the datetime strings.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
