### PR TITLE
Remove additional wrong DS

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1339,7 +1339,7 @@ class View implements EventDispatcherInterface
             } elseif (!$plugin || $this->templatePath !== $this->name) {
                 $name = $templatePath . $subDir . $name;
             } else {
-                $name = DIRECTORY_SEPARATOR . $subDir . $name;
+                $name = $subDir . $name;
             }
         }
 


### PR DESCRIPTION
The paths were wrongly double slashed:

> vendor/dereuromark/cakephp-queue/templates/bake//Task/task.twig

Every path was already always with trailing DS, and every name including subnames always without DS.
Except for this one case it seems.