### PR TITLE
Return PDOStatement instead of true for query mock return

### DIFF
--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -25,6 +25,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PDOStatement;
 
 /**
  * Tests Driver class
@@ -194,7 +195,7 @@ class DriverTest extends TestCase
         $connection
             ->expects($this->once())
             ->method('query')
-            ->willReturn(true);
+            ->willReturn(new PDOStatement());
 
         $this->driver->setConnection($connection);
         $this->assertTrue($this->driver->isConnected());


### PR DESCRIPTION
This was never valid. The return type for `query()` does not include `true` for any php version.