### PR TITLE
Deprecate colon prefixed route template placeholders.

### DIFF
--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -85,7 +85,7 @@ class RoutesCommandTest extends TestCase
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',
-            '/app/articles/:action/*',
+            '/app/articles/{action}/*',
             '',
             '',
             'Articles',
@@ -94,7 +94,7 @@ class RoutesCommandTest extends TestCase
         ]);
         $this->assertOutputContainsRow([
             'bake._controller:_action',
-            '/bake/:controller/:action',
+            '/bake/{controller}/{action}',
             'Bake',
             '',
             '',
@@ -103,7 +103,7 @@ class RoutesCommandTest extends TestCase
         ]);
         $this->assertOutputContainsRow([
             'testName',
-            '/app/tests/:action/*',
+            '/app/tests/{action}/*',
             '',
             '',
             'Tests',
@@ -133,7 +133,7 @@ class RoutesCommandTest extends TestCase
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',
-            '/app/articles/:action/*',
+            '/app/articles/{action}/*',
             '',
             '',
             'Articles',

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -109,7 +109,7 @@ class AssetTest extends TestCase
      */
     public function testAssetUrl()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
 
         $result = Asset::url('js/post.js', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
@@ -273,7 +273,7 @@ class AssetTest extends TestCase
      */
     public function testScript()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
 
         $result = Asset::scriptUrl('post.js', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -32,7 +32,7 @@ class DashedRouteTest extends TestCase
      */
     public function testMatchBasic()
     {
-        $route = new DashedRoute('/:controller/:action/:id', ['plugin' => null]);
+        $route = new DashedRoute('/{controller}/{action}/{id}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', 'plugin' => null]);
         $this->assertNull($result);
 
@@ -59,7 +59,7 @@ class DashedRouteTest extends TestCase
         $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
-        $route = new DashedRoute('/blog/:action', ['controller' => 'Posts']);
+        $route = new DashedRoute('/blog/{action}', ['controller' => 'Posts']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView']);
         $this->assertSame('/blog/my-view', $result);
 
@@ -69,11 +69,11 @@ class DashedRouteTest extends TestCase
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', 1]);
         $this->assertNull($result);
 
-        $route = new DashedRoute('/foo/:controller/:action', ['action' => 'index']);
+        $route = new DashedRoute('/foo/{controller}/{action}', ['action' => 'index']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView']);
         $this->assertSame('/foo/posts/my-view', $result);
 
-        $route = new DashedRoute('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'myView']);
+        $route = new DashedRoute('/{plugin}/{id}/*', ['controller' => 'Posts', 'action' => 'myView']);
         $result = $route->match([
             'plugin' => 'TestPlugin',
             'controller' => 'Posts',
@@ -107,7 +107,7 @@ class DashedRouteTest extends TestCase
         ]);
         $this->assertNull($result);
 
-        $route = new DashedRoute('/admin/subscriptions/:action/*', [
+        $route = new DashedRoute('/admin/subscriptions/{action}/*', [
             'controller' => 'Subscribe', 'prefix' => 'Admin',
         ]);
         $result = $route->match([
@@ -119,7 +119,7 @@ class DashedRouteTest extends TestCase
         $expected = '/admin/subscriptions/edit-admin-e/1';
         $this->assertSame($expected, $result);
 
-        $route = new DashedRoute('/:controller/:action-:id');
+        $route = new DashedRoute('/{controller}/{action}-{id}');
         $result = $route->match([
             'controller' => 'MyPosts',
             'action' => 'myView',
@@ -127,7 +127,7 @@ class DashedRouteTest extends TestCase
         ]);
         $this->assertSame('/my-posts/my-view-1', $result);
 
-        $route = new DashedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
+        $route = new DashedRoute('/{controller}/{action}/{slug}-{id}', [], ['id' => Router::ID]);
         $result = $route->match([
             'controller' => 'MyPosts',
             'action' => 'myView',
@@ -144,21 +144,21 @@ class DashedRouteTest extends TestCase
      */
     public function testParse()
     {
-        $route = new DashedRoute('/:controller/:action/:id', [], ['id' => Router::ID]);
+        $route = new DashedRoute('/{controller}/{action}/{id}', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my-posts/my-view/1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
         $this->assertSame('myView', $result['action']);
         $this->assertSame('1', $result['id']);
 
-        $route = new DashedRoute('/:controller/:action-:id');
+        $route = new DashedRoute('/{controller}/{action}-{id}');
         $route->compile();
         $result = $route->parse('/my-posts/my-view-1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
         $this->assertSame('myView', $result['action']);
         $this->assertSame('1', $result['id']);
 
-        $route = new DashedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
+        $route = new DashedRoute('/{controller}/{action}/{slug}-{id}', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my-posts/my-view/the-slug-1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
@@ -167,7 +167,7 @@ class DashedRouteTest extends TestCase
         $this->assertSame('the-slug', $result['slug']);
 
         $route = new DashedRoute(
-            '/admin/:controller',
+            '/admin/{controller}',
             ['prefix' => 'Admin', 'action' => 'index']
         );
         $route->compile();
@@ -198,7 +198,7 @@ class DashedRouteTest extends TestCase
      */
     public function testMatchThenParse()
     {
-        $route = new DashedRoute('/plugin/:controller/:action', [
+        $route = new DashedRoute('/plugin/{controller}/{action}', [
             'plugin' => 'Vendor/PluginName',
         ]);
         $url = $route->match([

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -39,7 +39,7 @@ class EntityRouteTest extends TestCase
         ]);
 
         $route = new EntityRoute(
-            '/articles/:category_id/:slug',
+            '/articles/{category_id}/{slug}',
             [
                 '_name' => 'articlesView',
             ]
@@ -67,7 +67,7 @@ class EntityRouteTest extends TestCase
         ]);
 
         $route = new EntityRoute(
-            '/articles/:category_id/:slug',
+            '/articles/{category_id}/{slug}',
             [
                 '_name' => 'articlesView',
             ]
@@ -94,7 +94,7 @@ class EntityRouteTest extends TestCase
         ]);
 
         $route = new EntityRoute(
-            '/articles/:category_id_:slug',
+            '/articles/{category_id}_{slug}',
             [
                 '_name' => 'articlesView',
             ]
@@ -121,7 +121,7 @@ class EntityRouteTest extends TestCase
         ];
 
         $route = new EntityRoute(
-            '/articles/:category_id/:slug',
+            '/articles/{category_id}/{slug}',
             [
                 '_name' => 'articlesView',
                 '_entity' => $entity,

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -32,7 +32,7 @@ class InflectedRouteTest extends TestCase
      */
     public function testMatchBasic()
     {
-        $route = new InflectedRoute('/:controller/:action/:id', ['plugin' => null]);
+        $route = new InflectedRoute('/{controller}/{action}/{id}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view', 'plugin' => null]);
         $this->assertNull($result);
 
@@ -59,7 +59,7 @@ class InflectedRouteTest extends TestCase
         $result = $route->match(['controller' => 'Pages', 'action' => 'display', 'about']);
         $this->assertNull($result);
 
-        $route = new InflectedRoute('/blog/:action', ['controller' => 'Posts']);
+        $route = new InflectedRoute('/blog/{action}', ['controller' => 'Posts']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view']);
         $this->assertSame('/blog/my_view', $result);
 
@@ -69,11 +69,11 @@ class InflectedRouteTest extends TestCase
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view', 1]);
         $this->assertNull($result);
 
-        $route = new InflectedRoute('/foo/:controller/:action', ['action' => 'index']);
+        $route = new InflectedRoute('/foo/{controller}/{action}', ['action' => 'index']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view']);
         $this->assertSame('/foo/posts/my_view', $result);
 
-        $route = new InflectedRoute('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'my_view']);
+        $route = new InflectedRoute('/{plugin}/{id}/*', ['controller' => 'Posts', 'action' => 'my_view']);
         $result = $route->match([
             'plugin' => 'TestPlugin',
             'controller' => 'Posts',
@@ -107,7 +107,7 @@ class InflectedRouteTest extends TestCase
         ]);
         $this->assertNull($result);
 
-        $route = new InflectedRoute('/admin/subscriptions/:action/*', [
+        $route = new InflectedRoute('/admin/subscriptions/{action}/*', [
             'controller' => 'Subscribe', 'prefix' => 'Admin',
         ]);
         $result = $route->match([
@@ -119,7 +119,7 @@ class InflectedRouteTest extends TestCase
         $expected = '/admin/subscriptions/edit_admin_e/1';
         $this->assertSame($expected, $result);
 
-        $route = new InflectedRoute('/:controller/:action-:id');
+        $route = new InflectedRoute('/{controller}/{action}-{id}');
         $result = $route->match([
             'controller' => 'MyPosts',
             'action' => 'my_view',
@@ -127,7 +127,7 @@ class InflectedRouteTest extends TestCase
         ]);
         $this->assertSame('/my_posts/my_view-1', $result);
 
-        $route = new InflectedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
+        $route = new InflectedRoute('/{controller}/{action}/{slug}-{id}', [], ['id' => Router::ID]);
         $result = $route->match([
             'controller' => 'MyPosts',
             'action' => 'my_view',
@@ -144,21 +144,21 @@ class InflectedRouteTest extends TestCase
      */
     public function testParse()
     {
-        $route = new InflectedRoute('/:controller/:action/:id', [], ['id' => Router::ID]);
+        $route = new InflectedRoute('/{controller}/{action}/{id}', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my_posts/my_view/1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
         $this->assertSame('my_view', $result['action']);
         $this->assertSame('1', $result['id']);
 
-        $route = new InflectedRoute('/:controller/:action-:id');
+        $route = new InflectedRoute('/{controller}/{action}-{id}');
         $route->compile();
         $result = $route->parse('/my_posts/my_view-1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
         $this->assertSame('my_view', $result['action']);
         $this->assertSame('1', $result['id']);
 
-        $route = new InflectedRoute('/:controller/:action/:slug-:id', [], ['id' => Router::ID]);
+        $route = new InflectedRoute('/{controller}/{action}/{slug}-{id}', [], ['id' => Router::ID]);
         $route->compile();
         $result = $route->parse('/my_posts/my_view/the-slug-1', 'GET');
         $this->assertSame('MyPosts', $result['controller']);
@@ -167,7 +167,7 @@ class InflectedRouteTest extends TestCase
         $this->assertSame('the-slug', $result['slug']);
 
         $route = new InflectedRoute(
-            '/admin/:controller',
+            '/admin/{controller}',
             ['prefix' => 'Admin', 'action' => 'index']
         );
         $route->compile();
@@ -200,7 +200,7 @@ class InflectedRouteTest extends TestCase
      */
     public function testParseMethodMatch()
     {
-        $route = new InflectedRoute('/:controller/:action', ['_method' => 'POST']);
+        $route = new InflectedRoute('/{controller}/{action}', ['_method' => 'POST']);
         $this->assertNull($route->parse('/blog_posts/add_new', 'GET'));
 
         $result = $route->parse('/blog_posts/add_new', 'POST');
@@ -213,7 +213,7 @@ class InflectedRouteTest extends TestCase
      */
     public function testMatchThenParse()
     {
-        $route = new InflectedRoute('/plugin/:controller/:action', [
+        $route = new InflectedRoute('/plugin/{controller}/{action}', [
             'plugin' => 'Vendor/PluginName',
         ]);
         $url = $route->match([

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -45,7 +45,7 @@ class PluginShortRouteTest extends TestCase
      */
     public function testParsing()
     {
-        $route = new PluginShortRoute('/:plugin', ['action' => 'index'], ['plugin' => 'foo|bar']);
+        $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'foo|bar']);
 
         $result = $route->parse('/foo', 'GET');
         $this->assertSame('Foo', $result['plugin']);
@@ -63,7 +63,7 @@ class PluginShortRouteTest extends TestCase
      */
     public function testMatch()
     {
-        $route = new PluginShortRoute('/:plugin', ['action' => 'index'], ['plugin' => 'foo|bar']);
+        $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'foo|bar']);
 
         $result = $route->match(['plugin' => 'Foo', 'controller' => 'Posts', 'action' => 'index']);
         $this->assertNull($result, 'plugin controller mismatch was converted. %s');

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -37,8 +37,8 @@ class RedirectRouteTest extends TestCase
         parent::setUp();
         Router::reload();
 
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}', ['action' => 'index']);
+        Router::connect('/{controller}/{action}/*');
     }
 
     /**
@@ -192,7 +192,7 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add/passme');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'Tags', 'action' => 'add'], ['persist' => true]);
+        $route = new RedirectRoute('/my_controllers/{action}/*', ['controller' => 'Tags', 'action' => 'add'], ['persist' => true]);
         $route->parse('/my_controllers/do_something/passme');
     }
 
@@ -206,7 +206,7 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/my_controllers/:action/*', ['controller' => 'Tags', 'action' => 'add']);
+        $route = new RedirectRoute('/my_controllers/{action}/*', ['controller' => 'Tags', 'action' => 'add']);
         $route->parse('/my_controllers/do_something/passme');
     }
 
@@ -220,7 +220,7 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add');
         $this->expectExceptionCode(301);
-        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        $route = new RedirectRoute('/{lang}/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }
 
@@ -234,8 +234,8 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/nl/preferred_controllers');
         $this->expectExceptionCode(301);
-        Router::connect('/:lang/preferred_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
-        $route = new RedirectRoute('/:lang/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        Router::connect('/{lang}/preferred_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+        $route = new RedirectRoute('/{lang}/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }
 

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -68,13 +68,13 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/some/path');
         $this->assertSame('/some/path', $routes->path());
 
-        $routes = new RouteBuilder($this->collection, '/:book_id');
+        $routes = new RouteBuilder($this->collection, '/{book_id}');
         $this->assertSame('/', $routes->path());
 
-        $routes = new RouteBuilder($this->collection, '/path/:book_id');
+        $routes = new RouteBuilder($this->collection, '/path/{book_id}');
         $this->assertSame('/path/', $routes->path());
 
-        $routes = new RouteBuilder($this->collection, '/path/book:book_id');
+        $routes = new RouteBuilder($this->collection, '/path/book{book_id}');
         $this->assertSame('/path/book', $routes->path());
     }
 
@@ -97,8 +97,8 @@ class RouteBuilderTest extends TestCase
     public function testRoutes()
     {
         $routes = new RouteBuilder($this->collection, '/l');
-        $routes->connect('/:controller', ['action' => 'index']);
-        $routes->connect('/:controller/:action/*');
+        $routes->connect('/{controller}', ['action' => 'index']);
+        $routes->connect('/{controller}/{action}/*');
 
         $all = $this->collection->routes();
         $this->assertCount(2, $all);
@@ -119,8 +119,8 @@ class RouteBuilderTest extends TestCase
             [],
             ['routeClass' => 'InflectedRoute']
         );
-        $routes->connect('/:controller', ['action' => 'index']);
-        $routes->connect('/:controller/:action/*');
+        $routes->connect('/{controller}', ['action' => 'index']);
+        $routes->connect('/{controller}/{action}/*');
 
         $all = $this->collection->routes();
         $this->assertInstanceOf(InflectedRoute::class, $all[0]);
@@ -131,7 +131,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame($routes, $routes->setRouteClass('TestApp\Routing\Route\DashedRoute'));
         $this->assertSame('TestApp\Routing\Route\DashedRoute', $routes->getRouteClass());
 
-        $routes->connect('/:controller', ['action' => 'index']);
+        $routes->connect('/{controller}', ['action' => 'index']);
         $all = $this->collection->routes();
         $this->assertInstanceOf('TestApp\Routing\Route\DashedRoute', $all[0]);
     }
@@ -145,7 +145,7 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
-        $route = new Route('/:controller');
+        $route = new Route('/{controller}');
         $this->assertSame($route, $routes->connect($route));
 
         $result = $this->collection->routes()[0];
@@ -161,11 +161,11 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
-        $route = $routes->connect('/:controller');
+        $route = $routes->connect('/{controller}');
         $this->assertInstanceOf(Route::class, $route);
 
         $this->assertSame($route, $this->collection->routes()[0]);
-        $this->assertSame('/l/:controller', $route->template);
+        $this->assertSame('/l/{controller}', $route->template);
         $expected = ['prefix' => 'Api', 'action' => 'index', 'plugin' => null];
         $this->assertEquals($expected, $route->defaults);
     }
@@ -338,13 +338,13 @@ class RouteBuilderTest extends TestCase
         );
         $this->assertEquals(['json'], $routes->getExtensions());
 
-        $routes->connect('/:controller');
+        $routes->connect('/{controller}');
         $route = $this->collection->routes()[0];
 
         $this->assertEquals(['json'], $route->options['_ext']);
         $routes->setExtensions(['xml', 'json']);
 
-        $routes->connect('/:controller/:action');
+        $routes->connect('/{controller}/{action}');
         $new = $this->collection->routes()[1];
         $this->assertEquals(['json'], $route->options['_ext']);
         $this->assertEquals(['xml', 'json'], $new->options['_ext']);
@@ -400,7 +400,7 @@ class RouteBuilderTest extends TestCase
             [],
             ['extensions' => ['json']]
         );
-        $routes->connect('/:controller', [], ['routeClass' => '\stdClass']);
+        $routes->connect('/{controller}', [], ['routeClass' => '\stdClass']);
     }
 
     /**
@@ -424,7 +424,7 @@ class RouteBuilderTest extends TestCase
     public function testRedirect()
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->redirect('/p/:id', ['controller' => 'Posts', 'action' => 'view'], ['status' => 301]);
+        $routes->redirect('/p/{id}', ['controller' => 'Posts', 'action' => 'view'], ['status' => 301]);
         $route = $this->collection->routes()[0];
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
@@ -538,7 +538,7 @@ class RouteBuilderTest extends TestCase
             $this->assertSame('/b/contacts', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
 
-            $r->connect('/:controller');
+            $r->connect('/{controller}');
             $route = $this->collection->routes()[0];
             $this->assertEquals(
                 ['key' => 'value', 'plugin' => 'Contacts', 'action' => 'index'],
@@ -1207,14 +1207,14 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);
         $route = $routes->{strtolower($method)}(
-            '/bookmarks/:id',
+            '/bookmarks/{id}',
             ['controller' => 'Bookmarks', 'action' => 'view'],
             'route-name'
         );
         $this->assertInstanceOf(Route::class, $route, 'Should return a route');
         $this->assertSame($method, $route->defaults['_method']);
         $this->assertSame('app:route-name', $route->options['_name']);
-        $this->assertSame('/bookmarks/:id', $route->template);
+        $this->assertSame('/bookmarks/{id}', $route->template);
         $this->assertEquals(
             ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view', '_method' => $method],
             $route->defaults
@@ -1231,14 +1231,14 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);
         $route = $routes->{strtolower($method)}(
-            '/bookmarks/:id',
+            '/bookmarks/{id}',
             'Bookmarks::view',
             'route-name'
         );
         $this->assertInstanceOf(Route::class, $route, 'Should return a route');
         $this->assertSame($method, $route->defaults['_method']);
         $this->assertSame('app:route-name', $route->options['_name']);
-        $this->assertSame('/bookmarks/:id', $route->template);
+        $this->assertSame('/bookmarks/{id}', $route->template);
         $this->assertEquals(
             ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view', '_method' => $method],
             $route->defaults
@@ -1254,11 +1254,11 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->scope('/', function (RouteBuilder $routes) {
-            $routes->get('/faq/:page', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
+            $routes->get('/faq/{page}', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
                 ->setPatterns(['page' => '[a-z0-9_]+'])
                 ->setHost('docs.example.com');
 
-            $routes->post('/articles/:id', ['controller' => 'Articles', 'action' => 'update'], 'article:update')
+            $routes->post('/articles/{id}', ['controller' => 'Articles', 'action' => 'update'], 'article:update')
                 ->setPatterns(['id' => '[0-9]+'])
                 ->setPass(['id']);
         });

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -52,7 +52,7 @@ class RouteCollectionTest extends TestCase
         $this->expectExceptionMessage('A route matching "/" could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
 
         $result = $this->collection->parse('/');
         $this->assertEquals([], $result, 'Should not match, missing /b');
@@ -85,7 +85,7 @@ class RouteCollectionTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
         $result = $this->collection->parse('/b/');
@@ -108,7 +108,7 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             'key' => 'value',
             '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/:id',
+            '_matchedRoute' => '/b/{id}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -144,7 +144,7 @@ class RouteCollectionTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
         $result = $this->collection->parse('/b/');
@@ -167,7 +167,7 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             'key' => 'value',
             '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/:id',
+            '_matchedRoute' => '/b/{id}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -205,7 +205,7 @@ class RouteCollectionTest extends TestCase
     public function testParseEncodedBytesInFixedSegment()
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->connect('/ден/:day-:month', ['controller' => 'Events', 'action' => 'index']);
+        $routes->connect('/ден/{day}-{month}', ['controller' => 'Events', 'action' => 'index']);
         $url = '/%D0%B4%D0%B5%D0%BD/15-%D0%BE%D0%BA%D1%82%D0%BE%D0%BC%D0%B2%D1%80%D0%B8?test=foo';
         $result = $this->collection->parse($url);
         $expected = [
@@ -216,7 +216,7 @@ class RouteCollectionTest extends TestCase
             'day' => '15',
             'month' => 'октомври',
             '?' => ['test' => 'foo'],
-            '_matchedRoute' => '/ден/:day-:month',
+            '_matchedRoute' => '/ден/{day}-{month}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -235,8 +235,8 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/', []);
 
         $routes->resources('Articles');
-        $routes->connect('/:controller', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);
-        $routes->connect('/:controller/:action', [], ['routeClass' => 'InflectedRoute']);
+        $routes->connect('/{controller}', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);
+        $routes->connect('/{controller}/{action}', [], ['routeClass' => 'InflectedRoute']);
 
         $result = $this->collection->parse('/articles/add');
         $expected = [
@@ -244,7 +244,7 @@ class RouteCollectionTest extends TestCase
             'action' => 'add',
             'plugin' => null,
             'pass' => [],
-            '_matchedRoute' => '/:controller/:action',
+            '_matchedRoute' => '/{controller}/{action}',
 
         ];
         $this->assertEquals($expected, $result);
@@ -261,7 +261,7 @@ class RouteCollectionTest extends TestCase
         $this->expectExceptionMessage('A route matching "/" could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
 
         $request = new ServerRequest(['url' => '/']);
         $result = $this->collection->parseRequest($request);
@@ -369,7 +369,7 @@ class RouteCollectionTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
         $request = new ServerRequest(['url' => '/b/']);
@@ -418,7 +418,7 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             'key' => 'value',
             '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/:id',
+            '_matchedRoute' => '/b/{id}',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -483,7 +483,7 @@ class RouteCollectionTest extends TestCase
         ];
         $routes = new RouteBuilder($this->collection, '/b');
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
 
         $result = $this->collection->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'index'], $context);
         $this->assertSame('b', $result);
@@ -509,7 +509,7 @@ class RouteCollectionTest extends TestCase
         ];
         $routes = new RouteBuilder($this->collection, '/b');
         $routes->connect('/', ['controller' => 'Articles']);
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
 
         $result = $this->collection->match(['_name' => 'article:view', 'id' => '2'], $context);
         $this->assertSame('/b/2', $result);
@@ -533,7 +533,7 @@ class RouteCollectionTest extends TestCase
             '_host' => 'example.org',
         ];
         $routes = new RouteBuilder($this->collection, '/b');
-        $routes->connect('/:lang/articles', ['controller' => 'Articles'], ['_name' => 'fail']);
+        $routes->connect('/{lang}/articles', ['controller' => 'Articles'], ['_name' => 'fail']);
 
         $this->collection->match(['_name' => 'fail'], $context);
     }
@@ -552,7 +552,7 @@ class RouteCollectionTest extends TestCase
             '_host' => 'example.org',
         ];
         $routes = new RouteBuilder($this->collection, '/b');
-        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
+        $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
 
         $this->collection->match(['_name' => 'derp'], $context);
     }
@@ -592,7 +592,7 @@ class RouteCollectionTest extends TestCase
             '_host' => 'example.org',
         ];
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->connect('/:action/*', ['controller' => 'Users']);
+        $routes->connect('/{action}/*', ['controller' => 'Users']);
         $routes->connect('/admin/{controller}', ['prefix' => 'Admin', 'action' => 'index']);
 
         $url = [
@@ -621,13 +621,13 @@ class RouteCollectionTest extends TestCase
     public function testNamed()
     {
         $routes = new RouteBuilder($this->collection, '/l');
-        $routes->connect('/:controller', ['action' => 'index'], ['_name' => 'cntrl']);
-        $routes->connect('/:controller/:action/*');
+        $routes->connect('/{controller}', ['action' => 'index'], ['_name' => 'cntrl']);
+        $routes->connect('/{controller}/{action}/*');
 
         $all = $this->collection->named();
         $this->assertCount(1, $all);
         $this->assertInstanceOf('Cake\Routing\Route\Route', $all['cntrl']);
-        $this->assertSame('/l/:controller', $all['cntrl']->template);
+        $this->assertSame('/l/{controller}', $all['cntrl']->template);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -113,7 +113,7 @@ class RouterTest extends TestCase
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->get('/:controller', ['action' => 'index']);
+            $routes->get('/{controller}', ['action' => 'index']);
         });
 
         $out = Router::url([
@@ -180,7 +180,7 @@ class RouterTest extends TestCase
      */
     public function testRouteExists()
     {
-        Router::connect('/posts/:action', ['controller' => 'Posts']);
+        Router::connect('/posts/{action}', ['controller' => 'Posts']);
         $this->assertTrue(Router::routeExists(['controller' => 'Posts', 'action' => 'view']));
 
         $this->assertFalse(Router::routeExists(['action' => 'view', 'controller' => 'Users', 'plugin' => 'test']));
@@ -193,7 +193,7 @@ class RouterTest extends TestCase
      */
     public function testMultipleResourceRoute()
     {
-        Router::connect('/:controller', ['action' => 'index', '_method' => ['GET', 'POST']]);
+        Router::connect('/{controller}', ['action' => 'index', '_method' => ['GET', 'POST']]);
 
         $result = Router::parseRequest($this->makeRequest('/Posts', 'GET'));
         $expected = [
@@ -202,7 +202,7 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['GET', 'POST'],
-            '_matchedRoute' => '/:controller',
+            '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -213,7 +213,7 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             '_method' => ['GET', 'POST'],
-            '_matchedRoute' => '/:controller',
+            '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -280,7 +280,7 @@ class RouterTest extends TestCase
      */
     public function testUrlNormalization()
     {
-        Router::connect('/:controller/:action');
+        Router::connect('/{controller}/{action}');
 
         $expected = '/users/logout';
 
@@ -351,7 +351,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithBasePath()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',
@@ -465,7 +465,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:plugin/:id/*', ['controller' => 'Posts', 'action' => 'view'], ['id' => $ID]);
+        Router::connect('/{plugin}/{id}/*', ['controller' => 'Posts', 'action' => 'view'], ['id' => $ID]);
 
         $result = Router::url([
             'plugin' => 'CakePlugin',
@@ -487,14 +487,14 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller/:action/:id', [], ['id' => $ID]);
+        Router::connect('/{controller}/{action}/{id}', [], ['id' => $ID]);
 
         $result = Router::url(['controller' => 'Posts', 'action' => 'view', 'id' => '1']);
         $expected = '/Posts/view/1';
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller/:id', ['action' => 'view']);
+        Router::connect('/{controller}/{id}', ['action' => 'view']);
 
         $result = Router::url(['controller' => 'Posts', 'action' => 'view', 'id' => '1']);
         $expected = '/Posts/1';
@@ -506,7 +506,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller/:action');
+        Router::connect('/{controller}/{action}');
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',
@@ -521,7 +521,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/contact/:action', ['plugin' => 'Contact', 'controller' => 'Contact']);
+        Router::connect('/contact/{action}', ['plugin' => 'Contact', 'controller' => 'Contact']);
 
         $result = Router::url([
             'plugin' => 'Contact',
@@ -533,7 +533,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller', ['action' => 'index']);
+        Router::connect('/{controller}', ['action' => 'index']);
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',
@@ -555,8 +555,8 @@ class RouterTest extends TestCase
      */
     public function testRouteNameCasing()
     {
-        Router::connect('/articles/:id', ['controller' => 'Articles', 'action' => 'view']);
-        Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
+        Router::connect('/articles/{id}', ['controller' => 'Articles', 'action' => 'view']);
+        Router::connect('/{controller}/{action}/*', [], ['routeClass' => 'InflectedRoute']);
         $result = Router::url(['controller' => 'Articles', 'action' => 'view', 'id' => 10]);
         $expected = '/articles/10';
         $this->assertSame($expected, $result);
@@ -569,7 +569,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithQueryStrings()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
 
         $result = Router::url([
             'controller' => 'Posts',
@@ -603,19 +603,19 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithRegexQualifiedParams()
     {
         Router::connect(
-            ':language/galleries',
+            '{language}/galleries',
             ['controller' => 'Galleries', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
 
         Router::connect(
-            '/:language/:admin/:controller/:action/*',
+            '/{language}/{admin}/{controller}/{action}/*',
             ['admin' => 'admin'],
             ['language' => '[a-z]{3}', 'admin' => 'admin']
         );
 
         Router::connect(
-            '/:language/:controller/:action/*',
+            '/{language}/{controller}/{action}/*',
             [],
             ['language' => '[a-z]{3}']
         );
@@ -630,11 +630,11 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/:language/pages',
+            '/{language}/pages',
             ['controller' => 'Pages', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
-        Router::connect('/:language/:controller/:action/*', [], ['language' => '[a-z]{3}']);
+        Router::connect('/{language}/{controller}/{action}/*', [], ['language' => '[a-z]{3}']);
 
         $result = Router::url(['language' => 'eng', 'action' => 'index', 'controller' => 'Pages']);
         $expected = '/eng/pages';
@@ -649,7 +649,7 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/forestillinger/:month/:year/*',
+            '/forestillinger/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
@@ -667,7 +667,7 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/kalender/:month/:year/*',
+            '/kalender/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
@@ -701,7 +701,7 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
         Router::connect('/reset/*', ['admin' => true, 'controller' => 'Users', 'action' => 'reset']);
         Router::connect('/tests', ['controller' => 'Tests', 'action' => 'index']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
         Router::extensions('rss', false);
 
         $request = new ServerRequest([
@@ -721,8 +721,8 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/subscriptions/:action/*', ['controller' => 'Subscribe', 'prefix' => 'Admin']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/subscriptions/{action}/*', ['controller' => 'Subscribe', 'prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
@@ -765,7 +765,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
@@ -784,7 +784,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
@@ -802,7 +802,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/:id', ['prefix' => 'Admin'], ['id' => '[0-9]+']);
+        Router::connect('/admin/{controller}/{action}/{id}', ['prefix' => 'Admin'], ['id' => '[0-9]+']);
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
@@ -820,7 +820,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
@@ -835,7 +835,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
 
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'params' => [
@@ -916,8 +916,8 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithExtensions()
     {
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action');
+        Router::connect('/{controller}', ['action' => 'index']);
+        Router::connect('/{controller}/{action}');
 
         $result = Router::url([
             'plugin' => null,
@@ -1004,7 +1004,7 @@ class RouterTest extends TestCase
             ['_name' => 'users-index']
         );
         Router::connect(
-            '/users/:name',
+            '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
@@ -1045,7 +1045,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
-            '/users/:name',
+            '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
@@ -1061,17 +1061,17 @@ class RouterTest extends TestCase
     {
         $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
         Router::connect(
-            '/users/:name',
+            '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
         Router::connect(
-            '/users/:name',
+            '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'otherName']
         );
         Router::connect(
-            '/users/:name',
+            '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
             ['_name' => 'test']
         );
@@ -1084,7 +1084,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithUrlFilter()
     {
-        Router::connect('/:lang/:controller/:action/*');
+        Router::connect('/{lang}/{controller}/{action}/*');
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
@@ -1125,7 +1125,7 @@ class RouterTest extends TestCase
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: nope/'
         );
-        Router::connect('/:lang/:controller/:action/*');
+        Router::connect('/{lang}/{controller}/{action}/*');
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
@@ -1154,7 +1154,7 @@ class RouterTest extends TestCase
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: /'
         );
-        Router::connect('/:lang/:controller/:action/*');
+        Router::connect('/{lang}/{controller}/{action}/*');
         $request = new ServerRequest([
             'params' => [
                 'plugin' => null,
@@ -1186,7 +1186,7 @@ class RouterTest extends TestCase
      */
     public function testUrlParamPersistence()
     {
-        Router::connect('/:lang/:controller/:action/*', [], ['persist' => ['lang']]);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['persist' => ['lang']]);
         $request = new ServerRequest([
             'url' => '/en/posts/index',
             'params' => [
@@ -1229,8 +1229,8 @@ class RouterTest extends TestCase
      */
     public function testCanLeavePlugin()
     {
-        Router::connect('/admin/:controller', ['action' => 'index', 'prefix' => 'Admin']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}', ['action' => 'index', 'prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
         $request = new ServerRequest([
             'url' => '/admin/this/interesting/index',
             'params' => [
@@ -1263,7 +1263,7 @@ class RouterTest extends TestCase
         extract(Router::getNamedExpressions());
 
         Router::connect(
-            '/posts/:value/:somevalue/:othervalue/*',
+            '/posts/{value}/{somevalue}/{othervalue}/*',
             ['controller' => 'Posts', 'action' => 'view'],
             ['value', 'somevalue', 'othervalue']
         );
@@ -1276,13 +1276,13 @@ class RouterTest extends TestCase
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
-            '_matchedRoute' => '/posts/:value/:somevalue/:othervalue/*',
+            '_matchedRoute' => '/posts/{value}/{somevalue}/{othervalue}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/posts/:year/:month/:day/*',
+            '/posts/{year}/{month}/{day}/*',
             ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
@@ -1295,13 +1295,13 @@ class RouterTest extends TestCase
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
-            '_matchedRoute' => '/posts/:year/:month/:day/*',
+            '_matchedRoute' => '/posts/{year}/{month}/{day}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/posts/:day/:year/:month/*',
+            '/posts/{day}/{year}/{month}/*',
             ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
@@ -1314,13 +1314,13 @@ class RouterTest extends TestCase
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
-            '_matchedRoute' => '/posts/:day/:year/:month/*',
+            '_matchedRoute' => '/posts/{day}/{year}/{month}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/posts/:month/:day/:year/*',
+            '/posts/{month}/{day}/{year}/*',
             ['controller' => 'Posts', 'action' => 'view'],
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
@@ -1333,13 +1333,13 @@ class RouterTest extends TestCase
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
-            '_matchedRoute' => '/posts/:month/:day/:year/*',
+            '_matchedRoute' => '/posts/{month}/{day}/{year}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/posts/:year/:month/:day/*',
+            '/posts/{year}/{month}/{day}/*',
             ['controller' => 'Posts', 'action' => 'view']
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
@@ -1351,7 +1351,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'plugin' => null,
             'pass' => ['0' => 'title-of-post-here'],
-            '_matchedRoute' => '/posts/:year/:month/:day/*',
+            '_matchedRoute' => '/posts/{year}/{month}/{day}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1387,7 +1387,7 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/:language/contact',
+            '/{language}/contact',
             ['language' => 'eng', 'plugin' => 'Contact', 'controller' => 'Contact', 'action' => 'index'],
             ['language' => '[a-z]{3}']
         );
@@ -1398,13 +1398,13 @@ class RouterTest extends TestCase
             'plugin' => 'Contact',
             'controller' => 'Contact',
             'action' => 'index',
-            '_matchedRoute' => '/:language/contact',
+            '_matchedRoute' => '/{language}/contact',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/forestillinger/:month/:year/*',
+            '/forestillinger/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
             ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
         );
@@ -1417,12 +1417,12 @@ class RouterTest extends TestCase
             'action' => 'calendar',
             'year' => 2007,
             'month' => 10,
-            '_matchedRoute' => '/forestillinger/:month/:year/*',
+            '_matchedRoute' => '/forestillinger/{month}/{year}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         Router::connect('/', ['plugin' => 'pages', 'controller' => 'Pages', 'action' => 'display']);
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
         $expected = [
@@ -1440,13 +1440,13 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'edit',
             'plugin' => null,
-            '_matchedRoute' => '/:controller/:action/*',
+            '_matchedRoute' => '/{controller}/{action}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/Posts/:id::url_title',
+            '/Posts/{id}:{url_title}',
             ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
@@ -1458,13 +1458,13 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Posts',
             'action' => 'view',
-            '_matchedRoute' => '/Posts/:id::url_title',
+            '_matchedRoute' => '/Posts/{id}:{url_title}',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/Posts/:id::url_title/*',
+            '/Posts/{id}:{url_title}/*',
             ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
@@ -1476,7 +1476,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Posts',
             'action' => 'view',
-            '_matchedRoute' => '/Posts/:id::url_title/*',
+            '_matchedRoute' => '/Posts/{id}:{url_title}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1495,7 +1495,7 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::connect(
-            '/posts/:url_title-(uuid::id)',
+            '/posts/{url_title}-(uuid:{id})',
             ['controller' => 'Posts', 'action' => 'view'],
             ['pass' => ['id', 'url_title'], 'id' => $UUID]
         );
@@ -1507,7 +1507,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Posts',
             'action' => 'view',
-            '_matchedRoute' => '/posts/:url_title-(uuid::id)',
+            '_matchedRoute' => '/posts/{url_title}-(uuid:{id})',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1531,7 +1531,7 @@ class RouterTest extends TestCase
      */
     public function testParseRequest()
     {
-        Router::connect('/articles/:action/*', ['controller' => 'Articles']);
+        Router::connect('/articles/{action}/*', ['controller' => 'Articles']);
         $request = new ServerRequest(['url' => '/articles/view/1']);
         $result = Router::parseRequest($request);
         $expected = [
@@ -1539,7 +1539,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Articles',
             'action' => 'view',
-            '_matchedRoute' => '/articles/:action/*',
+            '_matchedRoute' => '/articles/{action}/*',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1552,7 +1552,7 @@ class RouterTest extends TestCase
     public function testUuidRoutes()
     {
         Router::connect(
-            '/subjects/add/:category_id',
+            '/subjects/add/{category_id}',
             ['controller' => 'Subjects', 'action' => 'add'],
             ['category_id' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}']
         );
@@ -1563,7 +1563,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Subjects',
             'action' => 'add',
-            '_matchedRoute' => '/subjects/add/:category_id',
+            '_matchedRoute' => '/subjects/add/{category_id}',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1576,7 +1576,7 @@ class RouterTest extends TestCase
     public function testRouteSymmetry()
     {
         Router::connect(
-            '/:extra/page/:slug/*',
+            '/{extra}/page/{slug}/*',
             ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
             ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view']
         );
@@ -1589,7 +1589,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => 'some_extra',
-            '_matchedRoute' => '/:extra/page/:slug/*',
+            '_matchedRoute' => '/{extra}/page/{slug}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1601,13 +1601,13 @@ class RouterTest extends TestCase
             'action' => 'view',
             'slug' => 'this_is_the_slug',
             'extra' => null,
-            '_matchedRoute' => '/:extra/page/:slug/*',
+            '_matchedRoute' => '/{extra}/page/{slug}/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect(
-            '/:extra/page/:slug/*',
+            '/{extra}/page/{slug}/*',
             ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
             ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+']
         );
@@ -1856,9 +1856,9 @@ class RouterTest extends TestCase
     public function testUrlGenerationWithAutoPrefixes()
     {
         Router::reload();
-        Router::connect('/protected/:controller/:action/*', ['prefix' => 'Protected']);
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/protected/{controller}/{action}/*', ['prefix' => 'Protected']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
+        Router::connect('/{controller}/{action}/*');
 
         $request = new ServerRequest([
             'url' => '/images/index',
@@ -1914,7 +1914,7 @@ class RouterTest extends TestCase
     public function testGenerationWithSslOption()
     {
         Router::fullBaseUrl('http://app.test');
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
             'url' => '/images/index',
             'params' => [
@@ -1942,7 +1942,7 @@ class RouterTest extends TestCase
      */
     public function testGenerateWithSslInSsl()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
             'url' => '/images/index',
             'environment' => ['HTTP_HOST' => 'app.test', 'HTTPS' => 'on'],
@@ -1973,8 +1973,8 @@ class RouterTest extends TestCase
     public function testPrefixRoutePersistence()
     {
         Router::reload();
-        Router::connect('/protected/:controller/:action', ['prefix' => 'Protected']);
-        Router::connect('/:controller/:action');
+        Router::connect('/protected/{controller}/{action}', ['prefix' => 'Protected']);
+        Router::connect('/{controller}/{action}');
 
         $request = new ServerRequest([
             'url' => '/protected/images/index',
@@ -2007,8 +2007,8 @@ class RouterTest extends TestCase
      */
     public function testPrefixOverride()
     {
-        Router::connect('/admin/:controller/:action', ['prefix' => 'Admin']);
-        Router::connect('/protected/:controller/:action', ['prefix' => 'Protected']);
+        Router::connect('/admin/{controller}/{action}', ['prefix' => 'Admin']);
+        Router::connect('/protected/{controller}/{action}', ['prefix' => 'Protected']);
 
         $request = new ServerRequest([
             'url' => '/protected/images/index',
@@ -2069,7 +2069,7 @@ class RouterTest extends TestCase
      */
     public function testRemoveBase()
     {
-        Router::connect('/:controller/:action');
+        Router::connect('/{controller}/{action}');
         $request = new ServerRequest([
             'url' => '/',
             'base' => '/base',
@@ -2154,7 +2154,7 @@ class RouterTest extends TestCase
     public function testParsingWithTrailingPeriod()
     {
         Router::reload();
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $result = Router::parseRequest($this->makeRequest('/posts/view/something.', 'GET'));
         $this->assertSame('something.', $result['pass'][0], 'Period was chopped off');
 
@@ -2170,7 +2170,7 @@ class RouterTest extends TestCase
     public function testParsingWithTrailingPeriodAndParseExtensions()
     {
         Router::reload();
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/something.', 'GET'));
         $this->assertSame('something.', $result['pass'][0], 'Period was chopped off');
@@ -2180,7 +2180,7 @@ class RouterTest extends TestCase
     }
 
     /**
-     * test that patterns work for :action
+     * test that patterns work for {action}
      *
      * @return void
      */
@@ -2188,7 +2188,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
-            '/blog/:action/*',
+            '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
@@ -2199,7 +2199,7 @@ class RouterTest extends TestCase
             'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
-            '_matchedRoute' => '/blog/:action/*',
+            '_matchedRoute' => '/blog/{action}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -2319,7 +2319,7 @@ class RouterTest extends TestCase
     }
 
     /**
-     * Test url() works with patterns on :action
+     * Test url() works with patterns on {action}
      *
      * @return void
      */
@@ -2327,7 +2327,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
-            '/blog/:action/*',
+            '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
@@ -2348,8 +2348,8 @@ class RouterTest extends TestCase
     {
         Router::reload();
         $adminParams = ['prefix' => 'Admin'];
-        Router::connect('/admin/:controller', $adminParams);
-        Router::connect('/admin/:controller/:action/*', $adminParams);
+        Router::connect('/admin/{controller}', $adminParams);
+        Router::connect('/admin/{controller}/{action}/*', $adminParams);
 
         $request = new ServerRequest([
             'url' => '/',
@@ -2365,7 +2365,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Posts',
             'action' => 'index',
-            '_matchedRoute' => '/admin/:controller',
+            '_matchedRoute' => '/admin/{controller}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -2379,9 +2379,9 @@ class RouterTest extends TestCase
         Router::reload();
 
         $prefixParams = ['prefix' => 'Members'];
-        Router::connect('/members/:controller', $prefixParams);
-        Router::connect('/members/:controller/:action', $prefixParams);
-        Router::connect('/members/:controller/:action/*', $prefixParams);
+        Router::connect('/members/{controller}', $prefixParams);
+        Router::connect('/members/{controller}/{action}', $prefixParams);
+        Router::connect('/members/{controller}/{action}/*', $prefixParams);
 
         $request = new ServerRequest([
             'url' => '/',
@@ -2397,7 +2397,7 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'Posts',
             'action' => 'index',
-            '_matchedRoute' => '/members/:controller/:action',
+            '_matchedRoute' => '/members/{controller}/{action}',
         ];
         $this->assertEquals($expected, $result);
 
@@ -2413,8 +2413,8 @@ class RouterTest extends TestCase
      */
     public function testUrlWritingWithPrefixes()
     {
-        Router::connect('/company/:controller/:action/*', ['prefix' => 'Company']);
-        Router::connect('/:action', ['controller' => 'Users']);
+        Router::connect('/company/{controller}/{action}/*', ['prefix' => 'Company']);
+        Router::connect('/{action}', ['controller' => 'Users']);
 
         $result = Router::url(['controller' => 'Users', 'action' => 'login', 'prefix' => 'Company']);
         $expected = '/company/Users/login';
@@ -2496,7 +2496,7 @@ class RouterTest extends TestCase
      */
     public function testRegexRouteMatching()
     {
-        Router::connect('/:locale/:controller/:action/*', [], ['locale' => 'dan|eng']);
+        Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
 
         $result = Router::parseRequest($this->makeRequest('/eng/Test/testAction', 'GET'));
         $expected = [
@@ -2505,7 +2505,7 @@ class RouterTest extends TestCase
             'controller' => 'Test',
             'action' => 'testAction',
             'plugin' => null,
-            '_matchedRoute' => '/:locale/:controller/:action/*',
+            '_matchedRoute' => '/{locale}/{controller}/{action}/*',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -2518,7 +2518,7 @@ class RouterTest extends TestCase
     public function testRegexRouteMatchUrl()
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
-        Router::connect('/:locale/:controller/:action/*', [], ['locale' => 'dan|eng']);
+        Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
 
         $request = new ServerRequest([
             'url' => '/test/test_action',
@@ -2549,7 +2549,7 @@ class RouterTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         Router::connect(
-            '/:slug',
+            '/{slug}',
             ['plugin' => 'TestPlugin', 'action' => 'index'],
             ['routeClass' => 'PluginShortRoute', 'slug' => '[a-z_-]+']
         );
@@ -2560,7 +2560,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             'slug' => 'the-best',
             'pass' => [],
-            '_matchedRoute' => '/:slug',
+            '_matchedRoute' => '/{slug}',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -2574,7 +2574,7 @@ class RouterTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
         Router::connect(
-            '/:slug',
+            '/{slug}',
             ['controller' => 'Posts', 'action' => 'view'],
             ['routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+']
         );
@@ -2590,13 +2590,13 @@ class RouterTest extends TestCase
     public function testCustomRouteException()
     {
         $this->expectException(\InvalidArgumentException::class);
-        Router::connect('/:controller', [], ['routeClass' => 'Object']);
+        Router::connect('/{controller}', [], ['routeClass' => 'Object']);
     }
 
     public function testReverseLocalized()
     {
         Router::reload();
-        Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
             'controller' => 'Posts',
@@ -2610,7 +2610,7 @@ class RouterTest extends TestCase
 
     public function testReverseArrayQuery()
     {
-        Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
             'controller' => 'Posts',
@@ -2635,7 +2635,7 @@ class RouterTest extends TestCase
 
     public function testReverseCakeRequestQuery()
     {
-        Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $request = new ServerRequest([
             'url' => '/eng/posts/view/1',
             'params' => [
@@ -2674,7 +2674,7 @@ class RouterTest extends TestCase
      */
     public function testReverseWithExtension()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         Router::extensions('json', false);
 
         $request = new ServerRequest([
@@ -2693,7 +2693,7 @@ class RouterTest extends TestCase
 
     public function testReverseToArrayQuery()
     {
-        Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $params = [
             'lang' => 'eng',
             'controller' => 'Posts',
@@ -2714,7 +2714,7 @@ class RouterTest extends TestCase
 
     public function testReverseToArrayRequestQuery()
     {
-        Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);
+        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $request = new ServerRequest([
             'url' => '/eng/posts/view/1',
             'params' => [
@@ -2765,7 +2765,7 @@ class RouterTest extends TestCase
 
         $route = $this->getMockBuilder('Cake\Routing\Route\Route')
             ->onlyMethods(['match'])
-            ->setConstructorArgs(['/:controller/:action/*'])
+            ->setConstructorArgs(['/{controller}/{action}/*'])
             ->getMock();
         $route->expects($this->any())
             ->method('match')
@@ -2819,14 +2819,14 @@ class RouterTest extends TestCase
     }
 
     /**
-     * Testing that patterns on the :action param work properly.
+     * Testing that patterns on the {action} param work properly.
      *
      * @return void
      */
     public function testPatternOnAction()
     {
         $route = new Route(
-            '/blog/:action/*',
+            '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
             ['action' => 'other|actions']
         );
@@ -2841,7 +2841,7 @@ class RouterTest extends TestCase
             'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
-            '_matchedRoute' => '/blog/:action/*',
+            '_matchedRoute' => '/blog/{action}/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -3018,7 +3018,7 @@ class RouterTest extends TestCase
      */
     public function testDefaultRouteClass()
     {
-        Router::connect('/:controller', ['action' => 'index']);
+        Router::connect('/{controller}', ['action' => 'index']);
         $result = Router::url(['controller' => 'FooBar', 'action' => 'index']);
         $this->assertSame('/FooBar', $result);
 
@@ -3026,7 +3026,7 @@ class RouterTest extends TestCase
         static::setAppNamespace();
 
         Router::defaultRouteClass('DashedRoute');
-        Router::connect('/cake/:controller', ['action' => 'cake']);
+        Router::connect('/cake/{controller}', ['action' => 'cake']);
         $result = Router::url(['controller' => 'FooBar', 'action' => 'cake']);
         $this->assertSame('/cake/foo-bar', $result);
 
@@ -3050,7 +3050,7 @@ class RouterTest extends TestCase
      */
     public function testSetRequestContextCakePHP()
     {
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
             'base' => '/subdir',
             'url' => 'articles/view/1',
@@ -3082,7 +3082,7 @@ class RouterTest extends TestCase
             'SERVER_PORT' => 80,
         ];
 
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
         $request = ServerRequestFactory::fromGlobals($server);
         Router::setRequest($request);
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -67,20 +67,20 @@ class IntegrationTestTraitTest extends TestCase
             $routes->applyMiddleware('cookie');
 
             $routes->setRouteClass(InflectedRoute::class);
-            $routes->get('/get/:controller/:action', []);
-            $routes->head('/head/:controller/:action', []);
-            $routes->options('/options/:controller/:action', []);
-            $routes->connect('/:controller/:action/*', []);
+            $routes->get('/get/{controller}/{action}', []);
+            $routes->head('/head/{controller}/{action}', []);
+            $routes->options('/options/{controller}/{action}', []);
+            $routes->connect('/{controller}/{action}/*', []);
         });
         Router::scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes) {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware());
             $routes->applyMiddleware('cookieCsrf');
-            $routes->connect('/posts/:action', ['controller' => 'Posts']);
+            $routes->connect('/posts/{action}', ['controller' => 'Posts']);
         });
         Router::scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes) {
             $routes->registerMiddleware('sessionCsrf', new SessionCsrfProtectionMiddleware());
             $routes->applyMiddleware('sessionCsrf');
-            $routes->connect('/posts/:action/', ['controller' => 'Posts']);
+            $routes->connect('/posts/{action}/', ['controller' => 'Posts']);
         });
 
         $this->configApplication(Configure::read('App.namespace') . '\Application', null);
@@ -1065,7 +1065,7 @@ class IntegrationTestTraitTest extends TestCase
                 ]
             ));
             $routes->applyMiddleware('cookieCsrf');
-            $routes->connect('/posts/:action', ['controller' => 'Posts']);
+            $routes->connect('/posts/{action}', ['controller' => 'Posts']);
         });
         $this->enableCsrfToken('customCsrfToken');
         $data = [
@@ -1090,7 +1090,7 @@ class IntegrationTestTraitTest extends TestCase
                 ]
             ));
             $routes->applyMiddleware('cookieCsrf');
-            $routes->connect('/posts/:action', ['controller' => 'Posts']);
+            $routes->connect('/posts/{action}', ['controller' => 'Posts']);
         });
         $this->enableCsrfToken('customCsrfToken');
         $data = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -129,8 +129,8 @@ class FormHelperTest extends TestCase
         ];
 
         Security::setSalt('foo!');
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}', ['action' => 'index']);
+        Router::connect('/{controller}/{action}/*');
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -111,8 +111,8 @@ class HtmlHelperTest extends TestCase
     public function testLink()
     {
         Router::reload();
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/{controller}', ['action' => 'index']);
+        Router::connect('/{controller}/{action}/*');
         Router::setRequest(new ServerRequest());
 
         $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', ''));

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -80,8 +80,8 @@ class PaginatorHelperTest extends TestCase
 
         Router::reload();
         Router::connect('/', ['controller' => 'Articles', 'action' => 'index']);
-        Router::connect('/:controller/:action/*');
-        Router::connect('/:plugin/:controller/:action/*');
+        Router::connect('/{controller}/{action}/*');
+        Router::connect('/{plugin}/{controller}/{action}/*');
         Router::setRequest($request);
 
         $this->locale = I18n::getLocale();
@@ -763,7 +763,7 @@ class PaginatorHelperTest extends TestCase
     public function testSortAdminLinks()
     {
         Router::reload();
-        Router::connect('/admin/:controller/:action/*', ['prefix' => 'Admin']);
+        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'url' => '/admin/users',
@@ -967,8 +967,8 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixes()
     {
         Router::reload();
-        Router::connect('/members/:controller/:action/*', ['prefix' => 'Members']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
+        Router::connect('/{controller}/{action}/*');
 
         $request = new ServerRequest([
             'url' => '/Posts/index',
@@ -1044,8 +1044,8 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixesLeavePrefix()
     {
         Router::reload();
-        Router::connect('/members/:controller/:action/*', ['prefix' => 'Members']);
-        Router::connect('/:controller/:action/*');
+        Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
+        Router::connect('/{controller}/{action}/*');
 
         $request = new ServerRequest([
             'params' => [
@@ -1883,7 +1883,7 @@ class PaginatorHelperTest extends TestCase
     public function testRoutePlaceholder()
     {
         Router::reload();
-        Router::connect('/:controller/:action/:page');
+        Router::connect('/{controller}/{action}/{page}');
         $request = $this->View
             ->getRequest()
             ->withAttribute('params', [
@@ -1921,7 +1921,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         Router::reload();
-        Router::connect('/:controller/:action/:sort/:direction');
+        Router::connect('/{controller}/{action}/{sort}/{direction}');
         Router::setRequest($request);
 
         $this->Paginator->options(['routePlaceholders' => ['sort', 'direction']]);

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -87,10 +87,10 @@ class Application extends BaseApplication
     {
         $routes->scope('/app', function (RouteBuilder $routes) {
             $routes->connect('/articles', ['controller' => 'Articles']);
-            $routes->connect('/articles/:action/*', ['controller' => 'Articles']);
+            $routes->connect('/articles/{action}/*', ['controller' => 'Articles']);
 
             try {
-                $routes->connect('/tests/:action/*', ['controller' => 'Tests'], ['_name' => 'testName']);
+                $routes->connect('/tests/{action}/*', ['controller' => 'Tests'], ['_name' => 'testName']);
             } catch (DuplicateNamedRouteException $e) {
                 // do nothing. This happens when one test does multiple requests.
             }
@@ -98,7 +98,7 @@ class Application extends BaseApplication
             $routes->fallbacks();
         });
         $routes->connect('/posts', ['controller' => 'Posts', 'action' => 'index']);
-        $routes->connect('/bake/:controller/:action', ['plugin' => 'Bake']);
+        $routes->connect('/bake/{controller}/{action}', ['plugin' => 'Bake']);
     }
 
     /**


### PR DESCRIPTION
Braced placeholders should be used instead.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
