### PR TITLE
Fix OAuth 1 when consumer key is base64 string

### DIFF
--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -145,6 +145,10 @@ class Oauth
         ];
         $baseString = $this->baseString($request, $values);
 
+        // Consumer key should only be encoded for base string calculation as
+        // auth header generation already encodes independently
+        $values['oauth_consumer_key'] = $credentials['consumerKey'];
+
         if (isset($credentials['realm'])) {
             $values['oauth_realm'] = $credentials['realm'];
         }

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -141,7 +141,7 @@ class Oauth
             'oauth_timestamp' => $timestamp,
             'oauth_signature_method' => 'HMAC-SHA1',
             'oauth_token' => $credentials['token'],
-            'oauth_consumer_key' => $credentials['consumerKey'],
+            'oauth_consumer_key' => $this->_encode($credentials['consumerKey']),
         ];
         $baseString = $this->baseString($request, $values);
 

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -360,6 +360,37 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
     }
 
     /**
+     * Test HMAC-SHA1 signing with a base64 consumer key
+     *
+     * @return void
+     */
+    public function testHmacBase64Signing()
+    {
+        $request = new Request(
+            'http://photos.example.net/photos',
+            'GET'
+        );
+
+        $options = [
+            'consumerKey' => 'ZHBmNDNmM3AybDRrM2wwMw==',
+            'consumerSecret' => 'kd94hf93k423kf44',
+            'tokenSecret' => 'pfkkdhi9sl3r4s00',
+            'token' => 'nnch734d00sl2jdk',
+            'nonce' => 'kllo9940pd9333jh',
+            'timestamp' => '1191242096',
+        ];
+        $auth = new Oauth();
+        $request = $auth->authentication($request, $options);
+
+        $result = $request->getHeaderLine('Authorization');
+        $expected = '2hr/eoFyTSuWc6SfZIvkhpeRHdM=';
+        $this->assertStringContainsString(
+            'oauth_signature="' . $expected . '"',
+            urldecode($result)
+        );
+    }
+
+    /**
      * Test RSA-SHA1 signing with a private key string
      *
      * Hash result + parameters taken from


### PR DESCRIPTION
Fix consumer keys not being correctly encoded when the key is base64 and ends with an equals sign

Consider a consumer key like `...O0jGs=`. When creating an OAuth 1 base string, CakePHP encodes this part as follows:
`oauth_consumer_key%3D...0jGs%3D`

However, the correct encoding is as follows:
`oauth_consumer_key%3D...0jGs%253D`

Note how CakePHP does not encode the % sign, thus creating wrong base string and thus the signature is also incorrect.

Tested on 3.7.9, but seemingly affects other versions too.