### PR TITLE
4.x - Fix tuple comparison type handling

### DIFF
--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -71,6 +71,13 @@ trait TupleComparisonTranslatorTrait
             return;
         }
 
+        $type = $expression->getType();
+        if (!empty($type)) {
+            $typeMap = array_combine($fields, $type);
+        } else {
+            $typeMap = [];
+        }
+
         $surrogate = $query->getConnection()
             ->newQuery()
             ->select($true);
@@ -87,7 +94,7 @@ trait TupleComparisonTranslatorTrait
             }
             $conditions['OR'][] = $item;
         }
-        $surrogate->where($conditions);
+        $surrogate->where($conditions, $typeMap);
 
         $expression->setField($true);
         $expression->setValue($surrogate);

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -72,7 +72,7 @@ trait TupleComparisonTranslatorTrait
         }
 
         $type = $expression->getType();
-        if (!empty($type)) {
+        if ($type) {
             $typeMap = array_combine($fields, $type);
         } else {
             $typeMap = [];

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -29,7 +29,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * The type to be used for casting the value to a database representation
      *
-     * @var array
+     * @var array<string|null>
      * @psalm-suppress NonInvariantDocblockPropertyType
      */
     protected $_type;
@@ -39,7 +39,7 @@ class TupleComparison extends ComparisonExpression
      *
      * @param string|array|\Cake\Database\ExpressionInterface $fields the fields to use to form a tuple
      * @param array|\Cake\Database\ExpressionInterface $values the values to use to form a tuple
-     * @param array $types the types names to use for casting each of the values, only
+     * @param array<string|null> $types the types names to use for casting each of the values, only
      * one type per position in the value array in needed
      * @param string $conjunction the operator used for comparing field and value
      */
@@ -54,7 +54,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * Returns the type to be used for casting the value to a database representation
      *
-     * @return array
+     * @return array<string|null>
      */
     public function getType(): array
     {

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -52,6 +52,16 @@ class TupleComparison extends ComparisonExpression
     }
 
     /**
+     * Returns the type to be used for casting the value to a database representation
+     *
+     * @return array
+     */
+    public function getType(): array
+    {
+        return $this->_type;
+    }
+
+    /**
      * Sets the value
      *
      * @param mixed $value The value to compare

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -489,7 +489,12 @@ class Marshaller
             if (!is_array($first) || count($first) !== count($primaryKey)) {
                 return [];
             }
-            $filter = new TupleComparison($primaryKey, $ids, [], 'IN');
+            $type = [];
+            $schema = $target->getSchema();
+            foreach ((array)$target->getPrimaryKey() as $column) {
+                $type[] = $schema->getColumnType($column);
+            }
+            $filter = new TupleComparison($primaryKey, $ids, $type, 'IN');
         } else {
             $filter = [$primaryKey[0] . ' IN' => $ids];
         }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -24,6 +24,7 @@ use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\StringExpression;
+use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\Statement\StatementDecorator;
@@ -3750,6 +3751,87 @@ class QueryTest extends TestCase
             'substractYears' => '2005-03-18',
         ];
         $this->assertEquals($expected, $result[0]);
+    }
+
+    /**
+     * Tests that the values in tuple comparison expression are being bound correctly,
+     * specifically for dialects that translate tuple comparisons.
+     *
+     * @return void
+     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
+     * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
+     * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
+     */
+    public function testTupleComparisonValuesAreBeingBoundCorrectly()
+    {
+        // Load with force dropping tables to avoid identities not being reset properly
+        // in SQL Server when reseeding is applied directly after table creation.
+        $this->fixtureManager->loadSingle('Profiles', null, true);
+
+        $profiles = $this->getTableLocator()->get('Profiles');
+
+        $query = $profiles
+            ->find()
+            ->where(
+                new TupleComparison(
+                    ['id', 'user_id'],
+                    [[1, 1]],
+                    ['integer', 'integer'],
+                    'IN'
+                )
+            );
+
+        $result = $query->firstOrFail();
+
+        $bindings = array_values($query->getValueBinder()->bindings());
+        $this->assertCount(2, $bindings);
+        $this->assertSame(1, $bindings[0]['value']);
+        $this->assertSame('integer', $bindings[0]['type']);
+        $this->assertSame(1, $bindings[1]['value']);
+        $this->assertSame('integer', $bindings[1]['type']);
+
+        $this->assertSame(1, $result['id']);
+        $this->assertSame(1, $result['user_id']);
+    }
+
+    /**
+     * Tests that the values in tuple comparison expressions are being bound as expected
+     * when types are omitted, specifically for dialects that translate tuple comparisons.
+     *
+     * @return void
+     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
+     * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
+     * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
+     */
+    public function testTupleComparisonTypesCanBeOmitted()
+    {
+        // Load with force dropping tables to avoid identities not being reset properly
+        // in SQL Server when reseeding is applied directly after table creation.
+        $this->fixtureManager->loadSingle('Profiles', null, true);
+
+        $profiles = $this->getTableLocator()->get('Profiles');
+
+        $query = $profiles
+            ->find()
+            ->where(
+                new TupleComparison(
+                    ['id', 'user_id'],
+                    [[1, 1]],
+                    [],
+                    'IN'
+                )
+            );
+        $result = $query->firstOrFail();
+
+        $bindings = array_values($query->getValueBinder()->bindings());
+        $this->assertCount(2, $bindings);
+        $this->assertSame(1, $bindings[0]['value']);
+        $this->assertNull($bindings[0]['type']);
+        $this->assertSame(1, $bindings[1]['value']);
+        $this->assertNull($bindings[1]['type']);
+
+        $this->assertSame(1, $result['id']);
+        $this->assertSame(1, $result['user_id']);
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3486,4 +3486,46 @@ class MarshallerTest extends TestCase
         ];
         $this->assertEquals($expected, $result->toArray());
     }
+
+    /**
+     * Tests that ID values are being bound with the correct type when loading associated records.
+     */
+    public function testInvalidTypesWhenLoadingAssociatedByIds()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
+
+        $data = [
+            'title' => 'article',
+            'body' => 'some content',
+            'comments' => [
+                '_ids' => ['foobar'],
+            ],
+        ];
+
+        $marshaller = new Marshaller($this->articles);
+        $marshaller->one($data, ['associated' => ['Comments']]);
+    }
+
+    /**
+     * Tests that composite ID values are being bound with the correct type when loading associated records.
+     */
+    public function testInvalidTypesWhenLoadingAssociatedByCompositeIds()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
+
+        $data = [
+            'title' => 'article',
+            'body' => 'some content',
+            'comments' => [
+                '_ids' => [['foo', 'bar']],
+            ],
+        ];
+
+        $this->articles->Comments->setPrimaryKey(['id', 'article_id']);
+
+        $marshaller = new Marshaller($this->articles);
+        $marshaller->one($data, ['associated' => ['Comments']]);
+    }
 }


### PR DESCRIPTION
I've ran into the problem that types were lost in Sqlite tests when dealing with composite keys in associations, which was caused by the tuple comparison translation that happens for Sqlite and SqlSever, the surrogate query just didn't knew about the types.

Types were also being lost when marshalling composite keys via the `_ids` key, they were simply not passed.