### PR TITLE
Fix PDO returning proper column types in php 8.1

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -321,14 +321,14 @@ class ConnectionTest extends TestCase
 
         $collection = new Collection($statement);
         $result = $collection->extract('id')->toArray();
-        $this->assertSame([1, 2], $result);
+        $this->assertEquals(['1', '2'], $result);
 
         // Check iteration after extraction
         $result = [];
         foreach ($collection as $v) {
             $result[] = $v['id'];
         }
-        $this->assertSame([1, 2], $result);
+        $this->assertEquals(['1', '2'], $result);
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -321,14 +321,14 @@ class ConnectionTest extends TestCase
 
         $collection = new Collection($statement);
         $result = $collection->extract('id')->toArray();
-        $this->assertSame(['1', '2'], $result);
+        $this->assertSame([1, 2], $result);
 
         // Check iteration after extraction
         $result = [];
         foreach ($collection as $v) {
             $result[] = $v['id'];
         }
-        $this->assertSame(['1', '2'], $result);
+        $this->assertSame([1, 2], $result);
     }
 
     /**


### PR DESCRIPTION
The column type is `int`, but PDO was returning string until PHP 8.1.