### PR TITLE
Move fixture reset management to test case

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,11 @@ parameters:
 			path: src/Auth/Storage/SessionStorage.php
 
 		-
+			message: "#^Constructor of class Cake\\\\TestSuite\\\\Fixture\\\\TransactionStrategy has an unused parameter \\$loader\\.$#"
+			count: 1
+			path: src/TestSuite/Fixture/TransactionStrategy.php
+
+		-
 			message: "#^Method Cake\\\\Auth\\\\Storage\\\\SessionStorage\\:\\:redirectUrl\\(\\) should return array\\|string\\|null but return statement is missing\\.$#"
 			count: 1
 			path: src/Auth/Storage/SessionStorage.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,12 +18,7 @@
     </testsuites>
 
     <extensions>
-        <extension class="Cake\TestSuite\FixtureSchemaExtension">
-            <arguments>
-                <!-- core tests create/modify tables so we can't use TransactionStrategy -->
-                <string>Cake\TestSuite\Fixture\TruncationStrategy</string>
-            </arguments>
-        </extension>
+        <extension class="Cake\TestSuite\FixtureSchemaExtension" />
     </extensions>
 
     <!-- Prevent coverage reports from looking in tests, vendors, config folders -->

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -240,19 +240,21 @@
       <code>$this</code>
     </DeprecatedClass>
   </file>
+  <file src="src/TestSuite/Fixture/FixtureDataManager.php">
+    <DeprecatedProperty occurrences="1">
+      <code>$test-&gt;autoFixtures</code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/TestSuite/Fixture/FixtureInjector.php">
     <DeprecatedInterface occurrences="1">
       <code>FixtureInjector</code>
     </DeprecatedInterface>
   </file>
-  <file src="src/TestSuite/Fixture/TestFixture.php">
-    <ArgumentTypeCoercion occurrences="5">
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
-      <code>$db</code>
-    </ArgumentTypeCoercion>
+  <file src="src/TestSuite/Fixture/FixtureManager.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$test-&gt;autoFixtures</code>
+      <code>$test-&gt;dropTables</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/TestSuite/IntegrationTestTrait.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -268,6 +270,12 @@
       <code>\Cake\Console\Shell</code>
       <code>parent::__construct($args, $bootstrap)</code>
     </DeprecatedClass>
+  </file>
+  <file src="src/TestSuite/TestCase.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;autoFixtures</code>
+      <code>$this-&gt;autoFixtures</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/TestSuite/TestSuite.php">
     <InternalClass occurrences="1">

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -626,7 +626,10 @@ class Connection implements ConnectionInterface
      */
     public function releaseSavePoint($name): void
     {
-        $this->execute($this->_driver->releaseSavePointSQL($name))->closeCursor();
+        $sql = $this->_driver->releaseSavePointSQL($name);
+        if ($sql) {
+            $this->execute($sql)->closeCursor();
+        }
     }
 
     /**

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -238,7 +238,8 @@ class Sqlserver extends Driver
      */
     public function releaseSavePointSQL($name): string
     {
-        return 'COMMIT TRANSACTION t' . $name;
+        // SQLServer has no release save point operation.
+        return '';
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -237,12 +237,28 @@ class FixtureDataManager extends FixtureLoader
      */
     public function setupTest(TestCase $test): void
     {
+        $stateReset = $test->getStateResetStrategy();
+        $stateReset->setupTest();
+
         $this->inserted = [];
         if (!$test->getFixtures()) {
             return;
         }
         $this->loadFixtureClasses($test);
         $this->load($test);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function teardownTest(TestCase $test): void
+    {
+        if (!$test->getFixtures()) {
+            return;
+        }
+
+        $stateReset = $test->getStateResetStrategy();
+        $stateReset->teardownTest();
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -89,6 +89,16 @@ abstract class FixtureLoader
     abstract public function setupTest(TestCase $test): void;
 
     /**
+     * Teardown fixtures for the provided test.
+     *
+     * Called by TestCase during its tearDown() method.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test to inspect for fixture loading.
+     * @return void
+     */
+    abstract public function teardownTest(TestCase $test): void;
+
+    /**
      * Get the list of all fixtures that have been loaded.
      *
      * @return \Cake\Datasource\FixtureInterface[]

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -105,6 +105,20 @@ class FixtureManager extends FixtureLoader
     }
 
     /**
+     * Implemented to satisfy the abstract base class.
+     *
+     * For backwards compatibility reasons fixtures are reset
+     * via `shutdown` which is called by the TestListener.
+     *
+     * @param \Cake\TestSuite\TestCase $test The test case.
+     * @return void
+     */
+    public function teardownTest(TestCase $test): void
+    {
+        // Do nothing
+    }
+
+    /**
      * @inheritDoc
      */
     public function fixturize(TestCase $test): void

--- a/src/TestSuite/Fixture/StateResetStrategyInterface.php
+++ b/src/TestSuite/Fixture/StateResetStrategyInterface.php
@@ -30,18 +30,16 @@ interface StateResetStrategyInterface
      *
      * Fired before each test is started.
      *
-     * @param string $test The test class::method that is going to run.
      * @return void
      */
-    public function beforeTest(string $test): void;
+    public function setupTest(): void;
 
     /**
      * After test hook
      *
      * Fired after each test is complete.
      *
-     * @param string $test The test class::method that was completed.
      * @return void
      */
-    public function afterTest(string $test): void;
+    public function teardownTest(): void;
 }

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -33,53 +33,32 @@ class TransactionStrategy implements StateResetStrategyInterface
     /**
      * Constructor.
      *
-     * @param bool $enableLogging Whether or not to enable query logging.
+     * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
      * @return void
      */
-    public function __construct(bool $enableLogging = false)
+    public function __construct(FixtureLoader $fixtures)
     {
-        $this->aliasConnections($enableLogging);
+        $this->checkConnections();
     }
 
     /**
-     * Alias non test connections to the test ones
-     * so that models reach the test database connections instead.
+     * Ensure that all `Connection` connections support savepoints.
      *
-     * @param bool $enableLogging Whether or not to enable query logging.
      * @return void
      */
-    protected function aliasConnections(bool $enableLogging): void
+    protected function checkConnections(): void
     {
         $connections = ConnectionManager::configured();
-        ConnectionManager::alias('test', 'default');
-        $map = [];
-        foreach ($connections as $connection) {
-            if ($connection === 'test' || $connection === 'default') {
-                continue;
-            }
-            if (isset($map[$connection])) {
-                continue;
-            }
-            if (strpos($connection, 'test_') === 0) {
-                $map[$connection] = substr($connection, 5);
-            } else {
-                $map['test_' . $connection] = $connection;
-            }
-        }
-        foreach ($map as $testConnection => $normal) {
-            ConnectionManager::alias($testConnection, $normal);
-            $connection = ConnectionManager::get($normal);
+        foreach ($connections as $name) {
+            $connection = ConnectionManager::get($name);
             if ($connection instanceof Connection) {
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
                     throw new RuntimeException(
-                        "Could not enable save points for the `{$normal}` connection. " .
+                        "Could not enable save points for the `{$name}` connection. " .
                             'Your database needs to support savepoints in order to use the ' .
                             'TransactionStrategy for fixtures.'
                     );
-                }
-                if ($enableLogging) {
-                    $connection->enableQueryLogging();
                 }
             }
         }
@@ -88,10 +67,9 @@ class TransactionStrategy implements StateResetStrategyInterface
     /**
      * Before each test start a transaction.
      *
-     * @param string $test The test class::method that was completed.
      * @return void
      */
-    public function beforeTest(string $test): void
+    public function setupTest(): void
     {
         $connections = ConnectionManager::configured();
         foreach ($connections as $connection) {
@@ -113,10 +91,9 @@ class TransactionStrategy implements StateResetStrategyInterface
      * operations we should end up at a transaction depth of 0
      * and we will rollback the root transaction started in beforeTest()
      *
-     * @param string $test The test class::method that was completed.
      * @return void
      */
-    public function afterTest(string $test): void
+    public function teardownTest(): void
     {
         $connections = ConnectionManager::configured();
         foreach ($connections as $connection) {

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -33,7 +33,7 @@ class TransactionStrategy implements StateResetStrategyInterface
     /**
      * Constructor.
      *
-     * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
+     * @param \Cake\TestSuite\Fixture\FixtureLoader $loader The fixture loader being used.
      * @return void
      */
     public function __construct(FixtureLoader $loader)

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -36,7 +36,7 @@ class TransactionStrategy implements StateResetStrategyInterface
      * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
      * @return void
      */
-    public function __construct(FixtureLoader $fixtures)
+    public function __construct(FixtureLoader $loader)
     {
         $this->checkConnections();
     }

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -48,17 +48,17 @@ class TruncationStrategy implements StateResetStrategyInterface
     /**
      * @var \Cake\TestSuite\Fixture\FixtureLoader
      */
-    protected $fixtures;
+    protected $loader;
 
     /**
      * Constructor.
      *
-     * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
+     * @param \Cake\TestSuite\Fixture\FixtureLoader $loader The fixture loader being used.
      * @return void
      */
     public function __construct(FixtureLoader $loader)
     {
-        $this->fixtures = $loader;
+        $this->loader = $loader;
     }
 
     /**
@@ -77,7 +77,7 @@ class TruncationStrategy implements StateResetStrategyInterface
             if (!($db instanceof Connection)) {
                 continue;
             }
-            $lastInserted = $this->fixtures->lastInserted();
+            $lastInserted = $this->loader->lastInserted();
             if (empty($lastInserted)) {
                 continue;
             }

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -20,7 +20,6 @@ use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
-use RuntimeException;
 
 /**
  * Fixture state strategy that truncates tables before a test.
@@ -47,63 +46,28 @@ class TruncationStrategy implements StateResetStrategyInterface
     protected $tables = [];
 
     /**
-     * Constructor.
-     *
-     * @param bool $enableLogging Whether or not to enable query logging.
-     * @return void
+     * @var \Cake\TestSuite\Fixture\FixtureLoader
      */
-    public function __construct(bool $enableLogging = false)
-    {
-        $this->aliasConnections($enableLogging);
-    }
+    protected $fixtures;
 
     /**
-     * Alias non test connections to the test ones
-     * so that models reach the test database connections instead.
+     * Constructor.
      *
-     * @param bool $enableLogging Whether or not to enable query logging.
+     * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
      * @return void
      */
-    protected function aliasConnections(bool $enableLogging): void
+    public function __construct(FixtureLoader $fixtures)
     {
-        $connections = ConnectionManager::configured();
-        ConnectionManager::alias('test', 'default');
-        $map = [];
-        foreach ($connections as $connection) {
-            if ($connection === 'test' || $connection === 'default') {
-                continue;
-            }
-            if (isset($map[$connection])) {
-                continue;
-            }
-            if (strpos($connection, 'test_') === 0) {
-                $map[$connection] = substr($connection, 5);
-            } else {
-                $map['test_' . $connection] = $connection;
-            }
-        }
-        foreach ($map as $testConnection => $normal) {
-            ConnectionManager::alias($testConnection, $normal);
-            $connection = ConnectionManager::get($normal);
-            if ($connection instanceof Connection && $enableLogging) {
-                $connection->enableQueryLogging();
-            }
-        }
+        $this->fixtures = $fixtures;
     }
 
     /**
      * Before each test start a transaction.
      *
-     * @param string $test The test class::method that was completed.
      * @return void
      */
-    public function beforeTest(string $test): void
+    public function setupTest(): void
     {
-        $fixtures = FixtureLoader::getInstance();
-        if (!$fixtures) {
-            throw new RuntimeException('Cannot truncate tables without a FixtureLoader');
-        }
-
         $connections = ConnectionManager::configured();
         foreach ($connections as $connection) {
             if (strpos($connection, 'test') !== 0) {
@@ -113,7 +77,7 @@ class TruncationStrategy implements StateResetStrategyInterface
             if (!($db instanceof Connection)) {
                 continue;
             }
-            $lastInserted = $fixtures->lastInserted();
+            $lastInserted = $this->fixtures->lastInserted();
             if (empty($lastInserted)) {
                 continue;
             }
@@ -136,16 +100,12 @@ class TruncationStrategy implements StateResetStrategyInterface
     }
 
     /**
-     * No op.
+     * No op. Implemented because of interface.
      *
-     * Implemented to satisfy the interface.
-     *
-     * @param string $test The test class::method that was completed.
      * @return void
      */
-    public function afterTest(string $test): void
+    public function teardownTest(): void
     {
-        // Do nothing
     }
 
     /**

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -56,9 +56,9 @@ class TruncationStrategy implements StateResetStrategyInterface
      * @param \Cake\TestSuite\Fixture\FixtureLoader $fixtures The fixture loader being used.
      * @return void
      */
-    public function __construct(FixtureLoader $fixtures)
+    public function __construct(FixtureLoader $loader)
     {
-        $this->fixtures = $fixtures;
+        $this->fixtures = $loader;
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -90,6 +90,7 @@ abstract class TestCase extends BaseTestCase
      * If null the TruncationStrategy will be used.
      *
      * @var string|null
+     * @psalm-var class-string|null
      */
     protected $stateResetStrategy;
 
@@ -1070,6 +1071,7 @@ abstract class TestCase extends BaseTestCase
             );
         }
 
+        /** @var \Cake\TestSuite\Fixture\StateResetStrategyInterface */
         return $reflect->newInstance($this->fixtureManager);
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -33,15 +33,15 @@ class TransactionStrategyTest extends TestCase
     {
         $users = TableRegistry::get('Users');
 
-        $strategy = new TransactionStrategy();
-        $strategy->beforeTest(__METHOD__);
+        $strategy = new TransactionStrategy($this->fixtureManager);
+        $strategy->setupTest();
         $user = $users->newEntity(['username' => 'testing', 'password' => 'secrets']);
 
         $users->save($user, ['atomic' => true]);
         $this->assertNotEmpty($users->get($user->id), 'User should exist.');
 
         // Rollback and the user should be gone.
-        $strategy->afterTest(__METHOD__);
+        $strategy->teardownTest();
         $this->assertNull($users->findById($user->id)->first(), 'No user expected.');
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
@@ -32,7 +32,7 @@ class TruncationStrategyTest extends TestCase
      *
      * @return void
      */
-    public function testBeforeTestSimple()
+    public function testSetupSimple()
     {
         $articles = TableRegistry::get('Articles');
         $articlesTags = TableRegistry::get('ArticlesTags');
@@ -42,8 +42,8 @@ class TruncationStrategyTest extends TestCase
         $rowCount = $articlesTags->find()->count();
         $this->assertGreaterThan(0, $rowCount);
 
-        $strategy = new TruncationStrategy();
-        $strategy->beforeTest(__METHOD__);
+        $strategy = new TruncationStrategy($this->fixtureManager);
+        $strategy->setupTest();
 
         $rowCount = $articles->find()->count();
         $this->assertEquals(0, $rowCount);

--- a/tests/TestCase/TestSuite/FixtureSchemaExtensionTest.php
+++ b/tests/TestCase/TestSuite/FixtureSchemaExtensionTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\FixtureSchemaExtension;
+use Cake\TestSuite\TestCase;
+
+class FixtureSchemaExtensionTest extends TestCase
+{
+    /**
+     * Test connection aliasing during construction.
+     *
+     * @return void
+     */
+    public function testConnectionAliasing()
+    {
+        $this->skipIf(!extension_loaded('pdo_sqlite'), 'Requires SQLite extension');
+        ConnectionManager::setConfig('test_fixture_schema', [
+            'className' => Connection::class,
+            'driver' => Sqlite::class,
+            'database' => TMP . 'fixture_schema.sqlite',
+        ]);
+        $this->assertNotContains('fixture_schema', ConnectionManager::configured());
+        $extension = new FixtureSchemaExtension();
+
+        $this->assertContains('test_fixture_schema', ConnectionManager::configured());
+        $this->assertSame(
+            ConnectionManager::get('test_fixture_schema'),
+            ConnectionManager::get('fixture_schema')
+        );
+        $this->assertSame(
+            ConnectionManager::get('test'),
+            ConnectionManager::get('default')
+        );
+        $this->assertNull($extension->executeBeforeFirstTest());
+        ConnectionManager::drop('test_fixture_schema');
+    }
+}

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -26,8 +26,11 @@ use Cake\ORM\Table;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Router;
 use Cake\Test\Fixture\FixturizedTestCase;
+use Cake\TestSuite\Fixture\StateResetStrategyInterface;
+use Cake\TestSuite\Fixture\TruncationStrategy;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
+use RuntimeException;
 use TestApp\Model\Table\SecondaryPostsTable;
 
 /**
@@ -459,5 +462,43 @@ class TestCaseTest extends TestCase
 
         $result = Router::url($url);
         $this->assertSame('/app/articles', $result);
+    }
+
+    /**
+     * Test getting the state reset manager.
+     *
+     * @return void
+     */
+    public function testGetStateResetStrategySuccess()
+    {
+        $instance = $this->getStateResetStrategy();
+        $this->assertInstanceOf(StateResetStrategyInterface::class, $instance);
+        $this->assertInstanceOf(TruncationStrategy::class, $instance);
+    }
+
+    /**
+     * Test getting the state reset manager when class is invalid
+     *
+     * @return void
+     */
+    public function testGetStateResetStrategyMissingClass()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot find class `NotThere`');
+        $this->stateResetStrategy = 'NotThere';
+        $this->getStateResetStrategy();
+    }
+
+    /**
+     * Test getting the state reset manager when class is invalid
+     *
+     * @return void
+     */
+    public function testGetStateResetInvalidClass()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not implement the required');
+        $this->stateResetStrategy = static::class;
+        $this->getStateResetStrategy();
     }
 }


### PR DESCRIPTION
Having the reset strategy be global across the application complicates a few scenarios:

1. If an application has some end-to-end tests they would be forced to    use `TruncationStrategy` even for their integration tests.
2. Having multiple state managers that are used in different tests gets    harder. With this approach if a test only uses elasticsearch it can    use the elasticsearch state reset (once it exists).

In addition to these specfic problems having the state manager on the test case makes more of the framework's logic extensible and replaceable should an application need to.

For the core tests having this will unblock us to use the `TransactionStrategy` on a large number of our tests which should yield even faster test durations.

Part of #15308 
