### PR TITLE
RFC: Raise PHP min to 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '8.0']
+        php-version: ['7.3', '8.0']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         exclude:
-          - php-version: '7.2'
+          - php-version: '7.3'
             db-type: 'mysql'
         include:
           - php-version: '7.4'
             db-type: 'mariadb'
-          - php-version: '7.2'
+          - php-version: '7.3'
             db-type: 'mysql'
             prefer-lowest: 'prefer-lowest'
           - php-version: '8.1'
@@ -44,19 +44,19 @@ jobs:
 
     steps:
     - name: Setup MySQL latest
-      if: matrix.db-type == 'mysql' && matrix.php-version == '7.2'
+      if: matrix.db-type == 'mysql' && matrix.php-version == '7.3'
       run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin
 
     - name: Setup MySQL 5.6
-      if: matrix.db-type == 'mysql' && matrix.php-version != '7.2'
+      if: matrix.db-type == 'mysql' && matrix.php-version != '7.3'
       run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:5.6 --character-set-server=utf8
 
     - name: Setup PostgreSQL latest
-      if: matrix.db-type == 'pgsql' && matrix.php-version == '7.2'
+      if: matrix.db-type == 'pgsql' && matrix.php-version == '7.3'
       run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres
 
     - name: Setup PostgreSQL 9.4
-      if: matrix.db-type == 'pgsql' && matrix.php-version != '7.2'
+      if: matrix.db-type == 'pgsql' && matrix.php-version != '7.3'
       run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres:9.4
 
     - uses: getong/mariadb-action@v1.1
@@ -105,7 +105,7 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.2' && matrix.db-type == 'mysql'
+      if: matrix.php-version == '7.3' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
@@ -114,8 +114,8 @@ jobs:
         MEMCACHED_PORT: ${{ job.services.memcached.ports['11211'] }}
       run: |
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.2' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
-        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} != '7.2' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} == '7.3' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' && ${{ matrix.php-version }} != '7.3' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp?encoding=utf8'; fi
         if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.3.0",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -58,7 +58,7 @@
         "cakephp/cakephp-codesniffer": "^4.0",
         "mikey179/vfsstream": "^1.6",
         "paragonie/csp-builder": "^2.3",
-        "phpunit/phpunit": "^8.5 || ^9.3"
+        "phpunit/phpunit": "^9.3"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",


### PR DESCRIPTION
I would like to propose the min PHP for 4.3+ to be 7.3
This simplifies a lot, including the PHPUnit part (9, and soon 10).

Also, I think with 8.1 soon out, there is no need to stick to a long EOL PHP 7.2 (End of 2020 even security fixes)
https://www.php.net/supported-versions.php

Given that CakePHP 5.0 ~~could~~ will be 8.0+, a 7.3+ for upcoming new minor 4.3 sounds reasonably conservative to me.

In other words: There is currently no reason to not run 7.4 even on all systems for many months now, and therefore even 7.3 is quite super-conservative in a way :)
