### PR TITLE
Allow specifying middlewares at the controller level.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -156,6 +156,11 @@ parameters:
 			path: src/Controller/Controller.php
 
 		-
+			message: "#^Parameter \\#1 \\$request of method Cake\\\\Controller\\\\Controller\\:\\:setRequest\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
+			count: 1
+			path: src/Controller/ControllerFactory.php
+
+		-
 			message: "#^Parameter \\#1 \\$request of method Cake\\\\Controller\\\\ControllerFactory\\:\\:getControllerClass\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
 			count: 1
 			path: src/Controller/ControllerFactory.php

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -733,4 +733,39 @@ class ControllerFactoryTest extends TestCase
         $this->expectExceptionMessage('Too few arguments');
         $this->factory->invoke($controller);
     }
+
+    public function testMiddleware()
+    {
+        $request = new ServerRequest([
+            'url' => 'posts',
+            'params' => [
+                'controller' => 'Posts',
+                'action' => 'index',
+                'pass' => [],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+        $this->factory->invoke($controller);
+
+        $request = $controller->getRequest();
+        $this->assertTrue($request->getAttribute('for-all'));
+        $this->assertTrue($request->getAttribute('index-only'));
+        $this->assertNull($request->getAttribute('all-except-index'));
+
+        $request = new ServerRequest([
+            'url' => 'posts/get',
+            'params' => [
+                'controller' => 'Posts',
+                'action' => 'get',
+                'pass' => [],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+        $this->factory->invoke($controller);
+
+        $request = $controller->getRequest();
+        $this->assertTrue($request->getAttribute('for-all'));
+        $this->assertNull($request->getAttribute('index-only'));
+        $this->assertTrue($request->getAttribute('all-except-index'));
+    }
 }

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -32,6 +32,16 @@ class PostsController extends AppController
         $this->loadComponent('Flash');
         $this->loadComponent('RequestHandler');
         $this->loadComponent('FormProtection');
+
+        $this->middleware(function ($request, $handler) {
+            return $handler->handle($request->withAttribute('for-all', true));
+        });
+        $this->middleware(function ($request, $handler) {
+            return $handler->handle($request->withAttribute('index-only', true));
+        }, ['only' => 'index']);
+        $this->middleware(function ($request, $handler) {
+            return $handler->handle($request->withAttribute('all-except-index', true));
+        }, ['except' => ['index']]);
     }
 
     /**


### PR DESCRIPTION
While we can setup route based middlewares at times setting them can be
a bit cumbersome. If for e.g. you want a middleware to run for just one
action you would have to setup an extra route for it.

Middlewares for controllers provides a good convenience and also allow replacing
some components with middlewares.

P. S. Laravel allows setting up middleware for controller in a similar way.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
