### PR TITLE
Sync plugin short usage for i18n commands.

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -371,6 +371,7 @@ class I18nExtractCommand extends Command
         ])->addOption('plugin', [
             'help' => 'Extracts tokens only from the plugin specified and '
                 . 'puts the result in the plugin\'s Locale directory.',
+            'short' => 'p',
         ])->addOption('exclude', [
             'help' => 'Comma separated list of directories to exclude.' .
                 ' Any path containing a path segment with the provided values will be skipped. E.g. test,vendors',

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -370,7 +370,7 @@ class I18nExtractCommand extends Command
             'help' => 'Ignores all files in plugins if this command is run inside from the same app directory.',
         ])->addOption('plugin', [
             'help' => 'Extracts tokens only from the plugin specified and '
-                . 'puts the result in the plugin\'s Locale directory.',
+                . 'puts the result in the plugin\'s `locales` directory.',
             'short' => 'p',
         ])->addOption('exclude', [
             'help' => 'Comma separated list of directories to exclude.' .


### PR DESCRIPTION
Our commands usually allow -p for plugin option in commands.
The other I18nInit also has it even

           ->addOption('plugin', [
               'help' => 'The plugin to create a PO file in.',
               'short' => 'p',
           ])

When I was trying to run

    bin/cake i18n extract -p Queue --overwrite

as per my expectation, it of course errored with

> Error: Unknown short option `p`

So it only makes sense here to sync this and also allow the usual short hand here, too.

This could probably also be a patch for 4.2, but it is so minor that 4.3 probably suffices here for the fix to ship.
