### PR TITLE
cake 5: Require Event payload to be array or ArrayAccess

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use ArrayAccess;
 use Cake\Core\Exception\CakeException;
 
 /**
@@ -43,9 +44,9 @@ class Event implements EventInterface
     /**
      * Custom data for the method that receives the event
      *
-     * @var array
+     * @var \ArrayAccess|array
      */
-    protected $_data;
+    protected $payload;
 
     /**
      * Property used to retain the result value of the event listeners
@@ -76,15 +77,15 @@ class Event implements EventInterface
      * @param string $name Name of the event
      * @param object|null $subject the object that this event applies to
      *   (usually the object that is generating the event).
-     * @param \ArrayAccess|array|null $data any value you wish to be transported
+     * @param \ArrayAccess|array $payload any value you wish to be transported
      *   with this event to it can be read by listeners.
      * @psalm-param TSubject|null $subject
      */
-    public function __construct(string $name, $subject = null, $data = null)
+    public function __construct(string $name, ?object $subject = null, ArrayAccess|array $payload = [])
     {
         $this->_name = $name;
         $this->_subject = $subject;
-        $this->_data = (array)$data;
+        $this->payload = $payload;
     }
 
     /**
@@ -169,26 +170,25 @@ class Event implements EventInterface
     public function getData(?string $key = null)
     {
         if ($key !== null) {
-            return $this->_data[$key] ?? null;
+            return $this->payload[$key] ?? null;
         }
 
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        return (array)$this->_data;
+        return $this->payload;
     }
 
     /**
      * Assigns a value to the data/payload of this event.
      *
-     * @param array|string $key An array will replace all payload data, and a key will set just that array item.
+     * @param \ArrayAccess|array|string $key An array will replace all payload data, and a key will set just that array item.
      * @param mixed $value The value to set.
      * @return $this
      */
-    public function setData($key, $value = null)
+    public function setData(ArrayAccess|array|string $key, $value = null)
     {
-        if (is_array($key)) {
-            $this->_data = $key;
+        if (is_array($key) || $key instanceof ArrayAccess) {
+            $this->payload = $key;
         } else {
-            $this->_data[$key] = $value;
+            $this->payload[$key] = $value;
         }
 
         return $this;

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use ArrayAccess;
+
 /**
  * Objects implementing this interface can emit events.
  *
@@ -33,13 +35,17 @@ interface EventDispatcherInterface
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param \ArrayAccess|array $payload Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface;
+    public function dispatchEvent(
+        string $name,
+        ArrayAccess|array $payload = [],
+        ?object $subject = null
+    ): EventInterface;
 
     /**
      * Sets the Cake\Event\EventManager manager instance for this object.

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use ArrayAccess;
+
 /**
  * Implements Cake\Event\EventDispatcherInterface.
  */
@@ -75,20 +77,23 @@ trait EventDispatcherTrait
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param \ArrayAccess|array $payload Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface
-    {
+    public function dispatchEvent(
+        string $name,
+        ArrayAccess|array $payload = [],
+        ?object $subject = null
+    ): EventInterface {
         if ($subject === null) {
             $subject = $this;
         }
 
         /** @var \Cake\Event\EventInterface $event */
-        $event = new $this->_eventClass($name, $subject, $data);
+        $event = new $this->_eventClass($name, $subject, $payload);
         $this->getEventManager()->dispatch($event);
 
         return $event;

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use ArrayAccess;
+
 /**
  * Represents the transport class of events across the system. It receives a name, subject and an optional
  * payload. The name can be any string that uniquely identifies the event across the application, while the subject
@@ -78,9 +80,9 @@ interface EventInterface
     /**
      * Assigns a value to the data/payload of this event.
      *
-     * @param array|string $key An array will replace all payload data, and a key will set just that array item.
+     * @param \ArrayAccess|array|string $key An array will replace all payload data, and a key will set just that array item.
      * @param mixed $value The value to set.
      * @return $this
      */
-    public function setData($key, $value = null);
+    public function setData(ArrayAccess|array|string $key, $value = null);
 }

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -100,7 +100,7 @@ class EventTest extends TestCase
     {
         $data = new ArrayObject(['some' => 'data']);
         $event = new Event('fake.event', $this, $data);
-        $this->assertEquals(['some' => 'data'], $event->getData());
+        $this->assertEquals($data, $event->getData());
 
         $this->assertSame('data', $event->getData('some'));
         $this->assertNull($event->getData('undef'));


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/14482

Minimal change to fix issue. Would like to update interface to use payload instead of data.
