### PR TITLE
Fix up more controller casing issues

### DIFF
--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -602,7 +602,7 @@ class AuthComponentTest extends TestCase
         ]));
 
         $this->Auth->setConfig('loginRedirect', [
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             'welcome',
         ]);
@@ -812,7 +812,7 @@ class AuthComponentTest extends TestCase
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'auth_test',
+                'controller' => 'AuthTest',
                 'action' => 'login',
             ],
             'url' => '/auth_test/login',
@@ -828,7 +828,7 @@ class AuthComponentTest extends TestCase
             ->setMockClassName('NoLoginRedirectMockAuthorize')
             ->getMock();
         $this->Auth->setConfig('authorize', ['NoLoginRedirectMockAuthorize']);
-        $this->Auth->setConfig('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
 
         $event = new Event('Controller.startup', $this->Controller);
         $return = $this->Auth->startup($event);
@@ -847,7 +847,7 @@ class AuthComponentTest extends TestCase
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'auth_test',
+                'controller' => 'AuthTest',
                 'action' => 'login',
             ],
             'query' => ['redirect' => '/admin/articles'],
@@ -859,7 +859,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->getController()->getRequest()->getSession()->clear();
         $this->Auth->setConfig('authenticate', ['Form']);
         $this->Auth->setConfig('authorize', false);
-        $this->Auth->setConfig('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
 
         $event = new Event('Controller.startup', $this->Controller);
         $return = $this->Auth->startup($event);
@@ -894,7 +894,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'mariano', 'password' => 'cake']);
         $this->Auth->setConfig('loginRedirect', [
-            'controller' => 'something',
+            'controller' => 'Something',
             'action' => 'else',
         ]);
 
@@ -935,7 +935,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'admad', 'password' => 'cake']);
 
-        $expected = ['controller' => 'no_can_do', 'action' => 'jack'];
+        $expected = ['controller' => 'NoCanDo', 'action' => 'jack'];
         $this->Auth->setConfig('unauthorizedRedirect', $expected);
 
         $response = new Response();
@@ -1015,7 +1015,7 @@ class AuthComponentTest extends TestCase
         ]);
         $this->Auth->setConfig('authorize', ['Controller']);
         $this->Auth->setUser(['username' => 'admad', 'password' => 'cake']);
-        $expected = ['controller' => 'no_can_do', 'action' => 'jack'];
+        $expected = ['controller' => 'NoCanDo', 'action' => 'jack'];
         $this->Auth->setConfig('unauthorizedRedirect', $expected);
         $this->Auth->setConfig('authError', false);
 
@@ -1149,7 +1149,7 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->setConfig('loginAction', [
             'prefix' => 'Admin',
-            'controller' => 'auth_test',
+            'controller' => 'AuthTest',
             'action' => 'login',
         ]);
 
@@ -1157,7 +1157,7 @@ class AuthComponentTest extends TestCase
         $redirectHeader = $response->getHeaderLine('Location');
         $expected = Router::url([
             'prefix' => 'Admin',
-            'controller' => 'auth_test',
+            'controller' => 'AuthTest',
             'action' => 'login',
             '?' => ['redirect' => '/admin/auth_test/add'],
         ], true);
@@ -1207,9 +1207,9 @@ class AuthComponentTest extends TestCase
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'auth_test',
+                'controller' => 'AuthTest',
                 'action' => 'login',
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 'pass' => [],
             ],
             'webroot' => '/',
@@ -1218,8 +1218,8 @@ class AuthComponentTest extends TestCase
         Router::setRequest($request);
 
         $this->Auth->setConfig('loginAction', [
-            'prefix' => 'admin',
-            'controller' => 'auth_test',
+            'prefix' => 'Admin',
+            'controller' => 'AuthTest',
             'action' => 'login',
         ]);
         $result = $this->Auth->startup($event);
@@ -1275,13 +1275,13 @@ class AuthComponentTest extends TestCase
     public function testComponentSettings(): void
     {
         $this->Auth->setConfig([
-            'loginAction' => ['controller' => 'people', 'action' => 'login'],
-            'logoutRedirect' => ['controller' => 'people', 'action' => 'login'],
+            'loginAction' => ['controller' => 'People', 'action' => 'login'],
+            'logoutRedirect' => ['controller' => 'People', 'action' => 'login'],
         ]);
 
         $expected = [
-            'loginAction' => ['controller' => 'people', 'action' => 'login'],
-            'logoutRedirect' => ['controller' => 'people', 'action' => 'login'],
+            'loginAction' => ['controller' => 'People', 'action' => 'login'],
+            'logoutRedirect' => ['controller' => 'People', 'action' => 'login'],
         ];
         $this->assertEquals(
             $expected['loginAction'],
@@ -1463,7 +1463,7 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectSet(): void
     {
-        $value = ['controller' => 'users', 'action' => 'home'];
+        $value = ['controller' => 'Users', 'action' => 'home'];
         $result = $this->Auth->redirectUrl($value);
         $this->assertSame('/users/home', $result);
     }
@@ -1475,7 +1475,7 @@ class AuthComponentTest extends TestCase
      */
     public function testRedirectQueryStringRead(): void
     {
-        $this->Auth->setConfig('loginAction', ['controller' => 'users', 'action' => 'login']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'Users', 'action' => 'login']);
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => '/users/custom']));
 
         $result = $this->Auth->redirectUrl();
@@ -1509,8 +1509,8 @@ class AuthComponentTest extends TestCase
     public function testRedirectQueryStringReadEqualToLoginAction(): void
     {
         $this->Auth->setConfig([
-            'loginAction' => ['controller' => 'users', 'action' => 'login'],
-            'loginRedirect' => ['controller' => 'users', 'action' => 'home'],
+            'loginAction' => ['controller' => 'Users', 'action' => 'login'],
+            'loginRedirect' => ['controller' => 'Users', 'action' => 'home'],
         ]);
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => '/users/login']));
 
@@ -1527,8 +1527,8 @@ class AuthComponentTest extends TestCase
     public function testRedirectQueryStringInvalid(): void
     {
         $this->Auth->setConfig([
-            'loginAction' => ['controller' => 'users', 'action' => 'login'],
-            'loginRedirect' => ['controller' => 'users', 'action' => 'home'],
+            'loginAction' => ['controller' => 'Users', 'action' => 'login'],
+            'loginRedirect' => ['controller' => 'Users', 'action' => 'home'],
         ]);
         $this->Controller->setRequest($this->Controller->getRequest()->withQueryParams(['redirect' => 'http://some.domain.example/users/login']));
 
@@ -1564,8 +1564,8 @@ class AuthComponentTest extends TestCase
         ]));
         Router::setRequest($this->Controller->getRequest());
 
-        $this->Auth->setConfig('loginAction', ['controller' => 'users', 'action' => 'login']);
-        $this->Auth->setConfig('loginRedirect', ['controller' => 'users', 'action' => 'home']);
+        $this->Auth->setConfig('loginAction', ['controller' => 'Users', 'action' => 'login']);
+        $this->Auth->setConfig('loginRedirect', ['controller' => 'Users', 'action' => 'home']);
 
         $result = $this->Auth->redirectUrl();
         $this->assertSame('/users/home', $result);
@@ -1676,7 +1676,7 @@ class AuthComponentTest extends TestCase
         $this->Auth->setConfig([
             'authenticate' => ['Form'],
             'authorize' => false,
-            'loginAction' => ['controller' => 'auth_test', 'action' => 'login'],
+            'loginAction' => ['controller' => 'AuthTest', 'action' => 'login'],
         ]);
 
         $event = new Event('Controller.startup', $this->Controller);

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -59,7 +59,7 @@ class FormProtectionComponentTest extends TestCase
         $request = new ServerRequest([
             'url' => '/articles/index',
             'session' => $session,
-            'params' => ['controller' => 'articles', 'action' => 'index'],
+            'params' => ['controller' => 'Articles', 'action' => 'index'],
         ]);
 
         $this->Controller = new Controller($request);
@@ -104,7 +104,7 @@ class FormProtectionComponentTest extends TestCase
             'base' => '/subfolder',
             'webroot' => '/subfolder/',
             'session' => $session,
-            'params' => ['controller' => 'articles', 'action' => 'index'],
+            'params' => ['controller' => 'Articles', 'action' => 'index'],
         ]);
         Router::setRequest($request);
         $this->Controller->setRequest($request);

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -73,7 +73,7 @@ class SecurityComponentTest extends TestCase
         $request = new ServerRequest([
             'url' => '/articles/index',
             'session' => $session,
-            'params' => ['controller' => 'articles', 'action' => 'index'],
+            'params' => ['controller' => 'Articles', 'action' => 'index'],
         ]);
 
         $this->Controller = new SecurityTestController($request);
@@ -125,7 +125,7 @@ class SecurityComponentTest extends TestCase
             'url' => 'posts/index',
             'session' => new Session(),
             'params' => [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
         ]);
@@ -170,7 +170,7 @@ class SecurityComponentTest extends TestCase
             'session' => $this->Security->session,
             'method' => 'POST',
             'params' => [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
             'post' => [

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -80,7 +80,7 @@ class ControllerFactoryTest extends TestCase
             $request = new ServerRequest([
                 'url' => 'admin/posts/index',
                 'params' => [
-                    'prefix' => 'admin',
+                    'prefix' => 'Admin',
                     'controller' => 'Posts',
                     'action' => 'index',
                 ],

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -437,7 +437,7 @@ class ControllerTest extends TestCase
             'environment' => ['HTTP_REFERER' => 'http://localhost/posts/index'],
         ]);
         $Controller = new Controller($request);
-        $result = $Controller->referer(['controller' => 'posts', 'action' => 'index'], true);
+        $result = $Controller->referer(['controller' => 'Posts', 'action' => 'index'], true);
         $this->assertSame('/posts/index', $result);
 
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')
@@ -810,7 +810,7 @@ class ControllerTest extends TestCase
     {
         $request = new ServerRequest([
             'url' => 'admin/posts',
-            'params' => ['prefix' => 'admin'],
+            'params' => ['prefix' => 'Admin'],
         ]);
         $response = new Response();
         $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -541,7 +541,7 @@ class ExceptionRendererTest extends TestCase
         return [
             [
                 new MissingActionException([
-                    'controller' => 'postsController',
+                    'controller' => 'PostsController',
                     'action' => 'index',
                     'prefix' => '',
                     'plugin' => '',

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1324,7 +1324,7 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest([
             'params' => [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'admin' => true,
                 'truthy' => 1,
                 'zero' => '0',
@@ -1333,7 +1333,7 @@ class ServerRequestTest extends TestCase
         $this->assertNull($request->getParam('not_set'));
         $this->assertTrue($request->getParam('admin'));
         $this->assertSame(1, $request->getParam('truthy'));
-        $this->assertSame('posts', $request->getParam('controller'));
+        $this->assertSame('Posts', $request->getParam('controller'));
         $this->assertSame('0', $request->getParam('zero'));
     }
 

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -108,11 +108,11 @@ class DashedRouteTest extends TestCase
         $this->assertNull($result);
 
         $route = new DashedRoute('/admin/subscriptions/:action/*', [
-            'controller' => 'Subscribe', 'prefix' => 'admin',
+            'controller' => 'Subscribe', 'prefix' => 'Admin',
         ]);
         $result = $route->match([
             'controller' => 'Subscribe',
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'action' => 'editAdminE',
             1,
         ]);
@@ -168,7 +168,7 @@ class DashedRouteTest extends TestCase
 
         $route = new DashedRoute(
             '/admin/:controller',
-            ['prefix' => 'admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index']
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -108,11 +108,11 @@ class InflectedRouteTest extends TestCase
         $this->assertNull($result);
 
         $route = new InflectedRoute('/admin/subscriptions/:action/*', [
-            'controller' => 'Subscribe', 'prefix' => 'admin',
+            'controller' => 'Subscribe', 'prefix' => 'Admin',
         ]);
         $result = $route->match([
             'controller' => 'Subscribe',
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'action' => 'edit_admin_e',
             1,
         ]);
@@ -168,7 +168,7 @@ class InflectedRouteTest extends TestCase
 
         $route = new InflectedRoute(
             '/admin/:controller',
-            ['prefix' => 'admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index']
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -34,7 +34,7 @@ class PluginShortRouteTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        Configure::write('Routing', ['admin' => null, 'prefixes' => []]);
+        Configure::write('Routing', ['prefixes' => []]);
         Router::reload();
     }
 
@@ -65,10 +65,10 @@ class PluginShortRouteTest extends TestCase
     {
         $route = new PluginShortRoute('/:plugin', ['action' => 'index'], ['plugin' => 'foo|bar']);
 
-        $result = $route->match(['plugin' => 'foo', 'controller' => 'posts', 'action' => 'index']);
+        $result = $route->match(['plugin' => 'Foo', 'controller' => 'Posts', 'action' => 'index']);
         $this->assertNull($result, 'plugin controller mismatch was converted. %s');
 
-        $result = $route->match(['plugin' => 'foo', 'controller' => 'foo', 'action' => 'index']);
+        $result = $route->match(['plugin' => 'Foo', 'controller' => 'Foo', 'action' => 'index']);
         $this->assertSame('/foo', $result);
     }
 }

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -48,8 +48,8 @@ class RedirectRouteTest extends TestCase
      */
     public function testMatch()
     {
-        $route = new RedirectRoute('/home', ['controller' => 'posts']);
-        $this->assertNull($route->match(['controller' => 'posts', 'action' => 'index']));
+        $route = new RedirectRoute('/home', ['controller' => 'Posts']);
+        $this->assertNull($route->match(['controller' => 'Posts', 'action' => 'index']));
     }
 
     /**
@@ -59,7 +59,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testParseMiss()
     {
-        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $this->assertNull($route->parse('/nope'));
         $this->assertNull($route->parse('/homes'));
     }
@@ -72,9 +72,9 @@ class RedirectRouteTest extends TestCase
     public function testParseSimple()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/posts');
+        $this->expectExceptionMessage('http://localhost/Posts');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $route->parse('/home');
     }
 
@@ -86,9 +86,9 @@ class RedirectRouteTest extends TestCase
     public function testParseRedirectOption()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/posts');
+        $this->expectExceptionMessage('http://localhost/Posts');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/home', ['redirect' => ['controller' => 'posts']]);
+        $route = new RedirectRoute('/home', ['redirect' => ['controller' => 'Posts']]);
         $route->parse('/home');
     }
 
@@ -100,9 +100,9 @@ class RedirectRouteTest extends TestCase
     public function testParseArray()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/posts');
+        $this->expectExceptionMessage('http://localhost/Posts');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/home', ['controller' => 'posts', 'action' => 'index']);
+        $route = new RedirectRoute('/home', ['controller' => 'Posts', 'action' => 'index']);
         $route->parse('/home');
     }
 
@@ -128,9 +128,9 @@ class RedirectRouteTest extends TestCase
     public function testParseStatusCode()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/posts/view');
+        $this->expectExceptionMessage('http://localhost/Posts/view');
         $this->expectExceptionCode(302);
-        $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['status' => 302]);
+        $route = new RedirectRoute('/posts/*', ['controller' => 'Posts', 'action' => 'view'], ['status' => 302]);
         $route->parse('/posts/2');
     }
 
@@ -142,9 +142,9 @@ class RedirectRouteTest extends TestCase
     public function testParsePersist()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/posts/view/2');
+        $this->expectExceptionMessage('http://localhost/Posts/view/2');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['persist' => true]);
+        $route = new RedirectRoute('/posts/*', ['controller' => 'Posts', 'action' => 'view'], ['persist' => true]);
         $route->parse('/posts/2');
     }
 
@@ -162,9 +162,9 @@ class RedirectRouteTest extends TestCase
         Router::setRequest($request);
 
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/basedir/posts/view/2');
+        $this->expectExceptionMessage('http://localhost/basedir/Posts/view/2');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/posts/*', ['controller' => 'posts', 'action' => 'view'], ['persist' => true]);
+        $route = new RedirectRoute('/posts/*', ['controller' => 'Posts', 'action' => 'view'], ['persist' => true]);
         $route->parse('/posts/2');
     }
 
@@ -190,9 +190,9 @@ class RedirectRouteTest extends TestCase
     public function testParsePersistPassedArgs()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/tags/add/passme');
+        $this->expectExceptionMessage('http://localhost/Tags/add/passme');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'tags', 'action' => 'add'], ['persist' => true]);
+        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'Tags', 'action' => 'add'], ['persist' => true]);
         $route->parse('/my_controllers/do_something/passme');
     }
 
@@ -204,9 +204,9 @@ class RedirectRouteTest extends TestCase
     public function testParseNoPersistPassedArgs()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/tags/add');
+        $this->expectExceptionMessage('http://localhost/Tags/add');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'tags', 'action' => 'add']);
+        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'Tags', 'action' => 'add']);
         $route->parse('/my_controllers/do_something/passme');
     }
 
@@ -218,9 +218,9 @@ class RedirectRouteTest extends TestCase
     public function testParsePersistPatterns()
     {
         $this->expectException(RedirectException::class);
-        $this->expectExceptionMessage('http://localhost/tags/add');
+        $this->expectExceptionMessage('http://localhost/Tags/add');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }
 
@@ -234,8 +234,8 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/nl/preferred_controllers');
         $this->expectExceptionCode(301);
-        Router::connect('/:lang/preferred_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
-        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        Router::connect('/:lang/preferred_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }
 
@@ -246,7 +246,7 @@ class RedirectRouteTest extends TestCase
      */
     public function testSetStatus()
     {
-        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $result = $route->setStatus(302);
         $this->assertSame($result, $route);
         $this->assertSame(302, $route->options['status']);

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -36,7 +36,7 @@ class RouteTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        Configure::write('Routing', ['admin' => null, 'prefixes' => []]);
+        Configure::write('Routing', ['prefixes' => []]);
     }
 
     /**
@@ -79,13 +79,13 @@ class RouteTest extends TestCase
      */
     public function testBasicRouteCompiling()
     {
-        $route = new Route('/', ['controller' => 'pages', 'action' => 'display', 'home']);
+        $route = new Route('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
         $result = $route->compile();
         $expected = '#^/*$#';
         $this->assertSame($expected, $result);
         $this->assertEquals([], $route->keys);
 
-        $route = new Route('/:controller/:action', ['controller' => 'posts']);
+        $route = new Route('/:controller/:action', ['controller' => 'Posts']);
         $result = $route->compile();
 
         $this->assertMatchesRegularExpression($result, '/posts/edit');
@@ -94,7 +94,7 @@ class RouteTest extends TestCase
         $this->assertDoesNotMatchRegularExpression($result, '/posts/super_delete/1');
         $this->assertSame($result, $route->compile());
 
-        $route = new Route('/posts/foo:id', ['controller' => 'posts', 'action' => 'view']);
+        $route = new Route('/posts/foo:id', ['controller' => 'Posts', 'action' => 'view']);
         $result = $route->compile();
 
         $this->assertMatchesRegularExpression($result, '/posts/foo:1');
@@ -398,11 +398,11 @@ class RouteTest extends TestCase
      */
     public function testRouteParameterOverlap()
     {
-        $route = new Route('/invoices/add/:idd/:id', ['controller' => 'invoices', 'action' => 'add']);
+        $route = new Route('/invoices/add/:idd/:id', ['controller' => 'Invoices', 'action' => 'add']);
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/invoices/add/1/3');
 
-        $route = new Route('/invoices/add/:id/:idd', ['controller' => 'invoices', 'action' => 'add']);
+        $route = new Route('/invoices/add/:id/:idd', ['controller' => 'Invoices', 'action' => 'add']);
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/invoices/add/1/3');
     }
@@ -428,7 +428,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/:lang/:controller/:action/:id',
-            ['controller' => 'testing4'],
+            ['controller' => 'Testing4'],
             ['id' => Router::ID, 'lang' => '[a-z]{3}']
         );
         $result = $route->compile();
@@ -452,7 +452,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/posts/:id::title/:year',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['id' => Router::ID, 'year' => Router::YEAR, 'title' => '[a-z-_]+']
         );
         $result = $route->compile();
@@ -465,7 +465,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/posts/:url_title-(uuid::id)',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => Router::ID]
         );
         $result = $route->compile();
@@ -511,7 +511,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/posts/:month/:day/:year/*',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['year' => Router::YEAR, 'month' => Router::MONTH, 'day' => Router::DAY]
         );
         $result = $route->compile();
@@ -519,7 +519,7 @@ class RouteTest extends TestCase
         $result = $route->parse('/posts/08/01/2007/title-of-post', 'GET');
 
         $this->assertCount(7, $result);
-        $this->assertEquals($result['controller'], 'posts');
+        $this->assertEquals($result['controller'], 'Posts');
         $this->assertEquals($result['action'], 'view');
         $this->assertEquals($result['year'], '2007');
         $this->assertEquals($result['month'], '08');
@@ -529,7 +529,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/:extra/page/:slug/*',
-            ['controller' => 'pages', 'action' => 'view', 'extra' => null],
+            ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
             ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view']
         );
         $result = $route->compile();
@@ -539,7 +539,7 @@ class RouteTest extends TestCase
         $this->assertEquals(['slug', 'extra'], $route->keys);
         $this->assertEquals(['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view', '_ext' => []], $route->options);
         $expected = [
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'view',
         ];
         $this->assertEquals($expected, $route->defaults);
@@ -570,71 +570,71 @@ class RouteTest extends TestCase
     public function testMatchBasic()
     {
         $route = new Route('/:controller/:action/:id', ['plugin' => null]);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null]);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null]);
         $this->assertNull($result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 0]);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 0]);
         $this->assertNull($result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 1]);
-        $this->assertSame('/posts/view/1', $result);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 'id' => 1]);
+        $this->assertSame('/Posts/view/1', $result);
 
-        $route = new Route('/', ['controller' => 'pages', 'action' => 'display', 'home']);
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 'home']);
+        $route = new Route('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'home']);
         $this->assertSame('/', $result);
 
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 'about']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
-        $route = new Route('/pages/*', ['controller' => 'pages', 'action' => 'display']);
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 'home']);
+        $route = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'home']);
         $this->assertSame('/pages/home', $result);
 
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 'about']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertSame('/pages/about', $result);
 
-        $route = new Route('/blog/:action', ['controller' => 'posts']);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view']);
+        $route = new Route('/blog/:action', ['controller' => 'Posts']);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view']);
         $this->assertSame('/blog/view', $result);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', '?' => ['id' => 2]]);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', '?' => ['id' => 2]]);
         $this->assertSame('/blog/view?id=2', $result);
 
-        $result = $route->match(['controller' => 'nodes', 'action' => 'view']);
+        $result = $route->match(['controller' => 'Nodes', 'action' => 'view']);
         $this->assertNull($result);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 1]);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 1]);
         $this->assertNull($result);
 
         $route = new Route('/foo/:controller/:action', ['action' => 'index']);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view']);
-        $this->assertSame('/foo/posts/view', $result);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view']);
+        $this->assertSame('/foo/Posts/view', $result);
 
-        $route = new Route('/:plugin/:id/*', ['controller' => 'posts', 'action' => 'view']);
-        $result = $route->match(['plugin' => 'test', 'controller' => 'posts', 'action' => 'view', 'id' => '1']);
+        $route = new Route('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'view']);
+        $result = $route->match(['plugin' => 'test', 'controller' => 'Posts', 'action' => 'view', 'id' => '1']);
         $this->assertSame('/test/1/', $result);
 
-        $result = $route->match(['plugin' => 'fo', 'controller' => 'posts', 'action' => 'view', 'id' => '1', '0']);
+        $result = $route->match(['plugin' => 'fo', 'controller' => 'Posts', 'action' => 'view', 'id' => '1', '0']);
         $this->assertSame('/fo/1/0', $result);
 
-        $result = $route->match(['plugin' => 'fo', 'controller' => 'nodes', 'action' => 'view', 'id' => 1]);
+        $result = $route->match(['plugin' => 'fo', 'controller' => 'Nodes', 'action' => 'view', 'id' => 1]);
         $this->assertNull($result);
 
-        $result = $route->match(['plugin' => 'fo', 'controller' => 'posts', 'action' => 'edit', 'id' => 1]);
+        $result = $route->match(['plugin' => 'fo', 'controller' => 'Posts', 'action' => 'edit', 'id' => 1]);
         $this->assertNull($result);
 
         $route = new Route('/admin/subscriptions/:action/*', [
-            'controller' => 'subscribe', 'prefix' => 'admin',
+            'controller' => 'Subscribe', 'prefix' => 'Admin',
         ]);
 
-        $url = ['controller' => 'subscribe', 'prefix' => 'admin', 'action' => 'edit', 1];
+        $url = ['controller' => 'Subscribe', 'prefix' => 'Admin', 'action' => 'edit', 1];
         $result = $route->match($url);
         $expected = '/admin/subscriptions/edit/1';
         $this->assertSame($expected, $result);
 
         $url = [
-            'controller' => 'subscribe',
-            'prefix' => 'admin',
+            'controller' => 'Subscribe',
+            'prefix' => 'Admin',
             'action' => 'edit_admin_e',
             1,
         ];
@@ -655,10 +655,10 @@ class RouteTest extends TestCase
         ];
         $route = new Route('/:lang/:controller/:action', [], ['persist' => ['lang']]);
         $result = $route->match(
-            ['controller' => 'tasks', 'action' => 'add'],
+            ['controller' => 'Tasks', 'action' => 'add'],
             $context
         );
-        $this->assertSame('/en/tasks/add', $result);
+        $this->assertSame('/en/Tasks/add', $result);
     }
 
     /**
@@ -676,34 +676,34 @@ class RouteTest extends TestCase
         ];
         $route = new Route('/:controller/:action');
         $result = $route->match(
-            ['controller' => 'posts', 'action' => 'index', '_host' => 'example.com'],
+            ['controller' => 'Posts', 'action' => 'index', '_host' => 'example.com'],
             $context
         );
         // Http has port 80 as default, do not include it in the url
-        $this->assertSame('http://example.com/posts/index', $result);
+        $this->assertSame('http://example.com/Posts/index', $result);
 
         $result = $route->match(
-            ['controller' => 'posts', 'action' => 'index', '_scheme' => 'webcal'],
+            ['controller' => 'Posts', 'action' => 'index', '_scheme' => 'webcal'],
             $context
         );
         // Webcal is not on port 80 by default, include it in url
-        $this->assertSame('webcal://foo.com:80/posts/index', $result);
+        $this->assertSame('webcal://foo.com:80/Posts/index', $result);
 
         $result = $route->match(
-            ['controller' => 'posts', 'action' => 'index', '_port' => '8080'],
+            ['controller' => 'Posts', 'action' => 'index', '_port' => '8080'],
             $context
         );
-        $this->assertSame('http://foo.com:8080/posts/index', $result);
+        $this->assertSame('http://foo.com:8080/Posts/index', $result);
 
         $result = $route->match(
-            ['controller' => 'posts', 'action' => 'index', '_base' => '/dir'],
+            ['controller' => 'Posts', 'action' => 'index', '_base' => '/dir'],
             $context
         );
-        $this->assertSame('/dir/posts/index', $result);
+        $this->assertSame('/dir/Posts/index', $result);
 
         $result = $route->match(
             [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
                 '_port' => '8080',
                 '_host' => 'example.com',
@@ -712,7 +712,7 @@ class RouteTest extends TestCase
             ],
             $context
         );
-        $this->assertSame('https://example.com:8080/dir/posts/index', $result);
+        $this->assertSame('https://example.com:8080/dir/Posts/index', $result);
 
         $context = [
             '_host' => 'foo.com',
@@ -722,7 +722,7 @@ class RouteTest extends TestCase
         ];
         $result = $route->match(
             [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
                 '_port' => '8080',
                 '_host' => 'example.com',
@@ -732,7 +732,7 @@ class RouteTest extends TestCase
             $context
         );
         // Https scheme is not on port 8080 by default, include the port
-        $this->assertSame('https://example.com:8080/dir/posts/index', $result);
+        $this->assertSame('https://example.com:8080/dir/Posts/index', $result);
     }
 
     /**
@@ -820,11 +820,11 @@ class RouteTest extends TestCase
     public function testMatchGreedyRouteFailurePassedArg()
     {
         $route = new Route('/:controller/:action', ['plugin' => null]);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', '0']);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', '0']);
         $this->assertNull($result);
 
         $route = new Route('/:controller/:action', ['plugin' => null]);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'test']);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'test']);
         $this->assertNull($result);
     }
 
@@ -837,9 +837,9 @@ class RouteTest extends TestCase
     {
         $route = new Route('/:controller/:action/*', ['plugin' => null]);
         $result = $route->match([
-            'controller' => 'posts', 'action' => 'index', 'plugin' => null, 'admin' => false,
+            'controller' => 'Posts', 'action' => 'index', 'plugin' => null, 'admin' => false,
         ]);
-        $this->assertSame('/posts/index/', $result);
+        $this->assertSame('/Posts/index/', $result);
     }
 
     /**
@@ -851,26 +851,26 @@ class RouteTest extends TestCase
     {
         $route = new Route('/:controller/:action/*', ['plugin' => null]);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 5]);
-        $this->assertSame('/posts/view/5', $result);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null, 5]);
+        $this->assertSame('/Posts/view/5', $result);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 0]);
-        $this->assertSame('/posts/view/0', $result);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null, 0]);
+        $this->assertSame('/Posts/view/0', $result);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, '0']);
-        $this->assertSame('/posts/view/0', $result);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null, '0']);
+        $this->assertSame('/Posts/view/0', $result);
 
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'plugin' => null, 'word space']);
-        $this->assertSame('/posts/view/word%20space', $result);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null, 'word space']);
+        $this->assertSame('/Posts/view/word%20space', $result);
 
-        $route = new Route('/test2/*', ['controller' => 'pages', 'action' => 'display', 2]);
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 1]);
+        $route = new Route('/test2/*', ['controller' => 'Pages', 'action' => 'display', 2]);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 1]);
         $this->assertNull($result);
 
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 2, 'something']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 2, 'something']);
         $this->assertSame('/test2/something', $result);
 
-        $result = $route->match(['controller' => 'pages', 'action' => 'display', 5, 'something']);
+        $result = $route->match(['controller' => 'Pages', 'action' => 'display', 5, 'something']);
         $this->assertNull($result);
     }
 
@@ -965,43 +965,43 @@ class RouteTest extends TestCase
     {
         $route = new Route('/:controller/:action');
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_ext' => 'json',
         ]);
-        $this->assertSame('/posts/index.json', $result);
+        $this->assertSame('/Posts/index.json', $result);
 
         $route = new Route('/:controller/:action/*');
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_ext' => 'json',
         ]);
-        $this->assertSame('/posts/index.json', $result);
+        $this->assertSame('/Posts/index.json', $result);
 
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             1,
             '_ext' => 'json',
         ]);
-        $this->assertSame('/posts/view/1.json', $result);
+        $this->assertSame('/Posts/view/1.json', $result);
 
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             1,
             '_ext' => 'json',
             '?' => ['id' => 'b', 'c' => 'd', ],
         ]);
-        $this->assertSame('/posts/view/1.json?id=b&c=d', $result);
+        $this->assertSame('/Posts/view/1.json?id=b&c=d', $result);
 
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_ext' => 'json.gz',
         ]);
-        $this->assertSame('/posts/index.json.gz', $result);
+        $this->assertSame('/Posts/index.json.gz', $result);
     }
 
     /**
@@ -1012,19 +1012,19 @@ class RouteTest extends TestCase
     public function testMatchWithPatterns()
     {
         $route = new Route('/:controller/:action/:id', ['plugin' => null], ['id' => '[0-9]+']);
-        $result = $route->match(['controller' => 'posts', 'action' => 'view', 'id' => 'foo']);
+        $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'id' => 'foo']);
         $this->assertNull($result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 9]);
-        $this->assertSame('/posts/view/9', $result);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 'id' => 9]);
+        $this->assertSame('/Posts/view/9', $result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '9']);
-        $this->assertSame('/posts/view/9', $result);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 'id' => '9']);
+        $this->assertSame('/Posts/view/9', $result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '922']);
-        $this->assertSame('/posts/view/922', $result);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 'id' => '922']);
+        $this->assertSame('/Posts/view/922', $result);
 
-        $result = $route->match(['plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 'a99']);
+        $result = $route->match(['plugin' => null, 'controller' => 'Posts', 'action' => 'view', 'id' => 'a99']);
         $this->assertNull($result);
     }
 
@@ -1079,7 +1079,7 @@ class RouteTest extends TestCase
         ini_set('arg_separator.output', '&amp;');
 
         $result = $route->match([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             0,
             '?' => [
@@ -1088,7 +1088,7 @@ class RouteTest extends TestCase
                 'more' => 'test data',
             ],
         ]);
-        $expected = '/posts/index/0?test=var&amp;var2=test2&amp;more=test+data';
+        $expected = '/Posts/index/0?test=var&amp;var2=test2&amp;more=test+data';
         $this->assertSame($expected, $result);
         ini_set('arg_separator.output', $restore);
     }
@@ -1177,25 +1177,25 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/:controller/:action/:id',
-            ['controller' => 'testing4', 'id' => null],
+            ['controller' => 'Testing4', 'id' => null],
             ['id' => Router::ID]
         );
         $route->compile();
-        $result = $route->parse('/posts/view/1', 'GET');
-        $this->assertSame('posts', $result['controller']);
+        $result = $route->parse('/Posts/view/1', 'GET');
+        $this->assertSame('Posts', $result['controller']);
         $this->assertSame('view', $result['action']);
         $this->assertSame('1', $result['id']);
 
         $route = new Route(
             '/admin/:controller',
-            ['prefix' => 'admin', 'admin' => 1, 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index']
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');
         $this->assertNull($result);
 
-        $result = $route->parse('/admin/posts', 'GET');
-        $this->assertSame('posts', $result['controller']);
+        $result = $route->parse('/admin/Posts', 'GET');
+        $this->assertSame('Posts', $result['controller']);
         $this->assertSame('index', $result['action']);
 
         $route = new Route(
@@ -1244,9 +1244,9 @@ class RouteTest extends TestCase
     public function testParseWithPassDefaults()
     {
         $route = new Route('/:controller', ['action' => 'display', 'home']);
-        $result = $route->parse('/posts', 'GET');
+        $result = $route->parse('/Posts', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'display',
             'pass' => ['home'],
             '_matchedRoute' => '/:controller',
@@ -1263,9 +1263,9 @@ class RouteTest extends TestCase
     {
         $route = new Route('/:controller', ['action' => 'display', 'home']);
         $route->setMiddleware(['auth', 'cookie']);
-        $result = $route->parse('/posts', 'GET');
+        $result = $route->parse('/Posts', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'display',
             'pass' => ['home'],
             '_matchedRoute' => '/:controller',
@@ -1281,11 +1281,11 @@ class RouteTest extends TestCase
      */
     public function testParseWithHttpHeaderConditions()
     {
-        $route = new Route('/sample', ['controller' => 'posts', 'action' => 'index', '_method' => 'POST']);
+        $route = new Route('/sample', ['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
         $this->assertNull($route->parse('/sample', 'GET'));
 
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
             '_method' => 'POST',
@@ -1303,14 +1303,14 @@ class RouteTest extends TestCase
     public function testParseWithMultipleHttpMethodConditions()
     {
         $route = new Route('/sample', [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['put', 'post'],
         ]);
         $this->assertNull($route->parse('/sample', 'GET'));
 
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
             '_method' => ['PUT', 'POST'],
@@ -1327,39 +1327,39 @@ class RouteTest extends TestCase
     public function testMatchWithMultipleHttpMethodConditions()
     {
         $route = new Route('/sample', [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['PUT', 'POST'],
         ]);
         $url = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
         ];
         $this->assertNull($route->match($url));
 
         $url = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => 'GET',
         ];
         $this->assertNull($route->match($url));
 
         $url = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => 'PUT',
         ];
         $this->assertSame('/sample', $route->match($url));
 
         $url = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => 'POST',
         ];
         $this->assertSame('/sample', $route->match($url));
 
         $url = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['PUT', 'POST'],
         ];
@@ -1375,18 +1375,18 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/blog/:action/*',
-            ['controller' => 'blog_posts'],
+            ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
-        $result = $route->match(['controller' => 'blog_posts', 'action' => 'foo']);
+        $result = $route->match(['controller' => 'BlogPosts', 'action' => 'foo']);
         $this->assertNull($result);
 
-        $result = $route->match(['controller' => 'blog_posts', 'action' => 'actions']);
+        $result = $route->match(['controller' => 'BlogPosts', 'action' => 'actions']);
         $this->assertNotEmpty($result);
 
         $result = $route->parse('/blog/other', 'GET');
         $expected = [
-            'controller' => 'blog_posts',
+            'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
             '_matchedRoute' => '/blog/:action/*',
@@ -1405,9 +1405,9 @@ class RouteTest extends TestCase
     public function testParsePassedArgument()
     {
         $route = new Route('/:controller/:action/*');
-        $result = $route->parse('/posts/edit/1/2/0', 'GET');
+        $result = $route->parse('/Posts/edit/1/2/0', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'edit',
             'pass' => ['1', '2', '0'],
             '_matchedRoute' => '/:controller/:action/*',
@@ -1441,10 +1441,10 @@ class RouteTest extends TestCase
      */
     public function testMatchTrailing()
     {
-        $route = new Route('/pages/**', ['controller' => 'pages', 'action' => 'display']);
+        $route = new Route('/pages/**', ['controller' => 'Pages', 'action' => 'display']);
         $id = 'test/ spaces/漢字/la†în';
         $result = $route->match([
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             $id,
         ]);
@@ -1476,8 +1476,8 @@ class RouteTest extends TestCase
         $route = new Route('/:controller/', ['action' => 'index']);
         $this->assertNull($route->match(['controller' => null, 'action' => 'index']));
 
-        $route = new Route('/test/:action', ['controller' => 'thing']);
-        $this->assertNull($route->match(['action' => null, 'controller' => 'thing']));
+        $route = new Route('/test/:action', ['controller' => 'Thing']);
+        $this->assertNull($route->match(['action' => null, 'controller' => 'Thing']));
     }
 
     /**
@@ -1490,9 +1490,9 @@ class RouteTest extends TestCase
         $route = new Route('/:controller/:action/:slug', [], [
             'pass' => ['slug'],
         ]);
-        $result = $route->parse('/posts/view/my-title', 'GET');
+        $result = $route->parse('/Posts/view/my-title', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'slug' => 'my-title',
             'pass' => ['my-title'],
@@ -1509,18 +1509,18 @@ class RouteTest extends TestCase
     public function testParseTrailing()
     {
         $route = new Route('/:controller/:action/**');
-        $result = $route->parse('/posts/index/1/2/3/foo:bar', 'GET');
+        $result = $route->parse('/Posts/index/1/2/3/foo:bar', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => ['1/2/3/foo:bar'],
             '_matchedRoute' => '/:controller/:action/**',
         ];
         $this->assertEquals($expected, $result);
 
-        $result = $route->parse('/posts/index/http://example.com', 'GET');
+        $result = $route->parse('/Posts/index/http://example.com', 'GET');
         $expected = [
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => ['http://example.com'],
             '_matchedRoute' => '/:controller/:action/**',
@@ -1535,10 +1535,10 @@ class RouteTest extends TestCase
      */
     public function testParseTrailingUTF8()
     {
-        $route = new Route('/category/**', ['controller' => 'categories', 'action' => 'index']);
+        $route = new Route('/category/**', ['controller' => 'Categories', 'action' => 'index']);
         $result = $route->parse('/category/%D9%85%D9%88%D8%A8%D8%A7%DB%8C%D9%84', 'GET');
         $expected = [
-            'controller' => 'categories',
+            'controller' => 'Categories',
             'action' => 'index',
             'pass' => ['موبایل'],
             '_matchedRoute' => '/category/**',
@@ -1568,10 +1568,10 @@ class RouteTest extends TestCase
         $route = new Route('/{controller}/{action}');
         $this->assertSame('_controller:_action', $route->getName());
 
-        $route = new Route('/articles/:action', ['controller' => 'posts']);
+        $route = new Route('/articles/:action', ['controller' => 'Posts']);
         $this->assertSame('posts:_action', $route->getName());
 
-        $route = new Route('/articles/list', ['controller' => 'posts', 'action' => 'index']);
+        $route = new Route('/articles/list', ['controller' => 'Posts', 'action' => 'index']);
         $this->assertSame('posts:index', $route->getName());
 
         $route = new Route('/:controller/:action', ['action' => 'index']);
@@ -1587,19 +1587,19 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/a/:controller/:action',
-            ['plugin' => 'asset']
+            ['plugin' => 'Asset']
         );
         $this->assertSame('asset._controller:_action', $route->getName());
 
         $route = new Route(
             '/a/assets/:action',
-            ['plugin' => 'asset', 'controller' => 'assets']
+            ['plugin' => 'Asset', 'controller' => 'Assets']
         );
         $this->assertSame('asset.assets:_action', $route->getName());
 
         $route = new Route(
             '/assets/get',
-            ['plugin' => 'asset', 'controller' => 'assets', 'action' => 'get']
+            ['plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get']
         );
         $this->assertSame('asset.assets:get', $route->getName());
     }
@@ -1613,19 +1613,19 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/admin/:controller/:action',
-            ['prefix' => 'admin']
+            ['prefix' => 'Admin']
         );
         $this->assertSame('admin:_controller:_action', $route->getName());
 
         $route = new Route(
             '/:prefix/assets/:action',
-            ['controller' => 'assets']
+            ['controller' => 'Assets']
         );
         $this->assertSame('_prefix:assets:_action', $route->getName());
 
         $route = new Route(
             '/admin/assets/get',
-            ['prefix' => 'admin', 'plugin' => 'asset', 'controller' => 'assets', 'action' => 'get']
+            ['prefix' => 'Admin', 'plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get']
         );
         $this->assertSame('admin:asset.assets:get', $route->getName());
 
@@ -1645,7 +1645,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/:section',
-            ['plugin' => 'blogs', 'controller' => 'posts', 'action' => 'index'],
+            ['plugin' => 'blogs', 'controller' => 'Posts', 'action' => 'index'],
             [
                 'persist' => ['section'],
                 'section' => 'آموزش|weblog',
@@ -1656,7 +1656,7 @@ class RouteTest extends TestCase
         $expected = [
             'section' => 'آموزش',
             'plugin' => 'blogs',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
             '_matchedRoute' => '/:section',
@@ -1667,7 +1667,7 @@ class RouteTest extends TestCase
         $expected = [
             'section' => 'weblog',
             'plugin' => 'blogs',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
             '_matchedRoute' => '/:section',
@@ -1729,7 +1729,7 @@ class RouteTest extends TestCase
             'keys' => [],
             'options' => [],
             'defaults' => [
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'action' => 'display',
                 'home',
             ],
@@ -1738,10 +1738,10 @@ class RouteTest extends TestCase
             '_compiledRoute' => null,
         ]);
         $this->assertInstanceOf('Cake\Routing\Route\Route', $route);
-        $this->assertSame('/', $route->match(['controller' => 'pages', 'action' => 'display', 'home']));
-        $this->assertNull($route->match(['controller' => 'pages', 'action' => 'display', 'about']));
+        $this->assertSame('/', $route->match(['controller' => 'Pages', 'action' => 'display', 'home']));
+        $this->assertNull($route->match(['controller' => 'Pages', 'action' => 'display', 'about']));
         $expected = [
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             'pass' => ['home'],
             '_matchedRoute' => '/',

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -85,8 +85,8 @@ class RouteBuilderTest extends TestCase
      */
     public function testParams()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
-        $this->assertEquals(['prefix' => 'api'], $routes->params());
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
+        $this->assertEquals(['prefix' => 'Api'], $routes->params());
     }
 
     /**
@@ -143,7 +143,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testConnectInstance()
     {
-        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
         $route = new Route('/:controller');
         $this->assertSame($route, $routes->connect($route));
@@ -159,14 +159,14 @@ class RouteBuilderTest extends TestCase
      */
     public function testConnectBasic()
     {
-        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
         $route = $routes->connect('/:controller');
         $this->assertInstanceOf(Route::class, $route);
 
         $this->assertSame($route, $this->collection->routes()[0]);
         $this->assertSame('/l/:controller', $route->template);
-        $expected = ['prefix' => 'api', 'action' => 'index', 'plugin' => null];
+        $expected = ['prefix' => 'Api', 'action' => 'index', 'plugin' => null];
         $this->assertEquals($expected, $route->defaults);
     }
 
@@ -304,7 +304,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testNameExists()
     {
-        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
         $this->assertFalse($routes->nameExists('myRouteName'));
 
         $routes->connect('myRouteUrl', ['action' => 'index'], ['_name' => 'myRouteName']);
@@ -424,7 +424,7 @@ class RouteBuilderTest extends TestCase
     public function testRedirect()
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->redirect('/p/:id', ['controller' => 'posts', 'action' => 'view'], ['status' => 301]);
+        $routes->redirect('/p/:id', ['controller' => 'Posts', 'action' => 'view'], ['status' => 301]);
         $route = $this->collection->routes()[0];
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
@@ -496,10 +496,10 @@ class RouteBuilderTest extends TestCase
      */
     public function testNestedPrefix()
     {
-        $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
+        $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'Admin']);
         $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function (RouteBuilder $r) {
             $this->assertSame('/admin/api', $r->path());
-            $this->assertEquals(['prefix' => 'admin/Api'], $r->params());
+            $this->assertEquals(['prefix' => 'Admin/Api'], $r->params());
             $this->assertSame('api:', $r->namePrefix());
         });
         $this->assertSame($routes, $res);
@@ -588,7 +588,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testResources()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', ['_ext' => 'json']);
 
         $all = $this->collection->routes();
@@ -633,9 +633,9 @@ class RouteBuilderTest extends TestCase
     public function testResourcesPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/api');
-        $routes->resources('Articles', ['prefix' => 'rest']);
+        $routes->resources('Articles', ['prefix' => 'Rest']);
         $all = $this->collection->routes();
-        $this->assertSame('rest', $all[0]->defaults['prefix']);
+        $this->assertSame('Rest', $all[0]->defaults['prefix']);
     }
 
     /**
@@ -645,15 +645,15 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesNestedPrefix()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
-        $routes->resources('Articles', ['prefix' => 'rest']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
+        $routes->resources('Articles', ['prefix' => 'Rest']);
 
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
         $this->assertSame('/api/articles', $all[4]->template);
         foreach ($all as $route) {
-            $this->assertSame('api/rest', $route->defaults['prefix']);
+            $this->assertSame('Api/Rest', $route->defaults['prefix']);
             $this->assertSame('Articles', $route->defaults['controller']);
         }
     }
@@ -665,7 +665,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesInflection()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('BlogPosts', ['_ext' => 'json', 'inflect' => 'dasherize']);
 
         $all = $this->collection->routes();
@@ -710,7 +710,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesMappings()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', [
             '_ext' => 'json',
             'map' => [
@@ -746,7 +746,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesWithMapOnly()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', [
             'map' => [
                 'conditions' => ['action' => 'conditions', 'method' => 'DeLeTe'],
@@ -771,12 +771,12 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesInScope()
     {
-        Router::scope('/api', ['prefix' => 'api'], function (RouteBuilder $routes) {
+        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes) {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
         $url = Router::url([
-            'prefix' => 'api',
+            'prefix' => 'Api',
             'controller' => 'Articles',
             'action' => 'edit',
             '_method' => 'PUT',
@@ -785,7 +785,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/api/articles/99', $url);
 
         $url = Router::url([
-            'prefix' => 'api',
+            'prefix' => 'Api',
             'controller' => 'Articles',
             'action' => 'edit',
             '_method' => 'PUT',
@@ -896,10 +896,10 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesNested()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', function (RouteBuilder $routes) {
             $this->assertSame('/api/articles/', $routes->path());
-            $this->assertEquals(['prefix' => 'api'], $routes->params());
+            $this->assertEquals(['prefix' => 'Api'], $routes->params());
 
             $routes->resources('Comments');
             $route = $this->collection->routes()[3];
@@ -914,7 +914,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testFallbacks()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->fallbacks();
 
         $all = $this->collection->routes();
@@ -930,7 +930,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testFallbacksWithClass()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->fallbacks('InflectedRoute');
 
         $all = $this->collection->routes();
@@ -946,7 +946,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testDefaultRouteClassFallbacks()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->setRouteClass('TestApp\Routing\Route\DashedRoute');
         $routes->fallbacks();
 
@@ -961,10 +961,10 @@ class RouteBuilderTest extends TestCase
      */
     public function testScope()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes) {
             $this->assertSame('/api/v1', $routes->path());
-            $this->assertEquals(['prefix' => 'api', 'version' => 1], $routes->params());
+            $this->assertEquals(['prefix' => 'Api', 'version' => 1], $routes->params());
         });
     }
 
@@ -975,7 +975,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testScopeWithAction()
     {
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes) {
             $routes->connect('/shared', ['shared' => true]);
             $routes->get('/exclusive', ['exclusive' => true]);
@@ -999,7 +999,7 @@ class RouteBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Need a valid callable to connect routes. Got `string` instead.');
 
-        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->scope('/v1', 'fail');
     }
 
@@ -1013,13 +1013,13 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder(
             $this->collection,
             '/api',
-            ['prefix' => 'api'],
+            ['prefix' => 'Api'],
             ['middleware' => ['auth']]
         );
         $routes->scope('/v1', function (RouteBuilder $routes) {
             $this->assertSame(['auth'], $routes->getMiddleware(), 'Should inherit middleware');
             $this->assertSame('/api/v1', $routes->path());
-            $this->assertEquals(['prefix' => 'api'], $routes->params());
+            $this->assertEquals(['prefix' => 'Api'], $routes->params());
         });
     }
 

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -593,11 +593,11 @@ class RouteCollectionTest extends TestCase
         ];
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/:action/*', ['controller' => 'Users']);
-        $routes->connect('/admin/{controller}', ['prefix' => 'admin', 'action' => 'index']);
+        $routes->connect('/admin/{controller}', ['prefix' => 'Admin', 'action' => 'index']);
 
         $url = [
             'plugin' => null,
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'controller' => 'Users',
             'action' => 'index',
         ];

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -40,7 +40,7 @@ class RouterTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        Configure::write('Routing', ['admin' => null, 'prefixes' => []]);
+        Configure::write('Routing', ['prefixes' => []]);
         Router::reload();
     }
 
@@ -68,7 +68,7 @@ class RouterTest extends TestCase
         });
         $this->assertMatchesRegularExpression('/^http(s)?:\/\//', Router::url('/', true));
         $this->assertMatchesRegularExpression('/^http(s)?:\/\//', Router::url(null, true));
-        $this->assertMatchesRegularExpression('/^http(s)?:\/\//', Router::url(['controller' => 'test', '_full' => true]));
+        $this->assertMatchesRegularExpression('/^http(s)?:\/\//', Router::url(['controller' => 'Test', '_full' => true]));
     }
 
     /**
@@ -117,19 +117,19 @@ class RouterTest extends TestCase
         });
 
         $out = Router::url([
-            'controller' => 'tasks',
+            'controller' => 'Tasks',
             'action' => 'index',
             '_method' => 'GET',
         ], true);
-        $this->assertSame('http://example.com/cakephp/tasks', $out);
+        $this->assertSame('http://example.com/cakephp/Tasks', $out);
 
         $out = Router::url([
-            'controller' => 'tasks',
+            'controller' => 'Tasks',
             'action' => 'index',
             '_base' => false,
             '_method' => 'GET',
         ], true);
-        $this->assertSame('http://example.com/tasks', $out);
+        $this->assertSame('http://example.com/Tasks', $out);
     }
 
     /**
@@ -144,7 +144,7 @@ class RouterTest extends TestCase
             'params' => [
                 'action' => 'view',
                 'plugin' => null,
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'pass' => ['1'],
             ],
             'here' => '/cakephp',
@@ -180,10 +180,10 @@ class RouterTest extends TestCase
      */
     public function testRouteExists()
     {
-        Router::connect('/posts/:action', ['controller' => 'posts']);
-        $this->assertTrue(Router::routeExists(['controller' => 'posts', 'action' => 'view']));
+        Router::connect('/posts/:action', ['controller' => 'Posts']);
+        $this->assertTrue(Router::routeExists(['controller' => 'Posts', 'action' => 'view']));
 
-        $this->assertFalse(Router::routeExists(['action' => 'view', 'controller' => 'users', 'plugin' => 'test']));
+        $this->assertFalse(Router::routeExists(['action' => 'view', 'controller' => 'Users', 'plugin' => 'test']));
     }
 
     /**
@@ -195,22 +195,22 @@ class RouterTest extends TestCase
     {
         Router::connect('/:controller', ['action' => 'index', '_method' => ['GET', 'POST']]);
 
-        $result = Router::parseRequest($this->makeRequest('/posts', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/Posts', 'GET'));
         $expected = [
             'pass' => [],
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['GET', 'POST'],
             '_matchedRoute' => '/:controller',
         ];
         $this->assertEquals($expected, $result);
 
-        $result = Router::parseRequest($this->makeRequest('/posts', 'POST'));
+        $result = Router::parseRequest($this->makeRequest('/Posts', 'POST'));
         $expected = [
             'pass' => [],
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['GET', 'POST'],
             '_matchedRoute' => '/:controller',
@@ -293,7 +293,8 @@ class RouterTest extends TestCase
         $result = Router::normalize('users/logout');
         $this->assertSame($expected, $result);
 
-        $result = Router::normalize(['controller' => 'users', 'action' => 'logout']);
+        $expected = '/Users/logout';
+        $result = Router::normalize(['controller' => 'Users', 'action' => 'logout']);
         $this->assertSame($expected, $result);
 
         $result = Router::normalize('/');
@@ -355,7 +356,7 @@ class RouterTest extends TestCase
             'params' => [
                 'action' => 'index',
                 'plugin' => null,
-                'controller' => 'subscribe',
+                'controller' => 'Subscribe',
             ],
             'url' => '/subscribe',
             'base' => '/magazine',
@@ -381,8 +382,8 @@ class RouterTest extends TestCase
         $result = Router::url('/articles/view');
         $this->assertSame('/magazine/articles/view', $result);
 
-        $result = Router::url(['controller' => 'articles', 'action' => 'view', 1]);
-        $this->assertSame('/magazine/articles/view/1', $result);
+        $result = Router::url(['controller' => 'Articles', 'action' => 'view', 1]);
+        $this->assertSame('/magazine/Articles/view/1', $result);
     }
 
     /**
@@ -420,13 +421,13 @@ class RouterTest extends TestCase
      */
     public function testUrlCatchAllRoute()
     {
-        Router::connect('/*', ['controller' => 'categories', 'action' => 'index']);
-        $result = Router::url(['controller' => 'categories', 'action' => 'index', '0']);
+        Router::connect('/*', ['controller' => 'Categories', 'action' => 'index']);
+        $result = Router::url(['controller' => 'Categories', 'action' => 'index', '0']);
         $this->assertSame('/0', $result);
 
         $expected = [
             'plugin' => null,
-            'controller' => 'categories',
+            'controller' => 'Categories',
             'action' => 'index',
             'pass' => ['0'],
             '_matchedRoute' => '/*',
@@ -445,55 +446,62 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationBasic()
     {
+        /**
+         * @var string $ID
+         * @var string $UUID
+         * @var string $Year
+         * @var string $Month
+         * @var string $Action
+         */
         extract(Router::getNamedExpressions());
 
-        Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
-        $out = Router::url(['controller' => 'pages', 'action' => 'display', 'home']);
+        Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        $out = Router::url(['controller' => 'Pages', 'action' => 'display', 'home']);
         $this->assertSame('/', $out);
 
-        Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
-        $result = Router::url(['controller' => 'pages', 'action' => 'display', 'about']);
+        Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
+        $result = Router::url(['controller' => 'Pages', 'action' => 'display', 'about']);
         $expected = '/pages/about';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:plugin/:id/*', ['controller' => 'posts', 'action' => 'view'], ['id' => $ID]);
+        Router::connect('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'view'], ['id' => $ID]);
 
         $result = Router::url([
-            'plugin' => 'cake_plugin',
-            'controller' => 'posts',
+            'plugin' => 'CakePlugin',
+            'controller' => 'Posts',
             'action' => 'view',
             'id' => '1',
         ]);
-        $expected = '/cake_plugin/1';
+        $expected = '/CakePlugin/1';
         $this->assertSame($expected, $result);
 
         $result = Router::url([
-            'plugin' => 'cake_plugin',
-            'controller' => 'posts',
+            'plugin' => 'CakePlugin',
+            'controller' => 'Posts',
             'action' => 'view',
             'id' => '1',
             '0',
         ]);
-        $expected = '/cake_plugin/1/0';
+        $expected = '/CakePlugin/1/0';
         $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller/:action/:id', [], ['id' => $ID]);
 
-        $result = Router::url(['controller' => 'posts', 'action' => 'view', 'id' => '1']);
-        $expected = '/posts/view/1';
+        $result = Router::url(['controller' => 'Posts', 'action' => 'view', 'id' => '1']);
+        $expected = '/Posts/view/1';
         $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect('/:controller/:id', ['action' => 'view']);
 
-        $result = Router::url(['controller' => 'posts', 'action' => 'view', 'id' => '1']);
-        $expected = '/posts/1';
+        $result = Router::url(['controller' => 'Posts', 'action' => 'view', 'id' => '1']);
+        $expected = '/Posts/1';
         $this->assertSame($expected, $result);
 
-        Router::connect('/view/*', ['controller' => 'posts', 'action' => 'view']);
-        $result = Router::url(['controller' => 'posts', 'action' => 'view', '1']);
+        Router::connect('/view/*', ['controller' => 'Posts', 'action' => 'view']);
+        $result = Router::url(['controller' => 'Posts', 'action' => 'view', '1']);
         $expected = '/view/1';
         $this->assertSame($expected, $result);
 
@@ -503,21 +511,21 @@ class RouterTest extends TestCase
             'params' => [
                 'action' => 'index',
                 'plugin' => null,
-                'controller' => 'users',
+                'controller' => 'Users',
             ],
         ]);
         Router::setRequest($request);
 
         $result = Router::url(['action' => 'login']);
-        $expected = '/users/login';
+        $expected = '/Users/login';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/contact/:action', ['plugin' => 'contact', 'controller' => 'contact']);
+        Router::connect('/contact/:action', ['plugin' => 'Contact', 'controller' => 'Contact']);
 
         $result = Router::url([
-            'plugin' => 'contact',
-            'controller' => 'contact',
+            'plugin' => 'Contact',
+            'controller' => 'Contact',
             'action' => 'me',
         ]);
 
@@ -529,14 +537,14 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',
-                'plugin' => 'myplugin',
-                'controller' => 'mycontroller',
+                'plugin' => 'Myplugin',
+                'controller' => 'Mycontroller',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'myothercontroller']);
-        $expected = '/myothercontroller';
+        $result = Router::url(['plugin' => null, 'controller' => 'Myothercontroller']);
+        $expected = '/Myothercontroller';
         $this->assertSame($expected, $result);
     }
 
@@ -564,18 +572,18 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $result = Router::url([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             '0',
             '?' => ['var' => 'test', 'var2' => 'test2'],
         ]);
-        $expected = '/posts/index/0?var=test&var2=test2';
+        $expected = '/Posts/index/0?var=test&var2=test2';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'posts', '0', '?' => ['var' => null]]);
-        $this->assertSame('/posts/index/0', $result);
+        $result = Router::url(['controller' => 'Posts', '0', '?' => ['var' => null]]);
+        $this->assertSame('/Posts/index/0', $result);
 
         $result = Router::url([
-            'controller' => 'posts',
+            'controller' => 'Posts',
             '0',
             '?' => [
                 'var' => 'test',
@@ -583,7 +591,7 @@ class RouterTest extends TestCase
             ],
             '#' => 'unencoded string %',
         ]);
-        $expected = '/posts/index/0?var=test&var2=test2#unencoded string %';
+        $expected = '/Posts/index/0?var=test&var2=test2#unencoded string %';
         $this->assertSame($expected, $result);
     }
 
@@ -596,7 +604,7 @@ class RouterTest extends TestCase
     {
         Router::connect(
             ':language/galleries',
-            ['controller' => 'galleries', 'action' => 'index'],
+            ['controller' => 'Galleries', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
 
@@ -612,43 +620,43 @@ class RouterTest extends TestCase
             ['language' => '[a-z]{3}']
         );
 
-        $result = Router::url(['admin' => false, 'language' => 'dan', 'action' => 'index', 'controller' => 'galleries']);
+        $result = Router::url(['admin' => false, 'language' => 'dan', 'action' => 'index', 'controller' => 'Galleries']);
         $expected = '/dan/galleries';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['admin' => false, 'language' => 'eng', 'action' => 'index', 'controller' => 'galleries']);
+        $result = Router::url(['admin' => false, 'language' => 'eng', 'action' => 'index', 'controller' => 'Galleries']);
         $expected = '/eng/galleries';
         $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect(
             '/:language/pages',
-            ['controller' => 'pages', 'action' => 'index'],
+            ['controller' => 'Pages', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
         Router::connect('/:language/:controller/:action/*', [], ['language' => '[a-z]{3}']);
 
-        $result = Router::url(['language' => 'eng', 'action' => 'index', 'controller' => 'pages']);
+        $result = Router::url(['language' => 'eng', 'action' => 'index', 'controller' => 'Pages']);
         $expected = '/eng/pages';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['language' => 'eng', 'controller' => 'pages']);
+        $result = Router::url(['language' => 'eng', 'controller' => 'Pages']);
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['language' => 'eng', 'controller' => 'pages', 'action' => 'add']);
-        $expected = '/eng/pages/add';
+        $result = Router::url(['language' => 'eng', 'controller' => 'Pages', 'action' => 'add']);
+        $expected = '/eng/Pages/add';
         $this->assertSame($expected, $result);
 
         Router::reload();
         Router::connect(
             '/forestillinger/:month/:year/*',
-            ['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar'],
+            ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
 
         $result = Router::url([
-            'plugin' => 'shows',
-            'controller' => 'shows',
+            'plugin' => 'Shows',
+            'controller' => 'Shows',
             'action' => 'calendar',
             'month' => '10',
             'year' => '2007',
@@ -660,18 +668,18 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/kalender/:month/:year/*',
-            ['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar'],
+            ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
-        Router::connect('/kalender/*', ['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar']);
+        Router::connect('/kalender/*', ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar']);
 
-        $result = Router::url(['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'min-forestilling']);
+        $result = Router::url(['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar', 'min-forestilling']);
         $expected = '/kalender/min-forestilling';
         $this->assertSame($expected, $result);
 
         $result = Router::url([
-            'plugin' => 'shows',
-            'controller' => 'shows',
+            'plugin' => 'Shows',
+            'controller' => 'Shows',
             'action' => 'calendar',
             'year' => '2007',
             'month' => '10',
@@ -690,15 +698,15 @@ class RouterTest extends TestCase
     {
         Router::reload();
 
-        Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
-        Router::connect('/reset/*', ['admin' => true, 'controller' => 'users', 'action' => 'reset']);
-        Router::connect('/tests', ['controller' => 'tests', 'action' => 'index']);
+        Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
+        Router::connect('/reset/*', ['admin' => true, 'controller' => 'Users', 'action' => 'reset']);
+        Router::connect('/tests', ['controller' => 'Tests', 'action' => 'index']);
         Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
         Router::extensions('rss', false);
 
         $request = new ServerRequest([
             'params' => [
-                'controller' => 'registrations',
+                'controller' => 'Registrations',
                 'action' => 'index',
                 'plugin' => null,
                 'prefix' => 'Admin',
@@ -733,119 +741,119 @@ class RouterTest extends TestCase
         $expected = '/magazine/admin/subscriptions/edit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['prefix' => 'Admin', 'controller' => 'users', 'action' => 'login']);
-        $expected = '/magazine/admin/users/login';
+        $result = Router::url(['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'login']);
+        $expected = '/magazine/admin/Users/login';
         $this->assertSame($expected, $result);
 
         Router::reload();
         $request = new ServerRequest([
             'params' => [
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 'action' => 'index',
                 'plugin' => null,
-                'controller' => 'users',
+                'controller' => 'Users',
             ],
             'webroot' => '/',
             'url' => '/admin/users/index',
         ]);
         Router::setRequest($request);
 
-        Router::connect('/page/*', ['controller' => 'pages', 'action' => 'view', 'prefix' => 'admin']);
+        Router::connect('/page/*', ['controller' => 'Pages', 'action' => 'view', 'prefix' => 'Admin']);
 
-        $result = Router::url(['prefix' => 'admin', 'controller' => 'pages', 'action' => 'view', 'my-page']);
+        $result = Router::url(['prefix' => 'Admin', 'controller' => 'Pages', 'action' => 'view', 'my-page']);
         $expected = '/page/my-page';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'action' => 'add',
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
             ],
             'webroot' => '/',
             'url' => '/admin/pages/add',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
-        $expected = '/admin/pages/add';
+        $result = Router::url(['plugin' => null, 'controller' => 'Pages', 'action' => 'add', 'id' => false]);
+        $expected = '/admin/Pages/add';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'action' => 'add',
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
             ],
             'webroot' => '/',
             'url' => '/admin/pages/add',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
-        $expected = '/admin/pages/add';
+        $result = Router::url(['plugin' => null, 'controller' => 'Pages', 'action' => 'add', 'id' => false]);
+        $expected = '/admin/Pages/add';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/:id', ['prefix' => 'admin'], ['id' => '[0-9]+']);
+        Router::connect('/admin/:controller/:action/:id', ['prefix' => 'Admin'], ['id' => '[0-9]+']);
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'action' => 'edit',
                 'pass' => ['284'],
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
             ],
             'url' => '/admin/pages/edit/284',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'id' => '284']);
-        $expected = '/admin/pages/edit/284';
+        $result = Router::url(['plugin' => null, 'controller' => 'Pages', 'action' => 'edit', 'id' => '284']);
+        $expected = '/admin/Pages/edit/284';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
-                'plugin' => null, 'controller' => 'pages', 'action' => 'add', 'prefix' => 'admin',
+                'plugin' => null, 'controller' => 'Pages', 'action' => 'add', 'prefix' => 'Admin',
             ],
             'url' => '/admin/pages/add',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false]);
-        $expected = '/admin/pages/add';
+        $result = Router::url(['plugin' => null, 'controller' => 'Pages', 'action' => 'add', 'id' => false]);
+        $expected = '/admin/Pages/add';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
-                'plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'prefix' => 'admin',
+                'plugin' => null, 'controller' => 'Pages', 'action' => 'edit', 'prefix' => 'Admin',
             ],
             'url' => '/admin/pages/edit/284',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['plugin' => null, 'controller' => 'pages', 'action' => 'edit', 284]);
-        $expected = '/admin/pages/edit/284';
+        $result = Router::url(['plugin' => null, 'controller' => 'Pages', 'action' => 'edit', 284]);
+        $expected = '/admin/Pages/edit/284';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/posts/*', ['controller' => 'posts', 'action' => 'index', 'prefix' => 'admin']);
+        Router::connect('/admin/posts/*', ['controller' => 'Posts', 'action' => 'index', 'prefix' => 'Admin']);
         $request = new ServerRequest([
             'params' => [
-                'plugin' => null, 'controller' => 'posts', 'action' => 'index', 'prefix' => 'admin',
+                'plugin' => null, 'controller' => 'Posts', 'action' => 'index', 'prefix' => 'Admin',
                 'pass' => ['284'],
             ],
             'url' => '/admin/pages/edit/284',
@@ -913,41 +921,41 @@ class RouterTest extends TestCase
 
         $result = Router::url([
             'plugin' => null,
-            'controller' => 'articles',
+            'controller' => 'Articles',
             'action' => 'add',
             'id' => null,
             '_ext' => 'json',
         ]);
-        $expected = '/articles/add.json';
+        $expected = '/Articles/add.json';
         $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
-            'controller' => 'articles',
+            'controller' => 'Articles',
             'action' => 'add',
             '_ext' => 'json',
         ]);
-        $expected = '/articles/add.json';
+        $expected = '/Articles/add.json';
         $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
-            'controller' => 'articles',
+            'controller' => 'Articles',
             'action' => 'index',
             'id' => null,
             '_ext' => 'json',
         ]);
-        $expected = '/articles.json';
+        $expected = '/Articles.json';
         $this->assertSame($expected, $result);
 
         $result = Router::url([
             'plugin' => null,
-            'controller' => 'articles',
+            'controller' => 'Articles',
             'action' => 'index',
             '?' => ['id' => 'testing'],
             '_ext' => 'json',
         ]);
-        $expected = '/articles.json?id=testing';
+        $expected = '/Articles.json?id=testing';
         $this->assertSame($expected, $result);
     }
 
@@ -992,12 +1000,12 @@ class RouterTest extends TestCase
     {
         Router::connect(
             '/users',
-            ['controller' => 'users', 'action' => 'index'],
+            ['controller' => 'Users', 'action' => 'index'],
             ['_name' => 'users-index']
         );
         Router::connect(
             '/users/:name',
-            ['controller' => 'users', 'action' => 'view'],
+            ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
         Router::connect(
@@ -1038,7 +1046,7 @@ class RouterTest extends TestCase
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
             '/users/:name',
-            ['controller' => 'users', 'action' => 'view'],
+            ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
         $url = Router::url(['_name' => 'junk', 'name' => 'mark']);
@@ -1054,17 +1062,17 @@ class RouterTest extends TestCase
         $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
         Router::connect(
             '/users/:name',
-            ['controller' => 'users', 'action' => 'view'],
+            ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
         Router::connect(
             '/users/:name',
-            ['controller' => 'users', 'action' => 'view'],
+            ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'otherName']
         );
         Router::connect(
             '/users/:name',
-            ['controller' => 'users', 'action' => 'view'],
+            ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
     }
@@ -1081,7 +1089,7 @@ class RouterTest extends TestCase
             'params' => [
                 'plugin' => null,
                 'lang' => 'en',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
         ]);
@@ -1100,8 +1108,8 @@ class RouterTest extends TestCase
 
             return $url;
         });
-        $result = Router::url(['controller' => 'tasks', 'action' => 'edit']);
-        $this->assertSame('/en/tasks/edit/1234', $result);
+        $result = Router::url(['controller' => 'Tasks', 'action' => 'edit']);
+        $this->assertSame('/en/Tasks/edit/1234', $result);
         $this->assertSame(2, $calledCount);
     }
 
@@ -1122,7 +1130,7 @@ class RouterTest extends TestCase
             'params' => [
                 'plugin' => null,
                 'lang' => 'en',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
         ]);
@@ -1131,7 +1139,7 @@ class RouterTest extends TestCase
         Router::addUrlFilter(function ($url, $request) {
             throw new RuntimeException('nope');
         });
-        Router::url(['controller' => 'posts', 'action' => 'index', 'lang' => 'en']);
+        Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
     }
 
     /**
@@ -1151,14 +1159,14 @@ class RouterTest extends TestCase
             'params' => [
                 'plugin' => null,
                 'lang' => 'en',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
         ]);
         Router::setRequest($request);
 
         Router::addUrlFilter([$this, 'badFilter']);
-        Router::url(['controller' => 'posts', 'action' => 'index', 'lang' => 'en']);
+        Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
     }
 
     /**
@@ -1184,14 +1192,14 @@ class RouterTest extends TestCase
             'params' => [
                 'plugin' => null,
                 'lang' => 'en',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'tasks', 'action' => 'edit', '1234']);
-        $this->assertSame('/en/tasks/edit/1234', $result);
+        $result = Router::url(['controller' => 'Tasks', 'action' => 'edit', '1234']);
+        $this->assertSame('/en/Tasks/edit/1234', $result);
     }
 
     /**
@@ -1221,21 +1229,21 @@ class RouterTest extends TestCase
      */
     public function testCanLeavePlugin()
     {
-        Router::connect('/admin/:controller', ['action' => 'index', 'prefix' => 'admin']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller', ['action' => 'index', 'prefix' => 'Admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
         $request = new ServerRequest([
             'url' => '/admin/this/interesting/index',
             'params' => [
                 'pass' => [],
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 'plugin' => 'this',
                 'action' => 'index',
-                'controller' => 'interesting',
+                'controller' => 'Interesting',
             ],
         ]);
         Router::setRequest($request);
-        $result = Router::url(['plugin' => null, 'controller' => 'posts', 'action' => 'index']);
-        $this->assertSame('/admin/posts', $result);
+        $result = Router::url(['plugin' => null, 'controller' => 'Posts', 'action' => 'index']);
+        $this->assertSame('/admin/Posts', $result);
     }
 
     /**
@@ -1245,6 +1253,13 @@ class RouterTest extends TestCase
      */
     public function testUrlParsing()
     {
+        /**
+         * @var string $ID
+         * @var string $UUID
+         * @var string $Year
+         * @var string $Month
+         * @var string $Action
+         */
         extract(Router::getNamedExpressions());
 
         Router::connect(
@@ -1268,7 +1283,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/posts/:year/:month/:day/*',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
@@ -1276,7 +1291,7 @@ class RouterTest extends TestCase
             'year' => '2007',
             'month' => '08',
             'day' => '01',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
@@ -1287,7 +1302,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/posts/:day/:year/:month/*',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/01/2007/08/title-of-post-here', 'GET'));
@@ -1295,7 +1310,7 @@ class RouterTest extends TestCase
             'day' => '01',
             'year' => '2007',
             'month' => '08',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
@@ -1306,7 +1321,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/posts/:month/:day/:year/*',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/08/01/2007/title-of-post-here', 'GET'));
@@ -1314,7 +1329,7 @@ class RouterTest extends TestCase
             'month' => '08',
             'day' => '01',
             'year' => '2007',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
@@ -1325,14 +1340,14 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/posts/:year/:month/:day/*',
-            ['controller' => 'posts', 'action' => 'view']
+            ['controller' => 'Posts', 'action' => 'view']
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
         $expected = [
             'year' => '2007',
             'month' => '08',
             'day' => '01',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
@@ -1359,12 +1374,12 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/page/*', ['controller' => 'test']);
+        Router::connect('/page/*', ['controller' => 'Test']);
         $result = Router::parseRequest($this->makeRequest('/page/my-page', 'GET'));
         $expected = [
             'pass' => ['my-page'],
             'plugin' => null,
-            'controller' => 'test',
+            'controller' => 'Test',
             'action' => 'index',
             '_matchedRoute' => '/page/*',
         ];
@@ -1373,15 +1388,15 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/:language/contact',
-            ['language' => 'eng', 'plugin' => 'contact', 'controller' => 'contact', 'action' => 'index'],
+            ['language' => 'eng', 'plugin' => 'Contact', 'controller' => 'Contact', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
         $result = Router::parseRequest($this->makeRequest('/eng/contact', 'GET'));
         $expected = [
             'pass' => [],
             'language' => 'eng',
-            'plugin' => 'contact',
-            'controller' => 'contact',
+            'plugin' => 'Contact',
+            'controller' => 'Contact',
             'action' => 'index',
             '_matchedRoute' => '/:language/contact',
         ];
@@ -1390,15 +1405,15 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/forestillinger/:month/:year/*',
-            ['plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar'],
+            ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
 
         $result = Router::parseRequest($this->makeRequest('/forestillinger/10/2007/min-forestilling', 'GET'));
         $expected = [
             'pass' => ['min-forestilling'],
-            'plugin' => 'shows',
-            'controller' => 'shows',
+            'plugin' => 'Shows',
+            'controller' => 'Shows',
             'action' => 'calendar',
             'year' => 2007,
             'month' => 10,
@@ -1408,21 +1423,21 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect('/:controller/:action/*');
-        Router::connect('/', ['plugin' => 'pages', 'controller' => 'pages', 'action' => 'display']);
+        Router::connect('/', ['plugin' => 'pages', 'controller' => 'Pages', 'action' => 'display']);
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
         $expected = [
             'pass' => [],
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             'plugin' => 'pages',
             '_matchedRoute' => '/',
         ];
         $this->assertEquals($expected, $result);
 
-        $result = Router::parseRequest($this->makeRequest('/posts/edit/0', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/Posts/edit/0', 'GET'));
         $expected = [
             'pass' => [0],
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'edit',
             'plugin' => null,
             '_matchedRoute' => '/:controller/:action/*',
@@ -1431,47 +1446,47 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/posts/:id::url_title',
-            ['controller' => 'posts', 'action' => 'view'],
+            '/Posts/:id::url_title',
+            ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
-        $result = Router::parseRequest($this->makeRequest('/posts/5:sample-post-title', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title', 'GET'));
         $expected = [
             'pass' => ['5', 'sample-post-title'],
-            'id' => 5,
+            'id' => '5',
             'url_title' => 'sample-post-title',
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
-            '_matchedRoute' => '/posts/:id::url_title',
+            '_matchedRoute' => '/Posts/:id::url_title',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/posts/:id::url_title/*',
-            ['controller' => 'posts', 'action' => 'view'],
+            '/Posts/:id::url_title/*',
+            ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
-        $result = Router::parseRequest($this->makeRequest('/posts/5:sample-post-title/other/params/4', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title/other/params/4', 'GET'));
         $expected = [
             'pass' => ['5', 'sample-post-title', 'other', 'params', '4'],
             'id' => 5,
             'url_title' => 'sample-post-title',
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
-            '_matchedRoute' => '/posts/:id::url_title/*',
+            '_matchedRoute' => '/Posts/:id::url_title/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/posts/view/*', ['controller' => 'posts', 'action' => 'view']);
+        Router::connect('/posts/view/*', ['controller' => 'Posts', 'action' => 'view']);
         $result = Router::parseRequest($this->makeRequest('/posts/view/10?id=123&tab=abc', 'GET'));
         $expected = [
             'pass' => [10],
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             '?' => ['id' => '123', 'tab' => 'abc'],
             '_matchedRoute' => '/posts/view/*',
@@ -1481,7 +1496,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/posts/:url_title-(uuid::id)',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => $UUID]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/sample-post-title-(uuid:47fc97a9-019c-41d1-a058-1fa3cbdd56cb)', 'GET'));
@@ -1490,19 +1505,19 @@ class RouterTest extends TestCase
             'id' => '47fc97a9-019c-41d1-a058-1fa3cbdd56cb',
             'url_title' => 'sample-post-title',
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             '_matchedRoute' => '/posts/:url_title-(uuid::id)',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/posts/view/*', ['controller' => 'posts', 'action' => 'view']);
+        Router::connect('/posts/view/*', ['controller' => 'Posts', 'action' => 'view']);
         $result = Router::parseRequest($this->makeRequest('/posts/view/foo:bar/routing:fun', 'GET'));
         $expected = [
             'pass' => ['foo:bar', 'routing:fun'],
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             '_matchedRoute' => '/posts/view/*',
         ];
@@ -1538,7 +1553,7 @@ class RouterTest extends TestCase
     {
         Router::connect(
             '/subjects/add/:category_id',
-            ['controller' => 'subjects', 'action' => 'add'],
+            ['controller' => 'Subjects', 'action' => 'add'],
             ['category_id' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}']
         );
         $result = Router::parseRequest($this->makeRequest('/subjects/add/4795d601-19c8-49a6-930e-06a8b01d17b7', 'GET'));
@@ -1546,7 +1561,7 @@ class RouterTest extends TestCase
             'pass' => [],
             'category_id' => '4795d601-19c8-49a6-930e-06a8b01d17b7',
             'plugin' => null,
-            'controller' => 'subjects',
+            'controller' => 'Subjects',
             'action' => 'add',
             '_matchedRoute' => '/subjects/add/:category_id',
         ];
@@ -1562,7 +1577,7 @@ class RouterTest extends TestCase
     {
         Router::connect(
             '/:extra/page/:slug/*',
-            ['controller' => 'pages', 'action' => 'view', 'extra' => null],
+            ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
             ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view']
         );
 
@@ -1570,7 +1585,7 @@ class RouterTest extends TestCase
         $expected = [
             'pass' => [],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => 'some_extra',
@@ -1582,7 +1597,7 @@ class RouterTest extends TestCase
         $expected = [
             'pass' => [],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => null,
@@ -1593,14 +1608,13 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect(
             '/:extra/page/:slug/*',
-            ['controller' => 'pages', 'action' => 'view', 'extra' => null],
+            ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
             ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+']
         );
 
         $result = Router::url([
-            'admin' => null,
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => null,
@@ -1609,9 +1623,8 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         $result = Router::url([
-            'admin' => null,
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => 'some_extra',
@@ -1707,12 +1720,12 @@ class RouterTest extends TestCase
      */
     public function testResourcesInScope()
     {
-        Router::scope('/api', ['prefix' => 'api'], function (RouteBuilder $routes) {
+        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes) {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
         $url = Router::url([
-            'prefix' => 'api',
+            'prefix' => 'Api',
             'controller' => 'Articles',
             'action' => 'edit',
             '_method' => 'PUT',
@@ -1721,7 +1734,7 @@ class RouterTest extends TestCase
         $this->assertSame('/api/articles/99', $url);
 
         $url = Router::url([
-            'prefix' => 'api',
+            'prefix' => 'Api',
             'controller' => 'Articles',
             'action' => 'edit',
             '_method' => 'PUT',
@@ -1794,10 +1807,10 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/controller/action', ['controller' => 'controller', 'action' => 'action', '_ext' => 'rss']);
+        Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
         $expected = [
-            'controller' => 'controller',
+            'controller' => 'Controller',
             'action' => 'action',
             'plugin' => null,
             '_ext' => 'rss',
@@ -1807,10 +1820,10 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/controller/action', ['controller' => 'controller', 'action' => 'action', '_ext' => 'rss']);
+        Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
         $expected = [
-            'controller' => 'controller',
+            'controller' => 'Controller',
             'action' => 'action',
             'plugin' => null,
             '_ext' => 'rss',
@@ -1821,10 +1834,10 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::extensions('rss', false);
-        Router::connect('/controller/action', ['controller' => 'controller', 'action' => 'action', '_ext' => 'rss']);
+        Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
         $expected = [
-            'controller' => 'controller',
+            'controller' => 'Controller',
             'action' => 'action',
             'plugin' => null,
             '_ext' => 'rss',
@@ -1843,53 +1856,53 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithAutoPrefixes()
     {
         Router::reload();
-        Router::connect('/protected/:controller/:action/*', ['prefix' => 'protected']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/protected/:controller/:action/*', ['prefix' => 'Protected']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
         Router::connect('/:controller/:action/*');
 
         $request = new ServerRequest([
             'url' => '/images/index',
             'params' => [
-                'plugin' => null, 'controller' => 'images', 'action' => 'index',
+                'plugin' => null, 'controller' => 'Images', 'action' => 'index',
                 'prefix' => null, 'protected' => false, 'url' => ['url' => 'images/index'],
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add']);
-        $expected = '/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add']);
+        $expected = '/Images/add';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'protected']);
-        $expected = '/protected/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add', 'prefix' => 'Protected']);
+        $expected = '/protected/Images/add';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add_protected_test', 'prefix' => 'protected']);
-        $expected = '/protected/images/add_protected_test';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add_protected_test', 'prefix' => 'Protected']);
+        $expected = '/protected/Images/add_protected_test';
         $this->assertSame($expected, $result);
 
         $result = Router::url(['action' => 'edit', 1]);
-        $expected = '/images/edit/1';
+        $expected = '/Images/edit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['action' => 'edit', 1, 'prefix' => 'protected']);
-        $expected = '/protected/images/edit/1';
+        $result = Router::url(['action' => 'edit', 1, 'prefix' => 'Protected']);
+        $expected = '/protected/Images/edit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['action' => 'protectededit', 1, 'prefix' => 'protected']);
-        $expected = '/protected/images/protectededit/1';
+        $result = Router::url(['action' => 'protectedEdit', 1, 'prefix' => 'Protected']);
+        $expected = '/protected/Images/protectedEdit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['action' => 'edit', 1, 'prefix' => 'protected']);
-        $expected = '/protected/images/edit/1';
+        $result = Router::url(['action' => 'edit', 1, 'prefix' => 'Protected']);
+        $expected = '/protected/Images/edit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'others', 'action' => 'edit', 1]);
-        $expected = '/others/edit/1';
+        $result = Router::url(['controller' => 'Others', 'action' => 'edit', 1]);
+        $expected = '/Others/edit/1';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'others', 'action' => 'edit', 1, 'prefix' => 'protected']);
-        $expected = '/protected/others/edit/1';
+        $result = Router::url(['controller' => 'Others', 'action' => 'edit', 1, 'prefix' => 'Protected']);
+        $expected = '/protected/Others/edit/1';
         $this->assertSame($expected, $result);
     }
 
@@ -1905,7 +1918,7 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'url' => '/images/index',
             'params' => [
-                'plugin' => null, 'controller' => 'images', 'action' => 'index',
+                'plugin' => null, 'controller' => 'Images', 'action' => 'index',
             ],
             'environment' => ['HTTP_HOST' => 'localhost'],
         ]);
@@ -1914,12 +1927,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertSame('https://app.test/images/index', $result);
+        $this->assertSame('https://app.test/Images/index', $result);
 
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertSame('http://app.test/images/index', $result);
+        $this->assertSame('http://app.test/Images/index', $result);
     }
 
     /**
@@ -1935,7 +1948,7 @@ class RouterTest extends TestCase
             'environment' => ['HTTP_HOST' => 'app.test', 'HTTPS' => 'on'],
             'params' => [
                 'plugin' => null,
-                'controller' => 'images',
+                'controller' => 'Images',
                 'action' => 'index',
             ],
         ]);
@@ -1944,12 +1957,12 @@ class RouterTest extends TestCase
         $result = Router::url([
             '_ssl' => false,
         ]);
-        $this->assertSame('http://app.test/images/index', $result);
+        $this->assertSame('http://app.test/Images/index', $result);
 
         $result = Router::url([
             '_ssl' => true,
         ]);
-        $this->assertSame('https://app.test/images/index', $result);
+        $this->assertSame('https://app.test/Images/index', $result);
     }
 
     /**
@@ -1960,30 +1973,30 @@ class RouterTest extends TestCase
     public function testPrefixRoutePersistence()
     {
         Router::reload();
-        Router::connect('/protected/:controller/:action', ['prefix' => 'protected']);
+        Router::connect('/protected/:controller/:action', ['prefix' => 'Protected']);
         Router::connect('/:controller/:action');
 
         $request = new ServerRequest([
             'url' => '/protected/images/index',
             'params' => [
                 'plugin' => null,
-                'controller' => 'images',
+                'controller' => 'Images',
                 'action' => 'index',
-                'prefix' => 'protected',
+                'prefix' => 'Protected',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['prefix' => 'protected', 'controller' => 'images', 'action' => 'add']);
-        $expected = '/protected/images/add';
+        $result = Router::url(['prefix' => 'Protected', 'controller' => 'Images', 'action' => 'add']);
+        $expected = '/protected/Images/add';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add']);
-        $expected = '/protected/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add']);
+        $expected = '/protected/Images/add';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => false]);
-        $expected = '/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add', 'prefix' => false]);
+        $expected = '/Images/add';
         $this->assertSame($expected, $result);
     }
 
@@ -1994,30 +2007,30 @@ class RouterTest extends TestCase
      */
     public function testPrefixOverride()
     {
-        Router::connect('/admin/:controller/:action', ['prefix' => 'admin']);
-        Router::connect('/protected/:controller/:action', ['prefix' => 'protected']);
+        Router::connect('/admin/:controller/:action', ['prefix' => 'Admin']);
+        Router::connect('/protected/:controller/:action', ['prefix' => 'Protected']);
 
         $request = new ServerRequest([
             'url' => '/protected/images/index',
             'params' => [
-                'plugin' => null, 'controller' => 'images', 'action' => 'index', 'prefix' => 'protected',
+                'plugin' => null, 'controller' => 'Images', 'action' => 'index', 'prefix' => 'Protected',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'admin']);
-        $expected = '/admin/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add', 'prefix' => 'Admin']);
+        $expected = '/admin/Images/add';
         $this->assertSame($expected, $result);
 
         $request = new ServerRequest([
             'url' => '/admin/images/index',
             'params' => [
-                'plugin' => null, 'controller' => 'images', 'action' => 'index', 'prefix' => 'admin',
+                'plugin' => null, 'controller' => 'Images', 'action' => 'index', 'prefix' => 'Admin',
             ],
         ]);
         Router::setRequest($request);
-        $result = Router::url(['controller' => 'images', 'action' => 'add', 'prefix' => 'protected']);
-        $expected = '/protected/images/add';
+        $result = Router::url(['controller' => 'Images', 'action' => 'add', 'prefix' => 'Protected']);
+        $expected = '/protected/Images/add';
         $this->assertSame($expected, $result);
     }
 
@@ -2061,17 +2074,17 @@ class RouterTest extends TestCase
             'url' => '/',
             'base' => '/base',
             'params' => [
-                'plugin' => null, 'controller' => 'controller', 'action' => 'index',
+                'plugin' => null, 'controller' => 'Controller', 'action' => 'index',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'my_controller', 'action' => 'my_action']);
-        $expected = '/base/my_controller/my_action';
+        $result = Router::url(['controller' => 'MyController', 'action' => 'myAction']);
+        $expected = '/base/MyController/myAction';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'my_controller', 'action' => 'my_action', '_base' => false]);
-        $expected = '/my_controller/my_action';
+        $result = Router::url(['controller' => 'MyController', 'action' => 'myAction', '_base' => false]);
+        $expected = '/MyController/myAction';
         $this->assertSame($expected, $result);
     }
 
@@ -2082,14 +2095,14 @@ class RouterTest extends TestCase
      */
     public function testPagesUrlParsing()
     {
-        Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
-        Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
+        Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
 
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             '_matchedRoute' => '/',
         ];
@@ -2099,34 +2112,34 @@ class RouterTest extends TestCase
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             '_matchedRoute' => '/pages/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
+        Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
 
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             '_matchedRoute' => '/',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/', ['controller' => 'posts', 'action' => 'index']);
-        Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
+        Router::connect('/', ['controller' => 'Posts', 'action' => 'index']);
+        Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
         $result = Router::parseRequest($this->makeRequest('/pages/contact/', 'GET'));
 
         $expected = [
             'pass' => ['contact'],
             'plugin' => null,
-            'controller' => 'pages',
+            'controller' => 'Pages',
             'action' => 'display',
             '_matchedRoute' => '/pages/*',
         ];
@@ -2176,14 +2189,14 @@ class RouterTest extends TestCase
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
             '/blog/:action/*',
-            ['controller' => 'blog_posts'],
+            ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
 
         $result = Router::parseRequest($this->makeRequest('/blog/other', 'GET'));
         $expected = [
             'plugin' => null,
-            'controller' => 'blog_posts',
+            'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
             '_matchedRoute' => '/blog/:action/*',
@@ -2315,14 +2328,14 @@ class RouterTest extends TestCase
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
             '/blog/:action/*',
-            ['controller' => 'blog_posts'],
+            ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
 
-        $result = Router::url(['controller' => 'blog_posts', 'action' => 'actions']);
+        $result = Router::url(['controller' => 'BlogPosts', 'action' => 'actions']);
         $this->assertSame('/blog/actions', $result);
 
-        $result = Router::url(['controller' => 'blog_posts', 'action' => 'foo']);
+        $result = Router::url(['controller' => 'BlogPosts', 'action' => 'foo']);
         $this->assertSame('/', $result);
     }
 
@@ -2334,38 +2347,38 @@ class RouterTest extends TestCase
     public function testParsingWithLiteralPrefixes()
     {
         Router::reload();
-        $adminParams = ['prefix' => 'admin'];
+        $adminParams = ['prefix' => 'Admin'];
         Router::connect('/admin/:controller', $adminParams);
         Router::connect('/admin/:controller/:action/*', $adminParams);
 
         $request = new ServerRequest([
             'url' => '/',
             'base' => '/base',
-            'params' => ['plugin' => null, 'controller' => 'controller', 'action' => 'index'],
+            'params' => ['plugin' => null, 'controller' => 'Controller', 'action' => 'index'],
         ]);
         Router::setRequest($request);
 
-        $result = Router::parseRequest($this->makeRequest('/admin/posts/', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/admin/Posts/', 'GET'));
         $expected = [
             'pass' => [],
-            'prefix' => 'admin',
+            'prefix' => 'Admin',
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_matchedRoute' => '/admin/:controller',
         ];
         $this->assertEquals($expected, $result);
 
-        $result = Router::parseRequest($this->makeRequest('/admin/posts', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/admin/Posts', 'GET'));
         $this->assertEquals($expected, $result);
 
-        $result = Router::url(['prefix' => 'admin', 'controller' => 'posts']);
-        $expected = '/base/admin/posts';
+        $result = Router::url(['prefix' => 'Admin', 'controller' => 'Posts']);
+        $expected = '/base/admin/Posts';
         $this->assertSame($expected, $result);
 
         Router::reload();
 
-        $prefixParams = ['prefix' => 'members'];
+        $prefixParams = ['prefix' => 'Members'];
         Router::connect('/members/:controller', $prefixParams);
         Router::connect('/members/:controller/:action', $prefixParams);
         Router::connect('/members/:controller/:action/*', $prefixParams);
@@ -2373,23 +2386,23 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'url' => '/',
             'base' => '/base',
-            'params' => ['plugin' => null, 'controller' => 'controller', 'action' => 'index'],
+            'params' => ['plugin' => null, 'controller' => 'Controller', 'action' => 'index'],
         ]);
         Router::setRequest($request);
 
-        $result = Router::parseRequest($this->makeRequest('/members/posts/index', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/members/Posts/index', 'GET'));
         $expected = [
             'pass' => [],
-            'prefix' => 'members',
+            'prefix' => 'Members',
             'plugin' => null,
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'index',
             '_matchedRoute' => '/members/:controller/:action',
         ];
         $this->assertEquals($expected, $result);
 
-        $result = Router::url(['prefix' => 'members', 'controller' => 'users', 'action' => 'add']);
-        $expected = '/base/members/users/add';
+        $result = Router::url(['prefix' => 'Members', 'controller' => 'Users', 'action' => 'add']);
+        $expected = '/base/members/Users/add';
         $this->assertSame($expected, $result);
     }
 
@@ -2400,25 +2413,25 @@ class RouterTest extends TestCase
      */
     public function testUrlWritingWithPrefixes()
     {
-        Router::connect('/company/:controller/:action/*', ['prefix' => 'company']);
-        Router::connect('/:action', ['controller' => 'users']);
+        Router::connect('/company/:controller/:action/*', ['prefix' => 'Company']);
+        Router::connect('/:action', ['controller' => 'Users']);
 
-        $result = Router::url(['controller' => 'users', 'action' => 'login', 'prefix' => 'company']);
-        $expected = '/company/users/login';
+        $result = Router::url(['controller' => 'Users', 'action' => 'login', 'prefix' => 'Company']);
+        $expected = '/company/Users/login';
         $this->assertSame($expected, $result);
 
         $request = new ServerRequest([
             'url' => '/',
             'params' => [
                 'plugin' => null,
-                'controller' => 'users',
+                'controller' => 'Users',
                 'action' => 'login',
-                'prefix' => 'company',
+                'prefix' => 'Company',
             ],
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'users', 'action' => 'login', 'prefix' => false]);
+        $result = Router::url(['controller' => 'Users', 'action' => 'login', 'prefix' => false]);
         $expected = '/login';
         $this->assertSame($expected, $result);
     }
@@ -2432,23 +2445,23 @@ class RouterTest extends TestCase
     {
         Router::connect(
             '/admin/login',
-            ['controller' => 'users', 'action' => 'login', 'prefix' => 'admin']
+            ['controller' => 'Users', 'action' => 'login', 'prefix' => 'Admin']
         );
         $request = new ServerRequest([
             'url' => '/',
             'params' => [
                 'plugin' => null,
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'index',
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
             ],
             'webroot' => '/',
         ]);
         Router::setRequest($request);
-        $result = Router::url(['controller' => 'users', 'action' => 'login']);
+        $result = Router::url(['controller' => 'Users', 'action' => 'login']);
         $this->assertSame('/admin/login', $result);
 
-        $result = Router::url(['controller' => 'users', 'action' => 'login']);
+        $result = Router::url(['controller' => 'Users', 'action' => 'login']);
         $this->assertSame('/admin/login', $result);
     }
 
@@ -2459,19 +2472,19 @@ class RouterTest extends TestCase
      */
     public function testPassedArgsOrder()
     {
-        Router::connect('/test-passed/*', ['controller' => 'pages', 'action' => 'display', 'home']);
-        Router::connect('/test2/*', ['controller' => 'pages', 'action' => 'display', 2]);
-        Router::connect('/test/*', ['controller' => 'pages', 'action' => 'display', 1]);
+        Router::connect('/test-passed/*', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        Router::connect('/test2/*', ['controller' => 'Pages', 'action' => 'display', 2]);
+        Router::connect('/test/*', ['controller' => 'Pages', 'action' => 'display', 1]);
 
-        $result = Router::url(['controller' => 'pages', 'action' => 'display', 1, 'whatever']);
+        $result = Router::url(['controller' => 'Pages', 'action' => 'display', 1, 'whatever']);
         $expected = '/test/whatever';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'pages', 'action' => 'display', 2, 'whatever']);
+        $result = Router::url(['controller' => 'Pages', 'action' => 'display', 2, 'whatever']);
         $expected = '/test2/whatever';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['controller' => 'pages', 'action' => 'display', 'home', 'whatever']);
+        $result = Router::url(['controller' => 'Pages', 'action' => 'display', 'home', 'whatever']);
         $expected = '/test-passed/whatever';
         $this->assertSame($expected, $result);
     }
@@ -2485,12 +2498,12 @@ class RouterTest extends TestCase
     {
         Router::connect('/:locale/:controller/:action/*', [], ['locale' => 'dan|eng']);
 
-        $result = Router::parseRequest($this->makeRequest('/eng/test/test_action', 'GET'));
+        $result = Router::parseRequest($this->makeRequest('/eng/Test/testAction', 'GET'));
         $expected = [
             'pass' => [],
             'locale' => 'eng',
-            'controller' => 'test',
-            'action' => 'test_action',
+            'controller' => 'Test',
+            'action' => 'testAction',
             'plugin' => null,
             '_matchedRoute' => '/:locale/:controller/:action/*',
         ];
@@ -2511,18 +2524,18 @@ class RouterTest extends TestCase
             'url' => '/test/test_action',
             'params' => [
                 'plugin' => null,
-                'controller' => 'test',
+                'controller' => 'Test',
                 'action' => 'index',
             ],
             'webroot' => '/',
         ]);
         Router::setRequest($request);
 
-        $result = Router::url(['action' => 'test_another_action', 'locale' => 'eng']);
-        $expected = '/eng/test/test_another_action';
+        $result = Router::url(['action' => 'testAnotherAction', 'locale' => 'eng']);
+        $expected = '/eng/Test/testAnotherAction';
         $this->assertSame($expected, $result);
 
-        $result = Router::url(['action' => 'test_another_action']);
+        $result = Router::url(['action' => 'testAnotherAction']);
         $expected = '/';
         $this->assertSame($expected, $result);
     }
@@ -2562,7 +2575,7 @@ class RouterTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
         Router::connect(
             '/:slug',
-            ['controller' => 'posts', 'action' => 'view'],
+            ['controller' => 'Posts', 'action' => 'view'],
             ['routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+']
         );
         $this->assertTrue(true); // Just to make sure the connect do not throw exception
@@ -2586,13 +2599,13 @@ class RouterTest extends TestCase
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'pass' => [1],
             'url' => ['url' => 'eng/posts/view/1'],
         ];
         $result = Router::reverse($params);
-        $this->assertSame('/eng/posts/view/1', $result);
+        $this->assertSame('/eng/Posts/view/1', $result);
     }
 
     public function testReverseArrayQuery()
@@ -2600,24 +2613,24 @@ class RouterTest extends TestCase
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             1,
             '?' => ['foo' => 'bar'],
         ];
         $result = Router::reverse($params);
-        $this->assertSame('/eng/posts/view/1?foo=bar', $result);
+        $this->assertSame('/eng/Posts/view/1?foo=bar', $result);
 
         $params = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'pass' => [1],
             'url' => ['url' => 'eng/posts/view/1'],
             'models' => [],
         ];
         $result = Router::reverse($params);
-        $this->assertSame('/eng/posts/view/1', $result);
+        $this->assertSame('/eng/Posts/view/1', $result);
     }
 
     public function testReverseCakeRequestQuery()
@@ -2627,14 +2640,14 @@ class RouterTest extends TestCase
             'url' => '/eng/posts/view/1',
             'params' => [
                 'lang' => 'eng',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'view',
                 'pass' => [1],
             ],
             'query' => ['test' => 'value'],
         ]);
         $result = Router::reverse($request);
-        $expected = '/eng/posts/view/1?test=value';
+        $expected = '/eng/Posts/view/1?test=value';
         $this->assertSame($expected, $result);
     }
 
@@ -2645,7 +2658,7 @@ class RouterTest extends TestCase
         });
         $params = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'pass' => [1],
             'url' => ['url' => 'eng/posts/view/1'],
@@ -2667,14 +2680,14 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'url' => '/posts/view/1.json',
             'params' => [
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'view',
                 'pass' => [1],
                 '_ext' => 'json',
             ],
         ]);
         $result = Router::reverse($request);
-        $expected = '/posts/view/1.json';
+        $expected = '/Posts/view/1.json';
         $this->assertSame($expected, $result);
     }
 
@@ -2683,7 +2696,7 @@ class RouterTest extends TestCase
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             'pass' => [123],
             '?' => ['foo' => 'bar', 'baz' => 'quu'],
@@ -2691,7 +2704,7 @@ class RouterTest extends TestCase
         $actual = Router::reverseToArray($params);
         $expected = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             123,
             '?' => ['foo' => 'bar', 'baz' => 'quu'],
@@ -2706,7 +2719,7 @@ class RouterTest extends TestCase
             'url' => '/eng/posts/view/1',
             'params' => [
                 'lang' => 'eng',
-                'controller' => 'posts',
+                'controller' => 'Posts',
                 'action' => 'view',
                 'pass' => [123],
             ],
@@ -2715,7 +2728,7 @@ class RouterTest extends TestCase
         $actual = Router::reverseToArray($request);
         $expected = [
             'lang' => 'eng',
-            'controller' => 'posts',
+            'controller' => 'Posts',
             'action' => 'view',
             123,
             '?' => [
@@ -2759,7 +2772,7 @@ class RouterTest extends TestCase
             ->will($this->returnValue($url));
         Router::connect($route);
 
-        $result = Router::url(['controller' => 'posts', 'action' => 'view', 1]);
+        $result = Router::url(['controller' => 'Posts', 'action' => 'view', 1]);
         $this->assertSame($url, $result);
     }
 
@@ -2814,18 +2827,18 @@ class RouterTest extends TestCase
     {
         $route = new Route(
             '/blog/:action/*',
-            ['controller' => 'blog_posts'],
+            ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
-        $result = $route->match(['controller' => 'blog_posts', 'action' => 'foo']);
+        $result = $route->match(['controller' => 'BlogPosts', 'action' => 'foo']);
         $this->assertNull($result);
 
-        $result = $route->match(['controller' => 'blog_posts', 'action' => 'actions']);
+        $result = $route->match(['controller' => 'BlogPosts', 'action' => 'actions']);
         $this->assertSame('/blog/actions/', $result);
 
         $result = $route->parseRequest($this->makeRequest('/blog/other', 'GET'));
         $expected = [
-            'controller' => 'blog_posts',
+            'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
             '_matchedRoute' => '/blog/:action/*',
@@ -3043,11 +3056,11 @@ class RouterTest extends TestCase
             'url' => 'articles/view/1',
         ]);
         Router::setRequest($request);
-        $result = Router::url(['controller' => 'things', 'action' => 'add']);
-        $this->assertSame('/subdir/things/add', $result);
+        $result = Router::url(['controller' => 'Things', 'action' => 'add']);
+        $this->assertSame('/subdir/Things/add', $result);
 
-        $result = Router::url(['controller' => 'things', 'action' => 'add'], true);
-        $this->assertSame('http://localhost/subdir/things/add', $result);
+        $result = Router::url(['controller' => 'Things', 'action' => 'add'], true);
+        $this->assertSame('http://localhost/subdir/Things/add', $result);
 
         $result = Router::url('/pages/home');
         $this->assertSame('/subdir/pages/home', $result);
@@ -3073,11 +3086,11 @@ class RouterTest extends TestCase
         $request = ServerRequestFactory::fromGlobals($server);
         Router::setRequest($request);
 
-        $result = Router::url(['controller' => 'things', 'action' => 'add']);
-        $this->assertSame('/subdir/things/add', $result);
+        $result = Router::url(['controller' => 'Things', 'action' => 'add']);
+        $this->assertSame('/subdir/Things/add', $result);
 
-        $result = Router::url(['controller' => 'things', 'action' => 'add'], true);
-        $this->assertSame('http://localhost/subdir/things/add', $result);
+        $result = Router::url(['controller' => 'Things', 'action' => 'add'], true);
+        $this->assertSame('http://localhost/subdir/Things/add', $result);
 
         $result = Router::url('/pages/home');
         $this->assertSame('/subdir/pages/home', $result);
@@ -3190,7 +3203,7 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'params' => [
                 'plugin' => 'Cms',
-                'prefix' => 'admin',
+                'prefix' => 'Admin',
                 'controller' => 'Articles',
                 'action' => 'edit',
                 'pass' => ['3'],

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -385,7 +385,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar']])
-            ->add('Some text', ['controller' => 'tests_apps', 'action' => 'some_method'])
+            ->add('Some text', ['controller' => 'TestsApps', 'action' => 'someMethod'])
             ->add('Final crumb', null, ['class' => 'final', 'innerAttrs' => ['class' => 'final-link']]);
 
         $result = $this->breadcrumbs->render(
@@ -406,7 +406,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/span',
             '/li',
             ['li' => []],
-            ['a' => ['href' => '/tests_apps/some_method']],
+            ['a' => ['href' => '/TestsApps/someMethod']],
             'Some text',
             '/a',
             '/li',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -92,7 +92,7 @@ class FormHelperTest extends TestCase
             'base' => '',
             'url' => '/articles/add',
             'params' => [
-                'controller' => 'articles',
+                'controller' => 'Articles',
                 'action' => 'add',
                 'plugin' => null,
             ],
@@ -731,13 +731,13 @@ class FormHelperTest extends TestCase
 
         $this->article['defaults'] = ['id' => 1];
         $this->View->setRequest($this->View->getRequest()
-            ->withRequestTarget('/articles/edit/1')
+            ->withRequestTarget('/Articles/edit/1')
             ->withParam('action', 'delete'));
         $result = $this->Form->create($this->article, ['url' => ['action' => 'edit', 1]]);
         $expected = [
             'form' => [
                 'method' => 'post',
-                'action' => '/articles/edit/1',
+                'action' => '/Articles/edit/1',
                 'accept-charset' => $encoding,
             ],
             'div' => ['style' => 'display:none;'],
@@ -752,7 +752,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post',
-                'action' => '/articles/publish/1',
+                'action' => '/Articles/publish/1',
                 'accept-charset' => $encoding,
             ],
             'div' => ['style' => 'display:none;'],
@@ -761,9 +761,9 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->create($this->article, ['url' => '/articles/publish']);
+        $result = $this->Form->create($this->article, ['url' => '/Articles/publish']);
         $expected = [
-            'form' => ['method' => 'post', 'action' => '/articles/publish', 'accept-charset' => $encoding],
+            'form' => ['method' => 'post', 'action' => '/Articles/publish', 'accept-charset' => $encoding],
             'div' => ['style' => 'display:none;'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
@@ -809,11 +809,11 @@ class FormHelperTest extends TestCase
      */
     public function testCreateCustomRoute()
     {
-        Router::connect('/login', ['controller' => 'users', 'action' => 'login']);
+        Router::connect('/login', ['controller' => 'Users', 'action' => 'login']);
         $encoding = strtolower(Configure::read('App.encoding'));
 
         $this->View->setRequest($this->View->getRequest()
-            ->withParam('controller', 'users'));
+            ->withParam('controller', 'Users'));
 
         $result = $this->Form->create(null, ['url' => ['action' => 'login']]);
         $expected = [
@@ -826,7 +826,7 @@ class FormHelperTest extends TestCase
 
         Router::connect(
             '/new-article',
-            ['controller' => 'articles', 'action' => 'myaction'],
+            ['controller' => 'Articles', 'action' => 'myAction'],
             ['_name' => 'my-route']
         );
         $result = $this->Form->create(null, ['url' => ['_name' => 'my-route']]);
@@ -854,7 +854,7 @@ class FormHelperTest extends TestCase
         );
         $expected = [
             'form' => [
-                'method' => 'post', 'action' => '/articles',
+                'method' => 'post', 'action' => '/Articles',
                 'accept-charset' => 'iso-8859-1',
             ],
         ];
@@ -871,7 +871,7 @@ class FormHelperTest extends TestCase
             'type' => 'post',
             'escape' => false,
             'url' => [
-                'controller' => 'controller',
+                'controller' => 'Controller',
                 'action' => 'action',
                 '?' => ['param1' => 'value1', 'param2' => 'value2'],
             ],
@@ -879,7 +879,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post',
-                'action' => '/controller/action?param1=value1&amp;param2=value2',
+                'action' => '/Controller/action?param1=value1&amp;param2=value2',
                 'accept-charset' => $encoding,
             ],
         ];
@@ -888,7 +888,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->create($this->article, [
             'type' => 'post',
             'url' => [
-                'controller' => 'controller',
+                'controller' => 'Controller',
                 'action' => 'action',
                 '?' => ['param1' => 'value1', 'param2' => 'value2'],
             ],
@@ -938,7 +938,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post',
-                'action' => '/articles/edit/myparam',
+                'action' => '/Articles/edit/myparam',
                 'accept-charset' => $encoding,
             ],
         ];
@@ -988,13 +988,13 @@ class FormHelperTest extends TestCase
     public function testGetFormWithFalseModel()
     {
         $encoding = strtolower(Configure::read('App.encoding'));
-        $this->View->setRequest($this->View->getRequest()->withParam('controller', 'contact_test'));
+        $this->View->setRequest($this->View->getRequest()->withParam('controller', 'ContactTest'));
         $result = $this->Form->create(null, [
-            'type' => 'get', 'url' => ['controller' => 'contact_test'],
+            'type' => 'get', 'url' => ['controller' => 'ContactTest'],
         ]);
 
         $expected = ['form' => [
-            'method' => 'get', 'action' => '/contact_test/add',
+            'method' => 'get', 'action' => '/ContactTest/add',
             'accept-charset' => $encoding,
         ]];
         $this->assertHtml($expected, $result);
@@ -6984,11 +6984,11 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->postLink(
             'Delete',
-            ['controller' => 'posts', 'action' => 'delete', 1, '?' => ['a' => 'b', 'c' => 'd']]
+            ['controller' => 'Posts', 'action' => 'delete', 1, '?' => ['a' => 'b', 'c' => 'd']]
         );
         $expected = [
             'form' => [
-                'method' => 'post', 'action' => '/posts/delete/1?a=b&amp;c=d',
+                'method' => 'post', 'action' => '/Posts/delete/1?a=b&amp;c=d',
                 'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
@@ -7099,7 +7099,7 @@ class FormHelperTest extends TestCase
         $this->assertStringContainsString($hash, $result, 'Should contain the correct hash.');
         $reflect = new ReflectionProperty($this->Form, '_lastAction');
         $reflect->setAccessible(true);
-        $this->assertSame('/articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
+        $this->assertSame('/Articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -121,16 +121,16 @@ class HtmlHelperTest extends TestCase
         $expected = ['a' => ['href' => '/home'], 'preg:/\/home/', '/a'];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->link(['controller' => 'users', 'action' => 'login', '<[You]>']);
+        $result = $this->Html->link(['controller' => 'Users', 'action' => 'login', '<[You]>']);
         $expected = [
-            'a' => ['href' => '/users/login/%3C%5BYou%5D%3E'],
-            'preg:/\/users\/login\/&lt;\[You\]&gt;/',
+            'a' => ['href' => '/Users/login/%3C%5BYou%5D%3E'],
+            'preg:/\/Users\/login\/&lt;\[You\]&gt;/',
             '/a',
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->link('Posts', ['controller' => 'posts', 'action' => 'index', '_full' => true]);
-        $expected = ['a' => ['href' => Router::fullBaseUrl() . '/posts'], 'Posts', '/a'];
+        $result = $this->Html->link('Posts', ['controller' => 'Posts', 'action' => 'index', '_full' => true]);
+        $expected = ['a' => ['href' => Router::fullBaseUrl() . '/Posts'], 'Posts', '/a'];
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->link('Home', '/home', ['confirm' => 'Are you sure you want to do this?']);
@@ -246,10 +246,10 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->link('Original size', [
-            'controller' => 'images', 'action' => 'view', 3, '?' => ['height' => 100, 'width' => 200],
+            'controller' => 'Images', 'action' => 'view', 3, '?' => ['height' => 100, 'width' => 200],
         ]);
         $expected = [
-            'a' => ['href' => '/images/view/3?height=100&amp;width=200'],
+            'a' => ['href' => '/Images/view/3?height=100&amp;width=200'],
             'Original size',
             '/a',
         ];
@@ -373,7 +373,7 @@ class HtmlHelperTest extends TestCase
         $expected = ['img' => ['src' => '//google.com/logo.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->image(['controller' => 'test', 'action' => 'view', 1, '_ext' => 'gif']);
+        $result = $this->Html->image(['controller' => 'Test', 'action' => 'view', 1, '_ext' => 'gif']);
         $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
 
@@ -394,7 +394,7 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->image([
-            'controller' => 'images',
+            'controller' => 'Images',
             'action' => 'display',
             'test',
             '?' => ['one' => 'two', 'three' => 'four'],
@@ -1503,15 +1503,15 @@ class HtmlHelperTest extends TestCase
     {
         Router::connect('/:controller', ['action' => 'index']);
 
-        $result = $this->Html->meta('this is an rss feed', ['controller' => 'posts', '_ext' => 'rss']);
+        $result = $this->Html->meta('this is an rss feed', ['controller' => 'Posts', '_ext' => 'rss']);
         $expected = ['link' => ['href' => 'preg:/.*\/posts\.rss/', 'type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => 'this is an rss feed']];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->meta('rss', ['controller' => 'posts', '_ext' => 'rss'], ['title' => 'this is an rss feed']);
+        $result = $this->Html->meta('rss', ['controller' => 'Posts', '_ext' => 'rss'], ['title' => 'this is an rss feed']);
         $expected = ['link' => ['href' => 'preg:/.*\/posts\.rss/', 'type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => 'this is an rss feed']];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->meta('atom', ['controller' => 'posts', '_ext' => 'xml']);
+        $result = $this->Html->meta('atom', ['controller' => 'Posts', '_ext' => 'xml']);
         $expected = ['link' => ['href' => 'preg:/.*\/posts\.xml/', 'type' => 'application/atom+xml', 'title' => 'atom']];
         $this->assertHtml($expected, $result);
 
@@ -1527,7 +1527,7 @@ class HtmlHelperTest extends TestCase
         $expected = ['link' => ['href' => 'preg:/.*\/posts\.xpp/', 'type' => 'application/atom+xml', 'title' => 'nonexistent']];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->meta('atom', ['controller' => 'posts', '_ext' => 'xml'], ['link' => '/articles.rss']);
+        $result = $this->Html->meta('atom', ['controller' => 'Posts', '_ext' => 'xml'], ['link' => '/articles.rss']);
         $expected = ['link' => ['href' => 'preg:/.*\/articles\.rss/', 'type' => 'application/atom+xml', 'title' => 'atom']];
         $this->assertHtml($expected, $result);
 
@@ -1568,11 +1568,11 @@ class HtmlHelperTest extends TestCase
     public function dataMetaLinksProvider()
     {
         return [
-            ['canonical', ['controller' => 'posts', 'action' => 'show'], '/posts/show'],
-            ['first', ['controller' => 'posts', 'action' => 'index'], '/posts'],
-            ['last', ['controller' => 'posts', 'action' => 'index', '?' => ['page' => 10]], '/posts?page=10'],
-            ['prev', ['controller' => 'posts', 'action' => 'index', '?' => ['page' => 4]], '/posts?page=4'],
-            ['next', ['controller' => 'posts', 'action' => 'index', '?' => ['page' => 6]], '/posts?page=6'],
+            ['canonical', ['controller' => 'Posts', 'action' => 'show'], '/posts/show'],
+            ['first', ['controller' => 'Posts', 'action' => 'index'], '/posts'],
+            ['last', ['controller' => 'Posts', 'action' => 'index', '?' => ['page' => 10]], '/posts?page=10'],
+            ['prev', ['controller' => 'Posts', 'action' => 'index', '?' => ['page' => 4]], '/posts?page=4'],
+            ['next', ['controller' => 'Posts', 'action' => 'index', '?' => ['page' => 6]], '/posts?page=6'],
         ];
     }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -161,7 +161,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/accounts/',
             'params' => [
-                'plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Accounts', 'action' => 'index', 'pass' => [],
             ],
             'base' => '',
             'webroot' => '/',
@@ -184,7 +184,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc'],
             'Title',
             '/a',
         ];
@@ -198,7 +198,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('date');
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=date&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=date&amp;direction=desc', 'class' => 'asc'],
             'Date',
             '/a',
         ];
@@ -206,7 +206,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title', 'TestTitle');
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc'],
             'TestTitle',
             '/a',
         ];
@@ -214,7 +214,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc'],
             'ascending',
             '/a',
         ];
@@ -227,7 +227,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
             'descending',
             '/a',
         ];
@@ -241,7 +241,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
             'Title',
             '/a',
         ];
@@ -255,7 +255,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
             'Title',
             '/a',
         ];
@@ -269,7 +269,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
             'Title',
             '/a',
         ];
@@ -283,7 +283,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'ASC']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'],
             'Title',
             '/a',
         ];
@@ -297,7 +297,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'asc']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
             'Title',
             '/a',
         ];
@@ -311,7 +311,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title', 'Title', ['direction' => 'desc']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'],
             'Title',
             '/a',
         ];
@@ -353,7 +353,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/accounts/',
             'params' => [
-                'plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Accounts', 'action' => 'index', 'pass' => [],
             ],
             'base' => '',
             'webroot' => '/',
@@ -369,7 +369,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index?sort=Article.full_name&amp;direction=desc', 'class' => 'asc'],
             'Article Full Name',
             '/a',
         ];
@@ -377,7 +377,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('full_name');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=full_name&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index?sort=full_name&amp;direction=desc', 'class' => 'asc'],
             'Full Name',
             '/a',
         ];
@@ -391,7 +391,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('Article.full_name');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'],
             'Article Full Name',
             '/a',
         ];
@@ -399,7 +399,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('full_name');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=full_name&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index?sort=full_name&amp;direction=asc', 'class' => 'desc'],
             'Full Name',
             '/a',
         ];
@@ -416,7 +416,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/accounts/',
             'params' => [
-                'plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Accounts', 'action' => 'index', 'pass' => [],
             ],
             'base' => '',
             'webroot' => '/',
@@ -427,7 +427,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title', 'TestTitle', ['direction' => 'desc']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc'],
             'TestTitle',
             '/a',
         ];
@@ -435,7 +435,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title', ['asc' => 'ascending', 'desc' => 'descending'], ['direction' => 'desc']);
         $expected = [
-            'a' => ['href' => '/accounts/index/param?sort=title&amp;direction=desc'],
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=desc'],
             'descending',
             '/a',
         ];
@@ -452,7 +452,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/accounts/',
             'params' => [
-                'plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Accounts', 'action' => 'index', 'pass' => [],
             ],
             'base' => '',
             'webroot' => '/',
@@ -467,7 +467,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('Article.title');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
             'Article Title',
             '/a',
         ];
@@ -481,7 +481,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
+            'a' => ['href' => '/Accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'],
             'Title',
             '/a',
         ];
@@ -495,7 +495,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
+            'a' => ['href' => '/Accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'],
             'Title',
             '/a',
         ];
@@ -509,7 +509,7 @@ class PaginatorHelperTest extends TestCase
         ]);
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/accounts/index?sort=title&amp;direction=asc'],
+            'a' => ['href' => '/Accounts/index?sort=title&amp;direction=asc'],
             'Title',
             '/a',
         ];
@@ -526,7 +526,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/accounts/',
             'params' => [
-                'plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Accounts', 'action' => 'index', 'pass' => [],
             ],
             'base' => '',
             'webroot' => '/',
@@ -561,7 +561,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title', 'Title', ['model' => 'Articles']);
         $expected = [
-            'a' => ['href' => '/accounts/index?article%5Bsort%5D=title&amp;article%5Bdirection%5D=asc'],
+            'a' => ['href' => '/Accounts/index?article%5Bsort%5D=title&amp;article%5Bdirection%5D=asc'],
             'Title',
             '/a',
         ];
@@ -569,7 +569,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('tag', 'Tag', ['model' => 'Tags']);
         $expected = [
-            'a' => ['class' => 'asc', 'href' => '/accounts/index?tags%5Bsort%5D=tag&amp;tags%5Bdirection%5D=desc'],
+            'a' => ['class' => 'asc', 'href' => '/Accounts/index?tags%5Bsort%5D=tag&amp;tags%5Bdirection%5D=desc'],
             'Tag',
             '/a',
         ];
@@ -763,12 +763,12 @@ class PaginatorHelperTest extends TestCase
     public function testSortAdminLinks()
     {
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'admin']);
+        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'url' => '/admin/users',
             'params' => [
-                'plugin' => null, 'controller' => 'users', 'action' => 'index', 'prefix' => 'admin',
+                'plugin' => null, 'controller' => 'Users', 'action' => 'index', 'prefix' => 'Admin',
             ],
             'base' => '',
             'webroot' => '/',
@@ -783,7 +783,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
-            'a' => ['href' => '/admin/users/index?page=2', 'rel' => 'next'],
+            'a' => ['href' => '/admin/Users/index?page=2', 'rel' => 'next'],
             'Next',
             '/a',
             '/li',
@@ -793,7 +793,7 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator->options(['url' => ['param']]);
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/admin/users/index/param?sort=title&amp;direction=asc'],
+            'a' => ['href' => '/admin/Users/index/param?sort=title&amp;direction=asc'],
             'Title',
             '/a',
         ];
@@ -802,7 +802,7 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator->options(['url' => ['param']]);
         $result = $this->Paginator->sort('Article.title', 'Title');
         $expected = [
-            'a' => ['href' => '/admin/users/index/param?sort=Article.title&amp;direction=asc'],
+            'a' => ['href' => '/admin/Users/index/param?sort=Article.title&amp;direction=asc'],
             'Title',
             '/a',
         ];
@@ -819,7 +819,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/articles/index',
             'params' => [
-                'plugin' => null, 'controller' => 'articles', 'action' => 'index',
+                'plugin' => null, 'controller' => 'Articles', 'action' => 'index',
             ],
             'base' => '',
             'webroot' => '/',
@@ -837,7 +837,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
-            'a' => ['rel' => 'next', 'href' => '/articles/index?page=2'],
+            'a' => ['rel' => 'next', 'href' => '/?page=2'],
             'Next',
             '/a',
             '/li',
@@ -967,7 +967,7 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixes()
     {
         Router::reload();
-        Router::connect('/members/:controller/:action/*', ['prefix' => 'members']);
+        Router::connect('/members/:controller/:action/*', ['prefix' => 'Members']);
         Router::connect('/:controller/:action/*');
 
         $request = new ServerRequest([
@@ -986,7 +986,7 @@ class PaginatorHelperTest extends TestCase
                 'prevPage' => true,
             ],
         ]);
-        $url = ['prefix' => 'members'];
+        $url = ['prefix' => 'Members'];
 
         $result = $this->Paginator->generateUrl([], null, $url);
         $expected = '/members/Posts/index?page=2';
@@ -1022,7 +1022,7 @@ class PaginatorHelperTest extends TestCase
 
         $options = ['sort' => 'name', 'direction' => 'desc'];
         $url = [
-            'prefix' => 'members',
+            'prefix' => 'Members',
             'controller' => 'Posts',
         ];
         $result = $this->Paginator->generateUrl($options, null, $url);
@@ -1044,13 +1044,13 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixesLeavePrefix()
     {
         Router::reload();
-        Router::connect('/members/:controller/:action/*', ['prefix' => 'members']);
+        Router::connect('/members/:controller/:action/*', ['prefix' => 'Members']);
         Router::connect('/:controller/:action/*');
 
         $request = new ServerRequest([
             'params' => [
-                'prefix' => 'members',
-                'controller' => 'posts',
+                'prefix' => 'Members',
+                'controller' => 'Posts',
                 'action' => 'index',
                 'plugin' => null,
             ],
@@ -1061,15 +1061,15 @@ class PaginatorHelperTest extends TestCase
         $this->View->setRequest($request);
 
         $result = $this->Paginator->generateUrl();
-        $expected = '/members/posts/index?page=2';
+        $expected = '/members/Posts/index?page=2';
         $this->assertSame($expected, $result);
 
-        $result = $this->Paginator->generateUrl([], null, ['prefix' => 'members']);
-        $expected = '/members/posts/index?page=2';
+        $result = $this->Paginator->generateUrl([], null, ['prefix' => 'Members']);
+        $expected = '/members/Posts/index?page=2';
         $this->assertSame($expected, $result);
 
         $result = $this->Paginator->generateUrl([], null, ['prefix' => false]);
-        $expected = '/posts/index?page=2';
+        $expected = '/Posts/index?page=2';
         $this->assertSame($expected, $result);
 
         $this->Paginator->options(['url' => ['prefix' => false]]);
@@ -1239,7 +1239,7 @@ class PaginatorHelperTest extends TestCase
         $request = new ServerRequest([
             'url' => '/articles/',
             'params' => [
-                'plugin' => null, 'controller' => 'articles', 'action' => 'index', 'pass' => [],
+                'plugin' => null, 'controller' => 'Articles', 'action' => 'index', 'pass' => [],
             ],
         ]);
         Router::setRequest($request);
@@ -1259,7 +1259,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;sort=title&amp;direction=asc'],
+            'a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;sort=title&amp;direction=asc'],
             'Title',
             '/a',
         ];
@@ -1268,19 +1268,19 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers();
         $expected = [
             ['li' => ['class' => 'active']], '<a href=""', '1', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=2']], '2', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=3']], '3', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=4']], '4', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=5']], '5', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=6']], '6', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=7']], '7', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=2']], '2', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=3']], '3', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=4']], '4', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=5']], '5', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=6']], '6', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=7']], '7', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
-            'a' => ['href' => '/articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=2', 'rel' => 'next'],
+            'a' => ['href' => '/Articles/index/2?foo=bar&amp;x=y&amp;num=0&amp;page=2', 'rel' => 'next'],
             'Next',
             '/a',
             '/li',
@@ -1296,9 +1296,9 @@ class PaginatorHelperTest extends TestCase
     public function testDefaultSortRemovedFromUrl()
     {
         $request = new ServerRequest([
-            'url' => '/articles/',
+            'url' => '/Articles/',
             'params' => [
-                'plugin' => null, 'controller' => 'articles', 'action' => 'index',
+                'plugin' => null, 'controller' => 'Articles', 'action' => 'index',
             ],
         ]);
         Router::setRequest($request);
@@ -1314,7 +1314,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->next('Next');
         $expected = [
             'li' => ['class' => 'next'],
-            'a' => ['rel' => 'next', 'href' => '/articles/index?page=2'],
+            'a' => ['rel' => 'next', 'href' => '/?page=2'],
             'Next',
             '/a',
             '/li',
@@ -1330,8 +1330,8 @@ class PaginatorHelperTest extends TestCase
     public function testDefaultSortRemovedFromUrlWithAliases()
     {
         $request = new ServerRequest([
-            'params' => ['controller' => 'articles', 'action' => 'index', 'plugin' => null],
-            'url' => '/articles?sort=title&direction=asc',
+            'params' => ['controller' => 'Articles', 'action' => 'index', 'plugin' => null],
+            'url' => '/Articles?sort=title&direction=asc',
         ]);
         Router::setRequest($request);
 
@@ -1348,7 +1348,7 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['class' => 'asc', 'href' => '/articles/index'],
+            'a' => ['class' => 'asc', 'href' => '/'],
             'Title',
             '/a',
         ];
@@ -1888,7 +1888,7 @@ class PaginatorHelperTest extends TestCase
             ->getRequest()
             ->withAttribute('params', [
                 'plugin' => null,
-                'controller' => 'clients',
+                'controller' => 'Clients',
                 'action' => 'index',
             ])
             ->withAttribute('paging', [
@@ -1908,15 +1908,15 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->numbers();
         $expected = [
-            ['li' => []], ['a' => ['href' => '/clients/index/4']], '4', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/5']], '5', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/6']], '6', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/7']], '7', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/4']], '4', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/5']], '5', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/6']], '6', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/7']], '7', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '8', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/9']], '9', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/10']], '10', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/11']], '11', '/a', '/li',
-            ['li' => []], ['a' => ['href' => '/clients/index/12']], '12', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/9']], '9', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/10']], '10', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/11']], '11', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/Clients/index/12']], '12', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
 
@@ -1927,7 +1927,7 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator->options(['routePlaceholders' => ['sort', 'direction']]);
         $result = $this->Paginator->sort('title');
         $expected = [
-            'a' => ['href' => '/clients/index/title/asc'],
+            'a' => ['href' => '/Clients/index/title/asc'],
             'Title',
             '/a',
         ];

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -18,7 +18,7 @@ use Cake\Routing\Router;
 
 Router::extensions('json');
 Router::scope('/', function (RouteBuilder $routes) {
-    $routes->connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
+    $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
     $routes->connect(
         '/some_alias',
         [


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/15568
This removes almost all cases, with the exception of 1-2, that are hard to resolve.

The tests kind of show that the inflection not always works out of the box.
But I think we should adjust the tests to match the reality (CamelCase controllers always, same for plugin and prefix) and not the other way around.
Otherwise people can be confused if they see this syntax and try it, and it just doesn't work.