### PR TITLE
A custom message added in firstOrFail() method,

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -503,18 +503,22 @@ trait QueryTrait
     /**
      * Get the first result from the executing query or raise an exception.
      *
+     * @param string $message Custom message returns when record not found
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
      * @return \Cake\Datasource\EntityInterface|array The first result from the ResultSet.
      */
-    public function firstOrFail()
+    public function firstOrFail(string $message = null)
     {
         $entity = $this->first();
         if (!$entity) {
             $table = $this->getRepository();
-            throw new RecordNotFoundException(sprintf(
-                'Record not found in table "%s"',
-                $table->getTable()
-            ));
+            if ($message)
+                throw new RecordNotFoundException($message);
+            else
+                throw new RecordNotFoundException(sprintf(
+                    'Record not found in table "%s"',
+                    $table->getTable()
+                ));
         }
 
         return $entity;


### PR DESCRIPTION
Instead of  'Record not found in table "%s"' in response any one can add custom message.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
