### PR TITLE
Set mock methods for ResultSet

### DIFF
--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1937,6 +1937,7 @@ class QueryTest extends TestCase
             ->getMock();
         $query->select();
         $resultSet = $this->getMockbuilder('Cake\ORM\ResultSet')
+            ->onlyMethods([$method])
             ->setConstructorArgs([$query, $this->getMockBuilder(StatementInterface::class)->getMock()])
             ->getMock();
         $query->expects($this->once())


### PR DESCRIPTION
This throws a TypeError in 8.1 since the methods array is null. I'm pretty sure this is the cause.

```
186) Cake\Test\TestCase\ORM\QueryTest::testCollectionProxy with data set #2 ('every', Closure Object (...), false)
TypeError: PHPUnit\Framework\MockObject\InvocationHandler::__construct(): Argument #1 ($configurableMethods) must be of type array, null given, called in /home/runner/work/cakephp/cakephp/vendor/phpunit/phpunit/src/Framework/MockObject/Api/Api.php on line 70
```