### PR TITLE
Update test for var exporting recursive array.

### DIFF
--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -748,14 +748,17 @@ TEXT;
     }
 
     /**
-     * Test that exportVar() will stop traversing recursive arrays like GLOBALS.
+     * Test that exportVar() will stop traversing recursive arrays.
      *
      * @return void
      */
     public function testExportVarRecursion()
     {
-        $output = Debugger::exportVar($GLOBALS);
-        $this->assertMatchesRegularExpression("/'GLOBALS' => \[\s+'' \=\> \[maximum depth reached\]/", $output);
+        $array = [];
+        $array['foo'] = &$array;
+
+        $output = Debugger::exportVar($array);
+        $this->assertMatchesRegularExpression("/'foo' => \[\s+'' \=\> \[maximum depth reached\]/", $output);
     }
 
     /**


### PR DESCRIPTION
~~$GLOBALS is gone in PHP 8.1.~~
Behavior of $GLOBALS has changed in PHP 8.1.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
