### PR TITLE
Avoid duplicate php 7.2 + mysql matrix builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         php-version: ['7.2', '7.4', '8.0']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
+        exclude:
+          - php-version: '7.2'
+            db-type: 'mysql'
         include:
           - php-version: '7.2'
             db-type: 'mariadb'


### PR DESCRIPTION
We don't need to build php 7.2 + mysql twice.
