### PR TITLE
cake 5: Remove only E_USER_DEPRECATED flag when hiding deprecations

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -210,7 +210,7 @@ abstract class TestCase extends BaseTestCase
     public function deprecated(callable $callable): void
     {
         $errorLevel = error_reporting();
-        error_reporting(E_ALL ^ E_USER_DEPRECATED);
+        error_reporting($errorLevel & ~E_USER_DEPRECATED);
         try {
             $callable();
         } finally {


### PR DESCRIPTION
I don't think we should reset to E_ALL inside a `deprecated()` wrapper.