### PR TITLE
Try to find error template in parent directories

### DIFF
--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -210,8 +210,6 @@ class ErrorHandlerTest extends TestCase
      */
     public function testErrorSuppressed()
     {
-        $this->skipIf(version_compare(PHP_VERSION, '8.0.0-dev', '>='));
-
         $errorHandler = new ErrorHandler();
         $errorHandler->register();
         $this->_restoreError = true;


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/8099

This attempts to walk the parent directories looking for application error template before bailing out to safe rendering.

Want to get feedback on the implementation before writing the complicated tests for each of the scenarios.

1. Remove extension/subDir
2. Remove prefix
3. Remove plugin
4. Remove custom template name

All non-template exceptions are now considered internal exceptions. This means rendering errors don't stomp on the original exception and are handled by `ErrorHandlerMiddleware::handleInternalError()`. Most internal errors just need to be logged anyway as something is misconfigured.

