### PR TITLE
Don't set direction to false

### DIFF
--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -367,7 +367,7 @@ class Paginator implements PaginatorInterface
 
         $params += [
             'sort' => $data['options']['sort'],
-            'direction' => isset($data['options']['sort']) ? current($order) : null,
+            'direction' => isset($data['options']['sort']) && count($order) ? current($order) : null,
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,
             'completeSort' => $order,

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -165,4 +165,27 @@ class PaginatorTest extends TestCase
         $this->assertSame(2, $pagingParams['PaginatorPosts']['end']);
         $this->assertFalse($pagingParams['PaginatorPosts']['nextPage']);
     }
+
+    /**
+     * test direction setting.
+     *
+     * @return void
+     */
+    public function testPaginateDirection()
+    {
+        $settings = [
+            'PaginatorPosts' => [
+                'order' => ['Other.title' => 'ASC'],
+            ],
+        ];
+
+        $this->loadFixtures('Posts');
+        $table = $this->getTableLocator()->get('PaginatorPosts');
+
+        $this->Paginator->paginate($table, [], $settings);
+        $pagingParams = $this->Paginator->getPagingParams();
+
+        $this->assertSame('Other.title', $pagingParams['PaginatorPosts']['sort']);
+        $this->assertNull($pagingParams['PaginatorPosts']['direction']);
+    }
 }

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -171,7 +171,7 @@ class PaginatorTest extends TestCase
      *
      * @return void
      */
-    public function testPaginateDirection()
+    public function testPaginateDefaultDirection()
     {
         $settings = [
             'PaginatorPosts' => [


### PR DESCRIPTION
When the order data is empty because it is invalid, direction should not be set to `false`. Instead `null` is better as it doesn't cause downstream problems with PaginatorHelper

Fixes #15499