### PR TITLE
Avoid conflict with Exception::$file

### DIFF
--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -25,7 +25,7 @@ class MissingTemplateException extends CakeException
     /**
      * @var string
      */
-    protected $file;
+    protected $filename;
 
     /**
      * @var string[]
@@ -47,7 +47,7 @@ class MissingTemplateException extends CakeException
      */
     public function __construct($file, array $paths = [], ?int $code = null, ?Throwable $previous = null)
     {
-        $this->file = is_array($file) ? array_pop($file) : $file;
+        $this->filename = is_array($file) ? array_pop($file) : $file;
         $this->paths = $paths;
 
         parent::__construct($this->formatMessage(), $code, $previous);
@@ -60,11 +60,11 @@ class MissingTemplateException extends CakeException
      */
     public function formatMessage(): string
     {
-        $message = "{$this->type} file `{$this->file}` could not be found.";
+        $message = "{$this->type} file `{$this->filename}` could not be found.";
         if ($this->paths) {
             $message .= "\n\nThe following paths were searched:\n\n";
             foreach ($this->paths as $path) {
-                $message .= "- `{$path}{$this->file}`\n";
+                $message .= "- `{$path}{$this->filename}`\n";
             }
         }
 
@@ -80,7 +80,7 @@ class MissingTemplateException extends CakeException
     public function getAttributes(): array
     {
         return [
-            'file' => $this->file,
+            'file' => $this->filename,
             'paths' => $this->paths,
         ];
     }


### PR DESCRIPTION
We don't want to override Exception::$file even if we could make it the same type.
