### PR TITLE
cake 5: Use cakephp-codesniffer dev-5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^4.5",
+        "cakephp/cakephp-codesniffer": "5.0.x-dev",
         "mikey179/vfsstream": "^1.6.7",
         "paragonie/csp-builder": "^2.3",
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
We won't have an alpha release until more sniffs are updated and converted to slevomat.
