### PR TITLE
Deprecate syslog formatting with custom format string

### DIFF
--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -16,7 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Log\Engine;
 
-use Cake\Log\Formatter\SyslogFormatter;
+use Cake\Log\Formatter\DefaultFormatter;
+use Cake\Log\Formatter\LegacySyslogFormatter;
 
 /**
  * Syslog stream for Logging. Writes logs to the system logger
@@ -58,7 +59,8 @@ class SyslogLog extends BaseLog
         'prefix' => '',
         'facility' => LOG_USER,
         'formatter' => [
-            'className' => SyslogFormatter::class,
+            'className' => DefaultFormatter::class,
+            'includeDate' => false,
         ],
     ];
 
@@ -90,12 +92,18 @@ class SyslogLog extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        parent::__construct($config);
-
-        if (isset($this->_config['format'])) {
-            deprecationWarning('`format` option should now be set in the formatter options.');
-            $this->formatter->setConfig('format', $this->_config['format']);
+        if (isset($config['format'])) {
+            deprecationWarning(
+                '`format` option is now deprecated in favor of custom formatters. ' .
+                'Switching to `LegacySyslogFormatter`.'
+            );
+            /** @psalm-suppress DeprecatedClass */
+            $config['formatter'] = [
+                'className' => LegacySyslogFormatter::class,
+                'format' => $config['format'],
+            ];
         }
+        parent::__construct($config);
     }
 
     /**

--- a/src/Log/Formatter/DefaultFormatter.php
+++ b/src/Log/Formatter/DefaultFormatter.php
@@ -26,6 +26,7 @@ class DefaultFormatter extends AbstractFormatter
     protected $_defaultConfig = [
         'dateFormat' => 'Y-m-d H:i:s',
         'includeTags' => false,
+        'includeDate' => true,
     ];
 
     /**
@@ -41,7 +42,11 @@ class DefaultFormatter extends AbstractFormatter
      */
     public function format($level, string $message, array $context = []): string
     {
-        $message = sprintf('%s %s: %s', date($this->_config['dateFormat']), ucfirst($level), $message);
+        if ($this->_config['includeDate']) {
+            $message = sprintf('%s %s: %s', date($this->_config['dateFormat']), $level, $message);
+        } else {
+            $message = sprintf('%s: %s', $level, $message);
+        }
         if ($this->_config['includeTags']) {
             $message = sprintf('<%s>%s</%s>', $level, $message, $level);
         }

--- a/src/Log/Formatter/LegacySyslogFormatter.php
+++ b/src/Log/Formatter/LegacySyslogFormatter.php
@@ -16,7 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Log\Formatter;
 
-class SyslogFormatter extends AbstractFormatter
+/**
+ * @deprecated 4.3.0 Create a custom formatter and set it with `formatter` config instead.
+ */
+class LegacySyslogFormatter extends AbstractFormatter
 {
     /**
      * Default config for this class

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -56,8 +56,8 @@ class ConsoleLogTest extends TestCase
         $log->log('error', 'oh noes');
         $fh = fopen($filename, 'r');
         $line = fgets($fh);
-        $this->assertStringContainsString('Error: oh noes', $line);
-        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: oh noes/', $line);
+        $this->assertStringContainsString('error: oh noes', $line);
+        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ error: oh noes/', $line);
     }
 
     /**
@@ -93,7 +93,7 @@ class ConsoleLogTest extends TestCase
         $log->log('error', 'oh noes');
         $fh = fopen($filename, 'r');
         $line = fgets($fh);
-        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Error: oh noes/', $line);
+        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} error: oh noes/', $line);
     }
 
     /**
@@ -112,7 +112,7 @@ class ConsoleLogTest extends TestCase
             $log->log('error', 'oh noes');
             $fh = fopen($filename, 'r');
             $line = fgets($fh);
-            $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Error: oh noes/', $line);
+            $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} error: oh noes/', $line);
         });
     }
 }

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -40,19 +40,19 @@ class FileLogTest extends TestCase
         $this->assertFileExists(LOGS . 'error.log');
 
         $result = file_get_contents(LOGS . 'error.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ warning: Test warning/', $result);
 
         $log->log('debug', 'Test warning');
         $this->assertFileExists(LOGS . 'debug.log');
 
         $result = file_get_contents(LOGS . 'debug.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Debug: Test warning/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ debug: Test warning/', $result);
 
         $log->log('random', 'Test warning');
         $this->assertFileExists(LOGS . 'random.log');
 
         $result = file_get_contents(LOGS . 'random.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Random: Test warning/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ random: Test warning/', $result);
     }
 
     /**
@@ -90,7 +90,7 @@ class FileLogTest extends TestCase
         $this->assertFileExists($path . 'error.log');
 
         $result = file_get_contents($path . 'error.log');
-        $this->assertMatchesRegularExpression('/Warning: Test warning one/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning one/', $result);
         $this->assertCount(0, glob($path . 'error.log.*'));
 
         clearstatcache();
@@ -101,14 +101,14 @@ class FileLogTest extends TestCase
 
         $result = file_get_contents($files[0]);
         $this->assertMatchesRegularExpression('/this text is under 35 bytes/', $result);
-        $this->assertMatchesRegularExpression('/Warning: Test warning one/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning one/', $result);
 
         sleep(1);
         clearstatcache();
         $log->log('warning', 'Test warning third');
 
         $result = file_get_contents($path . 'error.log');
-        $this->assertMatchesRegularExpression('/Warning: Test warning third/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning third/', $result);
 
         $files = glob($path . 'error.log.*');
         $this->assertCount(2, $files);
@@ -117,7 +117,7 @@ class FileLogTest extends TestCase
         $this->assertMatchesRegularExpression('/this text is under 35 bytes/', $result);
 
         $result = file_get_contents($files[1]);
-        $this->assertMatchesRegularExpression('/Warning: Test warning second/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning second/', $result);
 
         file_put_contents($path . 'error.log.0000000000', "The oldest log file with over 35 bytes.\n");
 
@@ -130,13 +130,13 @@ class FileLogTest extends TestCase
         $this->assertCount(2, $files);
 
         $result = file_get_contents($path . 'error.log');
-        $this->assertMatchesRegularExpression('/Warning: Test warning fourth/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning fourth/', $result);
 
         $result = file_get_contents(array_pop($files));
-        $this->assertMatchesRegularExpression('/Warning: Test warning third/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning third/', $result);
 
         $result = file_get_contents(array_pop($files));
-        $this->assertMatchesRegularExpression('/Warning: Test warning second/', $result);
+        $this->assertMatchesRegularExpression('/warning: Test warning second/', $result);
 
         file_put_contents($path . 'debug.log', "this text is just greater than 35 bytes\n");
         $log = new FileLog([
@@ -149,7 +149,7 @@ class FileLogTest extends TestCase
         $this->assertFileExists($path . 'debug.log');
 
         $result = file_get_contents($path . 'debug.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Debug: Test debug/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ debug: Test debug/', $result);
         $this->assertFalse(strstr($result, 'greater than 5 bytes'));
         $this->assertCount(0, glob($path . 'debug.log.*'));
     }
@@ -213,7 +213,7 @@ class FileLogTest extends TestCase
         $log->log('warning', 'Test warning');
 
         $result = file_get_contents(LOGS . 'error.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Warning: Test warning/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} warning: Test warning/', $result);
     }
 
     /**
@@ -230,7 +230,7 @@ class FileLogTest extends TestCase
             $log->log('warning', 'Test warning');
 
             $result = file_get_contents(LOGS . 'error.log');
-            $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} Warning: Test warning/', $result);
+            $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+\+\d{2}:\d{2} warning: Test warning/', $result);
         });
     }
 }

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -111,6 +111,18 @@ class SyslogLogTest extends TestCase
     }
 
     /**
+     * Test deprecated format option
+     *
+     * @return void
+     */
+    public function testDeprecatedFormatMessage()
+    {
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage('`format` option is now deprecated in favor of custom formatters');
+        new SyslogLog(['format' => 'custom %s: %s']);
+    }
+
+    /**
      * Data provider for the write function test
      *
      * @return array

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -277,8 +277,8 @@ class LogTest extends TestCase
         Log::write(LOG_WARNING, 'Test warning 1');
         Log::write(LOG_WARNING, 'Test warning 2');
         $result = file_get_contents(LOGS . 'error.log');
-        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 1/', $result);
-        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 2$/', $result);
+        $this->assertMatchesRegularExpression('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ warning: Test warning 1/', $result);
+        $this->assertMatchesRegularExpression('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ warning: Test warning 2$/', $result);
         unlink(LOGS . 'error.log');
     }
 
@@ -318,9 +318,9 @@ class LogTest extends TestCase
         $this->assertFileExists(LOGS . 'spam.log');
 
         $contents = file_get_contents(LOGS . 'spam.log');
-        $this->assertStringContainsString('Debug: ' . $testMessage, $contents);
+        $this->assertStringContainsString('debug: ' . $testMessage, $contents);
         $contents = file_get_contents(LOGS . 'eggs.log');
-        $this->assertStringContainsString('Debug: ' . $testMessage, $contents);
+        $this->assertStringContainsString('debug: ' . $testMessage, $contents);
 
         if (file_exists(LOGS . 'spam.log')) {
             unlink(LOGS . 'spam.log');
@@ -366,9 +366,9 @@ class LogTest extends TestCase
         $this->assertFileExists(LOGS . 'spam.log');
 
         $contents = file_get_contents(LOGS . 'spam.log');
-        $this->assertStringContainsString('Debug: ' . $testMessage, $contents);
+        $this->assertStringContainsString('debug: ' . $testMessage, $contents);
         $contents = file_get_contents(LOGS . 'eggs.log');
-        $this->assertStringContainsString('Debug: ' . $testMessage, $contents);
+        $this->assertStringContainsString('debug: ' . $testMessage, $contents);
 
         if (file_exists(LOGS . 'spam.log')) {
             unlink(LOGS . 'spam.log');
@@ -631,56 +631,56 @@ class LogTest extends TestCase
         $testMessage = 'emergency message';
         Log::emergency($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
-        $this->assertMatchesRegularExpression('/(Emergency|Critical): ' . $testMessage . '/', $contents);
+        $this->assertMatchesRegularExpression('/(emergency|critical): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->_deleteLogs();
 
         $testMessage = 'alert message';
         Log::alert($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
-        $this->assertMatchesRegularExpression('/(Alert|Critical): ' . $testMessage . '/', $contents);
+        $this->assertMatchesRegularExpression('/(alert|critical): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->_deleteLogs();
 
         $testMessage = 'critical message';
         Log::critical($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
-        $this->assertStringContainsString('Critical: ' . $testMessage, $contents);
+        $this->assertStringContainsString('critical: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->_deleteLogs();
 
         $testMessage = 'error message';
         Log::error($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
-        $this->assertStringContainsString('Error: ' . $testMessage, $contents);
+        $this->assertStringContainsString('error: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->_deleteLogs();
 
         $testMessage = 'warning message';
         Log::warning($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
-        $this->assertStringContainsString('Warning: ' . $testMessage, $contents);
+        $this->assertStringContainsString('warning: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->_deleteLogs();
 
         $testMessage = 'notice message';
         Log::notice($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
-        $this->assertMatchesRegularExpression('/(Notice|Debug): ' . $testMessage . '/', $contents);
+        $this->assertMatchesRegularExpression('/(notice|debug): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
         $this->_deleteLogs();
 
         $testMessage = 'info message';
         Log::info($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
-        $this->assertMatchesRegularExpression('/(Info|Debug): ' . $testMessage . '/', $contents);
+        $this->assertMatchesRegularExpression('/(info|debug): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
         $this->_deleteLogs();
 
         $testMessage = 'debug message';
         Log::debug($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
-        $this->assertStringContainsString('Debug: ' . $testMessage, $contents);
+        $this->assertStringContainsString('debug: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
         $this->_deleteLogs();
     }


### PR DESCRIPTION
This renames SyslogFormatter to LegacySyslogFormatter so the intention is clear.

Added `includeDate` option to `DefaultFormatter` so it works with Syslog. We had to pick one format for the level, so switched console + file log tests. If the capitalization of the level is really important, we can change Syslog instead, but using the raw string seemed cleaner.
