### PR TITLE
Switch http client query encoding

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -122,6 +122,7 @@ class Client implements ClientInterface
         'ssl_verify_host' => true,
         'redirect' => false,
         'protocolVersion' => '1.1',
+        'query_encoding' => PHP_QUERY_RFC1738,
     ];
 
     /**
@@ -519,19 +520,25 @@ class Client implements ClientInterface
         if (empty($options) && empty($query)) {
             return $url;
         }
-        if ($query) {
-            $q = strpos($url, '?') === false ? '?' : '&';
-            $url .= $q;
-            $url .= is_string($query) ? $query : http_build_query($query);
-        }
         $defaults = [
             'host' => null,
             'port' => null,
             'scheme' => 'http',
             'basePath' => '',
             'protocolRelative' => false,
+            'query_encoding' => PHP_QUERY_RFC1738,
         ];
         $options += $defaults;
+
+        if ($query) {
+            $q = strpos($url, '?') === false ? '?' : '&';
+            $url .= $q;
+            if (is_string($query)) {
+                $url .= $query;
+            } else {
+                $url .= http_build_query($query, "", "&", $options['query_encoding']);
+            }
+        }
 
         if ($options['protocolRelative'] && preg_match('#^//#', $url)) {
             $url = $options['scheme'] . ':' . $url;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -536,7 +536,7 @@ class Client implements ClientInterface
             if (is_string($query)) {
                 $url .= $query;
             } else {
-                $url .= http_build_query($query, "", "&", $options['query_encoding']);
+                $url .= http_build_query($query, '', '&', $options['query_encoding']);
             }
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -122,7 +122,6 @@ class Client implements ClientInterface
         'ssl_verify_host' => true,
         'redirect' => false,
         'protocolVersion' => '1.1',
-        'queryEncoding' => PHP_QUERY_RFC3986,
     ];
 
     /**
@@ -526,7 +525,6 @@ class Client implements ClientInterface
             'scheme' => 'http',
             'basePath' => '',
             'protocolRelative' => false,
-            'queryEncoding' => PHP_QUERY_RFC3986,
         ];
         $options += $defaults;
 
@@ -536,7 +534,7 @@ class Client implements ClientInterface
             if (is_string($query)) {
                 $url .= $query;
             } else {
-                $url .= http_build_query($query, '', '&', $options['queryEncoding']);
+                $url .= http_build_query($query, '', '&', PHP_QUERY_RFC3986);
             }
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -122,7 +122,7 @@ class Client implements ClientInterface
         'ssl_verify_host' => true,
         'redirect' => false,
         'protocolVersion' => '1.1',
-        'query_encoding' => PHP_QUERY_RFC1738,
+        'queryEncoding' => PHP_QUERY_RFC3986,
     ];
 
     /**
@@ -526,7 +526,7 @@ class Client implements ClientInterface
             'scheme' => 'http',
             'basePath' => '',
             'protocolRelative' => false,
-            'query_encoding' => PHP_QUERY_RFC1738,
+            'queryEncoding' => PHP_QUERY_RFC3986,
         ];
         $options += $defaults;
 
@@ -536,7 +536,7 @@ class Client implements ClientInterface
             if (is_string($query)) {
                 $url .= $query;
             } else {
-                $url .= http_build_query($query, '', '&', $options['query_encoding']);
+                $url .= http_build_query($query, '', '&', $options['queryEncoding']);
             }
         }
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -210,7 +210,7 @@ class ClientTest extends TestCase
                 ['$filter' => 'operation_id eq 12'],
                 ['query_encoding' => PHP_QUERY_RFC3986],
                 'check RFC 3986 alternate query encoding',
-            ]
+            ],
         ];
     }
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -163,7 +163,7 @@ class ClientTest extends TestCase
                 'options do not duplicate',
             ],
             [
-                'http://example.com/search?q=hi+there&cat%5Bid%5D%5B0%5D=2&cat%5Bid%5D%5B1%5D=3',
+                'http://example.com/search?q=hi%20there&cat%5Bid%5D%5B0%5D=2&cat%5Bid%5D%5B1%5D=3',
                 'http://example.com/search',
                 ['q' => 'hi there', 'cat' => ['id' => [2, 3]]],
                 [],
@@ -198,18 +198,11 @@ class ClientTest extends TestCase
                 'protocol relative url',
             ],
             [
-                'https://example.com/operations?%24filter=operation_id+eq+12',
-                'https://example.com/operations',
-                ['$filter' => 'operation_id eq 12'],
-                ['queryEncoding' => PHP_QUERY_RFC1738],
-                'check the alternate RFC 1738 query encoding',
-            ],
-            [
                 'https://example.com/operations?%24filter=operation_id%20eq%2012',
                 'https://example.com/operations',
                 ['$filter' => 'operation_id eq 12'],
                 [],
-                'check the default RFC 3986 query encoding',
+                'check the RFC 3986 query encoding',
             ],
         ];
     }
@@ -320,7 +313,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) {
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame(
-                    'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
+                    'http://cakephp.org/search?q=hi%20there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
                     $request->getUri() . ''
                 );
 
@@ -742,7 +735,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) {
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertSame(Request::METHOD_HEAD, $request->getMethod());
-                $this->assertSame('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
+                $this->assertSame('http://cakephp.org/search?q=hi%20there', '' . $request->getUri());
 
                 return true;
             }))
@@ -1025,7 +1018,6 @@ class ClientTest extends TestCase
             'ssl_verify_host' => true,
             'redirect' => false,
             'protocolVersion' => '1.1',
-            'queryEncoding' => PHP_QUERY_RFC3986,
         ];
         $this->assertSame($expected, $config);
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -201,14 +201,14 @@ class ClientTest extends TestCase
                 'https://example.com/operations?%24filter=operation_id+eq+12',
                 'https://example.com/operations',
                 ['$filter' => 'operation_id eq 12'],
-                [],
+                ['queryEncoding' => PHP_QUERY_RFC1738],
                 'check default query encoding',
             ],
             [
                 'https://example.com/operations?%24filter=operation_id%20eq%2012',
                 'https://example.com/operations',
                 ['$filter' => 'operation_id eq 12'],
-                ['query_encoding' => PHP_QUERY_RFC3986],
+                [],
                 'check RFC 3986 alternate query encoding',
             ],
         ];
@@ -1025,7 +1025,7 @@ class ClientTest extends TestCase
             'ssl_verify_host' => true,
             'redirect' => false,
             'protocolVersion' => '1.1',
-            'query_encoding' => PHP_QUERY_RFC1738,
+            'queryEncoding' => PHP_QUERY_RFC3986,
         ];
         $this->assertSame($expected, $config);
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -197,6 +197,20 @@ class ClientTest extends TestCase
                 ],
                 'protocol relative url',
             ],
+            [
+                'https://example.com/operations?%24filter=operation_id+eq+12',
+                'https://example.com/operations',
+                ['$filter' => 'operation_id eq 12'],
+                [],
+                'check default query encoding',
+            ],
+            [
+                'https://example.com/operations?%24filter=operation_id%20eq%2012',
+                'https://example.com/operations',
+                ['$filter' => 'operation_id eq 12'],
+                ['query_encoding' => PHP_QUERY_RFC3986],
+                'check RFC 3986 alternate query encoding',
+            ]
         ];
     }
 
@@ -1011,6 +1025,7 @@ class ClientTest extends TestCase
             'ssl_verify_host' => true,
             'redirect' => false,
             'protocolVersion' => '1.1',
+            'query_encoding' => PHP_QUERY_RFC1738,
         ];
         $this->assertSame($expected, $config);
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -202,14 +202,14 @@ class ClientTest extends TestCase
                 'https://example.com/operations',
                 ['$filter' => 'operation_id eq 12'],
                 ['queryEncoding' => PHP_QUERY_RFC1738],
-                'check default query encoding',
+                'check the alternate RFC 1738 query encoding',
             ],
             [
                 'https://example.com/operations?%24filter=operation_id%20eq%2012',
                 'https://example.com/operations',
                 ['$filter' => 'operation_id eq 12'],
                 [],
-                'check RFC 3986 alternate query encoding',
+                'check the default RFC 3986 query encoding',
             ],
         ];
     }


### PR DESCRIPTION
Fix for the issue #15497.

This consists of the addition of the encoding query option and the tests to make sure it works.
