### PR TITLE
4.x - Add missing iterator unset calls.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -492,6 +492,8 @@ class FileEngine extends CacheEngine
             @unlink($path);
         }
 
+        // unsetting iterators helps releasing possible locks in certain environments,
+        // which could otherwise make `rmdir()` fail
         unset($directoryIterator, $contents, $filtered);
 
         return true;

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -742,12 +742,14 @@ class Folder
                     } else {
                         $this->_errors[] = sprintf('%s NOT removed', $filePath);
 
-                        // inner iterators need to be unset too in order for locks on parents to be released
                         unset($directory, $iterator, $item);
 
                         return false;
                     }
                 }
+
+                // inner iterators need to be unset too in order for locks on parents to be released
+                unset($item);
             }
 
             // unsetting iterators helps releasing possible locks in certain environments,


### PR DESCRIPTION
Just ran into a lock error yet again, I missed one required unset in the loop for `Folder::delete()`... also missed a comment. The perks of manual testing, hopefully I've catched all iterators for now. 