### PR TITLE
cake 5: Require array event payload

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -76,15 +76,15 @@ class Event implements EventInterface
      * @param string $name Name of the event
      * @param object|null $subject the object that this event applies to
      *   (usually the object that is generating the event).
-     * @param \ArrayAccess|array|null $data any value you wish to be transported
+     * @param array $data any value you wish to be transported
      *   with this event to it can be read by listeners.
      * @psalm-param TSubject|null $subject
      */
-    public function __construct(string $name, $subject = null, $data = null)
+    public function __construct(string $name, $subject = null, array $data = [])
     {
         $this->_name = $name;
         $this->_subject = $subject;
-        $this->_data = (array)$data;
+        $this->_data = $data;
     }
 
     /**
@@ -160,30 +160,21 @@ class Event implements EventInterface
     }
 
     /**
-     * Access the event data/payload.
-     *
-     * @param string|null $key The data payload element to return, or null to return all data.
-     * @return array|mixed|null The data payload if $key is null, or the data value for the given $key.
-     *   If the $key does not exist a null value is returned.
+     * @inheritDoc
      */
-    public function getData(?string $key = null)
+    public function getData(?string $key = null): mixed
     {
         if ($key !== null) {
             return $this->_data[$key] ?? null;
         }
 
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        return (array)$this->_data;
+        return $this->_data;
     }
 
     /**
-     * Assigns a value to the data/payload of this event.
-     *
-     * @param array|string $key An array will replace all payload data, and a key will set just that array item.
-     * @param mixed $value The value to set.
-     * @return $this
+     * @inheritDoc
      */
-    public function setData($key, $value = null)
+    public function setData(array|string $key, $value = null)
     {
         if (is_array($key)) {
             $this->_data = $key;

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -33,13 +33,13 @@ interface EventDispatcherInterface
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param array $data Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface;
+    public function dispatchEvent(string $name, array $data = [], ?object $subject = null): EventInterface;
 
     /**
      * Sets the Cake\Event\EventManager manager instance for this object.

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -75,13 +75,13 @@ trait EventDispatcherTrait
      * Returns a dispatched event.
      *
      * @param string $name Name of the event.
-     * @param array|null $data Any value you wish to be transported with this event to
+     * @param array $data Any value you wish to be transported with this event to
      * it can be read by listeners.
      * @param object|null $subject The object that this event applies to
      * ($this by default).
      * @return \Cake\Event\EventInterface
      */
-    public function dispatchEvent(string $name, ?array $data = null, ?object $subject = null): EventInterface
+    public function dispatchEvent(string $name, array $data = [], ?object $subject = null): EventInterface
     {
         if ($subject === null) {
             $subject = $this;

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -70,10 +70,10 @@ interface EventInterface
      * Accesses the event data/payload.
      *
      * @param string|null $key The data payload element to return, or null to return all data.
-     * @return array|mixed|null The data payload if $key is null, or the data value for the given $key.
+     * @return mixed The data payload if $key is null, or the data value for the given $key.
      *   If the $key does not exist a null value is returned.
      */
-    public function getData(?string $key = null);
+    public function getData(?string $key = null): mixed;
 
     /**
      * Assigns a value to the data/payload of this event.
@@ -82,5 +82,5 @@ interface EventInterface
      * @param mixed $value The value to set.
      * @return $this
      */
-    public function setData($key, $value = null);
+    public function setData(array|string $key, $value = null);
 }

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Event;
 
-use ArrayObject;
 use Cake\Core\Exception\CakeException;
 use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
@@ -84,22 +83,6 @@ class EventTest extends TestCase
     public function testEventData()
     {
         $event = new Event('fake.event', $this, ['some' => 'data']);
-        $this->assertEquals(['some' => 'data'], $event->getData());
-
-        $this->assertSame('data', $event->getData('some'));
-        $this->assertNull($event->getData('undef'));
-    }
-
-    /**
-     * Tests that it is possible to get/set custom data in a event
-     *
-     * @return void
-     * @triggers fake.event $this, array('some' => 'data')
-     */
-    public function testEventDataObject()
-    {
-        $data = new ArrayObject(['some' => 'data']);
-        $event = new Event('fake.event', $this, $data);
         $this->assertEquals(['some' => 'data'], $event->getData());
 
         $this->assertSame('data', $event->getData('some'));


### PR DESCRIPTION
This fixes the original issue until a new Event design is completed.

Casting ArrayAccess to array (such as entities) does not work well.