### PR TITLE
4.x - Fix `Text file busy` errors when deleting directories.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -254,11 +254,13 @@ class FileEngine extends CacheEngine
         /** @var \SplFileInfo $fileInfo */
         foreach ($contents as $fileInfo) {
             if ($fileInfo->isFile()) {
+                unset($fileInfo);
                 continue;
             }
 
             $realPath = $fileInfo->getRealPath();
             if (!$realPath) {
+                unset($fileInfo);
                 continue;
             }
 
@@ -267,7 +269,11 @@ class FileEngine extends CacheEngine
                 $this->_clearDirectory($path);
                 $cleared[] = $path;
             }
+
+            unset($fileInfo);
         }
+
+        unset($directory, $contents);
 
         return true;
     }
@@ -482,6 +488,8 @@ class FileEngine extends CacheEngine
             // phpcs:ignore
             @unlink($path);
         }
+
+        unset($directoryIterator, $contents, $filtered);
 
         return true;
     }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -208,12 +208,16 @@ class Filesystem
             if ($fileInfo->getType() === self::TYPE_DIR || $isWindowsLink) {
                 // phpcs:ignore
                 $result = $result && @rmdir($fileInfo->getPathname());
+                unset($fileInfo);
                 continue;
             }
 
             // phpcs:ignore
             $result = $result && @unlink($fileInfo->getPathname());
+            unset($fileInfo);
         }
+
+        unset($iterator);
 
         // phpcs:ignore
         $result = $result && @rmdir($path);

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -558,6 +558,8 @@ class Folder
             );
             $iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
         } catch (Exception $e) {
+            unset($directory, $iterator);
+
             if ($type === null) {
                 return [[], []];
             }
@@ -573,12 +575,14 @@ class Folder
             if ($skipHidden) {
                 $subPathName = $fsIterator->getSubPathname();
                 if ($subPathName[0] === '.' || strpos($subPathName, DIRECTORY_SEPARATOR . '.') !== false) {
+                    unset($fsIterator);
                     continue;
                 }
             }
             /** @var \FilesystemIterator $item */
             $item = $fsIterator->current();
             if (!empty($exceptions) && isset($exceptions[$item->getFilename()])) {
+                unset($fsIterator, $item);
                 continue;
             }
 
@@ -587,7 +591,12 @@ class Folder
             } elseif ($item->isDir() && !$item->isDot()) {
                 $directories[] = $itemPath;
             }
+
+            unset($fsIterator, $item);
         }
+
+        unset($directory, $iterator);
+
         if ($type === null) {
             return [$directories, $files];
         }
@@ -707,6 +716,8 @@ class Folder
                 $directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF);
                 $iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
             } catch (Exception $e) {
+                unset($directory, $iterator);
+
                 return false;
             }
 
@@ -728,10 +739,14 @@ class Folder
                     } else {
                         $this->_errors[] = sprintf('%s NOT removed', $filePath);
 
+                        unset($directory, $iterator, $item);
+
                         return false;
                     }
                 }
             }
+
+            unset($directory, $iterator);
 
             $path = rtrim($path, DIRECTORY_SEPARATOR);
             // phpcs:disable


### PR DESCRIPTION
I ran into this problem a few times over the years when working with VMs, where trying to delete directories would fail with an `rmdir(...): Text file busy` error, it came and go, and now I ran into it again, and it won't disappear.

[**Apparently**](https://github.com/thephpleague/flysystem/commit/d03f7e1e0f2fa47f52d445a60ec8ed93d433ddc1) unsetting the possible filesystem iterators helps releasing the locks, it certainly does so for me locally, no errors anymore using cache, folder and filesystem. I'm saying "_possible iterators_" here because these changes also unset variables that currently point to `SplFileInfo` objects, this won't do anything, it's just a preventive measure in case the code might change to use the "current as iterator" behavior.

Finally, tying into the preventive changes, I don't think I'd be able to write any tests for this, as I have no idea how to possibly force the problem.