### PR TITLE
Fixed the comment of the return value of get method on ConnectionManager.php

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -190,7 +190,7 @@ class ConnectionManager
      *
      * @param string $name The connection name.
      * @param bool $useAliases Set to false to not use aliased connections.
-     * @return \Cake\Datasource\ConnectionInterface A connection object.
+     * @return \Cake\Database\Connection A connection object.
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When config
      * data is missing.
      */


### PR DESCRIPTION
I noticed that the IDE's suggestions for the following two methods are different.

$connection = ConnectionManager :: get ('default');
// \Cake\Datasource\ConnectionInterface

$ connection2 = TableRegistry :: getTableLocator ()-> get ('Users')-> getConnection ();
// \Cake\Database\Connection

I thought the phpdoc comment was wrong.
