### PR TITLE
Fix error when accessing PDOStatement::$queryString.

### DIFF
--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -47,6 +47,20 @@ class PDOStatement extends StatementDecorator
     }
 
     /**
+     * Magic getter to return PDOStatement::$queryString as read-only.
+     *
+     * @param string $property internal property to get
+     * @return mixed
+     */
+    public function __get(string $property)
+    {
+        if ($property === 'queryString' && isset($this->_statement->queryString)) {
+            /** @psalm-suppress NoInterfaceProperties */
+            return $this->_statement->queryString;
+        }
+    }
+
+    /**
      * Assign a value to a positional or named variable in prepared query. If using
      * positional variables you need to start with index one, if using named params then
      * just use the name in any order.


### PR DESCRIPTION
On PHP 8.1 trying to access PDOStatement::$queryString before it's initialized results in
"Error: Typed property PDOStatement::$queryString must not be accessed before initialization".

Closes #15537
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
