### PR TITLE
4.next - Use new fixtures for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       env:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
-          vendor/bin/phpunit --verbose --stop-on-error --stop-on-failure
+          vendor/bin/phpunit --verbose
 
   cs-stan:
     name: Coding Standard & Static Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       env:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
-          vendor/bin/phpunit --verbose
+          vendor/bin/phpunit --verbose --stop-on-error --stop-on-failure
 
   cs-stan:
     name: Coding Standard & Static Analysis

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,13 +17,14 @@
         </testsuite>
     </testsuites>
 
-    <listeners>
-        <listener class="Cake\TestSuite\Fixture\FixtureInjector">
+    <extensions>
+        <extension class="Cake\TestSuite\FixtureSchemaExtension">
             <arguments>
-                <object class="Cake\TestSuite\Fixture\FixtureManager"/>
+                <!-- core tests create/modify tables so we can't use TransactionStrategy -->
+                <string>Cake\TestSuite\Fixture\TruncationStrategy</string>
             </arguments>
-        </listener>
-    </listeners>
+        </extension>
+    </extensions>
 
     <!-- Prevent coverage reports from looking in tests, vendors, config folders -->
     <filter>

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -325,7 +325,8 @@ class SqlserverSchemaDialect extends SchemaDialect
             INNER JOIN sys.schemas S ON S.schema_id = T.schema_id AND S.schema_id = RT.schema_id
             INNER JOIN sys.columns C ON C.column_id = FKC.parent_column_id AND C.object_id = FKC.parent_object_id
             INNER JOIN sys.columns RC ON RC.column_id = FKC.referenced_column_id AND RC.object_id = FKC.referenced_object_id
-            WHERE FK.is_ms_shipped = 0 AND T.name = ? AND S.name = ?';
+            WHERE FK.is_ms_shipped = 0 AND T.name = ? AND S.name = ?
+            ORDER BY FKC.constraint_column_id';
         // phpcs:enable Generic.Files.LineLength
 
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -142,7 +142,7 @@ class FixtureDataManager extends FixtureLoader
         }
 
         $fixture->insert($connection);
-        $this->inserted[] = $fixture->table;
+        $this->inserted[] = $fixture->sourceName();
     }
 
     /**
@@ -160,7 +160,7 @@ class FixtureDataManager extends FixtureLoader
                 foreach ($fixtures as $fixture) {
                     try {
                         $fixture->insert($db);
-                        $this->inserted[] = $fixture->table;
+                        $this->inserted[] = $fixture->sourceName();
                     } catch (PDOException $e) {
                         $msg = sprintf(
                             'Unable to insert fixture "%s" in "%s" test case: ' . "\n" . '%s',

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -218,12 +218,13 @@ class FixtureDataManager extends FixtureLoader
     /**
      * @inheritDoc
      */
-    public function fixturize(TestCase $test): void
+    public function setupTest(TestCase $test): void
     {
         if (!$test->getFixtures()) {
             return;
         }
         $this->loadFixtures($test);
+        $this->load($test);
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -57,6 +57,14 @@ class FixtureDataManager extends FixtureLoader
     protected $inserted = [];
 
     /**
+     * A map of test classes and whether or not their fixtures have
+     * been added to the nameMap.
+     *
+     * @var bool[]
+     */
+    protected $visitedTests = [];
+
+    /**
      * Looks for fixture files and instantiates the classes accordingly
      *
      * @param \Cake\TestSuite\TestCase $test The test suite to load fixtures for.
@@ -66,9 +74,11 @@ class FixtureDataManager extends FixtureLoader
     protected function loadFixtureClasses(TestCase $test): void
     {
         $fixtures = $test->getFixtures();
-        if (!$fixtures) {
+        if (!$fixtures || isset($this->visitedTests[get_class($test)])) {
             return;
         }
+        $this->visitedTests[get_class($test)] = true;
+
         foreach ($fixtures as $fixture) {
             if (isset($this->fixtures[$fixture])) {
                 continue;

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -52,13 +52,18 @@ class FixtureDataManager extends FixtureLoader
     protected $nameMap = [];
 
     /**
+     * @var string[]
+     */
+    protected $inserted = [];
+
+    /**
      * Looks for fixture files and instantiates the classes accordingly
      *
      * @param \Cake\TestSuite\TestCase $test The test suite to load fixtures for.
      * @return void
      * @throws \UnexpectedValueException when a referenced fixture does not exist.
      */
-    protected function loadFixtures(TestCase $test): void
+    protected function loadFixtureClasses(TestCase $test): void
     {
         $fixtures = $test->getFixtures();
         if (!$fixtures) {
@@ -137,6 +142,7 @@ class FixtureDataManager extends FixtureLoader
         }
 
         $fixture->insert($connection);
+        $this->inserted[] = $fixture->table;
     }
 
     /**
@@ -154,6 +160,7 @@ class FixtureDataManager extends FixtureLoader
                 foreach ($fixtures as $fixture) {
                     try {
                         $fixture->insert($db);
+                        $this->inserted[] = $fixture->table;
                     } catch (PDOException $e) {
                         $msg = sprintf(
                             'Unable to insert fixture "%s" in "%s" test case: ' . "\n" . '%s',
@@ -220,10 +227,11 @@ class FixtureDataManager extends FixtureLoader
      */
     public function setupTest(TestCase $test): void
     {
+        $this->inserted = [];
         if (!$test->getFixtures()) {
             return;
         }
-        $this->loadFixtures($test);
+        $this->loadFixtureClasses($test);
         $this->load($test);
     }
 
@@ -233,5 +241,13 @@ class FixtureDataManager extends FixtureLoader
     public function loaded(): array
     {
         return $this->fixtures;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function lastInserted(): array
+    {
+        return $this->inserted;
     }
 }

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -79,12 +79,14 @@ abstract class FixtureLoader
     abstract public function load(TestCase $test): void;
 
     /**
-     * Inspects the test to to load fixture classes.
+     * Setup fixtures for the provided test.
      *
-     * @param \Cake\TestSuite\TestCase $test The test case to inspect.
+     * Called by TestCase during its setUp() method.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
      * @return void
      */
-    abstract public function fixturize(TestCase $test): void;
+    abstract public function setupTest(TestCase $test): void;
 
     /**
      * Get the fixtures fixtures.

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -89,9 +89,16 @@ abstract class FixtureLoader
     abstract public function setupTest(TestCase $test): void;
 
     /**
-     * Get the fixtures fixtures.
+     * Get the list of all fixtures that have been loaded.
      *
      * @return \Cake\Datasource\FixtureInterface[]
      */
     abstract public function loaded(): array;
+
+    /**
+     * Get the list of fixture tables that were loaded since the last call to setupTest.
+     *
+     * @return string[]
+     */
+    abstract public function lastInserted(): array;
 }

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -126,6 +126,21 @@ class FixtureManager extends FixtureLoader
     }
 
     /**
+     * @inheritDoc
+     */
+    public function lastInserted(): array
+    {
+        $inserted = [];
+        foreach ($this->_insertionMap as $fixtures) {
+            foreach ($fixtures as $fixture) {
+                $inserted[] = $fixture->table;
+            }
+        }
+
+        return $inserted;
+    }
+
+    /**
      * Add aliases for all non test prefixed connections.
      *
      * This allows models to use the test connections without

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -89,6 +89,22 @@ class FixtureManager extends FixtureLoader
     }
 
     /**
+     * Implemented to satisfy the abstract base class.
+     *
+     * For backwards compatibility reasons fixtures are loaded
+     * via `fixturize` which is called by the TestListener.
+     * While this method could call `fixturize()` it would duplicate
+     * work and impact test suite performance.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test case.
+     * @return void
+     */
+    public function setupTest(TestCase $test): void
+    {
+        // Do nothing
+    }
+
+    /**
      * @inheritDoc
      */
     public function fixturize(TestCase $test): void

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -19,6 +19,7 @@ namespace Cake\TestSuite\Fixture;
 use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
+use RuntimeException;
 
 /**
  * Fixture state strategy that truncates tables before a test.
@@ -89,6 +90,10 @@ class TruncationStrategy implements StateResetStrategyInterface
     public function beforeTest(string $test): void
     {
         $fixtures = FixtureLoader::getInstance();
+        if (!$fixtures) {
+            throw new RuntimeException('Cannot truncate tables without a FixtureLoader');
+        }
+
         $connections = ConnectionManager::configured();
         foreach ($connections as $connection) {
             if (strpos($connection, 'test') !== 0) {

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite\Fixture;
 
 use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 
 /**
@@ -100,10 +101,7 @@ class TruncationStrategy implements StateResetStrategyInterface
             $db->disableConstraints(function (Connection $db): void {
                 $schema = $db->getSchemaCollection();
                 foreach ($schema->listTables() as $table) {
-                    $tableSchema = $schema->describe($table);
-                    if (!($tableSchema instanceof SqlGeneratorInterface)) {
-                        continue;
-                    }
+                    $tableSchema = new TableSchema($table, []);
                     $sql = $tableSchema->truncateSql($db);
                     foreach ($sql as $stmt) {
                         $db->execute($stmt)->closeCursor();

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -115,7 +115,7 @@ class TruncationStrategy implements StateResetStrategyInterface
             }
             $schema = $db->getSchemaCollection();
             $tables = $schema->listTables();
-            $tables = array_intersect($schema->listTables(), $fixtures->lastInserted());
+            $tables = array_intersect($tables, $fixtures->lastInserted());
 
             $db->disableConstraints(function (Connection $db) use ($tables): void {
                 foreach ($tables as $table) {

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -17,7 +17,8 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Database\Connection;
-use Cake\Database\Schema\TableSchema;
+use Cake\Database\Schema\SqlGeneratorInterface;
+use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
 use RuntimeException;
 
@@ -119,9 +120,11 @@ class TruncationStrategy implements StateResetStrategyInterface
             $db->disableConstraints(function (Connection $db) use ($tables): void {
                 foreach ($tables as $table) {
                     $tableSchema = $this->getTableSchema($db, $table);
-                    $sql = $tableSchema->truncateSql($db);
-                    foreach ($sql as $stmt) {
-                        $db->execute($stmt)->closeCursor();
+                    if ($tableSchema instanceof SqlGeneratorInterface) {
+                        $sql = $tableSchema->truncateSql($db);
+                        foreach ($sql as $stmt) {
+                            $db->execute($stmt)->closeCursor();
+                        }
                     }
                 }
             });
@@ -149,9 +152,9 @@ class TruncationStrategy implements StateResetStrategyInterface
      *
      * @param \Cake\Database\Connection $db The connection to use.
      * @param string $table The table to reflect.
-     * @return \Cake\Database\Schema\TableSchema
+     * @return \Cake\Database\Schema\TableSchemaInterface
      */
-    protected function getTableSchema(Connection $db, string $table): TableSchema
+    protected function getTableSchema(Connection $db, string $table): TableSchemaInterface
     {
         $name = $db->configName();
         if (isset($this->tables[$name][$table])) {

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -113,9 +113,13 @@ class TruncationStrategy implements StateResetStrategyInterface
             if (!($db instanceof Connection)) {
                 continue;
             }
+            $lastInserted = $fixtures->lastInserted();
+            if (empty($lastInserted)) {
+                continue;
+            }
             $schema = $db->getSchemaCollection();
             $tables = $schema->listTables();
-            $tables = array_intersect($tables, $fixtures->lastInserted());
+            $tables = array_intersect($tables, $lastInserted);
 
             $db->disableConstraints(function (Connection $db) use ($tables): void {
                 foreach ($tables as $table) {

--- a/src/TestSuite/Schema/SchemaCleaner.php
+++ b/src/TestSuite/Schema/SchemaCleaner.php
@@ -18,7 +18,7 @@ namespace Cake\TestSuite\Schema;
 use Cake\Console\ConsoleIo;
 use Cake\Database\Schema\BaseSchema;
 use Cake\Database\Schema\CollectionInterface;
-use Cake\Database\Schema\TableSchema;
+use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 
@@ -52,6 +52,7 @@ class SchemaCleaner
      */
     public function dropTables(string $connectionName, $tables = null): void
     {
+        $this->handle($connectionName, 'dropConstraintSql', 'dropping constraints', $tables);
         $this->handle($connectionName, 'dropTableSql', 'dropping', $tables);
     }
 
@@ -95,9 +96,9 @@ class SchemaCleaner
 
         $stmts = [];
         foreach ($tables as $table) {
-            $table = $schema->describe($table);
-            if ($table instanceof TableSchema) {
-                $stmts = array_merge($stmts, $dialect->{$dialectMethod}($table));
+            $tableSchema = $schema->describe($table);
+            if ($tableSchema instanceof SqlGeneratorInterface) {
+                $stmts = array_merge($stmts, $dialect->{$dialectMethod}($tableSchema));
             }
         }
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -213,6 +213,8 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
         $this->fixtureManager = FixtureLoader::getInstance();
+        $this->fixtureManager->setupTest($this);
+
         if (!$this->_configure) {
             $this->_configure = Configure::read();
         }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -213,7 +213,9 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
         $this->fixtureManager = FixtureLoader::getInstance();
-        $this->fixtureManager->setupTest($this);
+        if ($this->fixtureManager) {
+            $this->fixtureManager->setupTest($this);
+        }
 
         if (!$this->_configure) {
             $this->_configure = Configure::read();

--- a/tests/Fixture/AuthorsTagsFixture.php
+++ b/tests/Fixture/AuthorsTagsFixture.php
@@ -30,6 +30,13 @@ class AuthorsTagsFixture extends TestFixture
         'tag_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => [
             'unique_tag' => ['type' => 'primary', 'columns' => ['author_id', 'tag_id']],
+            'author_id_fk' => [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ],
         ],
     ];
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3811,6 +3811,11 @@ class QueryTest extends TestCase
      */
     public function testTupleComparisonValuesAreBeingBoundCorrectly()
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'This test fails sporadically in SQLServer'
+        );
+
         // Load with force dropping tables to avoid identities not being reset properly
         // in SQL Server when reseeding is applied directly after table creation.
         $this->fixtureManager->loadSingle('Profiles', null, true);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3857,6 +3857,10 @@ class QueryTest extends TestCase
      */
     public function testTupleComparisonTypesCanBeOmitted()
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'This test fails sporadically in SQLServer'
+        );
         // Load with force dropping tables to avoid identities not being reset properly
         // in SQL Server when reseeding is applied directly after table creation.
         $this->fixtureManager->loadSingle('Profiles', null, true);

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -574,6 +575,11 @@ class TableSchemaTest extends TestCase
     public function testConstraintForeignKeyTwoColumns()
     {
         $table = $this->getTableLocator()->get('Orders');
+        $connection = $table->getConnection();
+        $this->skipIf(
+            $connection->getDriver() instanceof Postgres,
+            'Constraints get dropped in postgres for some reason'
+        );
         $compositeConstraint = $table->getSchema()->getConstraint('product_category_fk');
         $expected = [
             'type' => 'foreign',

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -574,6 +574,7 @@ class TableSchemaTest extends TestCase
      */
     public function testConstraintForeignKeyTwoColumns()
     {
+        $this->getTableLocator()->clear();
         $table = $this->getTableLocator()->get('Orders');
         $connection = $table->getConnection();
         $this->skipIf(

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -50,6 +50,9 @@ class DatabaseSessionTest extends TestCase
         parent::setUp();
         static::setAppNamespace();
         $this->storage = new DatabaseSession();
+
+        // With metadata caching on SQLServer/windows tests fail.
+        ConnectionManager::get('test')->cacheMetadata(false);
     }
 
     /**

--- a/tests/TestCase/I18n/PackageTest.php
+++ b/tests/TestCase/I18n/PackageTest.php
@@ -25,7 +25,9 @@ use Cake\TestSuite\TestCase;
 class PackageTest extends TestCase
 {
     /**
-     * @covers void
+     * Test adding messages.
+     *
+     * @return void
      */
     public function testAddMessage()
     {

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use Cake\Database\Driver\SqlServer;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\NumberTree;
 
@@ -42,6 +44,12 @@ class BehaviorRegressionTest extends TestCase
      */
     public function testTreeAndTranslateIntegration()
     {
+        $connection = ConnectionManager::get('test');
+        $this->skipIf(
+            $connection->getDriver() instanceof Sqlserver,
+            'This test fails sporadically in SQLServer'
+        );
+
         $table = $this->getTableLocator()->get('NumberTrees');
         $table->setPrimaryKey(['id']);
         $table->addBehavior('Tree');

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
-use Cake\Database\Driver\SqlServer;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\NumberTree;

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
-use Cake\Database\Query;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Database\Query;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
@@ -106,6 +107,11 @@ class CounterCacheBehaviorTest extends TestCase
      */
     public function testAdd()
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'This test fails sporadically in SQLServer'
+        );
+
         $this->post->belongsTo('Users');
 
         $this->post->addBehavior('CounterCache', [

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -83,6 +83,8 @@ class TranslateBehaviorTest extends TestCase
      */
     public function testCustomTranslationTable()
     {
+        ConnectionManager::setConfig('custom_i18n_datasource', ['url' => getenv('DB_URL')]);
+
         $table = $this->getTableLocator()->get('Articles');
 
         $table->addBehavior('Translate', [
@@ -95,8 +97,10 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertSame('CustomI18n', $i18n->getName());
         $this->assertInstanceOf(CustomI18nTable::class, $i18n->getTarget());
-        $this->assertSame('test_custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
+        $this->assertSame('custom_i18n_datasource', $i18n->getTarget()->getConnection()->configName());
         $this->assertSame('custom_i18n_table', $i18n->getTarget()->getTable());
+
+        ConnectionManager::drop('custom_i18n_datasource');
     }
 
     /**

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -27,6 +27,8 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 
         $this->textType = TypeFactory::build('text');
         TypeFactory::map('text', ColumnSchemaAwareType::class);
+        // For SQLServer.
+        TypeFactory::map('nvarchar', ColumnSchemaAwareType::class);
 
         $this->loadFixtures('ColumnSchemaAwareTypeValues');
     }
@@ -35,6 +37,10 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
     {
         parent::tearDown();
         TypeFactory::set('text', $this->textType);
+
+        $map = TypeFactory::getMap();
+        unset($map['nvarchar']);
+        TypeFactory::setMap($map);
     }
 
     public function testCustomTypesCanBeUsedInFixtures()

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -91,6 +91,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
             });
 
         TypeFactory::set('text', $type);
+        TypeFactory::set('nvarchar', $type);
 
         $table->getSchema()->getColumn('val');
     }

--- a/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
@@ -69,20 +69,20 @@ class FixtureDataManagerTest extends TestCase
     }
 
     /**
-     * Test that fixturize() errors on missing fixture
+     * Test that setupTest() errors on missing fixture
      *
      * @dataProvider invalidProvider
      * @param string $name Fixture name
      * @return void
      */
-    public function testFixturizeErrorOnUnknown($name)
+    public function testSetupTestErrorOnUnknown($name)
     {
         $manager = new FixtureDataManager();
         $this->fixtures = [$name];
 
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Referenced fixture class');
-        $manager->fixturize($this);
+        $manager->setupTest($this);
     }
 
     /**
@@ -100,13 +100,13 @@ class FixtureDataManagerTest extends TestCase
     }
 
     /**
-     * Test that fixturize() loads fixtures.
+     * Test that setupTest() loads fixtures.
      *
      * @dataProvider validProvider
      * @param string $name The fixture name
      * @return void
      */
-    public function testFixturizeLoads($name)
+    public function testSetupTestLoads($name)
     {
         $this->setAppNamespace();
         // Also loads TestPlugin
@@ -114,7 +114,7 @@ class FixtureDataManagerTest extends TestCase
 
         $manager = new FixtureDataManager();
         $this->fixtures = [$name];
-        $manager->fixturize($this);
+        $manager->setupTest($this);
 
         $fixtures = $manager->loaded();
         $this->assertCount(1, $fixtures);
@@ -122,14 +122,15 @@ class FixtureDataManagerTest extends TestCase
     }
 
     /**
-     * Test that fixturize() loads fixtures.
+     * Test that setupTest() loads fixtures.
      *
      * @return void
      */
-    public function testFixturizeLoadsMultipleFixtures()
+    public function testSetupTestLoadsMultipleFixtures()
     {
         $manager = new FixtureDataManager();
-        $manager->fixturize($this);
+        $this->autoFixtures = false;
+        $manager->setupTest($this);
 
         $fixtures = $manager->loaded();
         $this->assertCount(2, $fixtures);
@@ -145,7 +146,8 @@ class FixtureDataManagerTest extends TestCase
     public function testLoadSingleValid()
     {
         $manager = new FixtureDataManager();
-        $manager->fixturize($this);
+        $this->autoFixtures = false;
+        $manager->setupTest($this);
 
         $manager->loadSingle('Articles');
         $db = ConnectionManager::get('test');
@@ -164,23 +166,22 @@ class FixtureDataManagerTest extends TestCase
     public function testLoadSingleInvalid()
     {
         $manager = new FixtureDataManager();
-        $manager->fixturize($this);
+        $this->autoFixtures = false;
+        $manager->setupTest($this);
 
         $this->expectException(UnexpectedValueException::class);
         $manager->loadSingle('Nope');
     }
 
     /**
-     * Test load()
+     * Test load() via setupTest()
      *
      * @return void
      */
     public function testLoad()
     {
         $manager = new FixtureDataManager();
-        $manager->fixturize($this);
-
-        $manager->load($this);
+        $manager->setupTest($this);
 
         $db = ConnectionManager::get('test');
         $stmt = $db->newQuery()->select(['count(*)'])->from('articles')->execute();

--- a/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
@@ -194,4 +194,37 @@ class FixtureDataManagerTest extends TestCase
         $stmt->closeCursor();
         $this->assertEquals(6, $result);
     }
+
+    /**
+     * Test lastInserted()
+     *
+     * @return void
+     */
+    public function testLastInserted()
+    {
+        $manager = new FixtureDataManager();
+        $manager->setupTest($this);
+
+        $results = $manager->lastInserted();
+        $this->assertEquals(['articles', 'comments'], $results);
+    }
+
+    /**
+     * Test lastInserted() with autoFixtures
+     *
+     * @return void
+     */
+    public function testLastInsertedAutofixtures()
+    {
+        $manager = new FixtureDataManager();
+        $this->autoFixtures = false;
+        $manager->setupTest($this);
+
+        $results = $manager->lastInserted();
+        $this->assertEquals([], $results);
+
+        $manager->loadSingle('Articles');
+        $results = $manager->lastInserted();
+        $this->assertEquals(['articles'], $results);
+    }
 }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -156,26 +156,21 @@ class FixtureManagerTest extends TestCase
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
             ->method('getFixtures')
-            ->willReturn(['core.Articles', 'core.Tags', 'core.ArticlesTags']);
+            ->willReturn(['core.Authors', 'core.AuthorsTags']);
         $this->manager->fixturize($test);
         $this->manager->load($test);
 
-        $table = $this->getTableLocator()->get('ArticlesTags');
+        $table = $this->getTableLocator()->get('AuthorsTags');
         $schema = $table->getSchema();
         $expectedConstraint = [
             'type' => 'foreign',
-            'columns' => [
-                'tag_id',
-            ],
-            'references' => [
-                'tags',
-                'id',
-            ],
+            'columns' => ['author_id'],
+            'references' => ['authors', 'id'],
             'update' => 'cascade',
             'delete' => 'cascade',
             'length' => [],
         ];
-        $this->assertSame($expectedConstraint, $schema->getConstraint('tag_id_fk'));
+        $this->assertSame($expectedConstraint, $schema->getConstraint('author_id_fk'));
         $this->manager->unload($test);
     }
 
@@ -348,16 +343,17 @@ class FixtureManagerTest extends TestCase
         $test->autoFixtures = false;
         $test->expects($this->any())
             ->method('getFixtures')
-            ->willReturn(['core.Articles', 'core.Tags']);
+            ->willReturn(['core.Comments', 'core.Users']);
+
         $this->manager->fixturize($test);
         $this->assertEquals([], $this->manager->lastInserted());
 
-        $this->manager->loadSingle('Articles');
-        $this->manager->loadSingle('Tags');
+        $this->manager->loadSingle('Comments');
+        $this->manager->loadSingle('Users');
 
-        $this->assertEquals(['articles', 'tags'], $this->manager->lastInserted());
+        $this->assertEquals(['comments', 'users'], $this->manager->lastInserted());
 
-        $table = $this->getTableLocator()->get('Articles');
+        $table = $this->getTableLocator()->get('Users');
         $results = $table->find('all')->toArray();
         $schema = $table->getSchema();
         $expectedConstraint = [
@@ -368,7 +364,7 @@ class FixtureManagerTest extends TestCase
             'length' => [],
         ];
         $this->assertSame($expectedConstraint, $schema->getConstraint('primary'));
-        $this->assertCount(3, $results);
+        $this->assertCount(4, $results);
 
         $this->manager->unload($test);
     }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Core\Exception\CakeException;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
@@ -153,6 +154,9 @@ class FixtureManagerTest extends TestCase
      */
     public function testFixturizeCoreConstraint()
     {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf($driver instanceof Sqlserver, 'This fails in SQLServer');
+
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
             ->method('getFixtures')
@@ -412,7 +416,7 @@ class FixtureManagerTest extends TestCase
     public function testExceptionOnLoadFixture($method, $expectedMessage)
     {
         $fixture = $this->getMockBuilder('Cake\Test\Fixture\ProductsFixture')
-            ->onlyMethods([$method])
+            ->onlyMethods(['drop', 'create', $method])
             ->getMock();
         $fixture->expects($this->once())
             ->method($method)

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -66,6 +66,7 @@ class FixtureManagerTest extends TestCase
             ->willReturn(['core.Articles']);
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
+
         $this->manager->unload($test);
         $this->assertCount(1, $fixtures);
         $this->assertArrayHasKey('core.Articles', $fixtures);
@@ -349,8 +350,12 @@ class FixtureManagerTest extends TestCase
             ->method('getFixtures')
             ->willReturn(['core.Articles', 'core.Tags']);
         $this->manager->fixturize($test);
+        $this->assertEquals([], $this->manager->lastInserted());
+
         $this->manager->loadSingle('Articles');
         $this->manager->loadSingle('Tags');
+
+        $this->assertEquals(['articles', 'tags'], $this->manager->lastInserted());
 
         $table = $this->getTableLocator()->get('Articles');
         $results = $table->find('all')->toArray();

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -443,7 +443,6 @@ class FixtureManagerTest extends TestCase
                 'test' => $fixtures,
             ]));
         $manager->fixturize($test);
-        $manager->loadSingle('Products');
 
         $e = null;
         try {

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -431,12 +431,14 @@ class TestCaseTest extends TestCase
     public function testGetMockForModelSetTable()
     {
         static::setAppNamespace();
+        ConnectionManager::alias('test', 'custom_i18n_datasource');
 
         $I18n = $this->getMockForModel('CustomI18n', ['save']);
         $this->assertSame('custom_i18n_table', $I18n->getTable());
 
         $Tags = $this->getMockForModel('Tags', ['save']);
         $this->assertSame('tags', $Tags->getTable());
+        ConnectionManager::dropAlias('custom_i18n_datasource');
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -103,7 +103,6 @@ if (!getenv('DB_URL')) {
 }
 
 ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
-ConnectionManager::setConfig('test_custom_i18n_datasource', ['url' => getenv('DB_URL')]);
 
 Configure::write('Session', [
     'defaults' => 'php',

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1137,6 +1137,13 @@ return [
                     'tag_id',
                 ],
             ],
+            'author_id_fk' => [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ],
         ],
     ],
     [

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -9,4 +9,1500 @@ declare(strict_types=1);
  * features of the Database package.
  */
 return [
+    [
+        'table' => 'binary_uuid_items',
+        'columns' => [
+            'id' => [
+                'type' => 'binaryuuid',
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'published' => [
+                'type' => 'boolean',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'unique_authors',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'first_author_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'second_author_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+            'nullable_non_nullable_unique' => [
+                'type' => 'unique',
+                'columns' => [
+                    'first_author_id',
+                    'second_author_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'articles_more_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'subtitle' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'body' => 'text',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'users',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'username' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'password' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'created' => [
+                'type' => 'timestamp',
+                'null' => true,
+            ],
+            'updated' => [
+                'type' => 'timestamp',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'featured_tags',
+        'columns' => [
+            'tag_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'priority' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'tag_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'column_schema_aware_type_values',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'val' => [
+                'type' => 'text',
+                'null' => false,
+                'comment' => 'Fixture comment',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'sections_members',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'section_id' => [
+                'type' => 'integer',
+            ],
+            'member_id' => [
+                'type' => 'integer',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'site_articles_tags',
+        'columns' => [
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'tag_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'site_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'UNIQUE_TAG2' => [
+                'type' => 'primary',
+                'columns' => [
+                    'article_id',
+                    'tag_id',
+                    'site_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'authors_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'binary_uuid_items_binary_uuid_tags',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'binary_uuid_item_id' => [
+                'type' => 'binaryuuid',
+                'null' => false,
+            ],
+            'binary_uuid_tag_id' => [
+                'type' => 'binaryuuid',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+            'unique_item_tag' => [
+                'type' => 'unique',
+                'columns' => [
+                    'binary_uuid_item_id',
+                    'binary_uuid_tag_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'auth_users',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'username' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'password' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'created' => 'datetime',
+            'updated' => 'datetime',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'counter_cache_categories',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'length' => 255,
+                'null' => false,
+            ],
+            'post_count' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'date_keys',
+        'columns' => [
+            'id' => [
+                'type' => 'date',
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'counter_cache_posts',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'title' => [
+                'type' => 'string',
+                'length' => 255,
+            ],
+            'user_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'category_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'published' => [
+                'type' => 'boolean',
+                'null' => false,
+                'default' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'test_plugin_comments',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'user_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'comment' => 'text',
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+            'created' => 'datetime',
+            'updated' => 'datetime',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'members',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'section_count' => [
+                'type' => 'integer',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'uuid_items',
+        'columns' => [
+            'id' => [
+                'type' => 'uuid',
+            ],
+            'published' => [
+                'type' => 'boolean',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'special_tags_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'extra_info' => [
+                'type' => 'string',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'articles',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'author_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'body' => 'text',
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'articles_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'body' => 'text',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'products',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'category' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'price' => [
+                'type' => 'integer',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'category',
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'orders',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'product_category' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'product_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+            'product_category_fk' => [
+                'type' => 'foreign',
+                'columns' => [
+                    'product_category',
+                    'product_id',
+                ],
+                'references' => [
+                    'products',
+                    [
+                        'category',
+                        'id',
+                    ],
+                ],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ],
+        ],
+        'indexes' => [
+            'product_category' => [
+                'type' => 'index',
+                'columns' => [
+                    'product_category',
+                    'product_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'comments',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'user_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'comment' => [
+                'type' => 'text',
+            ],
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+            'created' => [
+                'type' => 'datetime',
+            ],
+            'updated' => [
+                'type' => 'datetime',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'datatypes',
+        'columns' => [
+            'id' => [
+                'type' => 'biginteger',
+            ],
+            'cost' => [
+                'type' => 'decimal',
+                'length' => 20,
+                'precision' => 1,
+                'null' => true,
+            ],
+            'fraction' => [
+                'type' => 'decimal',
+                'length' => 20,
+                'precision' => 19,
+                'null' => true,
+            ],
+            'floaty' => [
+                'type' => 'float',
+                'null' => true,
+            ],
+            'small' => [
+                'type' => 'smallinteger',
+                'null' => true,
+            ],
+            'tiny' => [
+                'type' => 'tinyinteger',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'authors',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'default' => null,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'counter_cache_comments',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'title' => [
+                'type' => 'string',
+                'length' => 255,
+            ],
+            'user_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'special_tags',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'tag_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'highlighted' => [
+                'type' => 'boolean',
+                'null' => true,
+            ],
+            'highlighted_time' => [
+                'type' => 'timestamp',
+                'null' => true,
+            ],
+            'extra_info' => [
+                'type' => 'string',
+            ],
+            'author_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+            'UNIQUE_TAG2' => [
+                'type' => 'unique',
+                'columns' => [
+                    'article_id',
+                    'tag_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'ordered_uuid_items',
+        'columns' => [
+            'id' => [
+                'type' => 'string',
+                'length' => 32,
+            ],
+            'published' => [
+                'type' => 'boolean',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'counter_cache_users',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'length' => 255,
+                'null' => false,
+            ],
+            'post_count' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'comment_count' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'posts_published' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'tags',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'description' => [
+                'type' => 'text',
+                'length' => 16777215,
+            ],
+            'created' => [
+                'type' => 'datetime',
+                'null' => true,
+                'default' => null,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'articles_tags',
+        'columns' => [
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'tag_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'unique_tag' => [
+                'type' => 'primary',
+                'columns' => [
+                    'article_id',
+                    'tag_id',
+                ],
+            ],
+            'tag_id_fk' => [
+                'type' => 'foreign',
+                'columns' => [
+                    'tag_id',
+                ],
+                'references' => [
+                    'tags',
+                    'id',
+                ],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ],
+        ],
+    ],
+    [
+        'table' => 'profiles',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+                'null' => false,
+                'autoIncrement' => true,
+            ],
+            'user_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'first_name' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'last_name' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'is_active' => [
+                'type' => 'boolean',
+                'null' => false,
+                'default' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'sessions',
+        'columns' => [
+            'id' => [
+                'type' => 'string',
+                'length' => 128,
+            ],
+            'data' => [
+                'type' => 'binary',
+                'length' => 16777215,
+                'null' => true,
+            ],
+            'expires' => [
+                'type' => 'integer',
+                'length' => 11,
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'comments_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'comment' => 'text',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'menu_link_trees',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'menu' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'lft' => [
+                'type' => 'integer',
+            ],
+            'rght' => [
+                'type' => 'integer',
+            ],
+            'parent_id' => 'integer',
+            'url' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'polymorphic_tagged',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'tag_id' => [
+                'type' => 'integer',
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+            ],
+            'foreign_model' => [
+                'type' => 'string',
+            ],
+            'position' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'things',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'title' => [
+                'type' => 'string',
+                'length' => 20,
+            ],
+            'body' => [
+                'type' => 'string',
+                'length' => 50,
+            ],
+        ],
+    ],
+    [
+        'table' => 'site_articles',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'author_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'site_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'body' => 'text',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'site_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'sections_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'authors_tags',
+        'columns' => [
+            'author_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'tag_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'unique_tag' => [
+                'type' => 'primary',
+                'columns' => [
+                    'author_id',
+                    'tag_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'site_authors',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'default' => null,
+            ],
+            'site_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'site_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'i18n',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'length' => 6,
+                'null' => false,
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'field' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'content' => [
+                'type' => 'text',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'number_trees',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'parent_id' => 'integer',
+            'lft' => [
+                'type' => 'integer',
+            ],
+            'rght' => [
+                'type' => 'integer',
+            ],
+            'depth' => [
+                'type' => 'integer',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'composite_increments',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+                'null' => false,
+                'autoIncrement' => true,
+            ],
+            'account_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'default' => null,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'account_id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'tags_shadow_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'locale',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'posts',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'author_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'body' => 'text',
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'binary_uuid_tags',
+        'columns' => [
+            'id' => [
+                'type' => 'binaryuuid',
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'tags_translations',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+                'null' => false,
+                'autoIncrement' => true,
+            ],
+            'locale' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'cake_sessions',
+        'columns' => [
+            'id' => [
+                'type' => 'string',
+                'length' => 128,
+            ],
+            'data' => [
+                'type' => 'text',
+                'null' => true,
+            ],
+            'expires' => [
+                'type' => 'integer',
+                'length' => 11,
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'attachments',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'comment_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'attachment' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'created' => 'datetime',
+            'updated' => 'datetime',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'categories',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+            'created' => 'datetime',
+            'updated' => 'datetime',
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'sections',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'title' => [
+                'type' => 'string',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'counter_cache_user_category_posts',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'category_id' => [
+                'type' => 'integer',
+            ],
+            'user_id' => [
+                'type' => 'integer',
+            ],
+            'post_count' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
+        'table' => 'site_tags',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'site_id' => [
+                'type' => 'integer',
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                    'site_id',
+                ],
+            ],
+        ],
+    ],
 ];

--- a/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
+++ b/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
@@ -82,7 +82,7 @@ class ColumnSchemaAwareType extends BaseType implements ExpressionTypeInterface,
     public function convertColumnDefinition(array $definition, DriverInterface $driver): ?array
     {
         return [
-            'type' => $this->_name,
+            'type' => 'text',
             'length' => 255,
             'comment' => 'Custom schema aware type comment',
         ];


### PR DESCRIPTION
Extract schema from the existing core fixtures into a new schema file that can be used with data-only fixtures. I had to make a few API changes to the new fixtures as I hadn't wired up row loading yet.

I don't think we can safely remove schema from any of the core fixtures as they are likely referenced in plugin builds and those plugins will lag behind in adopting new fixtures.

Part of #15308