### PR TITLE
Add state reset aggregate class

### DIFF
--- a/src/TestSuite/Fixture/StateResetCollection.php
+++ b/src/TestSuite/Fixture/StateResetCollection.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Fixture;
+
+/**
+ * Fixture state strategy that combines other strategies
+ *
+ * Useful when your application is using multiple storage
+ * systems that require their own state resetting. For example,
+ * a relational database and elasticsearch.
+ */
+class StateResetCollection implements StateResetStrategyInterface
+{
+    /**
+     * @var \Cake\TestSuite\Fixture\StateResetStrategyInterface[]
+     */
+    protected $items = [];
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\TestSuite\Fixture\StateResetStrategyInterface[] $items The strategies to aggregate.
+     */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * Call setupTest on each item.
+     *
+     * @return void
+     */
+    public function setupTest(): void
+    {
+        foreach ($this->items as $item) {
+            $item->setupTest();
+        }
+    }
+
+    /**
+     * Call teardownTest on each item.
+     *
+     * @return void
+     */
+    public function teardownTest(): void
+    {
+        foreach ($this->items as $item) {
+            $item->teardownTest();
+        }
+    }
+}

--- a/tests/TestCase/TestSuite/Fixture/StateResetCollectionTest.php
+++ b/tests/TestCase/TestSuite/Fixture/StateResetCollectionTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\TestSuite\Fixture\StateResetCollection;
+use Cake\TestSuite\Fixture\StateResetStrategyInterface;
+use Cake\TestSuite\TestCase;
+
+class StateResetCollectionTest extends TestCase
+{
+    /**
+     * Test that setupTest calls items.
+     *
+     * @return void
+     */
+    public function testSetupTest()
+    {
+        $one = $this->getMockBuilder(StateResetStrategyInterface::class)->getMock();
+        $two = $this->getMockBuilder(StateResetStrategyInterface::class)->getMock();
+
+        $one->expects($this->once())->method('setupTest');
+        $two->expects($this->once())->method('setupTest');
+
+        $one->expects($this->never())->method('teardownTest');
+
+        $strategy = new StateResetCollection([$one, $two]);
+        $strategy->setupTest();
+    }
+
+    /**
+     * Test that teardownTest calls items.
+     *
+     * @return void
+     */
+    public function testTeardownTest()
+    {
+        $one = $this->getMockBuilder(StateResetStrategyInterface::class)->getMock();
+        $two = $this->getMockBuilder(StateResetStrategyInterface::class)->getMock();
+
+        $one->expects($this->once())->method('teardownTest');
+        $two->expects($this->once())->method('teardownTest');
+
+        $one->expects($this->never())->method('setupTest');
+
+        $strategy = new StateResetCollection([$one, $two]);
+        $strategy->teardownTest();
+    }
+}


### PR DESCRIPTION
Add an aggregate/collection class for state reset objects. This will be necessary for applications that use multiple fixture providers.

An example of this would be an application that has tests that insert data into both a relational database and elasticsearch. The application could define the `getStateResetStrategy()` method and return the aggregate object with a database and elastic search object inside.