### PR TITLE
cake 5: Remove deprecated cast() parameters

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -133,26 +133,13 @@ class FunctionsBuilder
      * is the default type name. Use `setReturnType()` to update it.
      *
      * @param \Cake\Database\ExpressionInterface|string $field Field or expression to cast.
-     * @param string $type The SQL data type
+     * @param string $dataType The SQL data type
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function cast($field, string $type = ''): FunctionExpression
+    public function cast($field, string $dataType): FunctionExpression
     {
-        if (is_array($field)) {
-            deprecationWarning(
-                'Build cast function by FunctionsBuilder::cast(array $args) is deprecated. ' .
-                'Use FunctionsBuilder::cast($field, string $type) instead.'
-            );
-
-            return new FunctionExpression('CAST', $field);
-        }
-
-        if (empty($type)) {
-            throw new InvalidArgumentException('The `$type` in a cast cannot be empty.');
-        }
-
         $expression = new FunctionExpression('CAST', $this->toLiteralParam($field));
-        $expression->setConjunction(' AS')->add([$type => 'literal']);
+        $expression->setConjunction(' AS')->add([$dataType => 'literal']);
 
         return $expression;
     }

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\FunctionsBuilder;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 
 /**
  * Tests FunctionsBuilder class
@@ -193,17 +192,6 @@ class FunctionsBuilderTest extends TestCase
         $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('CAST(NOW() AS varchar)', $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
-    }
-
-    /**
-     * Tests missing type in new CAST() wrapper throws exception.
-     *
-     * @return void
-     */
-    public function testInvalidCast()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->functions->cast('field');
     }
 
     /**


### PR DESCRIPTION
I didn't find a test for the deprecated parameters. 