### PR TITLE
Fix debug() exporting too much data.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -743,6 +743,8 @@ class Debugger
                     foreach ($var->__debugInfo() as $key => $val) {
                         $node->addProperty(new PropertyNode("'{$key}'", null, static::export($val, $context)));
                     }
+
+                    return $node;
                 } catch (Exception $e) {
                     $message = $e->getMessage();
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -23,6 +23,7 @@ use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
+use Cake\Form\Form;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use RuntimeException;
@@ -502,6 +503,20 @@ object(SplFixedArray) id:0 {
 }
 TEXT;
         $this->assertTextEquals($expected, $result);
+    }
+
+    /**
+     * test exportVar with cyclic objects.
+     *
+     * @return void
+     */
+    public function testExportVarDebugInfo()
+    {
+        $form = new Form();
+
+        $result = Debugger::exportVar($form, 6);
+        $this->assertStringContainsString("'_schema' => [", $result, 'Has debuginfo keys');
+        $this->assertStringContainsString("'_validator' => [", $result);
     }
 
     /**


### PR DESCRIPTION
When an object implements `__debugInfo()` we shouldn't also pull all of its object properties out. This helps align output with earlier versions of 4.x and also not double up on objects that have curated debug output.