### PR TITLE
Deprecate calling ResultSetInterface methods on query instances directly

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -552,6 +552,11 @@ trait QueryTrait
     {
         $resultSetClass = $this->_decoratorClass();
         if (in_array($method, get_class_methods($resultSetClass), true)) {
+            deprecationWarning(sprintf(
+                'Calling result set method `%s()` directly on query instance is deprecated. ' .
+                'You must call `all()` to retrieve the results first.',
+                $method
+            ));
             $results = $this->all();
 
             return $results->$method(...$arguments);

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -136,7 +136,7 @@ class LazyEagerLoader
      * entities.
      *
      * @param \Cake\Datasource\EntityInterface[]|\Traversable $objects The original list of entities
-     * @param \Cake\Collection\CollectionInterface|\Cake\ORM\Query $results The loaded results
+     * @param \Cake\ORM\Query $results The loaded results
      * @param string[] $associations The top level associations that were loaded
      * @param \Cake\ORM\Table $source The table where the entities came from
      * @return array
@@ -147,6 +147,7 @@ class LazyEagerLoader
         $properties = $this->_getPropertyMap($source, $associations);
         $primaryKey = (array)$source->getPrimaryKey();
         $results = $results
+            ->all()
             ->indexBy(function ($e) use ($primaryKey) {
                 /** @var \Cake\Datasource\EntityInterface $e */
                 return implode(';', $e->extract($primaryKey));

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -452,7 +452,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         ]);
 
         $table->setLocale('eng');
-        $results = $table->find()->combine('title', 'subtitle', 'id')->toArray();
+        $results = $table->find()->all()->combine('title', 'subtitle', 'id')->toArray();
         $expected = [
             1 => ['Title #1' => 'SubTitle #1'],
             2 => ['Title #2' => 'SubTitle #2'],

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -128,7 +128,7 @@ class TranslateBehaviorTest extends TestCase
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 
         $table->setLocale('eng');
-        $results = $table->find()->combine('title', 'body', 'id')->toArray();
+        $results = $table->find()->all()->combine('title', 'body', 'id')->toArray();
         $expected = [
             1 => ['Title #1' => 'Content #1'],
             2 => ['Title #2' => 'Content #2'],
@@ -293,7 +293,9 @@ class TranslateBehaviorTest extends TestCase
         $table->setLocale('spa');
         $results = $table->find()
             ->where(['Comments.id' => 6])
-            ->combine('id', 'comment')->toArray();
+            ->all()
+            ->combine('id', 'comment')
+            ->toArray();
         $expected = [6 => 'Second Comment for Second Article'];
         $this->assertSame($expected, $results);
     }
@@ -468,7 +470,7 @@ class TranslateBehaviorTest extends TestCase
             3 => ['Third Article' => 'Third Article Body'],
         ];
 
-        $grouped = $results->combine('title', 'body', 'id');
+        $grouped = $results->all()->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -504,7 +506,7 @@ class TranslateBehaviorTest extends TestCase
             3 => ['Third Article' => 'Third Article Body'],
         ];
 
-        $grouped = $results->combine('title', 'body', 'id');
+        $grouped = $results->all()->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -564,7 +566,7 @@ class TranslateBehaviorTest extends TestCase
             3 => ['Titulek #3' => 'Obsah #3'],
         ];
 
-        $grouped = $results->combine('title', 'body', 'id');
+        $grouped = $results->all()->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -1231,7 +1233,7 @@ class TranslateBehaviorTest extends TestCase
         $query = $table->find()->where(['Comments.id' => 6]);
         $query2 = $table->find()->where(['Comments.id' => 5]);
         $query->union($query2);
-        $results = $query->sortBy('id', SORT_ASC)->toList();
+        $results = $query->all()->sortBy('id', SORT_ASC)->toList();
         $this->assertCount(2, $results);
 
         $this->assertSame('First Comment for Second Article', $results[0]->comment);

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -108,16 +108,16 @@ class TreeBehaviorTest extends TestCase
     public function testFindPath(): void
     {
         $nodes = $this->table->find('path', ['for' => 9]);
-        $this->assertEquals([1, 6, 9], $nodes->extract('id')->toArray());
+        $this->assertEquals([1, 6, 9], $nodes->all()->extract('id')->toArray());
 
         $nodes = $this->table->find('path', ['for' => 10]);
-        $this->assertSame([1, 6, 10], $nodes->extract('id')->toArray());
+        $this->assertSame([1, 6, 10], $nodes->all()->extract('id')->toArray());
 
         $nodes = $this->table->find('path', ['for' => 5]);
-        $this->assertSame([1, 2, 5], $nodes->extract('id')->toArray());
+        $this->assertSame([1, 2, 5], $nodes->all()->extract('id')->toArray());
 
         $nodes = $this->table->find('path', ['for' => 1]);
-        $this->assertSame([1], $nodes->extract('id')->toArray());
+        $this->assertSame([1], $nodes->all()->extract('id')->toArray());
 
         $entity = $this->table->newEntity(['name' => 'odd one', 'parent_id' => 1]);
         $entity = $this->table->save($entity);
@@ -128,13 +128,13 @@ class TreeBehaviorTest extends TestCase
         $this->table->save($entity);
 
         $nodes = $this->table->find('path', ['for' => 4]);
-        $this->assertSame([1, $newId, 2, 4], $nodes->extract('id')->toArray());
+        $this->assertSame([1, $newId, 2, 4], $nodes->all()->extract('id')->toArray());
 
         // find path with scope
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $nodes = $table->find('path', ['for' => 5]);
-        $this->assertSame([1, 3, 4, 5], $nodes->extract('id')->toArray());
+        $this->assertSame([1, 3, 4, 5], $nodes->all()->extract('id')->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -75,13 +75,13 @@ class BindingKeyTest extends TestCase
         $expected = array_combine($expected, $expected);
         $this->assertEquals(
             $expected,
-            $result->combine('username', 'auth_user.username')->toArray()
+            $result->all()->combine('username', 'auth_user.username')->toArray()
         );
 
         $expected = [1 => 1, 2 => 5, 3 => 2, 4 => 4];
         $this->assertEquals(
             $expected,
-            $result->combine('id', 'auth_user.id')->toArray()
+            $result->all()->combine('id', 'auth_user.id')->toArray()
         );
     }
 
@@ -128,7 +128,7 @@ class BindingKeyTest extends TestCase
             ->where(['username' => 'garrett']);
 
         $expected = [3, 4];
-        $result = $result->extract('site_authors.{*}.id')->toList();
+        $result = $result->all()->extract('site_authors.{*}.id')->toArray();
         $this->assertEquals($expected, $result);
     }
 }

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -51,7 +51,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
             'this text has been processed via a custom type',
             'this text also has been processed via a custom type',
         ];
-        $result = $table->find()->orderAsc('id')->extract('val')->toArray();
+        $result = $table->find()->orderAsc('id')->all()->extract('val')->toArray();
         $this->assertSame($expected, $result);
     }
 

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -701,7 +701,7 @@ class CompositeKeysTest extends TestCase
         ]);
 
         /** @var \Cake\Datasource\EntityInterface[] $authors */
-        $authors = $table->find()->toList();
+        $authors = $table->find()->toArray();
         $result = $table->loadInto($authors, ['SiteArticles']);
 
         foreach ($authors as $k => $v) {
@@ -709,7 +709,7 @@ class CompositeKeysTest extends TestCase
         }
 
         /** @var \Cake\Datasource\EntityInterface[] $expected */
-        $expected = $table->find('all', ['contain' => ['SiteArticles']])->toList();
+        $expected = $table->find('all', ['contain' => ['SiteArticles']])->toArray();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1034,6 +1034,7 @@ class QueryRegressionTest extends TestCase
             ->select(['Comments.id', 'Comments.user_id'])
             ->contain(['Users'])
             ->where(['Users.id' => 1])
+            ->all()
             ->combine('id', 'user_id');
 
         $this->assertEquals([3 => 1, 4 => 1, 5 => 1], $results->toArray());
@@ -1080,6 +1081,7 @@ class QueryRegressionTest extends TestCase
             ->matching('Comments', function ($q) {
                 return $q->where(['Comments.id' => 1]);
             })
+            ->all()
             ->extract('id')
             ->toList();
         $this->assertEquals([2], $results);
@@ -1132,20 +1134,6 @@ class QueryRegressionTest extends TestCase
             ->first()
             ->ratio;
         $this->assertSame(0.5, (float)$ratio);
-    }
-
-    /**
-     * Tests calling last on an empty table
-     *
-     * @see https://github.com/cakephp/cakephp/issues/6683
-     */
-    public function testFindLastOnEmptyTable(): void
-    {
-        $this->loadFixtures('Comments');
-        $table = $this->getTableLocator()->get('Comments');
-        $table->deleteAll(['1 = 1']);
-        $this->assertSame(0, $table->find()->count());
-        $this->assertNull($table->find()->last());
     }
 
     /**
@@ -1742,7 +1730,7 @@ class QueryRegressionTest extends TestCase
                 ];
             });
 
-        $results = $query->extract('value')->toArray();
+        $results = $query->all()->extract('value')->toArray();
         $this->assertEquals(['mariano', '1', 'mariano'], $results);
     }
 

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -402,10 +402,10 @@ class ResultSetTest extends TestCase
     {
         $query = $this->table->find('all');
 
-        $min = $query->min('id');
+        $min = $query->all()->min('id');
         $minExpected = $this->table->get(1);
 
-        $max = $query->max('id');
+        $max = $query->all()->max('id');
         $maxExpected = $this->table->get(3);
 
         $this->assertEquals($minExpected, $min);
@@ -422,8 +422,8 @@ class ResultSetTest extends TestCase
             'counter' => 'COUNT(*)',
         ])->group('author_id');
 
-        $min = $query->min('counter');
-        $max = $query->max('counter');
+        $min = $query->all()->min('counter');
+        $max = $query->all()->max('counter');
 
         $this->assertTrue($max > $min);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6282,7 +6282,7 @@ class TableTest extends TestCase
         $articles = $table->hasMany('Articles');
         $articles->belongsToMany('Tags');
 
-        $entities = $table->find()->compile();
+        $entities = $table->find()->all()->compile();
         $contain = ['SiteArticles', 'Articles.Tags'];
         $result = $table->loadInto($entities, $contain);
 
@@ -6290,7 +6290,7 @@ class TableTest extends TestCase
             $this->assertSame($v, $result[$k]);
         }
 
-        $expected = $table->find()->contain($contain)->toList();
+        $expected = $table->find()->contain($contain)->toArray();
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
This fixes every use of Collection methods on query instances in the tests.