### PR TITLE
Fix up controller casing

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -766,7 +766,7 @@ class RouteBuilder
      * Examples:
      *
      * ```
-     * $routes->redirect('/home/*', ['controller' => 'posts', 'action' => 'view']);
+     * $routes->redirect('/home/*', ['controller' => 'Posts', 'action' => 'view']);
      * ```
      *
      * Redirects /home/* to /posts/view and passes the parameters to /posts/view. Using an array as the

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -380,7 +380,7 @@ class Router
      *
      * - `Router::url('/posts/edit/1');` Returns the string with the base dir prepended.
      *   This usage does not use reverser routing.
-     * - `Router::url(['controller' => 'posts', 'action' => 'edit']);` Returns a URL
+     * - `Router::url(['controller' => 'Posts', 'action' => 'edit']);` Returns a URL
      *   generated through reverse routing.
      * - `Router::url(['_name' => 'custom-name', ...]);` Returns a URL generated
      *   through reverse routing. This form allows you to leverage named routes.

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -93,7 +93,7 @@ class UrlHelperTest extends TestCase
         $result = $this->Helper->build('/controller/action/1?one=1&two=2');
         $this->assertSame('/controller/action/1?one=1&amp;two=2', $result);
 
-        $result = $this->Helper->build(['controller' => 'posts', 'action' => 'index', '?' => ['page' => '1" onclick="alert(\'XSS\');"']]);
+        $result = $this->Helper->build(['controller' => 'Posts', 'action' => 'index', '?' => ['page' => '1" onclick="alert(\'XSS\');"']]);
         $this->assertSame('/posts?page=1%22+onclick%3D%22alert%28%27XSS%27%29%3B%22', $result);
 
         $result = $this->Helper->build('/controller/action/1/param:this+one+more');
@@ -106,13 +106,13 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24', $result);
 
         $result = $this->Helper->build([
-            'controller' => 'posts', 'action' => 'index',
+            'controller' => 'Posts', 'action' => 'index',
             '?' => ['param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24'],
         ]);
         $this->assertSame('/posts?param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
 
         $result = $this->Helper->build([
-            'controller' => 'posts', 'action' => 'index',
+            'controller' => 'Posts', 'action' => 'index',
             '?' => ['one' => 'value', 'two' => 'value', 'three' => 'purple', 'page' => '1'],
         ]);
         $this->assertSame('/posts?one=value&amp;two=value&amp;three=purple&amp;page=1', $result);
@@ -130,7 +130,7 @@ class UrlHelperTest extends TestCase
             'params' => [
                 'action' => 'index',
                 'plugin' => null,
-                'controller' => 'subscribe',
+                'controller' => 'Subscribe',
             ],
             'url' => '/subscribe',
             'base' => '/magazine',
@@ -141,7 +141,7 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/magazine/subscribe', $this->Helper->build());
         $this->assertSame(
             '/magazine/articles/add',
-            $this->Helper->build(['controller' => 'articles', 'action' => 'add'])
+            $this->Helper->build(['controller' => 'Articles', 'action' => 'add'])
         );
     }
 
@@ -154,7 +154,7 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/controller/action/1?one=1&two=2', $result);
 
         $result = $this->Helper->build([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             '?' => [
                 'k' => 'v',


### PR DESCRIPTION
Is a lowercase controller actually a "thing" still?
Since according to psr class names should be CamelCase, and since the name should match the class name, there cannot be such a version.