### PR TITLE
Add __serialize()/__unserialize() magic methods.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -55,6 +55,16 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
     }
 
     /**
+     * Returns an array for serializing this of this object.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return $this->buffered()->toArray();
+    }
+
+    /**
      * Unserializes the passed string and rebuilds the Collection instance
      *
      * @param string $collection The serialized collection
@@ -63,6 +73,17 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
     public function unserialize($collection): void
     {
         $this->__construct(unserialize($collection));
+    }
+
+    /**
+     * Rebuilds the Collection instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->__construct($data);
     }
 
     /**

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -202,6 +202,20 @@ class BufferedIterator extends Collection implements Countable, Serializable
     }
 
     /**
+     * Magic method used for serializing the iterator instance.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        if (!$this->_finished) {
+            $this->count();
+        }
+
+        return iterator_to_array($this->_buffer);
+    }
+
+    /**
      * Unserializes the passed string and rebuilds the BufferedIterator instance
      *
      * @param string $buffer The serialized buffer iterator
@@ -211,6 +225,24 @@ class BufferedIterator extends Collection implements Countable, Serializable
     {
         $this->__construct([]);
         $this->_buffer = unserialize($buffer);
+        $this->_started = true;
+        $this->_finished = true;
+    }
+
+    /**
+     * Magic method used to rebuild the iterator instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->__construct([]);
+
+        foreach ($data as $value) {
+            $this->_buffer->push($value);
+        }
+
         $this->_started = true;
         $this->_finished = true;
     }

--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -111,6 +111,16 @@ class ZipIterator extends MultipleIterator implements CollectionInterface, Seria
     }
 
     /**
+     * Magic method used for serializing the iterator instance.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return $this->_iterators;
+    }
+
+    /**
      * Unserializes the passed string and rebuilds the ZipIterator instance
      *
      * @param string $iterators The serialized iterators
@@ -120,6 +130,22 @@ class ZipIterator extends MultipleIterator implements CollectionInterface, Seria
     {
         parent::__construct(MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC);
         $this->_iterators = unserialize($iterators);
+        foreach ($this->_iterators as $it) {
+            $this->attachIterator($it);
+        }
+    }
+
+    /**
+     * Magic method used to rebuild the iterator instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        parent::__construct(MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC);
+
+        $this->_iterators = $data;
         foreach ($this->_iterators as $it) {
             $this->attachIterator($it);
         }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -140,13 +140,18 @@ abstract class BaseLog extends AbstractLogger
             }
 
             if (is_object($value)) {
-                if (method_exists($value, '__toString')) {
-                    $replacements['{' . $key . '}'] = (string)$value;
+                if (method_exists($value, 'toArray')) {
+                    $replacements['{' . $key . '}'] = json_encode($value->toArray(), JSON_UNESCAPED_UNICODE);
                     continue;
                 }
 
-                if (method_exists($value, 'toArray')) {
-                    $replacements['{' . $key . '}'] = json_encode($value->toArray(), JSON_UNESCAPED_UNICODE);
+                if (method_exists($value, '__serialize')) {
+                    $replacements['{' . $key . '}'] = serialize($value);
+                    continue;
+                }
+
+                if (method_exists($value, '__toString')) {
+                    $replacements['{' . $key . '}'] = (string)$value;
                     continue;
                 }
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -586,6 +586,18 @@ class Email implements JsonSerializable, Serializable
      */
     public function serialize(): string
     {
+        $array = $this->__serialize();
+
+        return serialize($array);
+    }
+
+    /**
+     * Magic method used for serializing the Email object.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
         $array = $this->jsonSerialize();
         array_walk_recursive($array, function (&$item, $key): void {
             if ($item instanceof SimpleXMLElement) {
@@ -593,7 +605,7 @@ class Email implements JsonSerializable, Serializable
             }
         });
 
-        return serialize($array);
+        return $array;
     }
 
     /**
@@ -605,6 +617,17 @@ class Email implements JsonSerializable, Serializable
     public function unserialize($data): void
     {
         $this->createFromArray(unserialize($data));
+    }
+
+    /**
+     * Magic method used to rebuild the Email object.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->createFromArray($data);
     }
 
     /**

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1895,6 +1895,18 @@ class Message implements JsonSerializable, Serializable
      */
     public function serialize(): string
     {
+        $array = $this->__serialize();
+
+        return serialize($array);
+    }
+
+    /**
+     * Magic method used for serializing the Message object.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
         $array = $this->jsonSerialize();
         array_walk_recursive($array, function (&$item, $key): void {
             if ($item instanceof SimpleXMLElement) {
@@ -1902,7 +1914,7 @@ class Message implements JsonSerializable, Serializable
             }
         });
 
-        return serialize($array);
+        return $array;
     }
 
     /**
@@ -1919,5 +1931,16 @@ class Message implements JsonSerializable, Serializable
         }
 
         $this->createFromArray($array);
+    }
+
+    /**
+     * Magic method used to rebuild the Message object.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->createFromArray($data);
     }
 }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -299,6 +299,16 @@ class ResultSet implements ResultSetInterface
      */
     public function serialize(): string
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Serializes a resultset.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
         if (!$this->_useBuffering) {
             $msg = 'You cannot serialize an un-buffered ResultSet. '
                 . 'Use Query::bufferResults() to get a buffered ResultSet.';
@@ -310,10 +320,10 @@ class ResultSet implements ResultSetInterface
         }
 
         if ($this->_results instanceof SplFixedArray) {
-            return serialize($this->_results->toArray());
+            return $this->_results->toArray();
         }
 
-        return serialize($this->_results);
+        return $this->_results;
     }
 
     /**
@@ -326,8 +336,18 @@ class ResultSet implements ResultSetInterface
      */
     public function unserialize($serialized)
     {
-        $results = (array)(unserialize($serialized) ?: []);
-        $this->_results = SplFixedArray::fromArray($results);
+        $this->__unserialize((array)(unserialize($serialized) ?: []));
+    }
+
+    /**
+     * Unserializes a resultset.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->_results = SplFixedArray::fromArray($data);
         $this->_useBuffering = true;
         $this->_count = $this->_results->count();
     }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -663,6 +663,16 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
+     * Magic method used for serializing the view builder object.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return $this->jsonSerialize();
+    }
+
+    /**
      * Unserializes the view builder object.
      *
      * @param string $data Serialized string.
@@ -671,5 +681,16 @@ class ViewBuilder implements JsonSerializable, Serializable
     public function unserialize($data): void
     {
         $this->createFromArray(unserialize($data));
+    }
+
+    /**
+     * Magic method used to rebuild the view builder object.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->createFromArray($data);
     }
 }

--- a/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
@@ -90,4 +90,25 @@ class BufferedIteratorTest extends TestCase
         }
         $this->assertEquals([1, 2, 3], $result);
     }
+
+    /**
+     * Testing serialize and unserialize features.
+     *
+     * @return void
+     */
+    public function testSerialization()
+    {
+        $items = new ArrayObject([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ]);
+        $expected = (array)$items;
+
+        $iterator = new BufferedIterator($items);
+
+        $serialized = serialize($iterator);
+        $outcome = unserialize($serialized);
+        $this->assertEquals($expected, $outcome->toArray());
+    }
 }


### PR DESCRIPTION
The Serializable interface is deprecated in PHP 8.1 and adding these methods
avoids deprecation errors.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
