### PR TITLE
Update return types for session handler methods.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "^2.0",
+        "cakephp/chronos": "dev-2.next as 2.3",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",
@@ -55,7 +55,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^4.0",
+        "cakephp/cakephp-codesniffer": "^4.5",
         "mikey179/vfsstream": "^1.6",
         "paragonie/csp-builder": "^2.3",
         "phpunit/phpunit": "^8.5 || ^9.3"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "dev-2.next as 2.3",
+        "cakephp/chronos": "^2.2",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -20,6 +20,7 @@ namespace Cake\Http\Session;
 
 use Cake\Cache\Cache;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 use SessionHandlerInterface;
 
 /**
@@ -55,11 +56,11 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Method called on open of a database session.
      *
-     * @param string $savePath The path where to store/retrieve the session.
+     * @param string $path The path where to store/retrieve the session.
      * @param string $name The session name.
      * @return bool Success
      */
-    public function open($savePath, $name): bool
+    public function open($path, $name): bool
     {
         return true;
     }
@@ -78,14 +79,15 @@ class CacheSession implements SessionHandlerInterface
      * Method used to read from a cache session.
      *
      * @param string $id ID that uniquely identifies session in cache.
-     * @return string Session data or empty string if it does not exist.
+     * @return string|false Session data or false if it does not exist.
      */
-    public function read($id): string
+    #[ReturnTypeWillChange]
+    public function read($id)
     {
         $value = Cache::read($id, $this->_options['config']);
 
-        if (empty($value)) {
-            return '';
+        if ($value === null) {
+            return false;
         }
 
         return $value;
@@ -121,13 +123,14 @@ class CacheSession implements SessionHandlerInterface
     }
 
     /**
-     * No-op method. Always returns true since cache engine don't have garbage collection.
+     * No-op method. Always returns 0 since cache engine don't have garbage collection.
      *
      * @param int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
-     * @return bool Always true.
+     * @return int|false
      */
-    public function gc($maxlifetime): bool
+    #[ReturnTypeWillChange]
+    public function gc($maxlifetime)
     {
-        return true;
+        return 0;
     }
 }

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -21,6 +21,7 @@ use Closure;
 use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
+use ReturnTypeWillChange;
 use RuntimeException;
 
 /**
@@ -443,6 +444,7 @@ trait DateFormatTrait
      *
      * @return string|int
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if (static::$_jsonEncodeFormat instanceof Closure) {

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -133,7 +133,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertSame($expected, $result);
 
         $result = $this->storage->read('made up value');
-        $this->assertSame('', $result);
+        $this->assertFalse($result);
     }
 
     /**
@@ -146,7 +146,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertTrue($this->storage->write('foo', 'Some value'));
 
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy failed');
-        $this->assertSame('', $this->storage->read('foo'), 'Value still present.');
+        $this->assertFalse($this->storage->read('foo'), 'Value still present.');
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy should always return true');
     }
 
@@ -165,7 +165,7 @@ class DatabaseSessionTest extends TestCase
 
         sleep(1);
         $storage->gc(0);
-        $this->assertSame('', $storage->read('foo'));
+        $this->assertFalse($storage->read('foo'));
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TestPlugin\Http\Session;
 
+use ReturnTypeWillChange;
 use SessionHandlerInterface;
 
 /**
@@ -10,28 +11,34 @@ use SessionHandlerInterface;
  */
 class TestPluginSession implements SessionHandlerInterface
 {
-    public function open($savePath, $name)
+    public function open($path, $name): bool
     {
         return true;
     }
 
-    public function close()
+    public function close(): bool
     {
+        return true;
     }
 
+    #[ReturnTypeWillChange]
     public function read($id)
     {
     }
 
-    public function write($id, $data)
+    public function write($id, $data): bool
     {
+        return true;
     }
 
-    public function destroy($id)
+    public function destroy($id): bool
     {
+        return true;
     }
 
+    #[ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
+        return 0;
     }
 }

--- a/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
+++ b/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Http\Session;
 
+use ReturnTypeWillChange;
 use SessionHandlerInterface;
 
 /**
@@ -17,28 +18,34 @@ class TestAppLibSession implements SessionHandlerInterface
         $this->options = $options;
     }
 
-    public function open($savePath, $name)
+    public function open($path, $name): bool
     {
         return true;
     }
 
-    public function close()
+    public function close(): bool
     {
+        return true;
     }
 
+    #[ReturnTypeWillChange]
     public function read($id)
     {
     }
 
-    public function write($id, $data)
+    public function write($id, $data): bool
     {
+        return true;
     }
 
-    public function destroy($id)
+    public function destroy($id): bool
     {
+        return true;
     }
 
+    #[ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
+        return 0;
     }
 }


### PR DESCRIPTION
The return types now match those of `SessionHandlerInterface` methods.

https://www.php.net/manual/en/class.sessionhandlerinterface.php
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
