### PR TITLE
Add 8.1.0alpha1 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
         else
           vendor/bin/phpunit
         fi
+      continue-on-error: ${{ matrix.php-version == '8.1' }}
 
     - name: Submit code coverage
       if: matrix.php-version == '8.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
         include:
           - php-version: '7.4'
             db-type: 'mariadb'
-            allow-failure: false
           - php-version: '7.2'
             db-type: 'mysql'
             prefer-lowest: 'prefer-lowest'
-            allow-failure: false
+          - php-version: '8.1'
+            db-type: 'sqlite'
 
     services:
       redis:


### PR DESCRIPTION
I don't see an option for 8.1.0alpha1 so this is just nightly still.
