### PR TITLE
cake 5: Use `null` instead of `false` to disable log scopes.

### DIFF
--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -57,13 +57,16 @@ abstract class BaseLog extends AbstractLogger
     {
         $this->setConfig($config);
 
-        if (!is_array($this->_config['scopes']) && $this->_config['scopes'] !== false) {
+        assert(
+            $this->_config['scopes'] !== false,
+            new InvalidArgumentException('Use `null` instead of `false` to disable scopes.')
+        );
+
+        if ($this->_config['scopes'] !== null) {
             $this->_config['scopes'] = (array)$this->_config['scopes'];
         }
 
-        if (!is_array($this->_config['levels'])) {
-            $this->_config['levels'] = (array)$this->_config['levels'];
-        }
+        $this->_config['levels'] = (array)$this->_config['levels'];
 
         if (!empty($this->_config['types']) && empty($this->_config['levels'])) {
             $this->_config['levels'] = (array)$this->_config['types'];
@@ -105,9 +108,9 @@ abstract class BaseLog extends AbstractLogger
     /**
      * Get the scopes this logger is interested in.
      *
-     * @return array|false
+     * @return array|null
      */
-    public function scopes()
+    public function scopes(): ?array
     {
         return $this->_config['scopes'];
     }

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -378,12 +378,9 @@ class Log
                 $levels = $logger->levels();
                 $scopes = $logger->scopes();
             }
-            if ($scopes === null) {
-                $scopes = [];
-            }
 
             $correctLevel = empty($levels) || in_array($level, $levels, true);
-            $inScope = $scopes === false && empty($context['scope']) || $scopes === [] ||
+            $inScope = $scopes === null && empty($context['scope']) || $scopes === [] ||
                 is_array($scopes) && array_intersect((array)$context['scope'], $scopes);
 
             if ($correctLevel && $inScope) {

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -471,7 +471,7 @@ class LogTest extends TestCase
             'path' => LOGS,
             'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
-            'scopes' => false,
+            'scopes' => null,
         ]);
         Log::setConfig('shops', [
             'engine' => 'File',


### PR DESCRIPTION
Closes #15544.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
