### PR TITLE
Make SQL logging in tests much simpler to operate

### DIFF
--- a/src/TestSuite/FixtureSchemaExtension.php
+++ b/src/TestSuite/FixtureSchemaExtension.php
@@ -36,26 +36,14 @@ class FixtureSchemaExtension implements BeforeFirstTestHook
         FixtureLoader::setInstance(new FixtureDataManager());
 
         $enableLogging = in_array('--debug', $_SERVER['argv'] ?? [], true);
-        $this->enableLogging($enableLogging);
         $this->aliasConnections($enableLogging);
-    }
-
-    /**
-     * Enables a logger for SQL queries.
-     *
-     * @param bool $enableLogging Whether or not logging should be enabled.
-     * @return void
-     */
-    protected function enableLogging(bool $enableLogging): void
-    {
-        if (!$enableLogging) {
-            return;
+        if ($enableLogging) {
+            Log::setConfig('queries', [
+                'className' => 'Console',
+                'stream' => 'php://stderr',
+                'scopes' => ['queriesLog'],
+            ]);
         }
-        Log::setConfig('queries', [
-            'className' => 'Console',
-            'stream' => 'php://stderr',
-            'scopes' => ['queriesLog'],
-        ]);
     }
 
     /**

--- a/src/TestSuite/FixtureSchemaExtension.php
+++ b/src/TestSuite/FixtureSchemaExtension.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -15,7 +14,6 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\TestSuite;
 
 use Cake\Database\Connection;
@@ -38,17 +36,17 @@ class FixtureSchemaExtension implements BeforeFirstTestHook
         FixtureLoader::setInstance(new FixtureDataManager());
 
         $enableLogging = in_array('--debug', $_SERVER['argv'] ?? [], true);
-        $this->configureLogging($enableLogging);
+        $this->enableLogging($enableLogging);
         $this->aliasConnections($enableLogging);
     }
 
     /**
-     * Configures a logger for SQL queries.
+     * Enables a logger for SQL queries.
      *
      * @param bool $enableLogging Whether or not logging should be enabled.
      * @return void
      */
-    protected function configureLogging(bool $enableLogging): void
+    protected function enableLogging(bool $enableLogging): void
     {
         if (!$enableLogging) {
             return;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,11 +110,6 @@ Configure::write('Session', [
 Configure::write('Debugger.exportFormatter', TextFormatter::class);
 
 Log::setConfig([
-    // 'queries' => [
-    //     'className' => 'Console',
-    //     'stream' => 'php://stderr',
-    //     'scopes' => ['queriesLog'],
-    // ],
     'debug' => [
         'engine' => 'Cake\Log\Engine\FileLog',
         'levels' => ['notice', 'info', 'debug'],


### PR DESCRIPTION
Instead of having to edit the phpunit.xml and/or application configuration to enable logging, we can use the `--debug` flag that PHPUnit has to also enable debug mode for our fixtures and database package. This feature will only work with the new fixture extension.

Part of #15308