### PR TITLE
fix #15588: eliminate the sprintf error on asserting command output

### DIFF
--- a/src/TestSuite/Constraint/Console/ContentsContain.php
+++ b/src/TestSuite/Constraint/Console/ContentsContain.php
@@ -40,6 +40,6 @@ class ContentsContain extends ContentsBase
      */
     public function toString(): string
     {
-        return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL . $this->contents, $this->output);
+        return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL, $this->output) . $this->contents;
     }
 }

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -93,6 +93,19 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * tests that exec with a format specifier
+     *
+     * @return void
+     */
+    public function testExecCommandWithFormatSpecifier()
+    {
+        $this->useCommandRunner();
+        $this->exec('format_specifier_command');
+        $this->assertOutputContains('format specifier');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
+
+    /**
      * tests a valid core command
      *
      * @return void

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -28,6 +28,7 @@ use Cake\Routing\RouteBuilder;
 use stdClass;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DependencyCommand;
+use TestApp\Command\FormatSpecifierCommand;
 
 class Application extends BaseApplication
 {
@@ -54,6 +55,7 @@ class Application extends BaseApplication
     {
         return $commands
             ->add('abort_command', new AbortCommand())
+            ->add('format_specifier_command', new FormatSpecifierCommand())
             ->addMany($commands->autoDiscover());
     }
 

--- a/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
+++ b/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+
+class FormatSpecifierCommand extends Command
+{
+    public function execute(Arguments $args, ConsoleIo $io): void
+    {
+        $io->out('Be careful! %s is a format specifier!');
+    }
+}


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
