### PR TITLE
Rename FixtureLoader::lastInserted

### DIFF
--- a/src/TestSuite/Fixture/FixtureDataManager.php
+++ b/src/TestSuite/Fixture/FixtureDataManager.php
@@ -272,7 +272,7 @@ class FixtureDataManager extends FixtureLoader
     /**
      * @inheritDoc
      */
-    public function lastInserted(): array
+    public function getInserted(): array
     {
         return $this->inserted;
     }

--- a/src/TestSuite/Fixture/FixtureLoader.php
+++ b/src/TestSuite/Fixture/FixtureLoader.php
@@ -110,5 +110,5 @@ abstract class FixtureLoader
      *
      * @return string[]
      */
-    abstract public function lastInserted(): array;
+    abstract public function getInserted(): array;
 }

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -142,7 +142,7 @@ class FixtureManager extends FixtureLoader
     /**
      * @inheritDoc
      */
-    public function lastInserted(): array
+    public function getInserted(): array
     {
         $inserted = [];
         foreach ($this->_insertionMap as $fixtures) {

--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -77,13 +77,13 @@ class TruncationStrategy implements StateResetStrategyInterface
             if (!($db instanceof Connection)) {
                 continue;
             }
-            $lastInserted = $this->loader->lastInserted();
-            if (empty($lastInserted)) {
+            $inserted = $this->loader->getInserted();
+            if (empty($inserted)) {
                 continue;
             }
             $schema = $db->getSchemaCollection();
             $tables = $schema->listTables();
-            $tables = array_intersect($tables, $lastInserted);
+            $tables = array_intersect($tables, $inserted);
 
             $db->disableConstraints(function (Connection $db) use ($tables): void {
                 foreach ($tables as $table) {

--- a/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
@@ -196,35 +196,35 @@ class FixtureDataManagerTest extends TestCase
     }
 
     /**
-     * Test lastInserted()
+     * Test getInserted()
      *
      * @return void
      */
-    public function testLastInserted()
+    public function testGetInserted()
     {
         $manager = new FixtureDataManager();
         $manager->setupTest($this);
 
-        $results = $manager->lastInserted();
+        $results = $manager->getInserted();
         $this->assertEquals(['articles', 'comments'], $results);
     }
 
     /**
-     * Test lastInserted() with autoFixtures
+     * Test getInserted() with autoFixtures
      *
      * @return void
      */
-    public function testLastInsertedAutofixtures()
+    public function testGetInsertedAutofixtures()
     {
         $manager = new FixtureDataManager();
         $this->autoFixtures = false;
         $manager->setupTest($this);
 
-        $results = $manager->lastInserted();
+        $results = $manager->getInserted();
         $this->assertEquals([], $results);
 
         $manager->loadSingle('Articles');
-        $results = $manager->lastInserted();
+        $results = $manager->getInserted();
         $this->assertEquals(['articles'], $results);
     }
 }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -350,12 +350,12 @@ class FixtureManagerTest extends TestCase
             ->willReturn(['core.Comments', 'core.Users']);
 
         $this->manager->fixturize($test);
-        $this->assertEquals([], $this->manager->lastInserted());
+        $this->assertEquals([], $this->manager->getInserted());
 
         $this->manager->loadSingle('Comments');
         $this->manager->loadSingle('Users');
 
-        $this->assertEquals(['comments', 'users'], $this->manager->lastInserted());
+        $this->assertEquals(['comments', 'users'], $this->manager->getInserted());
 
         $table = $this->getTableLocator()->get('Users');
         $results = $table->find('all')->toArray();


### PR DESCRIPTION
It isn't a great name. This change removes 'last' from it and uses a more generic get. I think the doc block covers the temporal coupling this method has to setupTest() well enough.