### PR TITLE
Set allowFallbackClass to TableLocator config

### DIFF
--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -57,7 +57,7 @@ class DatabaseSession implements SessionHandlerInterface
         $tableLocator = $this->getTableLocator();
 
         if (empty($config['model'])) {
-            $config = $tableLocator->exists('Sessions') ? [] : ['table' => 'sessions'];
+            $config = $tableLocator->exists('Sessions') ? [] : ['table' => 'sessions', 'allowFallbackClass' => true];
             $this->_table = $tableLocator->get('Sessions', $config);
         } else {
             $this->_table = $tableLocator->get($config['model']);


### PR DESCRIPTION
This adds support to use the database session handler without having to enable `TableLocator::allowFallbackClass` or creating a specific `Table::class`.