### PR TITLE
Remove php 7.4 from build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0']
+        php-version: ['7.2', '8.0']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         exclude:
           - php-version: '7.2'
             db-type: 'mysql'
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             db-type: 'mariadb'
           - php-version: '7.2'
             db-type: 'mysql'
@@ -101,7 +101,7 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.4' && matrix.db-type == 'mysql'
+      if: matrix.php-version == '7.2' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
@@ -122,7 +122,7 @@ jobs:
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.0'
       uses: codecov/codecov-action@v1
 
   testsuite-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
 
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit


### PR DESCRIPTION
Trying to further reduce our build matrix after removing redundant php 7.2 + mysql build.

Since we don't use php 7.4 or 8.0 features, just testing against 8.0 should cover any deprecations or changes to PDO. If we bump mariadb to 7.4, it covers most of it.
