### PR TITLE
Deprecate DoublePassDecoratorMiddleware.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -140,6 +140,12 @@
       <code>$this-&gt;headers</code>
     </PropertyTypeCoercion>
   </file>
+  <file src="src/Http/MiddlewareQueue.php">
+    <DeprecatedClass occurrences="2">
+      <code>new DoublePassDecoratorMiddleware($middleware)</code>
+      <code>new DoublePassDecoratorMiddleware($middleware)</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Http/ServerRequest.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;data</code>

--- a/src/Http/Middleware/DoublePassDecoratorMiddleware.php
+++ b/src/Http/Middleware/DoublePassDecoratorMiddleware.php
@@ -38,6 +38,9 @@ use Psr\Http\Server\RequestHandlerInterface;
  * or a class with `__invoke()` method with same signature as above.
  *
  * Neither the arguments nor the return value need be typehinted.
+ *
+ * @deprecated 4.3.0 "Double pass" middleware are deprecated.
+ *   Use a `Closure` or a class which implements `Psr\Http\Server\MiddlewareInterface` instead.
  */
 class DoublePassDecoratorMiddleware implements MiddlewareInterface
 {
@@ -55,6 +58,10 @@ class DoublePassDecoratorMiddleware implements MiddlewareInterface
      */
     public function __construct(callable $callable)
     {
+        deprecationWarning(
+            '"Double pass" middleware are deprecated. Use a `Closure` with the signature of'
+            . ' `($request, $handler)` or a class which implements `Psr\Http\Server\MiddlewareInterface` instead.'
+        );
         $this->callable = $callable;
     }
 

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -39,13 +39,13 @@ class RunnerTest extends TestCase
 
         $this->queue = new MiddlewareQueue();
 
-        $this->ok = function ($req, $res, $next) {
-            return $next($req, $res);
+        $this->ok = function ($request, $handler) {
+            return $handler->handle($request);
         };
-        $this->pass = function ($req, $res, $next) {
-            return $next($req, $res);
+        $this->pass = function ($request, $handler) {
+            return $handler->handle($request);
         };
-        $this->fail = function ($req, $res, $next) {
+        $this->fail = function ($request, $handler) {
             throw new RuntimeException('A bad thing');
         };
     }
@@ -73,20 +73,20 @@ class RunnerTest extends TestCase
     public function testRunSequencing()
     {
         $log = [];
-        $one = function ($req, $handler) use (&$log) {
+        $one = function ($request, $handler) use (&$log) {
             $log[] = 'one';
 
-            return $handler->handle($req);
+            return $handler->handle($request);
         };
-        $two = function ($req, $res, $next) use (&$log) {
+        $two = function ($request, $handler) use (&$log) {
             $log[] = 'two';
 
-            return $next($req, $res);
+            return $handler->handle($request);
         };
-        $three = function ($req, $res, $next) use (&$log) {
+        $three = function ($request, $handler) use (&$log) {
             $log[] = 'three';
 
-            return $next($req, $res);
+            return $handler->handle($request);
         };
         $this->queue->add($one)->add($two)->add($three);
         $runner = new Runner();

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -304,10 +304,10 @@ class ServerTest extends TestCase
         $called = false;
 
         $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) use (&$called) {
-            $middlewareQueue->add(function ($req, $res, $next) use (&$called) {
+            $middlewareQueue->add(function ($request, $handler) use (&$called) {
                 $called = true;
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
             $this->middlewareQueue = $middlewareQueue;
         });

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -272,15 +272,15 @@ class RoutingMiddlewareTest extends TestCase
     public function testInvokeScopedMiddleware()
     {
         Router::scope('/api', function (RouteBuilder $routes) {
-            $routes->registerMiddleware('first', function ($req, $res, $next) {
+            $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
-            $routes->registerMiddleware('second', function ($req, $res, $next) {
+            $routes->registerMiddleware('second', function ($request, $handler) {
                 $this->log[] = 'second';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
             $routes->registerMiddleware('dumb', DumbMiddleware::class);
 
@@ -315,15 +315,15 @@ class RoutingMiddlewareTest extends TestCase
     public function testInvokeScopedMiddlewareReturnResponse()
     {
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->registerMiddleware('first', function ($req, $res, $next) {
+            $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
-            $routes->registerMiddleware('second', function ($req, $res, $next) {
+            $routes->registerMiddleware('second', function ($request, $handler) {
                 $this->log[] = 'second';
 
-                return $res;
+                return new Response();
             });
 
             $routes->applyMiddleware('first');
@@ -356,15 +356,15 @@ class RoutingMiddlewareTest extends TestCase
     public function testInvokeScopedMiddlewareReturnResponseMainScope()
     {
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->registerMiddleware('first', function ($req, $res, $next) {
+            $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
-                return $res;
+                return new Response();
             });
-            $routes->registerMiddleware('second', function ($req, $res, $next) {
+            $routes->registerMiddleware('second', function ($request, $handler) {
                 $this->log[] = 'second';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
 
             $routes->applyMiddleware('first');
@@ -401,15 +401,15 @@ class RoutingMiddlewareTest extends TestCase
     public function testInvokeScopedMiddlewareIsolatedScopes(string $url, array $expected)
     {
         Router::scope('/', function (RouteBuilder $routes) {
-            $routes->registerMiddleware('first', function ($req, $res, $next) {
+            $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
-            $routes->registerMiddleware('second', function ($req, $res, $next) {
+            $routes->registerMiddleware('second', function ($request, $handler) {
                 $this->log[] = 'second';
 
-                return $next($req, $res);
+                return $handler->handle($request);
             });
 
             $routes->scope('/api', function (RouteBuilder $routes) {

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -31,8 +31,8 @@ class Plugin extends BasePlugin
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueue->add(function ($req, $res, $next) {
-            return $next($req, $res);
+        $middlewareQueue->add(function ($request, $handler) {
+            return $handler->handle($request);
         });
 
         return $middlewareQueue;

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -63,11 +63,8 @@ class Application extends BaseApplication
      */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueue->add(function ($req, $res, $next) {
-            /** @var \Cake\Http\ServerRequest $res */
-            $res = $next($req, $res);
-
-            return $res->withHeader('X-Middleware', 'true');
+        $middlewareQueue->add(function ($request, $handler) {
+            return $handler->handle($request)->withHeader('X-Middleware', 'true');
         });
         $middlewareQueue->add(new ErrorHandlerMiddleware(Configure::read('Error', [])));
         $middlewareQueue->add(new RoutingMiddleware($this));

--- a/tests/test_app/TestApp/Http/EventApplication.php
+++ b/tests/test_app/TestApp/Http/EventApplication.php
@@ -18,8 +18,6 @@ use Cake\Console\CommandCollection;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Command\DemoCommand;
 
 class EventApplication extends BaseApplication
@@ -40,10 +38,5 @@ class EventApplication extends BaseApplication
     public function console(CommandCollection $commands): CommandCollection
     {
         return $commands->addMany(['ex' => DemoCommand::class]);
-    }
-
-    public function __invoke(ServerRequestInterface $req, ResponseInterface $res, callable $next): ResponseInterface
-    {
-        return $res;
     }
 }

--- a/tests/test_app/TestApp/Http/MiddlewareApplication.php
+++ b/tests/test_app/TestApp/Http/MiddlewareApplication.php
@@ -18,24 +18,20 @@ class MiddlewareApplication extends BaseApplication
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue
-            ->add(function ($req, $res, $next) {
-                $res = $next($req, $res);
-
-                return $res->withHeader('X-First', 'first');
+            ->add(function ($request, $handler) {
+                return $handler->handle($request)->withHeader('X-First', 'first');
             })
-            ->add(function ($req, $res, $next) {
-                $res = $next($req, $res);
-
-                return $res->withHeader('X-Second', 'second');
+            ->add(function ($request, $handler) {
+                return $handler->handle($request)->withHeader('X-Second', 'second');
             })
-            ->add(function ($req, $res, $next) {
-                $res = $next($req, $res);
+            ->add(function ($request, $handler) {
+                $response = $handler->handle($request);
 
-                if ($req->hasHeader('X-pass')) {
-                    $res = $res->withHeader('X-pass', $req->getHeaderLine('X-pass'));
+                if ($request->hasHeader('X-pass')) {
+                    $response = $response->withHeader('X-pass', $request->getHeaderLine('X-pass'));
                 }
 
-                return $res->withHeader('X-Second', 'second');
+                return $response->withHeader('X-Second', 'second');
             });
 
         return $middlewareQueue;

--- a/tests/test_app/TestApp/Middleware/DumbMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/DumbMiddleware.php
@@ -18,14 +18,16 @@ namespace TestApp\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Testing stub for middleware tests.
  */
-class DumbMiddleware
+class DumbMiddleware implements MiddlewareInterface
 {
-    public function __invoke(ServerRequestInterface $req, ResponseInterface $res, callable $next)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        return $next($req, $res);
+        return $handler->handle($request);
     }
 }

--- a/tests/test_app/TestApp/Middleware/SampleMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/SampleMiddleware.php
@@ -16,12 +16,18 @@ declare(strict_types=1);
  */
 namespace TestApp\Middleware;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
 /**
  * Testing stub for middleware tests.
  */
-class SampleMiddleware
+class SampleMiddleware implements MiddlewareInterface
 {
-    public function __invoke(ServerRequestInterface $req, ResponseInterface $res, callable $next)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        return $handler->handle($request);
     }
 }

--- a/tests/test_app/TestApp/Middleware/ThrowsExceptionMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/ThrowsExceptionMiddleware.php
@@ -19,13 +19,15 @@ namespace TestApp\Middleware;
 use Cake\Http\Exception\ForbiddenException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Testing stub for middleware tests.
  */
-class ThrowsExceptionMiddleware
+class ThrowsExceptionMiddleware implements MiddlewareInterface
 {
-    public function __invoke(ServerRequestInterface $req, ResponseInterface $res, callable $next)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         throw new ForbiddenException('Sample Message');
     }


### PR DESCRIPTION
Support for "double pass" middleware was added just to make upgrading from 3.x easier.
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
