### PR TITLE
Export __debugInfo() variables only

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -746,9 +746,7 @@ class Debugger
 
                     return $node;
                 } catch (Exception $e) {
-                    $message = $e->getMessage();
-
-                    return new SpecialNode("(unable to export object: $message)");
+                    return new SpecialNode("(unable to export object: {$e->getMessage()})");
                 }
             }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -32,6 +32,7 @@ use stdClass;
 use TestApp\Error\TestDebugger;
 use TestApp\Error\Thing\DebuggableThing;
 use TestApp\Error\Thing\SecurityThing;
+use TestApp\Utility\ThrowsDebugInfo;
 
 /**
  * DebuggerTest class
@@ -517,6 +518,18 @@ TEXT;
         $result = Debugger::exportVar($form, 6);
         $this->assertStringContainsString("'_schema' => [", $result, 'Has debuginfo keys');
         $this->assertStringContainsString("'_validator' => [", $result);
+    }
+
+    /**
+     * Test exportVar with an exception during __debugInfo()
+     *
+     * @return void
+     */
+    public function testExportVarInvalidDebugInfo()
+    {
+        $result = Debugger::exportVar(new ThrowsDebugInfo());
+        $expected = '(unable to export object: from __debugInfo)';
+        $this->assertTextEquals($expected, $result);
     }
 
     /**

--- a/tests/test_app/TestApp/Utility/ThrowsDebugInfo.php
+++ b/tests/test_app/TestApp/Utility/ThrowsDebugInfo.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Utility;
+
+use Exception;
+
+class ThrowsDebugInfo
+{
+    public function __debugInfo()
+    {
+        throw new Exception('from __debugInfo');
+    }
+}


### PR DESCRIPTION
This early return was lost when the debugger node exports were re-written.
