### PR TITLE
Explicitly check against null, to enable testing attributes of email #0

### DIFF
--- a/src/TestSuite/Constraint/Email/MailConstraintBase.php
+++ b/src/TestSuite/Constraint/Email/MailConstraintBase.php
@@ -47,7 +47,7 @@ abstract class MailConstraintBase extends Constraint
     {
         $emails = TestEmailTransport::getEmails();
 
-        if ($this->at) {
+        if ($this->at !== null) {
             if (!isset($emails[$this->at])) {
                 return [];
             }

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -110,9 +110,6 @@ class EmailTraitTest extends TestCase
         $this->assertMailSentFromAt(0, 'default@example.com');
         $this->assertMailSentFromAt(1, 'alternate@example.com');
 
-        // Confirm that "at 0" is really testing email 0, not all the emails
-        $this->assertThat('alternate@example.com', new LogicalNot(new MailSentFrom(0)));
-
         $this->assertMailSentToAt(0, 'to@example.com');
         $this->assertMailSentToAt(1, 'to2@example.com');
         $this->assertMailSentToAt(2, 'to3@example.com');
@@ -121,6 +118,24 @@ class EmailTraitTest extends TestCase
         $this->assertMailContainsAt(1, 'html');
 
         $this->assertMailSentWithAt(0, 'Hello world', 'subject');
+    }
+
+    /**
+     * confirm that "at 0" is really testing email 0, not all the emails
+     *
+     * @return void
+     */
+    public function testAt0()
+    {
+        $this->skipIf(!class_exists('PHPUnit\Framework\Constraint\LogicalNot'), 'LogicalNot class not supported on PHP5.6');
+
+        $this->assertNoMailSent();
+
+        $this->sendEmails();
+
+        $this->assertMailCount(3);
+
+        $this->assertThat('alternate@example.com', new LogicalNot(new MailSentFrom(0)));
     }
 
     /**

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -16,10 +16,12 @@ namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Mailer\Email;
 use Cake\Mailer\TransportFactory;
+use Cake\TestSuite\Constraint\Email\MailSentFrom;
 use Cake\TestSuite\EmailTrait;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestEmailTransport;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Constraint\LogicalNot;
 
 /**
  * Tests EmailTrait assertions
@@ -107,6 +109,9 @@ class EmailTraitTest extends TestCase
 
         $this->assertMailSentFromAt(0, 'default@example.com');
         $this->assertMailSentFromAt(1, 'alternate@example.com');
+
+        // Confirm that "at 0" is really testing email 0, not all the emails
+        $this->assertThat('alternate@example.com', new LogicalNot(new MailSentFrom(0)));
 
         $this->assertMailSentToAt(0, 'to@example.com');
         $this->assertMailSentToAt(1, 'to2@example.com');


### PR DESCRIPTION
The classes for testing email constraints do not work when specifying email #0 (the first email sent). We often send multiple emails to different recipients in one step, and need to ensure the specific contents of each, not just that *some* email contained a certain string. The code as written extracts the specified email if it is truthy, which 0 is not. Changing to specifically check for null resolves this.

I'm not sure what to do about unit testing of this, as there are currently no unit tests at all under TestSuite/Constraint/Email (that folder doesn't exist). If there were other unit tests there, I'd update them to test for this, but I don't have the time right now to build a whole set of test cases for this area of the code.